### PR TITLE
docs(arch): v0 PRD and architecture — crew, runners, missions, signals, messages

### DIFF
--- a/docs/arch/v0-arch.md
+++ b/docs/arch/v0-arch.md
@@ -200,13 +200,18 @@ Every runner has an **inbox**: the subset of the mission's messages that are rel
 inbox(X) = all message events in the mission where to = null OR to = X
 ```
 
-`runners msg read` returns the calling runner's inbox, sorted by ULID (chronological).
+`runners msg read` returns the calling runner's inbox, sorted by ULID (chronological). `--since <ts>` restricts to messages newer than a given ULID/timestamp so agents can poll without re-reading history.
 
-This design keeps the storage model simple (one event log per mission, same as before) while giving each runner a clean "what's for me" view. Broadcasts end up in everyone's inbox; direct messages end up in exactly one.
+This design keeps the storage model simple (one event log per mission, same as before) while giving each runner a clean "what for me" view. Broadcasts end up in everyone's inbox; direct messages end up in exactly one.
 
-**Why LLM agents won't see direct messages unless they're told:** agents act on their prompt. They don't spontaneously poll the filesystem. A message landing in the inbox doesn't itself make the agent aware of it. We solve this with an orchestrator action: when a directed message arrives, the orchestrator nudges the recipient's stdin with a one-line hint ("new message from `coder` — run `msg read`"). The agent then reads its inbox as a normal tool call. See §5.5 action `nudge_recipient`.
+**The inbox is pull-based.** Messages are read when the recipient runs `msg read`; the system does not automatically interrupt a busy runner every time mail arrives. This is deliberate — not every direct message is urgent, and auto-interrupting on every DM would blur the signal/message split (§2.7.1 vs §2.7.2) and corrupt in-flight tool calls.
 
-The inbox is not a queue in the delete-on-read sense — messages stay in the log forever (well, for the mission). The "read" in `msg read` is lookup, not consumption. `msg read --since <ts>` lets agents fetch just what's new.
+The recipient learns to read its inbox through two mechanisms:
+
+1. **Convention** — the composed system prompt (§4.3) instructs every runner to check its inbox at natural task boundaries.
+2. **Signals as the urgent wake-up** — if a sender needs the recipient to drop everything, they emit a signal in addition to (or instead of) the message. The signal goes through the orchestrator's policy, which typically injects stdin. On any stdin injection, the orchestrator automatically appends a summary of the recipient's unread inbox messages (§5.5), so urgent wake-ups carry relevant conversation context with them.
+
+The inbox is not a queue in the delete-on-read sense — messages stay in the log forever (well, for the mission). The "read" in `msg read` is lookup, not consumption.
 
 #### 2.7.4 Thread *(v0.x)* — *scoped conversation*
 
@@ -300,7 +305,7 @@ MissionManager builds each runner's prompt from four parts:
 1. **The user-authored brief** (`runners.system_prompt`).
 2. **The mission brief** (`missions.goal_override` or `crews.goal`).
 3. **The roster** — crewmates' names, roles, one-line brief summaries.
-4. **Coordination notes** — how to use `runners signal` and `runners msg`, and the crew's allowed signal types.
+4. **Coordination notes** — how to use `runners signal` and `runners msg`, the crew's allowed signal types, and conventions for inbox checking.
 
 Example for a Reviewer:
 
@@ -322,8 +327,15 @@ Goal: Implement feature X with tests and a clean PR.
 == Coordination ==
 - Signal milestones with `runners signal <type>`.
   Signal types: review_requested, changes_requested, approved, blocked.
-- Post prose with `runners msg post "<text>"`.
-- Read the mission's message stream with `runners msg read`.
+- Post prose with `runners msg post "<text>"` (broadcast) or
+  `runners msg post --to <runner> "<text>"` (direct to one crewmate).
+- Your inbox is `runners msg read` (broadcasts + messages addressed to you).
+  Check it at natural task boundaries:
+    * before starting a new task,
+    * before emitting a signal that affects another runner,
+    * whenever you're waiting on something (poll with `--since <last_ulid>`).
+  Urgent items will also arrive via stdin when someone signals — but by
+  default, the inbox is pull-based.
 ```
 
 ### 4.4 Frontend wiring and human takeover
@@ -461,7 +473,6 @@ On orchestrator boot: open the mission's file, fold events into in-memory state 
 | Action | Effect | Emits event? |
 |---|---|---|
 | `inject_stdin` | write template + `\r` to target runner's PTY writer | `stdin_injected` (signal) |
-| `nudge_recipient` | write a short "new message from X, run `msg read`" hint into the recipient's stdin | `recipient_nudged` (signal) |
 | `ask_human` | add card to HITL panel; wait for click | `human_question` then `human_response` (signals) |
 | `notify_human` | fire a toast | `human_notified` (signal) |
 | `pause_runner` | SIGSTOP to target PTY | `runner_paused` (signal) |
@@ -469,7 +480,30 @@ On orchestrator boot: open the mission's file, fold events into in-memory state 
 
 Emitted events have `causation_id` = the triggering event's `id`.
 
-**Default policy for direct messages.** Every crew starts with a built-in rule `{ when: { kind: "message", to: "*" }, do: { action: "nudge_recipient" } }` that fires on any directed message. This ensures recipients know mail has arrived without the sender having to also emit a signal. Users can disable this per crew if they want silent inboxes.
+**Messages do not trigger orchestrator actions in v0.** The inbox is pull-based (§2.7.3). If a sender needs the recipient to drop everything, they emit a signal — signals are the urgent wake-up mechanism; direct messages are async conversation.
+
+#### 5.5.1 Enriched stdin injection
+
+When `inject_stdin` fires, the orchestrator automatically enriches the template with the recipient's unread inbox summary. Concretely:
+
+1. The orchestrator tracks a per-runner `last_read_ulid` marker. It advances on the recipient's `msg read` calls (observed via the CLI writing an audit event, or inferred from the next read's `--since`).
+2. Before injecting, the orchestrator gathers all inbox messages newer than `last_read_ulid` — i.e. messages the runner hasn't yet seen.
+3. The injected stdin is: `{template}\n\n{unread summary}`.
+
+Example — rule `{when: signal=changes_requested, do: inject_stdin target=coder template="Reviewer requested changes — check msg read for details."}` fires after Reviewer posted two direct messages. The Coder's PTY receives:
+
+```
+Reviewer requested changes — check msg read for details.
+
+You have 2 new messages:
+  [reviewer 12:38]: Line 47 auth.rs needs a null check.
+  [reviewer 12:39]: session.rs timeout is 30s; our convention is 10s.
+Run `runners msg read` for full content.
+```
+
+The Coder wakes up with both the signal and the conversation context in one interruption — no separate polling needed. If the runner does go call `runners msg read`, the injected summary matches.
+
+This makes the urgent path (signal → inject_stdin) carry the async path (direct messages) with it automatically. Senders don't have to decide between "just message" and "signal-plus-message" — they send a message for data, and signal only when they need immediate attention; the enrichment glues the two together on arrival.
 
 **Crash correctness:** emit the event *before* performing the action. Worst case on crash+replay is a duplicate action, recoverable (stdin seen twice; HITL cards deduped by event id). Silent loss is not.
 
@@ -478,20 +512,22 @@ Emitted events have `causation_id` = the triggering event's `id`.
 Two different delivery models, by primitive kind:
 
 - **Signals are orchestrator-routed.** Runners never address other runners with a signal. A signal is emitted into the bus; the orchestrator policy decides what happens (including whether to inject stdin into some specific runner). This keeps all control-flow routing in one place and lets you swap runners without rewriting emitters.
-- **Messages support both broadcast and direct addressing.** A runner can `msg post` (everyone's inbox) or `msg post --to <runner>` (that runner's inbox only). No orchestrator in the delivery path; messages are data, not control. The orchestrator is involved only to nudge recipients so they know mail arrived (§5.5, `nudge_recipient`).
+- **Messages support both broadcast and direct addressing, but are pull-based.** A runner can `msg post` (everyone's inbox) or `msg post --to <runner>` (that runner's inbox only). The orchestrator is *not* in the delivery path — messages sit in the inbox until the recipient runs `msg read`. If a sender needs immediate attention, they emit a signal; signals are the urgent-wake-up channel.
 
 The split:
 
-| | Sender addresses recipient? | Orchestrator involved? |
-|---|:---:|:---:|
-| Signal | No — policy decides | Always |
-| Broadcast message | No | Only to nudge |
-| Direct message | Yes (`--to`) | Only to nudge |
+| | Sender addresses recipient? | Delivery timing | Orchestrator in path? |
+|---|:---:|---|:---:|
+| Signal | No — policy decides | Immediate (via `inject_stdin` etc.) | Always |
+| Broadcast message | No | On recipient's `msg read` | No |
+| Direct message | Yes (`--to`) | On recipient's `msg read` | No |
+
+When the orchestrator does inject stdin on a signal, it automatically enriches the injection with the recipient's unread inbox summary (§5.5.1) — so an urgent signal pulls the associated async conversation along with it. That's how messages effectively "get delivered" to a running agent without a dedicated nudge mechanism.
 
 - **Decoupled control flow** — the Coder doesn't need to know the Reviewer's name to *signal* a review. Swap the Reviewer without rewriting the Coder's signal emissions.
 - **Coupled content flow where it's natural** — if Coder wants to ask Reviewer a specific question, it can just `msg post --to reviewer ...`. The roster injection (§4.3) already tells each runner the current names of its crewmates, so direct addressing works without extra config.
 - **Single policy location** for control — every "when signal X, do Y" lives on the crew row.
-- **Orchestrator is the only side-effecting component** outside runner processes. Direct messaging doesn't violate this — a direct `msg post` writes an event; the actual stdin hint is still an orchestrator action.
+- **No auto-interrupt for messages** — agents check their inboxes on convention and on signal-triggered wake-ups. This preserves the signal/message split (urgent vs async) and keeps in-flight tool calls uncorrupted.
 
 ### 5.7 Known failure modes
 

--- a/docs/arch/v0-arch.md
+++ b/docs/arch/v0-arch.md
@@ -35,7 +35,7 @@ Runners is a local desktop app. A user configures a **crew** of CLI coding agent
 │  │   │  master  │ ◄────►  │  child: claude-code / codex / shell     │   │   │
 │  │   └──────────┘         │  env: RUNNERS_CREW_ID,                  │   │   │
 │  │                        │       RUNNERS_MISSION_ID,               │   │   │
-│  │                        │       RUNNERS_RUNNER_NAME,              │   │   │
+│  │                        │       RUNNERS_RUNNER_HANDLE,              │   │   │
 │  │                        │       RUNNERS_EVENT_LOG, PATH=…         │   │   │
 │  │                        └─────┬───────────────────────────────────┘   │   │
 │  └─────────────────────────────┼──────────────────────────────────────┘   │
@@ -107,7 +107,14 @@ Lifecycle: created by the user, edited freely, deleted when no longer needed. Pe
 
 An individual CLI agent within a crew: what binary to run, with what args, in what working directory, with what system prompt (the role's brief). Persistent config. A runner doesn't run either; it describes a process that will be spawned when a mission starts.
 
-A runner belongs to exactly one crew. Examples: "Coder (claude-code)", "Reviewer (claude-code)", "Tester (shell)".
+A runner has two identifying fields:
+
+- **`handle`** — a lowercase slug (e.g. `coder`, `reviewer`, `tester`). Required, immutable once set, unique within the crew. Used everywhere addressing is needed: as `from` and `to` in events, as `--to <handle>` on the CLI, and in policy rules. Handles are what runners call each other by.
+- **`display_name`** — a free-form label for the UI (e.g. "Coder", "Lead Reviewer"). Editable; not used in event fields or addressing.
+
+Keeping these separate means renaming a runner for the UI doesn't break briefs, rules, or historical events. `handle` is the identity; `display_name` is just presentation.
+
+A runner belongs to exactly one crew. Examples: `coder` (claude-code), `reviewer` (claude-code), `tester` (shell).
 
 ### 2.4 Orchestrator Policy — *the crew's decision rules*
 
@@ -194,10 +201,10 @@ Messages and signals are separate for good reasons:
 
 #### 2.7.3 Inbox — *"what's in my mailbox"*
 
-Every runner has an **inbox**: the subset of the mission's messages that are relevant to it. The inbox is a **projection** over the event log, not a separate data structure. For runner `X`:
+Every runner has an **inbox**: the subset of the mission's messages that are relevant to it. The inbox is a **projection** over the event log, not a separate data structure. For the runner with handle `h`:
 
 ```
-inbox(X) = all message events in the mission where to = null OR to = X
+inbox(h) = all events in the mission where kind = "message" AND (to = null OR to = h)
 ```
 
 `runners msg read` returns the calling runner's inbox, sorted by ULID (chronological). `--since <ts>` restricts to messages newer than a given ULID/timestamp so agents can poll without re-reading history.
@@ -227,9 +234,11 @@ Facts differ from messages and signals: they're **current state**, not events. R
 
 ### 2.8 Events — *the unifying transport*
 
-Every coordination primitive is persisted as an **event** — one line in the per-mission NDJSON file. Signals become `signal_emitted` events. Messages become `message_posted` events. (Later: `thread_opened`, `fact_recorded`, etc.) This is a transport detail, not a separate concept for users; runners interact through the CLI verbs, not the event schema.
+Every coordination primitive is persisted as an **event** — one line in the per-mission NDJSON file. An event has: `{id, ts, crew_id, mission_id, kind, from, to, type, payload, correlation_id, causation_id}`.
 
-An event has: `{id, ts, crew_id, mission_id, from, to, kind, payload, correlation_id, causation_id}`. `kind` distinguishes primitive types (`signal`, `message`, ...). The orchestrator and UI project events into the primitive-specific views.
+The `kind` field is the primitive discriminator — `signal`, `message`, and (later) `fact`, `thread_opened`. For `kind: "signal"`, the `type` field carries the signal's semantic verb (`review_requested`, `changes_requested`, etc.); for `kind: "message"`, `type` is omitted and the prose lives in `payload.text`. The orchestrator and UI project events into primitive-specific views based on `kind`.
+
+This is a transport detail — runners interact through the CLI verbs (`runners signal`, `runners msg`), not the event schema directly. There is no separate `signal_emitted` or `message_posted` event type; the `kind` field is authoritative.
 
 ## 3. Mission lifecycle
 
@@ -288,7 +297,7 @@ Child inherits:
   PATH                = $APPDATA/runners/bin:<original PATH>
   RUNNERS_CREW_ID     = <ulid>
   RUNNERS_MISSION_ID  = <ulid>
-  RUNNERS_RUNNER_NAME = coder
+  RUNNERS_RUNNER_HANDLE = coder
   RUNNERS_EVENT_LOG   = $APPDATA/runners/crews/<crew>/missions/<mission>/events.ndjson
 
 Reader thread (blocking):
@@ -307,28 +316,31 @@ MissionManager builds each runner's prompt from four parts:
 3. **The roster** — crewmates' names, roles, one-line brief summaries.
 4. **Coordination notes** — how to use `runners signal` and `runners msg`, the crew's allowed signal types, and conventions for inbox checking.
 
-Example for a Reviewer:
+Example for the `reviewer` runner (display name "Reviewer"):
 
 ```
-You are Reviewer, a runner in crew "Feature Ship".
+You are `reviewer` (Reviewer), a runner in crew "Feature Ship".
 Your role: code review.
 
 == Your brief ==
-When the Coder requests review, read their messages and the diff,
+When `coder` requests review, read their messages and the diff,
 then either approve or request changes with specific feedback.
 
 == Mission ==
 Goal: Implement feature X with tests and a clean PR.
 
 == Your crewmates ==
-- Coder (implementation): Writes code. Will signal review_requested and
-  post messages explaining what changed.
+- `coder` (Coder, implementation): Writes code. Will signal review_requested
+  and post messages explaining what changed.
+
+Handles (the lowercase names in backticks above) are what you use to
+address crewmates. Display names are shown for readability only.
 
 == Coordination ==
 - Signal milestones with `runners signal <type>`.
   Signal types: review_requested, changes_requested, approved, blocked.
 - Post prose with `runners msg post "<text>"` (broadcast) or
-  `runners msg post --to <runner> "<text>"` (direct to one crewmate).
+  `runners msg post --to <handle> "<text>"` (direct to one crewmate).
 - Your inbox is `runners msg read` (broadcasts + messages addressed to you).
   Check it at natural task boundaries:
     * before starting a new task,
@@ -390,8 +402,26 @@ One line per event. Append-only. **Each mission has its own file** — scopes lo
 Why a file instead of an in-memory bus:
 - **Debuggable** — `tail -f events.ndjson | jq .`.
 - **Crash-durable** — whatever's on disk survived the crash.
-- **Atomic** — writes < `PIPE_BUF` (4KB on macOS) to `O_APPEND` are atomic; concurrent `runners` invocations interleave correctly.
+- **Atomic** under explicit guards (see §5.1.1) — concurrent `runners` invocations interleave correctly at line granularity.
 - **Replayable for free** — restart the orchestrator, re-scan, resume.
+
+#### 5.1.1 Concurrent-write correctness
+
+Multiple runners can invoke `runners signal` / `runners msg` at the same time from different PTYs. We need line-granular atomicity regardless of filesystem. The approach:
+
+1. Open the log with `O_APPEND | O_WRONLY | O_CREAT`.
+2. Acquire an advisory exclusive lock: `flock(fd, LOCK_EX)`.
+3. Emit exactly one `write(2)` call with the serialized JSON line including the trailing `\n`.
+4. `close(fd)`, which releases the lock.
+
+This gives us:
+- **Ordering**: `O_APPEND` guarantees the write lands at end-of-file at the moment the kernel performs it.
+- **Atomicity across writers**: `flock(LOCK_EX)` serializes writers. Without it we cannot safely rely on filesystem-level write atomicity — `PIPE_BUF` applies to pipes, not regular files, and small-write atomicity on regular files is filesystem-specific.
+- **No partial lines**: a single `write(2)` call of the full line + `\n` means either the whole line lands or none of it does (the kernel writes sequentially under the lock).
+
+**Filesystem requirements.** The app data directory must be on a local POSIX filesystem (APFS, ext4, XFS, etc.). Network filesystems (NFS, SMB) and iCloud-synced volumes may not honor `flock()` or may re-order appends across clients; v0 documents this and checks at app startup.
+
+Writers: only the bundled `runners` CLI writes to the log (the Rust backend also writes orchestrator-generated events — it uses the same `flock`-guarded path). No other process should write to this file; the orchestrator refuses to start a mission if another holder has an exclusive lock at boot.
 
 ### 5.2 Event schema
 
@@ -402,11 +432,11 @@ Why a file instead of an in-memory bus:
   "crew_id": "01HG...",
   "mission_id": "01HG...",
   "kind": "signal",                 // signal | message  (v0.x adds: fact, thread_opened, ...)
-  "from": "coder",                  // runner name | "human" | "orchestrator"
-  "to": null,                       // null = broadcast; runner name = directed (messages);
+  "from": "coder",                  // runner handle | "human" | "orchestrator"
+  "to": null,                       // null = broadcast; runner handle = directed (messages);
                                     //   for signals, always null in v0 (policy decides routing)
   "type": "review_requested",       // for kind=signal; omitted for kind=message
-  "payload": { "...": "..." },      // kind-specific
+  "payload": { "...": "..." },      // kind-specific (e.g. { "text": "..." } for messages)
   "correlation_id": null,
   "causation_id": null
 }
@@ -433,7 +463,8 @@ The backend prepends `$APPDATA/runners/bin/` to PATH and drops the `runners` bin
 
 On invocation, the CLI:
 1. Reads env vars; errors if missing.
-2. Builds an event (ULID, timestamps, `from` = `$RUNNERS_RUNNER_NAME`, `crew_id`, `mission_id`, `kind`).
+2. Builds an event (ULID, timestamps, `from` = `$RUNNERS_RUNNER_HANDLE`, `crew_id`, `mission_id`, `kind`).
+3. For directed messages, validates `--to <handle>` against the crew's runner handles (rejects unknown handles with a clear stderr message).
 3. For signals: validates `type` against the allowlist sidecar at `$APPDATA/runners/crews/{crew_id}/signal_types.json`.
 4. Appends one JSON line to `$RUNNERS_EVENT_LOG` via `open(O_APPEND | O_WRONLY)` + `write_all` + close.
 5. Exits 0.
@@ -470,25 +501,69 @@ On orchestrator boot: open the mission's file, fold events into in-memory state 
 
 ### 5.5 Orchestrator actions
 
-| Action | Effect | Emits event? |
-|---|---|---|
-| `inject_stdin` | write template + `\r` to target runner's PTY writer | `stdin_injected` (signal) |
-| `ask_human` | add card to HITL panel; wait for click | `human_question` then `human_response` (signals) |
-| `notify_human` | fire a toast | `human_notified` (signal) |
-| `pause_runner` | SIGSTOP to target PTY | `runner_paused` (signal) |
-| `resume_runner` | SIGCONT to target PTY | `runner_resumed` (signal) |
+Every action emits at least one signal event with `causation_id` = the triggering event's `id`.
 
-Emitted events have `causation_id` = the triggering event's `id`.
+| Action | Effect | Emits signal(s) with `type` |
+|---|---|---|
+| `inject_stdin` | write template + `\r` to target runner's PTY writer | `stdin_injected`, payload `{ target, watermark }` |
+| `ask_human` | add card to HITL panel; wait for click | `human_question` on card open; `human_response` on click |
+| `notify_human` | fire a toast | `human_notified` |
+| `pause_runner` | SIGSTOP to target PTY | `runner_paused` |
+| `resume_runner` | SIGCONT to target PTY | `runner_resumed` |
+
+#### 5.5.0 `ask_human` — payload shapes and matching
+
+`ask_human { prompt, choices }` produces two correlated signals:
+
+```jsonc
+// When the card is shown:
+{
+  "kind": "signal",
+  "type": "human_question",
+  "from": "orchestrator",
+  "payload": {
+    "prompt": "Reviewer requested changes. Accept or override?",
+    "choices": ["accept", "override"]
+  },
+  "correlation_id": <triggering-signal.id>,   // e.g. the changes_requested signal
+  "causation_id":   <triggering-signal.id>
+}
+
+// When the human clicks a choice:
+{
+  "kind": "signal",
+  "type": "human_response",
+  "from": "human",
+  "payload": {
+    "question_id": <human_question.id>,       // lets rules target a specific card
+    "choice": "accept"                         // the clicked value (always one of choices[])
+  },
+  "correlation_id": <triggering-signal.id>,   // same as the question
+  "causation_id":   <human_question.id>
+}
+```
+
+**Matching semantics for follow-up rules.** Downstream rules can match on `human_response` in two ways:
+
+1. **By choice value** — `{ when: { signal: "human_response", payload: { choice: "accept" } }, do: ... }`. Matches any accept, regardless of which question triggered it.
+2. **By correlation** — rules can reference `$correlation` in `when` clauses (implemented as a lookup into the triggering event's fields). Useful when two `ask_human` prompts are outstanding at once and we need to discriminate: `{ when: { signal: "human_response", correlated_with: { type: "changes_requested" } } }`.
+
+For v0 we ship option (1); option (2) is flagged for v0.x if we hit cases where two outstanding questions collide.
 
 **Messages do not trigger orchestrator actions in v0.** The inbox is pull-based (§2.7.3). If a sender needs the recipient to drop everything, they emit a signal — signals are the urgent wake-up mechanism; direct messages are async conversation.
 
 #### 5.5.1 Enriched stdin injection
 
-When `inject_stdin` fires, the orchestrator automatically enriches the template with the recipient's unread inbox summary. Concretely:
+When `inject_stdin` fires, the orchestrator automatically enriches the template with the recipient's unread inbox summary.
 
-1. The orchestrator tracks a per-runner `last_read_ulid` marker. It advances on the recipient's `msg read` calls (observed via the CLI writing an audit event, or inferred from the next read's `--since`).
-2. Before injecting, the orchestrator gathers all inbox messages newer than `last_read_ulid` — i.e. messages the runner hasn't yet seen.
-3. The injected stdin is: `{template}\n\n{unread summary}`.
+**Watermark tracking.** The orchestrator maintains a per-runner `read_watermark` — the ULID of the newest message that runner has been shown. The watermark advances only on authoritative events, not on heuristics:
+
+- Every `runners msg read` invocation ends by emitting an `inbox_read` audit event with `kind: "signal"`, `type: "inbox_read"`, `from: <runner>`, `payload: { up_to: <max_ulid_returned> }`. The orchestrator advances the runner's watermark to `payload.up_to`.
+- An `inject_stdin` that included an unread summary also emits a `stdin_injected` event with `payload: { watermark: <max_ulid_in_summary> }`, so the next summary is scoped strictly to messages newer than this value — the injection itself counts as showing them.
+
+The watermark is initialized to `"0"` (before any ULID) at mission start and is rebuilt from the log on crash-replay by scanning these events. It is never inferred from `--since` flags (agents can set those to arbitrary values).
+
+**Injection shape.** Before firing, the orchestrator gathers all inbox messages newer than the recipient's watermark. The injected stdin is: `{template}\n\n{unread summary}`, and the watermark advances on the resulting `stdin_injected` event.
 
 Example — rule `{when: signal=changes_requested, do: inject_stdin target=coder template="Reviewer requested changes — check msg read for details."}` fires after Reviewer posted two direct messages. The Coder's PTY receives:
 
@@ -501,9 +576,9 @@ You have 2 new messages:
 Run `runners msg read` for full content.
 ```
 
-The Coder wakes up with both the signal and the conversation context in one interruption — no separate polling needed. If the runner does go call `runners msg read`, the injected summary matches.
+The Coder wakes up with both the signal and the conversation context in one interruption. If the Coder does then call `runners msg read`, the CLI returns the same two messages, emits `inbox_read { up_to: <reviewer's second message ULID> }`, and the watermark is already at that point from the injection — so nothing further is shown on the next signal unless genuinely new.
 
-This makes the urgent path (signal → inject_stdin) carry the async path (direct messages) with it automatically. Senders don't have to decide between "just message" and "signal-plus-message" — they send a message for data, and signal only when they need immediate attention; the enrichment glues the two together on arrival.
+This makes the urgent path (signal → inject_stdin) carry the async path (direct messages) with it automatically. Senders don't decide between "just message" and "signal-plus-message" — they send a message for data, and signal only when they need immediate attention; the enrichment glues the two together on arrival, and the watermark keeps them in sync.
 
 **Crash correctness:** emit the event *before* performing the action. Worst case on crash+replay is a duplicate action, recoverable (stdin seen twice; HITL cards deduped by event id). Silent loss is not.
 
@@ -589,7 +664,8 @@ crews (
 runners (
   id TEXT PRIMARY KEY,
   crew_id TEXT REFERENCES crews(id) ON DELETE CASCADE,
-  name TEXT NOT NULL,
+  handle TEXT NOT NULL,               -- lowercase slug, immutable, unique within crew
+  display_name TEXT NOT NULL,         -- free-form UI label
   role TEXT NOT NULL,
   runtime TEXT NOT NULL,
   command TEXT NOT NULL,
@@ -597,7 +673,8 @@ runners (
   working_dir TEXT,
   system_prompt TEXT,
   env_json TEXT,
-  created_at TEXT, updated_at TEXT
+  created_at TEXT, updated_at TEXT,
+  UNIQUE (crew_id, handle)
 );
 
 missions (

--- a/docs/arch/v0-arch.md
+++ b/docs/arch/v0-arch.md
@@ -304,22 +304,40 @@ Goal: Implement feature X with tests and a clean PR.
 - Read the mission's message stream with `runners msg read`.
 ```
 
-### 4.4 Frontend wiring
+### 4.4 Frontend wiring and human takeover
 
 - On first view: fetch the session's scrollback ring; write to xterm.js to restore history.
 - Subscribe to `session:{id}:out` for live output.
 - xterm.js `onData` → `send_input(session_id, bytes)` → `master.writer.write_all(bytes)`.
 - Frontend window resize → debounced (~100ms) `master.resize(rows, cols)` → SIGWINCH to child. Non-optional; without it, TUIs mis-render.
 
-### 4.5 Threads, not async
+**Human takeover is a first-class capability.** At any moment, the human can type directly into any runner's stdin — the same writer the orchestrator uses for `inject_stdin`. This is deliberate: the human can step in to answer a prompt the agent is stuck on, correct a bad plan, kill a runaway tool call, or just chat with the agent mid-flight.
+
+The UI surface for this is the xterm pane itself — it's a real terminal, not a log viewer. Typing sends keystrokes through untouched, including special keys (arrows, Enter, Ctrl-C). The agent on the other end can't tell whether the bytes came from the orchestrator, the human, or a replay — which is the whole point.
+
+### 4.5 Sessions outlive the UI
+
+Sessions live in the Rust backend and belong to the mission, not to any webview or tab. Closing the mission control window does *not* kill the sessions — the agents keep running, events keep flowing into the NDJSON file, the orchestrator keeps applying rules. Re-opening the window re-attaches: the frontend fetches each session's scrollback ring to rebuild xterm state, then subscribes to live output from wherever it was.
+
+The only things that end a session in v0 are: user clicks End Mission, the child process exits, or the app itself quits. A closed webview window is none of those.
+
+**Why this matters for human takeover:** if the only way to type into a runner required the UI to be visible, then minimizing or closing the mission view to focus on something else would silently cut the human out of the loop. That's wrong — the human should be able to close the monitor and still inject stdin (or let the orchestrator do it) without anything changing about how agents run.
+
+### 4.6 Writer serialization
+
+The PTY master writer is shared between the human (via `send_input` command) and the orchestrator (via `inject_stdin` action). Concurrent writers could interleave bytes mid-line, which would confuse the TUI on the other end.
+
+Solution: wrap each session's writer in a `tokio::sync::Mutex`. Every write is one `write_all` call under the lock. Small writes (keystrokes, short prompts) are fast enough that contention is invisible.
+
+### 4.7 Threads, not async
 
 `portable-pty`'s reader is blocking. Spawn an OS thread per session. Writers stay on the Tauri async runtime (writes are short).
 
-### 4.6 Scrollback in Rust
+### 4.8 Scrollback in Rust
 
 `VecDeque<String>` ring (~10k lines) per session in SessionManager, so scrollback survives tab-switches and app restarts. Overflow lines append to `missions/{mission_id}/sessions/{session_id}.log`. The ring sees raw bytes including alt-screen toggles — acceptable v0 scuff.
 
-### 4.7 Death and kill
+### 4.9 Death and kill
 
 Reader thread owns the child handle. On EOF, it calls `wait()`, emits `session:{id}:exit`, updates the sessions row. No auto-restart in v0.
 

--- a/docs/arch/v0-arch.md
+++ b/docs/arch/v0-arch.md
@@ -16,7 +16,7 @@ Runners is a local desktop app. A user configures a **crew** of CLI coding agent
 │  │ MissionManager       │   │ SessionManager       │   │ EventBus        │  │
 │  │  - mission lifecycle │   │  - PTY spawn/kill    │   │  - tail NDJSON  │  │
 │  │  - compose prompts   │   │  - reader threads    │   │  - notify watch │  │
-│  │  - roster + brief    │   │  - scrollback rings  │   │  - fact project │  │
+│  │  - roster + brief    │   │  - scrollback rings  │   │  - projections  │  │
 │  └────────┬─────────────┘   └────────┬─────────────┘   └────────┬────────┘  │
 │           │                          │                          │           │
 │           │                          │                          ▼           │
@@ -39,7 +39,7 @@ Runners is a local desktop app. A user configures a **crew** of CLI coding agent
 │  │                        │       RUNNERS_EVENT_LOG, PATH=…         │   │   │
 │  │                        └─────┬───────────────────────────────────┘   │   │
 │  └─────────────────────────────┼──────────────────────────────────────┘   │
-│                                │ runs `runners emit` / `runners ctx`      │
+│                                │ runs `runners signal` / `runners msg`    │
 │                                ▼                                          │
 │                  ┌─────────────────────────────┐                          │
 │                  │  events.ndjson (per mission)│                          │
@@ -49,40 +49,42 @@ Runners is a local desktop app. A user configures a **crew** of CLI coding agent
                                   ▼
                          ┌───────────────────────┐
                          │ React + xterm.js      │
-                         │  terminals, timeline, │
-                         │  HITL cards, facts    │
+                         │  terminals, messages, │
+                         │  signals, HITL        │
                          └───────────────────────┘
 ```
 
 ### 1.2 The one-paragraph story
 
-The user defines a **crew** (configuration: runners + policy). They click **Start Mission**, which creates a **mission** (runtime container), spawns one PTY-backed **session** per runner, and composes each runner's system prompt with the mission brief, the crew roster, and coordination instructions. Runners run real CLI binaries inside PTYs; they emit **events** via a bundled `runners` CLI that appends to the mission's NDJSON file. The **orchestrator** tails that file, applies a rule-based policy, and dispatches actions (inject stdin, ask human, pause, etc.). Runners share state through a **fact** whiteboard backed by the same event log. The UI is a read-only tail that renders terminals, events, facts, and HITL prompts.
+The user defines a **crew** (configuration: runners + policy). They click **Start Mission**, which creates a **mission** (runtime container), spawns one PTY-backed **session** per runner, and composes each runner's system prompt with the mission brief, the crew roster, and coordination instructions. Runners run real CLI binaries inside PTYs. They coordinate through two primitives — **signals** (typed events for the orchestrator to route on) and **messages** (flat prose stream for runner-to-runner conversation) — both carried through a bundled `runners` CLI that appends to the mission's NDJSON file. The **orchestrator** tails that file, applies a rule-based policy, and dispatches actions (inject stdin, ask human, pause, etc.). The UI is a read-only tail that renders terminals, messages, signals, and HITL prompts.
 
 ## 2. Concepts
 
-Seven domain objects. Two kinds: **configuration** (persistent, edited by the user) and **runtime** (live, created at mission start, torn down at mission end).
+Domain objects fall into three layers: **configuration** (persistent, edited by the user), **runtime containers** (live, created at mission start), and **coordination primitives** (what flows between runners during a mission).
 
 ### 2.1 Relationship diagram
 
 ```
-Configuration (persistent)          Runtime (live or historical)
+Configuration (persistent)     Runtime (live or historical)
 
-  Crew ─┬── Runner ────────────────► Session ────► PTY process
-        │                              ▲
-        │                              │ spawns
-        └── Orchestrator Policy        │
-              │                        │
+  Crew ─┬── Runner ───────────► Session ────► PTY process
+        │                          ▲
+        └── Orchestrator Policy    │ spawned by
+              │                    │
               └─ attached to ─► Mission ────► events.ndjson
                                   │             │
-                                  │             ├─► Event
-                                  │             └─► Fact (via fact_recorded)
+                                  │             ├─► Signal      [v0]
+                                  │             ├─► Message     [v0]
+                                  │             ├─► Thread      [v0.x]
+                                  │             └─► Fact        [v0.x]
                                   │
-                                  └─► Shared context (brief + roster + facts)
+                                  └─► Shared context: brief + roster (v0)
+                                                      + facts (v0.x)
 ```
 
 ### 2.2 Crew — *a configured team*
 
-The persistent "who's on the team and how they work together" record. A crew has a name, a default mission goal, a list of runners, an orchestrator policy, and an event-type allowlist. It does not run. It is blueprint.
+The persistent "who's on the team and how they work together" record. A crew has a name, a default mission goal, a list of runners, an orchestrator policy, and a signal-type allowlist. It does not run. It is blueprint.
 
 Lifecycle: created by the user, edited freely, deleted when no longer needed. Persisted in SQLite.
 
@@ -102,7 +104,7 @@ There is no code here — just a lookup table. No scripting, no LLM. v0 is delib
 
 A runtime container. When the user clicks **Start Mission**, a mission row is created, sessions are spawned for every runner, the orchestrator is booted with a fresh in-memory state, and an NDJSON event log is opened. When the mission ends (explicit stop, or all sessions exited), everything in the container shuts down together.
 
-A mission scopes: the event log, the fact whiteboard, pending HITL cards, orchestrator memory. Each mission starts empty on all four.
+A mission scopes: the event log, the signal stream, the message stream, pending HITL cards, orchestrator memory.
 
 v0 constraint: a crew can have at most one live mission at a time. A crew can have many historical missions.
 
@@ -112,17 +114,62 @@ The live process for one runner inside one mission. One runner × one mission = 
 
 A session is the only object that actually *executes* something — everything else is metadata or a coordination channel.
 
-### 2.7 Event — *a durable coordination message*
+### 2.7 Coordination primitives — *what flows between runners*
 
-One line in a mission's NDJSON file. Structured JSON: `{id, ts, crew_id, mission_id, from, to, type, payload, correlation_id, causation_id}`. Emitted by runners (via the `runners emit` CLI), humans (via the UI), or the orchestrator itself (as a side effect of actions). Consumed by the orchestrator for policy dispatch and by the UI for the timeline.
+Runners don't share a programming model; they share an IM-like surface. The same way Slack/Lark/Teams gave humans a small vocabulary of coordination (messages, threads, pings, pinned canvas), Runners gives agents a parallel vocabulary. We ship a subset in each milestone.
 
-Events are the system's source of truth for runtime state. The orchestrator's in-memory state is a *projection* of the events; on crash, it's rebuilt by replaying the file.
+| Primitive | Role | v0 | v0.x | v1+ |
+|---|---|:---:|:---:|:---:|
+| **Signal** | Typed notification; orchestrator routes on these. Verb grammar. | ✅ | | |
+| **Message** | Prose posted to the mission stream. Runner-to-runner conversation. | ✅ | | |
+| **Thread** | Scoped sub-conversation within a mission. | | ✅ | |
+| **Fact** | KV whiteboard; "what is currently true in this mission." | | ✅ | |
+| **Mention** | Targeted `@name` inside a message. | | | ✅ |
+| **Reaction** | Lightweight signal attached to a message (`👍`, `🔍`, `blocking`). | | | ✅ |
 
-### 2.8 Fact — *an entry on the shared whiteboard*
+#### 2.7.1 Signal — *"something happened, please decide"*
 
-A key-value pair any runner can read or write during a mission via the `runners ctx` CLI. Implemented as a specific event type (`fact_recorded`), so facts are just events with a particular shape — no separate store. Last-writer-wins per key. Mission-scoped: each mission starts with an empty whiteboard.
+Short, typed, orchestrator-routable. Grammar: past-tense verb.
 
-Facts are how runners share state that doesn't fit the event model cleanly: "the PR URL is X," "we're targeting branch Y," "the build is green." Think of events as *things that happened* and facts as *things that are currently true*.
+Examples: `review_requested`, `changes_requested`, `approved`, `blocked`.
+
+Signals are machine-readable by design. The orchestrator has rules keyed to signal types. Runners emit them when they want the mission to move to its next state.
+
+A signal carries an optional `payload` (JSON) but the payload is meant for the orchestrator's decision logic, not for runners to read as prose.
+
+#### 2.7.2 Message — *"here's what I think"*
+
+Prose, posted to the mission's flat stream. Runner-to-runner (and human-readable). Grammar: sentence.
+
+Examples:
+- `"Branch feat/x is ready. Touched auth.rs and session.rs."`
+- `"Line 47 in auth.rs: null check missing when the token is expired."`
+- `"Kept the 30s timeout — provider is slow on cold start."`
+
+Messages are **flat in v0** — one stream per mission, no thread scoping. Every runner can read the whole stream via `runners msg read`.
+
+Messages and signals are separate for good reasons:
+- Signals are typed and small; orchestrator logic keys off them. Messages are prose; orchestrator doesn't parse them.
+- A signal without prose works ("approved"). Prose without a signal works too ("I noticed X"). Conflating them forces every signal to carry prose and every note to carry a type.
+- Runners (LLM agents) already know how to use both: signals are like exit codes, messages are like comments. The CLI keeps them linguistically separate.
+
+#### 2.7.3 Thread *(v0.x)* — *scoped conversation*
+
+When a mission has 3+ runners or runs for long enough to develop sub-topics, the flat message stream gets noisy. Threads add a scoping layer: messages can be posted to a named thread; runners can `msg read <thread>` to get just that conversation.
+
+Cut from v0 because the v0 demo is two runners on one loop — the whole mission *is* the thread.
+
+#### 2.7.4 Fact *(v0.x)* — *queryable state*
+
+A KV whiteboard. Any runner can `ctx set key value` and `ctx get key`. Mission-scoped; each mission starts with an empty whiteboard. Backed by the event log as a `fact_recorded` event type, projected in-memory by the orchestrator for O(1) reads.
+
+Facts differ from messages and signals: they're **current state**, not events. Reading a fact answers "what is true right now?" not "what happened?" Cut from v0 because the demo doesn't need a dashboard-style current-state view.
+
+### 2.8 Events — *the unifying transport*
+
+Every coordination primitive is persisted as an **event** — one line in the per-mission NDJSON file. Signals become `signal_emitted` events. Messages become `message_posted` events. (Later: `thread_opened`, `fact_recorded`, etc.) This is a transport detail, not a separate concept for users; runners interact through the CLI verbs, not the event schema.
+
+An event has: `{id, ts, crew_id, mission_id, from, to, kind, payload, correlation_id, causation_id}`. `kind` distinguishes primitive types (`signal`, `message`, ...). The orchestrator and UI project events into the primitive-specific views.
 
 ## 3. Mission lifecycle
 
@@ -138,7 +185,7 @@ user clicks Start Mission on a crew
         │     composed_prompt = compose(runner.system_prompt,
         │                                mission.brief,
         │                                roster(crew),
-        │                                coordination_notes(crew.event_types))
+        │                                coordination_notes(crew.signal_types))
         │     SessionManager.spawn(mission_id, runner, composed_prompt)
         ├─ Orchestrator.start(mission_id)  ← fresh in-memory state
         │     open events.ndjson, read history (empty), tail via notify
@@ -198,7 +245,7 @@ MissionManager builds each runner's prompt from four parts:
 1. **The user-authored brief** (`runners.system_prompt`).
 2. **The mission brief** (`missions.goal_override` or `crews.goal`).
 3. **The roster** — crewmates' names, roles, one-line brief summaries.
-4. **Coordination notes** — how to use `runners emit`, `runners ctx`, and the crew's allowed event types.
+4. **Coordination notes** — how to use `runners signal` and `runners msg`, and the crew's allowed signal types.
 
 Example for a Reviewer:
 
@@ -207,19 +254,21 @@ You are Reviewer, a runner in crew "Feature Ship".
 Your role: code review.
 
 == Your brief ==
-Wait for review_requested events. Read the diff on the branch recorded
-in the `pr_branch` fact. Emit `approved` or `changes_requested`.
+When the Coder requests review, read their messages and the diff,
+then either approve or request changes with specific feedback.
 
 == Mission ==
 Goal: Implement feature X with tests and a clean PR.
 
 == Your crewmates ==
-- Coder (implementation): Writes code. Emits review_requested when ready.
+- Coder (implementation): Writes code. Will signal review_requested and
+  post messages explaining what changed.
 
 == Coordination ==
-Use `runners emit <type> [--payload '{...}']` to signal milestones.
-Use `runners ctx get <key>` to read facts, `runners ctx set <key> <value>` to record them.
-Event types in this crew: review_requested, changes_requested, approved, blocked.
+- Signal milestones with `runners signal <type>`.
+  Signal types: review_requested, changes_requested, approved, blocked.
+- Post prose with `runners msg post "<text>"`.
+- Read the mission's message stream with `runners msg read`.
 ```
 
 ### 4.4 Frontend wiring
@@ -243,7 +292,7 @@ Reader thread owns the child handle. On EOF, it calls `wait()`, emits `session:{
 
 Kill: drop master → SIGHUP via `portable-pty`; escalate to SIGKILL if child lingers. v0 targets macOS; Linux best-effort; Windows deferred.
 
-## 5. Event bus (inter-runner communication)
+## 5. Coordination bus
 
 ### 5.1 Transport
 
@@ -251,15 +300,15 @@ Kill: drop master → SIGHUP via `portable-pty`; escalate to SIGKILL if child li
 $APPDATA/runners/crews/{crew_id}/missions/{mission_id}/events.ndjson
 ```
 
-One line per event. Append-only. **Each mission has its own file** — this scopes log rotation (no rotation policy needed; a new mission = a new file), crash-replay (orchestrator reads only the live mission's file), and deletion (drop the mission directory).
+One line per event. Append-only. **Each mission has its own file** — scopes log rotation, crash-replay, and deletion.
 
 Why a file instead of an in-memory bus:
 - **Debuggable** — `tail -f events.ndjson | jq .`.
 - **Crash-durable** — whatever's on disk survived the crash.
-- **Atomic** — writes < `PIPE_BUF` (4KB on macOS) to `O_APPEND` are atomic at the OS level; concurrent `runners emit` invocations interleave correctly.
+- **Atomic** — writes < `PIPE_BUF` (4KB on macOS) to `O_APPEND` are atomic; concurrent `runners` invocations interleave correctly.
 - **Replayable for free** — restart the orchestrator, re-scan, resume.
 
-### 5.2 Schema
+### 5.2 Event schema
 
 ```jsonc
 {
@@ -267,26 +316,30 @@ Why a file instead of an in-memory bus:
   "ts": "2026-04-21T12:34:56.123Z",
   "crew_id": "01HG...",
   "mission_id": "01HG...",
+  "kind": "signal",                 // signal | message  (v0.x adds: fact, thread_opened, ...)
   "from": "coder",                  // runner name | "human" | "orchestrator"
   "to": null,                       // null = broadcast, or target runner name
-  "type": "review_requested",
-  "payload": { "...": "..." },
-  "correlation_id": null,           // groups events in one conversation
-  "causation_id": null              // which event caused this one
+  "type": "review_requested",       // for kind=signal; omitted for kind=message
+  "payload": { "...": "..." },      // kind-specific
+  "correlation_id": null,
+  "causation_id": null
 }
 ```
 
-- **ULID** — sortable, embeds a ms timestamp, deterministic ordering within a millisecond.
-- **`correlation_id`** — shared by all events in one conversation (e.g. every event in one review cycle). Set by the first emitter; propagated by the orchestrator to events it generates in response.
-- **`causation_id`** — the immediate trigger. Together with correlation, reconstructs the event DAG.
+For a signal event: `kind=signal`, `type` is set, payload optional.
+For a message event: `kind=message`, `payload.text` is the prose.
 
-### 5.3 How runners emit events
+- **ULID `id`** — sortable, embeds a ms timestamp.
+- **`correlation_id`** — groups events in one conversation (set by first emitter, propagated by orchestrator).
+- **`causation_id`** — which event caused this one. Together with correlation, forms the event DAG.
 
-The three-layer mechanism that answers "how does the agent know to append?"
+### 5.3 How runners emit signals and messages
+
+Three layers — answers "how does the agent know to append to the event log?"
 
 #### Layer 1 — system prompt tells the convention
 
-The composed prompt (§4.3) includes a Coordination section describing the `runners emit` CLI and listing allowed event types. LLM agents already know how to read CLI docs and invoke tools — it's the same capability they use for `git`, `gh`, `npm`.
+The composed prompt (§4.3) includes a Coordination section describing the `runners` CLI and listing allowed signal types. LLM agents already know how to read CLI docs and invoke tools — same capability they use for `git`, `gh`, `npm`.
 
 #### Layer 2 — the CLI exists on PATH with context in env
 
@@ -294,58 +347,60 @@ The backend prepends `$APPDATA/runners/bin/` to PATH and drops the `runners` bin
 
 On invocation, the CLI:
 1. Reads env vars; errors if missing.
-2. Builds an event (ULID, timestamps, `from` = `$RUNNERS_RUNNER_NAME`, `crew_id`, `mission_id`).
-3. Validates `type` against the allowlist sidecar at `$APPDATA/runners/crews/{crew_id}/event_types.json`.
+2. Builds an event (ULID, timestamps, `from` = `$RUNNERS_RUNNER_NAME`, `crew_id`, `mission_id`, `kind`).
+3. For signals: validates `type` against the allowlist sidecar at `$APPDATA/runners/crews/{crew_id}/signal_types.json`.
 4. Appends one JSON line to `$RUNNERS_EVENT_LOG` via `open(O_APPEND | O_WRONLY)` + `write_all` + close.
-5. Exits 0 on success.
+5. Exits 0.
 
-Each invocation writes ≤ one 4KB line in one `write` syscall, so concurrent emitters interleave safely.
+Each invocation writes ≤ one 4KB line in one `write` syscall; concurrent emitters interleave safely.
 
 #### Layer 3 — role briefs reinforce usage
 
-User-authored briefs include examples at the moments where emission matters. We ship sensible defaults per-runtime.
+User-authored briefs include examples at the moments where signaling or messaging matters. We ship sensible defaults per-runtime.
 
 #### Why robust
 
 - No in-band protocol in the PTY stream. Not parsing stdout for magic markers.
 - Works for any CLI agent (MCP or not). Only requirement: can run shell commands.
-- Fails visibly. If the agent forgets to emit, the orchestrator sees nothing and the user sees an idle runner.
-- Fully observable. `$ runners emit review_requested` shows up literally in the terminal pane; the resulting event shows up in the timeline.
+- Fails visibly. If the agent forgets to signal, the orchestrator sees nothing and the user sees an idle runner.
+- Fully observable. `$ runners signal review_requested` shows up literally in the terminal pane; the resulting event shows up in the timeline and messages panel.
 
-#### Failure mode: hallucinated event types
+#### Failure mode: hallucinated signal types
 
 CLI validates against the allowlist; unknown types exit non-zero with a clear stderr message. Agent reads the error from shell history and self-corrects.
+
+Messages have no allowlist — they're prose.
 
 ### 5.4 Consumers
 
 Two subscribers to the NDJSON file, both via `notify`:
 
-- **Orchestrator** — deserializes each new line, runs policy, dispatches actions, updates the fact projection when `fact_recorded` appears.
-- **UI** — the backend re-emits each line as a `mission:{id}:event` Tauri event. Frontend renders timeline, HITL cards, and fact view.
+- **Orchestrator** — deserializes each new line. For signals, runs the policy and dispatches actions. For messages, no-op by default (v0.x: threads, routing-by-mention).
+- **UI** — the backend re-emits each line as a `mission:{id}:event` Tauri event. Frontend splits by `kind` into the messages panel and the signal/timeline panel.
 
 #### Startup replay
 
-On orchestrator boot (triggered by mission start or app restart mid-mission): open the mission's file, fold events into in-memory state (fact projection, pending asks, correlation tracking), then switch to tailing. The file *is* the state.
+On orchestrator boot: open the mission's file, fold events into in-memory state (pending asks, correlation tracking), then switch to tailing. The file *is* the state.
 
 ### 5.5 Orchestrator actions
 
 | Action | Effect | Emits event? |
 |---|---|---|
-| `inject_stdin` | write template + `\r` to target runner's PTY writer | `stdin_injected` |
-| `ask_human` | add card to HITL panel; wait for click | `human_question`, then `human_response` |
-| `notify_human` | fire a toast | `human_notified` |
-| `pause_runner` | SIGSTOP to target PTY | `runner_paused` |
-| `resume_runner` | SIGCONT to target PTY | `runner_resumed` |
+| `inject_stdin` | write template + `\r` to target runner's PTY writer | `stdin_injected` (signal) |
+| `ask_human` | add card to HITL panel; wait for click | `human_question` then `human_response` (signals) |
+| `notify_human` | fire a toast | `human_notified` (signal) |
+| `pause_runner` | SIGSTOP to target PTY | `runner_paused` (signal) |
+| `resume_runner` | SIGCONT to target PTY | `runner_resumed` (signal) |
 
-Emitted events have `causation_id` = the triggering event's `id`. Full chain is reconstructable.
+Emitted events have `causation_id` = the triggering event's `id`.
 
-**Crash correctness:** emit the event *before* performing the action. Worst case on crash+replay is a duplicate action, which is recoverable (stdin seen twice; HITL cards deduped by event id). Silent loss is not.
+**Crash correctness:** emit the event *before* performing the action. Worst case on crash+replay is a duplicate action, recoverable (stdin seen twice; HITL cards deduped by event id). Silent loss is not.
 
 ### 5.6 Who does delivery
 
-Runners never address other runners. They emit; the orchestrator routes. This gives us:
+Runners never address other runners directly with signals; they emit, the orchestrator routes. Messages are broadcast to the mission stream — any runner can `msg read` to consume them. In both cases, no runner addresses another by name (yet — mentions are v1).
 
-- **Decoupled runners** — Coder doesn't know Reviewer exists. Swap Reviewer without touching Coder's brief.
+- **Decoupled runners** — the Coder doesn't know the Reviewer exists by id. Swap the Reviewer without touching the Coder's brief.
 - **Single policy location** — every "when X, do Y" lives on the crew row.
 - **Orchestrator is the only side-effecting component** outside runner processes. Easy to reason about.
 
@@ -355,14 +410,15 @@ Runners never address other runners. They emit; the orchestrator routes. This gi
 |---|---|
 | Orchestrator crashes mid-action | Emit event before action; replay on boot; accept duplicates |
 | Two runners ask human at once | HITL queues both; user answers in order |
-| Event storm (runner bug-looping) | Surface events/sec warning; no rate limit in v0 |
+| Event storm | Surface events/sec warning; no rate limit in v0 |
 | Malformed NDJSON line | Skip and warn; file stays valid |
-| NDJSON file grows large | End the mission; new mission = new file |
-| Hallucinated event type | Allowlist validation + clear stderr for self-correction |
+| NDJSON grows large | End the mission; new mission = new file |
+| Hallucinated signal type | Allowlist validation + clear stderr |
+| Runner posts messages nobody reads | Surface "unread by crewmate X" indicator in UI (v0.x) |
 
 ## 6. Shared context (mission-scoped)
 
-Three layers, different mechanics. All scoped to the mission — each new mission starts empty on all three.
+Two layers in v0.
 
 ### 6.1 Mission brief (read-only, prompt-injected)
 
@@ -370,50 +426,20 @@ Three layers, different mechanics. All scoped to the mission — each new missio
 
 ### 6.2 Roster (read-only, prompt-injected)
 
-Rendered from `crew.runners` at mission start into each runner's prompt as `== Your crewmates ==` with name, role, and a one-line brief summary. Never changes during a mission (v0 constraint: no mid-mission crew edits).
+Rendered from `crew.runners` at mission start into each runner's prompt as `== Your crewmates ==` with name, role, and one-line brief summary. Never changes during a mission.
 
 This is how the Reviewer knows there's a Coder.
 
-### 6.3 Facts — the shared whiteboard (mutable, event-backed)
-
-A KV store any runner reads/writes during the mission, via `runners ctx`. Implemented on the event log — no second store.
-
-**Write:**
-```
-runners ctx set <key> <value>    → emits { type: "fact_recorded", payload: {key, value} }
-runners ctx unset <key>          → emits { type: "fact_recorded", payload: {key, value: null} }
-```
-
-**Read:**
-```
-runners ctx get <key>            → prints value
-runners ctx list                 → prints all current key/value pairs
-```
-
-Last-writer-wins per key. Flat namespace in v0.
-
-**Projection:** the orchestrator maintains a `HashMap<String, Value>`, updated on every `fact_recorded`. Rebuilt from scratch on boot replay. The UI's fact view is driven by this projection via a Tauri event.
-
-**Read path in v0:** the CLI re-scans the log (small, per-mission). If this ever becomes slow, add a localhost HTTP endpoint on the orchestrator.
-
-**Why log-structured:**
-- Single source of truth — facts are events.
-- Auditable — every write is a durable event with who/when.
-- Replayable — projection rebuilds from the log.
-- Atomic — one append per write.
-- Observable — fact updates appear in the timeline.
-
-**Optional snapshot** at `missions/{mission_id}/context.json`, rebuilt from events for `cat`-ability. Not load-bearing.
-
-### 6.4 The `runners` CLI surface
+### 6.3 The `runners` CLI surface in v0
 
 ```
-runners emit <type> [--payload <json>] [--correlation-id <id>] [--causation-id <id>]
-runners ctx  get <key> | set <key> <value> | unset <key> | list
+runners signal <type> [--payload <json>] [--correlation-id <id>] [--causation-id <id>]
+runners msg    post <text> [--correlation-id <id>] [--causation-id <id>]
+runners msg    read [--since <ts>]
 runners help
 ```
 
-One binary, two verbs, bundled with the app. Context always from env.
+One binary. Two verbs. Context always from env.
 
 ## 7. Data model
 
@@ -425,7 +451,7 @@ crews (
   name TEXT NOT NULL,
   goal TEXT,
   orchestrator_policy TEXT,           -- JSON: [{ when, do }]
-  event_types TEXT,                   -- JSON array: allowlist
+  signal_types TEXT,                  -- JSON array: allowlist
   created_at TEXT, updated_at TEXT
 );
 
@@ -466,15 +492,14 @@ sessions (
 ```
 $APPDATA/runners/
 ├── bin/
-│   └── runners                              # the CLI (emit + ctx)
+│   └── runners                              # the CLI (signal + msg)
 ├── runners.db                               # SQLite
 └── crews/
     └── {crew_id}/
-        ├── event_types.json                 # CLI allowlist sidecar
+        ├── signal_types.json                # CLI allowlist sidecar
         └── missions/
             └── {mission_id}/
                 ├── events.ndjson            # per-mission event log
-                ├── context.json             # optional fact snapshot
                 └── sessions/
                     └── {session_id}.log     # scrollback overflow
 ```
@@ -497,40 +522,69 @@ For v0 scale (one live mission, ≤ ~10 sessions): fine.
 
 ## 9. Out of scope for v0
 
+- Threads (v0.x)
+- Facts / shared whiteboard (v0.x)
+- Mentions, reactions (v1)
 - Concurrent live missions per crew
-- Cross-mission memory (fact or prompt carryover)
+- Cross-mission memory
 - Remote runners / SSH
 - Sandboxing beyond the child's own permissions
-- MCP-based event emission
+- MCP-based signal emission
 - Auto-restart on crash
 - Event log rotation (solved implicitly by per-mission files)
 - LLM-based orchestrator rules
-- Typed event schemas per type
-- Multi-user / multi-machine event bus
+- Multi-user / multi-machine coordination bus
 
-## 10. Architectural bets
+## 10. Next milestones (vision)
 
-1. **Mission is the runtime unit.** Crew is config; mission is a run. Scopes event log, HITL queue, facts, orchestrator state.
-2. **PTY, not pipes.** Required for TUI fidelity.
-3. **NDJSON file per mission, not broker.** Debuggability and crash-durability.
+### v0.x — Threads and Facts
+
+**Threads** — when missions grow past 2 runners or 1 hour, messages get noisy. Add:
+- `runners thread open <name>` → returns thread_id
+- `runners msg post --thread <id> <text>`
+- `runners msg read --thread <id>`
+- Orchestrator rules gain "open thread on signal X" action
+- UI splits message stream by thread
+
+**Facts** — the shared whiteboard. Add:
+- `runners ctx set/get/unset/list`
+- `fact_recorded` event type; last-writer-wins projection in orchestrator
+- UI gains a facts panel
+- Solves "current state of the mission" at a glance
+
+Both live on the same event log as new `kind` values. No transport changes.
+
+### v1 — Mentions, reactions, richer routing
+
+- `@runner` mentions inside messages → orchestrator can route on them
+- Reactions (`👍`, `blocking`) on messages — lightweight signals
+- Cross-mission memory / "crew memory"
+- Concurrent missions per crew
+
+## 11. Architectural bets
+
+1. **Mission is the runtime unit.** Crew is config; mission is a run.
+2. **PTY, not pipes.** TUI fidelity is non-negotiable.
+3. **NDJSON file per mission, not broker.** Debuggable and crash-durable.
 4. **CLI wrapper, not MCP.** Works with every agent today.
-5. **Orchestrator is the only router.** Runners stay decoupled.
-6. **Facts on the event log, not a separate store.** Single source of truth.
+5. **Signals and messages as distinct primitives.** Keeps orchestrator simple and prose natural.
+6. **Orchestrator is the only router.** Runners stay decoupled.
 7. **Prompt composition at spawn time.** Replaces runtime handshakes.
-8. **xterm.js for rendering.** Don't reinvent the terminal emulator.
-9. **ULID for event IDs.** Sortable, monotonic within ms.
+8. **Incremental vocabulary.** v0 = signals + messages; v0.x adds threads + facts; v1 adds mentions + reactions.
+9. **xterm.js for rendering.** Don't reinvent the terminal emulator.
+10. **ULID for event IDs.** Sortable, monotonic within ms.
 
-## 11. Open questions
+## 12. Open questions
 
 1. CLI installation: bundled with `.app`, copied to `$APPDATA/runners/bin/` on first run — ok?
-2. Fact reads: CLI re-scans log (v0) vs orchestrator HTTP endpoint (v0.x if needed).
-3. Resize debounce: 100ms is a guess; tune with a real TUI.
-4. Event type allowlist: per-crew only (current), or global defaults + per-crew overrides?
-5. `from` field: locked to env (v0), or `--from` override?
-6. Mid-mission fact-change notifications (push into stdin vs pull-only): v0 is pull-only.
+2. Resize debounce: 100ms is a guess; tune with a real TUI.
+3. Signal type allowlist: per-crew only (current), or global defaults + per-crew overrides?
+4. `from` field: locked to env (v0), or `--from` override?
+5. Does `runners msg read` return everything or paginate? v0: everything, sorted by ULID.
+6. Does the orchestrator ever inject messages (not signals) into runners' stdin? v0: yes — when it routes a signal to a runner, it can include a summary of recent messages as context.
 
-## 12. What would break this architecture
+## 13. What would break this architecture
 
 - A runtime with no way to inject a system prompt at spawn (we'd type into stdin post-spawn — ugly but doable).
-- An agent that won't learn to call CLI tools (hasn't happened with any modern coding agent).
+- An agent that won't learn to call CLI tools.
 - NDJSON append atomicity breaking on an exotic filesystem (NFS, iCloud-synced). v0: document that app data must be on a local POSIX filesystem.

--- a/docs/arch/v0-arch.md
+++ b/docs/arch/v0-arch.md
@@ -60,27 +60,42 @@ The user defines a **crew** (configuration: runners + policy). They click **Star
 
 ## 2. Concepts
 
-Domain objects fall into three layers: **configuration** (persistent, edited by the user), **runtime containers** (live, created at mission start), and **coordination primitives** (what flows between runners during a mission).
+Domain objects split cleanly into two layers:
+
+- **Configuration** — persistent, user-edited. Outlives missions. Crew, Runner, Orchestrator Policy.
+- **Runtime** — created at mission start, torn down at mission end. Everything here is scoped to a mission: the Mission itself, its Sessions, its coordination primitives (Signals, Messages), and the orchestrator's in-memory state.
+
+The key insight: **Runner is config; Session is its runtime instance** — the same pattern as Crew (config) → Mission (runtime). A runner never runs on its own. A runner runs *inside a mission* as a session. The session is born when the mission starts, lives while the mission runs, and dies when the mission ends.
 
 ### 2.1 Relationship diagram
 
 ```
-Configuration (persistent)     Runtime (live or historical)
-
-  Crew ─┬── Runner ───────────► Session ────► PTY process
-        │                          ▲
-        └── Orchestrator Policy    │ spawned by
-              │                    │
-              └─ attached to ─► Mission ────► events.ndjson
-                                  │             │
-                                  │             ├─► Signal      [v0]
-                                  │             ├─► Message     [v0]
-                                  │             ├─► Thread      [v0.x]
-                                  │             └─► Fact        [v0.x]
-                                  │
-                                  └─► Shared context: brief + roster (v0)
-                                                      + facts (v0.x)
+┌─ Configuration (persistent) ─────────┐    ┌─ Runtime (mission-scoped) ──────────────┐
+│                                      │    │                                         │
+│   Crew ─┬── Runner ──────────────────┼────┼──► Session ─► PTY process               │
+│         │      (describes a role,    │    │     (one instance per runner per         │
+│         │       binary, brief)       │    │      mission; lives & dies with the      │
+│         │                            │    │      mission)                            │
+│         │                            │    │                                         │
+│         └── Orchestrator Policy      │    │     ▲                                    │
+│               │                      │    │     │  spawned & owned by                │
+│               └── attached to ───────┼────┼──► Mission ─── events.ndjson             │
+│                                      │    │     │              │                    │
+│                                      │    │     │              ├─► Signal   [v0]    │
+│                                      │    │     │              ├─► Message  [v0]    │
+│                                      │    │     │              ├─► Thread   [v0.x]  │
+│                                      │    │     │              └─► Fact     [v0.x]  │
+│                                      │    │     │                                   │
+│                                      │    │     ├─► Orchestrator in-memory state    │
+│                                      │    │     │    (pending asks, correlations)   │
+│                                      │    │     │                                   │
+│                                      │    │     └─► Shared context:                 │
+│                                      │    │           brief + roster (v0)           │
+│                                      │    │           + facts (v0.x)                │
+└──────────────────────────────────────┘    └─────────────────────────────────────────┘
 ```
+
+A mission is a container. Everything in the runtime column is either the container itself (Mission) or an object whose lifecycle is scoped by it. **Sessions are first-class members of this container** alongside the coordination bus and the orchestrator state — not a side effect of spawning runners.
 
 ### 2.2 Crew — *a configured team*
 
@@ -100,19 +115,37 @@ A JSON list of `{when, do}` rules attached to the crew. This is where all routin
 
 There is no code here — just a lookup table. No scripting, no LLM. v0 is deliberately dumb.
 
-### 2.5 Mission — *one activation of the crew*
+### 2.5 Mission — *one activation of the crew, and the runtime container*
 
-A runtime container. When the user clicks **Start Mission**, a mission row is created, sessions are spawned for every runner, the orchestrator is booted with a fresh in-memory state, and an NDJSON event log is opened. When the mission ends (explicit stop, or all sessions exited), everything in the container shuts down together.
+A mission is the only runtime container in the system. Everything alive at runtime lives *inside* a mission and dies with it:
 
-A mission scopes: the event log, the signal stream, the message stream, pending HITL cards, orchestrator memory.
+- A **Session** per runner (the PTY processes — see §2.6).
+- The **coordination bus** — the NDJSON event log carrying signals and messages.
+- The **orchestrator's in-memory state** — pending HITL asks, correlation tracking, (later) fact projection.
+- The **shared context** injected into each runner's composed prompt — the mission brief and the roster.
+
+Lifecycle:
+- **Start**: user clicks Start Mission on a crew. A mission row is created, one session is spawned per runner in the crew, the orchestrator boots with fresh state, and an NDJSON file is opened.
+- **End**: explicit stop, or all sessions exited. Every session is killed, the orchestrator stops, the mission row is closed out.
+
+This framing matters: when we say "the coordination bus is mission-scoped" or "the fact whiteboard is mission-scoped," we're saying the same thing as "sessions are mission-scoped." They all share one lifecycle because they all belong to the same container.
 
 v0 constraint: a crew can have at most one live mission at a time. A crew can have many historical missions.
 
-### 2.6 Session — *one runner's PTY process*
+### 2.6 Session — *one runner's PTY process, running inside a mission*
 
-The live process for one runner inside one mission. One runner × one mission = one session. Owns: a PTY master handle, a reader thread, a writer, a scrollback ring buffer. When the session's child process exits, the session is done; a new one is only created by starting a new mission.
+The runtime instance of a Runner. A Session is to a Runner what a Mission is to a Crew: the *run* of a *configuration*.
 
-A session is the only object that actually *executes* something — everything else is metadata or a coordination channel.
+A session exists if and only if a mission exists. One runner × one mission = one session. When the mission starts, each runner in the crew gets a session spawned for it. When the mission ends, every session in that mission is killed. A session cannot outlive its mission; a session cannot exist without one.
+
+A session owns:
+- A PTY master handle (the only object in the system with a file descriptor to a running child process).
+- A blocking reader thread that drains the PTY and pushes to the scrollback ring.
+- A writer for stdin injection (used by the human and by the orchestrator's `inject_stdin` action).
+- A ring buffer (~10k lines) for scrollback that survives frontend tab-switches and app restarts within the mission.
+- An exit status once the child has terminated.
+
+A session is the only object in the system that actually *executes* code — everything else is metadata, a coordination channel, or a projection over the event log.
 
 ### 2.7 Coordination primitives — *what flows between runners*
 

--- a/docs/arch/v0-arch.md
+++ b/docs/arch/v0-arch.md
@@ -154,10 +154,11 @@ Runners don't share a programming model; they share an IM-like surface. The same
 | Primitive | Role | v0 | v0.x | v1+ |
 |---|---|:---:|:---:|:---:|
 | **Signal** | Typed notification; orchestrator routes on these. Verb grammar. | ✅ | | |
-| **Message** | Prose posted to the mission stream. Runner-to-runner conversation. | ✅ | | |
+| **Message** | Prose, broadcast or directed to a specific runner. | ✅ | | |
+| **Inbox** | Per-runner projection: broadcasts + messages addressed to me. | ✅ | | |
 | **Thread** | Scoped sub-conversation within a mission. | | ✅ | |
 | **Fact** | KV whiteboard; "what is currently true in this mission." | | ✅ | |
-| **Mention** | Targeted `@name` inside a message. | | | ✅ |
+| **Mention** | Targeted `@name` inside a message's prose (lighter-weight than `--to`). | | | ✅ |
 | **Reaction** | Lightweight signal attached to a message (`👍`, `🔍`, `blocking`). | | | ✅ |
 
 #### 2.7.1 Signal — *"something happened, please decide"*
@@ -172,27 +173,48 @@ A signal carries an optional `payload` (JSON) but the payload is meant for the o
 
 #### 2.7.2 Message — *"here's what I think"*
 
-Prose, posted to the mission's flat stream. Runner-to-runner (and human-readable). Grammar: sentence.
+Prose, addressed either to the mission (broadcast) or to a specific crewmate (direct). Runner-to-runner (and human-readable). Grammar: sentence.
+
+Two shapes:
+- **Broadcast** — `runners msg post "<text>"`. Goes to everyone's inbox. Use for status updates, open questions, mission-wide announcements.
+- **Direct** — `runners msg post --to <runner> "<text>"`. Goes to that runner's inbox only. Use for targeted questions, replies, or private back-and-forth.
 
 Examples:
-- `"Branch feat/x is ready. Touched auth.rs and session.rs."`
-- `"Line 47 in auth.rs: null check missing when the token is expired."`
-- `"Kept the 30s timeout — provider is slow on cold start."`
+- broadcast: `"Branch feat/x is ready. Touched auth.rs and session.rs."`
+- direct: `runners msg post --to reviewer "Line 47 in auth.rs: null check missing when the token is expired."`
+- direct reply: `runners msg post --to coder "Kept the 30s timeout — provider is slow on cold start."`
 
-Messages are **flat in v0** — one stream per mission, no thread scoping. Every runner can read the whole stream via `runners msg read`.
+Messages are **flat in v0** — one stream per mission, no thread scoping. Each runner consumes messages through their **inbox** (§2.7.5): broadcasts plus directly-addressed messages.
 
 Messages and signals are separate for good reasons:
 - Signals are typed and small; orchestrator logic keys off them. Messages are prose; orchestrator doesn't parse them.
 - A signal without prose works ("approved"). Prose without a signal works too ("I noticed X"). Conflating them forces every signal to carry prose and every note to carry a type.
 - Runners (LLM agents) already know how to use both: signals are like exit codes, messages are like comments. The CLI keeps them linguistically separate.
+- Direct messages enable real conversation between runners without forcing every interaction through the orchestrator policy.
 
-#### 2.7.3 Thread *(v0.x)* — *scoped conversation*
+#### 2.7.3 Inbox — *"what's in my mailbox"*
+
+Every runner has an **inbox**: the subset of the mission's messages that are relevant to it. The inbox is a **projection** over the event log, not a separate data structure. For runner `X`:
+
+```
+inbox(X) = all message events in the mission where to = null OR to = X
+```
+
+`runners msg read` returns the calling runner's inbox, sorted by ULID (chronological).
+
+This design keeps the storage model simple (one event log per mission, same as before) while giving each runner a clean "what's for me" view. Broadcasts end up in everyone's inbox; direct messages end up in exactly one.
+
+**Why LLM agents won't see direct messages unless they're told:** agents act on their prompt. They don't spontaneously poll the filesystem. A message landing in the inbox doesn't itself make the agent aware of it. We solve this with an orchestrator action: when a directed message arrives, the orchestrator nudges the recipient's stdin with a one-line hint ("new message from `coder` — run `msg read`"). The agent then reads its inbox as a normal tool call. See §5.5 action `nudge_recipient`.
+
+The inbox is not a queue in the delete-on-read sense — messages stay in the log forever (well, for the mission). The "read" in `msg read` is lookup, not consumption. `msg read --since <ts>` lets agents fetch just what's new.
+
+#### 2.7.4 Thread *(v0.x)* — *scoped conversation*
 
 When a mission has 3+ runners or runs for long enough to develop sub-topics, the flat message stream gets noisy. Threads add a scoping layer: messages can be posted to a named thread; runners can `msg read <thread>` to get just that conversation.
 
 Cut from v0 because the v0 demo is two runners on one loop — the whole mission *is* the thread.
 
-#### 2.7.4 Fact *(v0.x)* — *queryable state*
+#### 2.7.5 Fact *(v0.x)* — *queryable state*
 
 A KV whiteboard. Any runner can `ctx set key value` and `ctx get key`. Mission-scoped; each mission starts with an empty whiteboard. Backed by the event log as a `fact_recorded` event type, projected in-memory by the orchestrator for O(1) reads.
 
@@ -369,7 +391,8 @@ Why a file instead of an in-memory bus:
   "mission_id": "01HG...",
   "kind": "signal",                 // signal | message  (v0.x adds: fact, thread_opened, ...)
   "from": "coder",                  // runner name | "human" | "orchestrator"
-  "to": null,                       // null = broadcast, or target runner name
+  "to": null,                       // null = broadcast; runner name = directed (messages);
+                                    //   for signals, always null in v0 (policy decides routing)
   "type": "review_requested",       // for kind=signal; omitted for kind=message
   "payload": { "...": "..." },      // kind-specific
   "correlation_id": null,
@@ -438,6 +461,7 @@ On orchestrator boot: open the mission's file, fold events into in-memory state 
 | Action | Effect | Emits event? |
 |---|---|---|
 | `inject_stdin` | write template + `\r` to target runner's PTY writer | `stdin_injected` (signal) |
+| `nudge_recipient` | write a short "new message from X, run `msg read`" hint into the recipient's stdin | `recipient_nudged` (signal) |
 | `ask_human` | add card to HITL panel; wait for click | `human_question` then `human_response` (signals) |
 | `notify_human` | fire a toast | `human_notified` (signal) |
 | `pause_runner` | SIGSTOP to target PTY | `runner_paused` (signal) |
@@ -445,15 +469,29 @@ On orchestrator boot: open the mission's file, fold events into in-memory state 
 
 Emitted events have `causation_id` = the triggering event's `id`.
 
+**Default policy for direct messages.** Every crew starts with a built-in rule `{ when: { kind: "message", to: "*" }, do: { action: "nudge_recipient" } }` that fires on any directed message. This ensures recipients know mail has arrived without the sender having to also emit a signal. Users can disable this per crew if they want silent inboxes.
+
 **Crash correctness:** emit the event *before* performing the action. Worst case on crash+replay is a duplicate action, recoverable (stdin seen twice; HITL cards deduped by event id). Silent loss is not.
 
 ### 5.6 Who does delivery
 
-Runners never address other runners directly with signals; they emit, the orchestrator routes. Messages are broadcast to the mission stream — any runner can `msg read` to consume them. In both cases, no runner addresses another by name (yet — mentions are v1).
+Two different delivery models, by primitive kind:
 
-- **Decoupled runners** — the Coder doesn't know the Reviewer exists by id. Swap the Reviewer without touching the Coder's brief.
-- **Single policy location** — every "when X, do Y" lives on the crew row.
-- **Orchestrator is the only side-effecting component** outside runner processes. Easy to reason about.
+- **Signals are orchestrator-routed.** Runners never address other runners with a signal. A signal is emitted into the bus; the orchestrator policy decides what happens (including whether to inject stdin into some specific runner). This keeps all control-flow routing in one place and lets you swap runners without rewriting emitters.
+- **Messages support both broadcast and direct addressing.** A runner can `msg post` (everyone's inbox) or `msg post --to <runner>` (that runner's inbox only). No orchestrator in the delivery path; messages are data, not control. The orchestrator is involved only to nudge recipients so they know mail arrived (§5.5, `nudge_recipient`).
+
+The split:
+
+| | Sender addresses recipient? | Orchestrator involved? |
+|---|:---:|:---:|
+| Signal | No — policy decides | Always |
+| Broadcast message | No | Only to nudge |
+| Direct message | Yes (`--to`) | Only to nudge |
+
+- **Decoupled control flow** — the Coder doesn't need to know the Reviewer's name to *signal* a review. Swap the Reviewer without rewriting the Coder's signal emissions.
+- **Coupled content flow where it's natural** — if Coder wants to ask Reviewer a specific question, it can just `msg post --to reviewer ...`. The roster injection (§4.3) already tells each runner the current names of its crewmates, so direct addressing works without extra config.
+- **Single policy location** for control — every "when signal X, do Y" lives on the crew row.
+- **Orchestrator is the only side-effecting component** outside runner processes. Direct messaging doesn't violate this — a direct `msg post` writes an event; the actual stdin hint is still an orchestrator action.
 
 ### 5.7 Known failure modes
 
@@ -485,12 +523,18 @@ This is how the Reviewer knows there's a Coder.
 
 ```
 runners signal <type> [--payload <json>] [--correlation-id <id>] [--causation-id <id>]
-runners msg    post <text> [--correlation-id <id>] [--causation-id <id>]
-runners msg    read [--since <ts>]
+runners msg    post <text> [--to <runner>] [--correlation-id <id>] [--causation-id <id>]
+runners msg    read [--since <ts>] [--from <runner>]
 runners help
 ```
 
 One binary. Two verbs. Context always from env.
+
+- `msg post` with no `--to` → broadcast.
+- `msg post --to <runner>` → directed; lands in that runner's inbox only.
+- `msg read` → the calling runner's inbox (broadcasts + directs addressed to me), sorted by ULID.
+- `msg read --from <runner>` → filter to messages authored by a specific sender.
+- `msg read --since <ts>` → only messages newer than `ts` (for polling without re-reading history).
 
 ## 7. Data model
 

--- a/docs/arch/v0-arch.md
+++ b/docs/arch/v0-arch.md
@@ -87,7 +87,7 @@ The key insight: **Runner is config; Session is its runtime instance** — the s
 │                                      │    │     │              └─► Fact     [v0.x]  │
 │                                      │    │     │                                   │
 │                                      │    │     ├─► Orchestrator in-memory state    │
-│                                      │    │     │    (pending asks, correlations)   │
+│                                      │    │     │    (pending asks, dispatch ledger)│
 │                                      │    │     │                                   │
 │                                      │    │     └─► Shared context:                 │
 │                                      │    │           brief + roster (v0)           │
@@ -128,7 +128,7 @@ A mission is the only runtime container in the system. Everything alive at runti
 
 - A **Session** per runner (the PTY processes — see §2.6).
 - The **coordination bus** — the NDJSON event log carrying signals and messages.
-- The **orchestrator's in-memory state** — pending HITL asks, correlation tracking, (later) fact projection.
+- The **orchestrator's in-memory state** — pending HITL asks, dispatch ledger (which triggering events have been handled), per-runner read watermarks, (later) fact projection.
 - The **shared context** injected into each runner's composed prompt — the mission brief and the roster.
 
 Lifecycle:
@@ -234,7 +234,7 @@ Facts differ from messages and signals: they're **current state**, not events. R
 
 ### 2.8 Events — *the unifying transport*
 
-Every coordination primitive is persisted as an **event** — one line in the per-mission NDJSON file. An event has: `{id, ts, crew_id, mission_id, kind, from, to, type, payload, correlation_id, causation_id}`.
+Every coordination primitive is persisted as an **event** — one line in the per-mission NDJSON file. An event has: `{id, ts, crew_id, mission_id, kind, from, to, type, payload}`.
 
 The `kind` field is the primitive discriminator — `signal`, `message`, and (later) `fact`, `thread_opened`. For `kind: "signal"`, the `type` field carries the signal's semantic verb (`review_requested`, `changes_requested`, etc.); for `kind: "message"`, `type` is omitted and the prose lives in `payload.text`. The orchestrator and UI project events into primitive-specific views based on `kind`.
 
@@ -436,18 +436,22 @@ Writers: only the bundled `runners` CLI writes to the log (the Rust backend also
   "to": null,                       // null = broadcast; runner handle = directed (messages);
                                     //   for signals, always null in v0 (policy decides routing)
   "type": "review_requested",       // for kind=signal; omitted for kind=message
-  "payload": { "...": "..." },      // kind-specific (e.g. { "text": "..." } for messages)
-  "correlation_id": null,
-  "causation_id": null
+  "payload": { "...": "..." }       // kind-specific (e.g. { "text": "..." } for messages)
 }
 ```
 
 For a signal event: `kind=signal`, `type` is set, payload optional.
 For a message event: `kind=message`, `payload.text` is the prose.
 
-- **ULID `id`** — sortable, embeds a ms timestamp.
-- **`correlation_id`** — groups events in one conversation (set by first emitter, propagated by orchestrator).
-- **`causation_id`** — which event caused this one. Together with correlation, forms the event DAG.
+- **ULID `id`** — sortable, embeds a ms timestamp. Ordering *is* the graph in v0.
+
+**On `correlation_id` / `causation_id` (deferred).** An earlier draft carried both fields on every event. They're dropped from v0:
+
+- The only real use case in v0 is matching an `ask_human` card to the `human_response` the operator clicks — that's handled in-payload via `human_response.payload.question_id` (§5.5.0).
+- No runner-authored event has a reliable prior cause to cite; exposing `--correlation-id` / `--causation-id` as CLI flags just invites agents to leave them null or hallucinate values.
+- "Groups events in one conversation" has no referent until threads (v0.x) define what a conversation is. Ship the concept with the thing that needs it.
+
+v0.x will reintroduce explicit event-DAG fields when threads and richer routing require them. Until then, the orchestrator's in-memory dispatch table carries causality for the actions that need it.
 
 ### 5.3 How runners emit signals and messages
 
@@ -497,19 +501,19 @@ Two subscribers to the NDJSON file, both via `notify`:
 
 #### Startup replay
 
-On orchestrator boot: open the mission's file, fold events into in-memory state (pending asks, correlation tracking), then switch to tailing. The file *is* the state.
+On orchestrator boot: open the mission's file, fold events into in-memory state (pending asks, dispatch ledger, read watermarks), then switch to tailing. The file *is* the state.
 
 ### 5.5 Orchestrator actions
 
-Every action emits at least one signal event with `causation_id` = the triggering event's `id`.
+Every action emits at least one audit signal. Each audit payload carries `triggered_by: <triggering-event.id>` so causality is visible without relying on envelope fields.
 
 | Action | Effect | Emits signal(s) with `type` |
 |---|---|---|
-| `inject_stdin` | write template + `\r` to target runner's PTY writer | `stdin_injected`, payload `{ target, watermark }` |
-| `ask_human` | add card to HITL panel; wait for click | `human_question` on card open; `human_response` on click |
-| `notify_human` | fire a toast | `human_notified` |
-| `pause_runner` | SIGSTOP to target PTY | `runner_paused` |
-| `resume_runner` | SIGCONT to target PTY | `runner_resumed` |
+| `inject_stdin` | write template + `\r` to target runner's PTY writer | `stdin_injected`, payload `{ triggered_by, target, watermark }` |
+| `ask_human` | add card to HITL panel; wait for click | `human_question` on card open; `human_response` on click (shapes in §5.5.0) |
+| `notify_human` | fire a toast | `human_notified`, payload `{ triggered_by, message }` |
+| `pause_runner` | SIGSTOP to target PTY | `runner_paused`, payload `{ triggered_by, target }` |
+| `resume_runner` | SIGCONT to target PTY | `runner_resumed`, payload `{ triggered_by, target }` |
 
 #### 5.5.0 `ask_human` — payload shapes and matching
 
@@ -522,11 +526,11 @@ Every action emits at least one signal event with `causation_id` = the triggerin
   "type": "human_question",
   "from": "orchestrator",
   "payload": {
+    "question_id": "01HG...",                  // = this event's id; echoed here for convenience
+    "triggered_by": <triggering-signal.id>,    // e.g. the changes_requested signal's id
     "prompt": "Reviewer requested changes. Accept or override?",
     "choices": ["accept", "override"]
-  },
-  "correlation_id": <triggering-signal.id>,   // e.g. the changes_requested signal
-  "causation_id":   <triggering-signal.id>
+  }
 }
 
 // When the human clicks a choice:
@@ -537,18 +541,15 @@ Every action emits at least one signal event with `causation_id` = the triggerin
   "payload": {
     "question_id": <human_question.id>,       // lets rules target a specific card
     "choice": "accept"                         // the clicked value (always one of choices[])
-  },
-  "correlation_id": <triggering-signal.id>,   // same as the question
-  "causation_id":   <human_question.id>
+  }
 }
 ```
 
-**Matching semantics for follow-up rules.** Downstream rules can match on `human_response` in two ways:
+Causality is carried in-payload rather than on the envelope: `human_question.payload.triggered_by` records which signal opened the card, and `human_response.payload.question_id` records which card the human clicked. The orchestrator needs no additional schema fields to match them.
 
-1. **By choice value** — `{ when: { signal: "human_response", payload: { choice: "accept" } }, do: ... }`. Matches any accept, regardless of which question triggered it.
-2. **By correlation** — rules can reference `$correlation` in `when` clauses (implemented as a lookup into the triggering event's fields). Useful when two `ask_human` prompts are outstanding at once and we need to discriminate: `{ when: { signal: "human_response", correlated_with: { type: "changes_requested" } } }`.
+**Matching semantics for follow-up rules.** Downstream rules match `human_response` by choice value — `{ when: { signal: "human_response", payload: { choice: "accept" } }, do: ... }`. Matches any accept, regardless of which question triggered it.
 
-For v0 we ship option (1); option (2) is flagged for v0.x if we hit cases where two outstanding questions collide.
+If two `ask_human` prompts are ever outstanding at once and we need to discriminate between them, v0.x will add richer matching (via the v0.x event-DAG fields). v0 ships the simple case; concurrent prompts are out of scope.
 
 **Messages do not trigger orchestrator actions in v0.** The inbox is pull-based (§2.7.3). If a sender needs the recipient to drop everything, they emit a signal — signals are the urgent wake-up mechanism; direct messages are async conversation.
 
@@ -633,13 +634,13 @@ This is how the Reviewer knows there's a Coder.
 ### 6.3 The `runners` CLI surface in v0
 
 ```
-runners signal <type> [--payload <json>] [--correlation-id <id>] [--causation-id <id>]
-runners msg    post <text> [--to <runner>] [--correlation-id <id>] [--causation-id <id>]
+runners signal <type> [--payload <json>]
+runners msg    post <text> [--to <runner>]
 runners msg    read [--since <ts>] [--from <runner>]
 runners help
 ```
 
-One binary. Two verbs. Context always from env.
+One binary. Two verbs. Context always from env. No event-DAG flags in v0 — causality is implicit (ordering in the log) or in-payload where it needs to be explicit (`human_response.payload.question_id`).
 
 - `msg post` with no `--to` → broadcast.
 - `msg post --to <runner>` → directed; lands in that runner's inbox only.

--- a/docs/arch/v0-prd.md
+++ b/docs/arch/v0-prd.md
@@ -28,8 +28,8 @@ v0 proves the loop works end-to-end with two runners on a single mission. v1+ sc
 - **Session** — the live PTY process for a single runner within a single mission.
 - **Signal** — a typed notification runners emit for the orchestrator to route on. Verb grammar (`review_requested`, `approved`, `blocked`).
 - **Message** — prose posted to the mission. Can be broadcast (to the mission) or directed (to a specific runner via `--to`).
-- **Inbox** — each runner's projection of the mission: broadcast messages plus messages addressed directly to it. Read via `runners msg read`.
-- **Orchestrator** — the rule-based router that reads signals and decides what happens next, including nudging runners when directed messages land in their inbox.
+- **Inbox** — each runner's projection of the mission: broadcast messages plus messages addressed directly to it. Read via `runners msg read`. Pull-based: runners check their inbox on convention; there is no automatic interrupt for arriving messages.
+- **Orchestrator** — the rule-based router that reads signals and decides what happens next. Signals are the urgent wake-up channel; when the orchestrator injects stdin on a signal, it also appends a summary of the recipient's unread inbox so relevant messages ride along.
 
 ## 4. v0 scope
 
@@ -71,8 +71,8 @@ The concrete loop v0 must support end-to-end:
    - reads the diff
    - `runners msg post --to coder "Line 47 auth.rs needs a null check."`
    - `runners msg post --to coder "session.rs timeout is 30s; our convention is 10s."`
-       *(orchestrator nudges Coder's stdin: "New message from reviewer — run `msg read`.")*
    - `runners signal changes_requested`
+       *(orchestrator rule fires: injects into Coder's stdin — "Reviewer requested changes — check msg read." — and automatically appends a summary of Coder's 2 unread direct messages.)*
 7. Orchestrator policy for `changes_requested` says `ask_human`. The HITL panel pops a card: *"Reviewer requested changes. Accept and forward to Coder, or override?"*
 8. User clicks **Accept**. Orchestrator injects into Coder's stdin: "Reviewer requested changes — check `runners msg read`."
 9. Coder:
@@ -134,7 +134,12 @@ If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
 
 **Inbox as a concept.** Every runner has an inbox — a projection over the mission's message events where `to = null OR to = my_name`. This is not a separate store; it's a filtered view of the event log. "Inbox" names the view so users and agents share a clear mental model: *I have an inbox; I can read mine; I can address others.*
 
-**How recipients know mail has arrived.** LLM agents don't spontaneously poll. When a directed message arrives, the orchestrator (by default) injects a one-line hint into the recipient's stdin: *"New message from `coder` — run `msg read`."* The agent then reads its inbox as a normal tool call. This nudge is implemented as a built-in orchestrator rule and can be disabled per crew.
+**Messages are pull-based.** The system does not automatically interrupt a busy runner every time a message arrives. Two reasons: (1) not every direct message is urgent, and auto-interrupting would blur the signal/message split; (2) stdin injection on every DM risks corrupting in-flight tool calls.
+
+Runners learn to check their inboxes through two mechanisms:
+
+1. **Convention.** Each runner's composed prompt instructs it to check `runners msg read` at natural task boundaries (before a new task, before emitting a signal, while waiting).
+2. **Signals as the wake-up channel.** If a sender needs immediate attention, they emit a signal in addition to (or instead of) the message. Signal routing through `inject_stdin` automatically enriches the injection with the recipient's unread inbox summary — so urgent wake-ups carry the related conversation with them. See `v0-arch.md` §5.5.1.
 
 ### 6.7 Coordination bus
 - Single append-only NDJSON file per mission at `$APPDATA/runners/crews/{crew_id}/missions/{mission_id}/events.ndjson`.
@@ -173,12 +178,11 @@ See `v0-arch.md` §5.3 for the full three-layer emission mechanism (system promp
   ]
   ```
 - Supported actions in v0:
-  - `inject_stdin` — write a message into the target runner's stdin.
-  - `nudge_recipient` — write a short "new message from X, run `msg read`" hint into the recipient's stdin. Fires by default on any directed message.
+  - `inject_stdin` — write a message into the target runner's stdin. Automatically enriched with the recipient's unread inbox summary, so signal-driven wake-ups carry along any async conversation the recipient hasn't read yet.
   - `ask_human` — show a card in the HITL panel, wait for response.
   - `notify_human` — fire a toast.
   - `pause_runner` / `resume_runner` — SIGSTOP/SIGCONT the target PTY.
-- Rules fire on signals and on directed messages. Broadcast messages don't drive routing in v0 (v0.x: mentions will).
+- Rules fire on signals only. Messages do not trigger orchestrator actions in v0 — the inbox is pull-based. Senders escalate via signals when immediate attention is needed. (v0.x: mentions inside messages will trigger routing.)
 
 ### 6.10 Human-in-the-loop panel
 - Right-rail panel showing all pending `ask_human` cards for the current mission.

--- a/docs/arch/v0-prd.md
+++ b/docs/arch/v0-prd.md
@@ -58,9 +58,9 @@ All four are described in `v0-arch.md` §2.7 with milestone tags, so the vision 
 The concrete loop v0 must support end-to-end:
 
 1. User creates a crew called *Feature Ship*.
-2. User spawns two runners on the crew:
-   - **Coder** — runtime `claude-code`, working dir `~/src/myproj`, brief "Implement feature X. When ready, signal `review_requested` and post a message explaining what changed."
-   - **Reviewer** — runtime `claude-code`, same working dir, brief "When review is requested, read the Coder's messages and the diff, then signal `approved` or `changes_requested` and post messages with specific feedback."
+2. User spawns two runners on the crew (handles shown in backticks; display names in parens):
+   - `coder` (Coder) — runtime `claude-code`, working dir `~/src/myproj`, brief "Implement feature X. When ready, signal `review_requested` and post a message explaining what changed."
+   - `reviewer` (Reviewer) — runtime `claude-code`, same working dir, brief "When review is requested, read `coder`'s messages and the diff, then signal `approved` or `changes_requested` and post messages with specific feedback."
 3. User clicks **Start Mission**. Both PTYs spawn. User sees two terminals, one per runner.
 4. Coder writes code, runs tests, then:
    - `runners msg post "Branch feat/x is ready. I refactored auth and added session tests."`
@@ -95,8 +95,9 @@ If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
 ### 6.2 Runner CRUD (scoped to a crew)
 - Spawn, edit, remove runners within a crew.
 - A runner has:
-  - `name` (display, e.g. "Coder")
-  - `role` (short label, e.g. "implementation")
+  - `handle` — lowercase slug (e.g. `coder`). Immutable once set; unique within the crew. Used everywhere addressing is needed (`from`/`to` in events, `--to <handle>` on the CLI, policy rules).
+  - `display_name` — free-form UI label (e.g. "Coder", "Lead Reviewer"). Editable; presentation-only.
+  - `role` — short label, e.g. "implementation".
   - `runtime` — enum: `claude-code | codex | shell`. Adds the right default `command` + `args`.
   - `command` + `args` — concrete binary to spawn. Pre-filled from runtime, editable.
   - `working_dir`
@@ -132,7 +133,7 @@ If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
 - No thread scoping in v0 — one flat stream per mission.
 - Messages are human-readable and runner-readable. They are the "what I think" layer; signals are the "please act" layer.
 
-**Inbox as a concept.** Every runner has an inbox — a projection over the mission's message events where `to = null OR to = my_name`. This is not a separate store; it's a filtered view of the event log. "Inbox" names the view so users and agents share a clear mental model: *I have an inbox; I can read mine; I can address others.*
+**Inbox as a concept.** Every runner has an inbox — a projection over the mission's message events where `to = null OR to = my_handle`. This is not a separate store; it's a filtered view of the event log. "Inbox" names the view so users and agents share a clear mental model: *I have an inbox; I can read mine; I can address others.*
 
 **Messages are pull-based.** The system does not automatically interrupt a busy runner every time a message arrives. Two reasons: (1) not every direct message is urgent, and auto-interrupting would blur the signal/message split; (2) stdin injection on every DM risks corrupting in-flight tool calls.
 
@@ -178,8 +179,8 @@ See `v0-arch.md` §5.3 for the full three-layer emission mechanism (system promp
   ]
   ```
 - Supported actions in v0:
-  - `inject_stdin` — write a message into the target runner's stdin. Automatically enriched with the recipient's unread inbox summary, so signal-driven wake-ups carry along any async conversation the recipient hasn't read yet.
-  - `ask_human` — show a card in the HITL panel, wait for response.
+  - `inject_stdin` — write a message into the target runner's stdin. Automatically enriched with the recipient's unread inbox summary; watermark advances on the resulting `stdin_injected` event (see `v0-arch.md` §5.5.1).
+  - `ask_human` — show a card in the HITL panel; emits a `human_question` signal. On click, emits a `human_response` signal with payload `{ question_id, choice }` and `correlation_id` = the original triggering signal's id. Downstream rules match on `payload.choice`.
   - `notify_human` — fire a toast.
   - `pause_runner` / `resume_runner` — SIGSTOP/SIGCONT the target PTY.
 - Rules fire on signals only. Messages do not trigger orchestrator actions in v0 — the inbox is pull-based. Senders escalate via signals when immediate attention is needed. (v0.x: mentions inside messages will trigger routing.)
@@ -239,7 +240,8 @@ crews (
 runners (
   id TEXT PRIMARY KEY,
   crew_id TEXT REFERENCES crews(id) ON DELETE CASCADE,
-  name TEXT NOT NULL,
+  handle TEXT NOT NULL,               -- lowercase slug, immutable, unique within crew
+  display_name TEXT NOT NULL,
   role TEXT NOT NULL,
   runtime TEXT NOT NULL,              -- claude-code | codex | shell
   command TEXT NOT NULL,
@@ -247,7 +249,8 @@ runners (
   working_dir TEXT,
   system_prompt TEXT,
   env_json TEXT,
-  created_at TEXT, updated_at TEXT
+  created_at TEXT, updated_at TEXT,
+  UNIQUE (crew_id, handle)
 );
 
 missions (

--- a/docs/arch/v0-prd.md
+++ b/docs/arch/v0-prd.md
@@ -27,8 +27,9 @@ v0 proves the loop works end-to-end with two runners on a single mission. v1+ sc
 - **Mission** — one activation of the crew. Everyone spawns together, shares a coordination bus, ends together.
 - **Session** — the live PTY process for a single runner within a single mission.
 - **Signal** — a typed notification runners emit for the orchestrator to route on. Verb grammar (`review_requested`, `approved`, `blocked`).
-- **Message** — prose posted to the mission's flat stream. Runner-to-runner conversation.
-- **Orchestrator** — the rule-based router that reads signals and decides what happens next.
+- **Message** — prose posted to the mission. Can be broadcast (to the mission) or directed (to a specific runner via `--to`).
+- **Inbox** — each runner's projection of the mission: broadcast messages plus messages addressed directly to it. Read via `runners msg read`.
+- **Orchestrator** — the rule-based router that reads signals and decides what happens next, including nudging runners when directed messages land in their inbox.
 
 ## 4. v0 scope
 
@@ -68,8 +69,9 @@ The concrete loop v0 must support end-to-end:
 6. Reviewer:
    - `runners msg read` (sees Coder's message)
    - reads the diff
-   - `runners msg post "Line 47 auth.rs needs a null check."`
-   - `runners msg post "session.rs timeout is 30s; our convention is 10s."`
+   - `runners msg post --to coder "Line 47 auth.rs needs a null check."`
+   - `runners msg post --to coder "session.rs timeout is 30s; our convention is 10s."`
+       *(orchestrator nudges Coder's stdin: "New message from reviewer — run `msg read`.")*
    - `runners signal changes_requested`
 7. Orchestrator policy for `changes_requested` says `ask_human`. The HITL panel pops a card: *"Reviewer requested changes. Accept and forward to Coder, or override?"*
 8. User clicks **Accept**. Orchestrator injects into Coder's stdin: "Reviewer requested changes — check `runners msg read`."
@@ -123,11 +125,16 @@ If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
 - Payload is optional JSON for the orchestrator's decision logic.
 - Emitted signals appear as events in the coordination bus (see §6.7) and drive the orchestrator.
 
-### 6.6 Messages — flat prose stream per mission
-- Runners post via `runners msg post "<text>"`.
-- Read via `runners msg read [--since <ts>]` — returns all messages in the mission in ULID order.
+### 6.6 Messages — prose with broadcast or direct addressing
+- Broadcast: `runners msg post "<text>"` — visible to everyone in the mission.
+- Direct: `runners msg post --to <runner> "<text>"` — lands only in that runner's inbox.
+- Read the inbox: `runners msg read [--since <ts>] [--from <runner>]` — returns the calling runner's inbox (broadcasts + directs addressed to me), sorted by ULID.
 - No thread scoping in v0 — one flat stream per mission.
 - Messages are human-readable and runner-readable. They are the "what I think" layer; signals are the "please act" layer.
+
+**Inbox as a concept.** Every runner has an inbox — a projection over the mission's message events where `to = null OR to = my_name`. This is not a separate store; it's a filtered view of the event log. "Inbox" names the view so users and agents share a clear mental model: *I have an inbox; I can read mine; I can address others.*
+
+**How recipients know mail has arrived.** LLM agents don't spontaneously poll. When a directed message arrives, the orchestrator (by default) injects a one-line hint into the recipient's stdin: *"New message from `coder` — run `msg read`."* The agent then reads its inbox as a normal tool call. This nudge is implemented as a built-in orchestrator rule and can be disabled per crew.
 
 ### 6.7 Coordination bus
 - Single append-only NDJSON file per mission at `$APPDATA/runners/crews/{crew_id}/missions/{mission_id}/events.ndjson`.
@@ -139,8 +146,8 @@ If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
 
 ```
 runners signal <type> [--payload <json>] [--correlation-id <id>] [--causation-id <id>]
-runners msg    post <text> [--correlation-id <id>] [--causation-id <id>]
-runners msg    read [--since <ts>]
+runners msg    post <text> [--to <runner>] [--correlation-id <id>] [--causation-id <id>]
+runners msg    read [--since <ts>] [--from <runner>]
 runners help
 ```
 
@@ -167,10 +174,11 @@ See `v0-arch.md` §5.3 for the full three-layer emission mechanism (system promp
   ```
 - Supported actions in v0:
   - `inject_stdin` — write a message into the target runner's stdin.
+  - `nudge_recipient` — write a short "new message from X, run `msg read`" hint into the recipient's stdin. Fires by default on any directed message.
   - `ask_human` — show a card in the HITL panel, wait for response.
   - `notify_human` — fire a toast.
   - `pause_runner` / `resume_runner` — SIGSTOP/SIGCONT the target PTY.
-- Rules fire only on signals in v0. Messages don't drive routing (v0.x: mentions will).
+- Rules fire on signals and on directed messages. Broadcast messages don't drive routing in v0 (v0.x: mentions will).
 
 ### 6.10 Human-in-the-loop panel
 - Right-rail panel showing all pending `ask_human` cards for the current mission.

--- a/docs/arch/v0-prd.md
+++ b/docs/arch/v0-prd.md
@@ -15,7 +15,7 @@ A local desktop app where one person can:
 1. Assemble a **crew** of CLI coding agents on their own machine.
 2. Give each **runner** a role and a brief (system prompt / instructions).
 3. **Launch a mission** — one activation of the whole crew — and watch every runner's live output in one window.
-4. Let runners **coordinate** through a shared event log and a shared fact whiteboard.
+4. Let runners **coordinate** through two channels: **signals** (typed, orchestrator-routable) and **messages** (prose, runner-to-runner).
 5. Get pulled in by an **orchestrator** only when a decision needs a human.
 
 v0 proves the loop works end-to-end with two runners on a single mission. v1+ scales it.
@@ -23,23 +23,33 @@ v0 proves the loop works end-to-end with two runners on a single mission. v1+ sc
 ## 3. Vocabulary
 
 - **Crew** — a named, persistent group of runners configured to work together.
-- **Runner** — an individual CLI agent (one PTY, one role, one system prompt). Configured once as part of a crew; spawned fresh on each mission.
-- **Mission** — one activation of the crew. Everyone spawns together, shares an event log and a fact whiteboard, ends together. A crew can have many missions over its lifetime; only one is live at a time.
-- **Session** — the live PTY process for a single runner within a single mission. One runner × one mission = one session.
-- **Event** — a structured NDJSON line runners emit to coordinate; routed by the orchestrator.
-- **Fact** — a key/value entry in the mission's shared whiteboard, written by any runner via `runners ctx set`.
-- **Orchestrator** — the rule-based router that reads events and decides what happens next (route to another runner, ask the human, etc.).
+- **Runner** — an individual CLI agent (one PTY, one role, one system prompt).
+- **Mission** — one activation of the crew. Everyone spawns together, shares a coordination bus, ends together.
+- **Session** — the live PTY process for a single runner within a single mission.
+- **Signal** — a typed notification runners emit for the orchestrator to route on. Verb grammar (`review_requested`, `approved`, `blocked`).
+- **Message** — prose posted to the mission's flat stream. Runner-to-runner conversation.
+- **Orchestrator** — the rule-based router that reads signals and decides what happens next.
 
-## 4. Non-goals for v0
+## 4. v0 scope
+
+Runners and the mission coordinate through two primitives — **signals** and **messages**. We deliberately defer three concepts that belong to the vision but aren't needed for v0:
+
+- **Threads** (v0.x) — scoped sub-conversations. v0 has flat messages.
+- **Facts** (v0.x) — KV whiteboard for mission state. v0 has no shared queryable state.
+- **Mentions, reactions** (v1) — targeted pings, lightweight signals on messages.
+
+All four are described in `v0-arch.md` §2.7 with milestone tags, so the vision is clear — v0 just ships less.
+
+### Other non-goals for v0
 
 - Multiple concurrent missions per crew
-- Cross-mission memory (each mission starts with an empty fact whiteboard)
+- Cross-mission memory
 - Session replay, session history browsing
 - LLM-based orchestrator (v0 is rule-based only)
 - Remote / cloud / multi-host runners
-- Cost tracking, observability dashboards, telemetry
-- Runner templates, presets, or marketplace
-- Multi-human collaboration (a crew is a crew of runners, not humans)
+- Cost tracking, observability dashboards
+- Runner templates, presets, marketplace
+- Multi-human collaboration
 - Secrets management beyond plain env vars
 
 ## 5. User journey (the v0 demo)
@@ -48,16 +58,27 @@ The concrete loop v0 must support end-to-end:
 
 1. User creates a crew called *Feature Ship*.
 2. User spawns two runners on the crew:
-   - **Coder** — runtime `claude-code`, working dir `~/src/myproj`, brief "Implement feature X. When done, emit `review_requested`."
-   - **Reviewer** — runtime `claude-code`, same working dir, brief "Wait for `review_requested`. Read the diff. Emit `approved` or `changes_requested`."
-3. User clicks **Start Mission**. A new mission is created; both PTYs spawn; user sees two terminals, one per runner.
-4. Coder records a fact: `runners ctx set pr_branch feat/x`. Event appears on the mission timeline.
-5. Coder writes code, runs tests, then calls `runners emit review_requested`.
-6. Orchestrator policy routes the event: injects a message into Reviewer's stdin ("A review is pending, please proceed.").
-7. Reviewer runs `runners ctx get pr_branch` to learn which branch to review, reads the diff, emits `changes_requested` with a payload listing issues.
-8. Orchestrator policy for `changes_requested` says `ask_human`. The human-in-the-loop panel pops a card: *"Reviewer requested changes. Accept and forward to Coder, or override?"*
-9. User clicks **Accept**. Orchestrator writes a `forward_to_coder` event with the reviewer's notes, which injects into Coder's stdin.
-10. Coder fixes the issues, re-emits `review_requested`. Loop continues until `approved`.
+   - **Coder** — runtime `claude-code`, working dir `~/src/myproj`, brief "Implement feature X. When ready, signal `review_requested` and post a message explaining what changed."
+   - **Reviewer** — runtime `claude-code`, same working dir, brief "When review is requested, read the Coder's messages and the diff, then signal `approved` or `changes_requested` and post messages with specific feedback."
+3. User clicks **Start Mission**. Both PTYs spawn. User sees two terminals, one per runner.
+4. Coder writes code, runs tests, then:
+   - `runners msg post "Branch feat/x is ready. I refactored auth and added session tests."`
+   - `runners signal review_requested`
+5. Orchestrator routes `review_requested`: injects into Reviewer's stdin "A review is pending — check `runners msg read`."
+6. Reviewer:
+   - `runners msg read` (sees Coder's message)
+   - reads the diff
+   - `runners msg post "Line 47 auth.rs needs a null check."`
+   - `runners msg post "session.rs timeout is 30s; our convention is 10s."`
+   - `runners signal changes_requested`
+7. Orchestrator policy for `changes_requested` says `ask_human`. The HITL panel pops a card: *"Reviewer requested changes. Accept and forward to Coder, or override?"*
+8. User clicks **Accept**. Orchestrator injects into Coder's stdin: "Reviewer requested changes — check `runners msg read`."
+9. Coder:
+   - `runners msg read`
+   - fixes the null check; defends the 30s timeout
+   - `runners msg post "Added null check. Kept 30s timeout — provider is slow on cold start."`
+   - `runners signal review_requested`
+10. Reviewer reads, agrees, `runners signal approved`.
 11. User clicks **End Mission**. Sessions terminate, mission status flips to `completed`, the mission appears in the crew's history list.
 
 If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
@@ -66,7 +87,7 @@ If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
 
 ### 6.1 Crew CRUD
 - Create, rename, delete crews.
-- A crew has: `name`, `goal` (default mission brief), list of runners, an orchestrator policy, an allowlist of event types.
+- A crew has: `name`, `goal` (default mission brief), list of runners, orchestrator policy, signal-type allowlist.
 - Persisted in SQLite.
 
 ### 6.2 Runner CRUD (scoped to a crew)
@@ -82,104 +103,82 @@ If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
 
 ### 6.3 Missions (a crew's runtime activations)
 - One-click **Start Mission** on a crew. Creates a new mission row, spawns a session per runner, opens the mission control screen.
-- **End Mission** stops all sessions in the mission and marks status `completed` (or `aborted` if stopped mid-flight).
-- v0: one live mission per crew at a time. Starting a new mission requires ending the current one.
+- **End Mission** stops all sessions and marks status `completed` (or `aborted` if stopped mid-flight).
+- v0: one live mission per crew. Starting a new mission requires ending the current one.
 - A mission has: `id`, `crew_id`, `status` (running/completed/aborted), `goal_override` (optional per-mission brief overlay), `started_at`, `stopped_at`.
 - Crew page shows mission history: list of past missions with start time, duration, outcome summary.
 
-### 6.4 Live per-runner terminal (first-class)
+### 6.4 Live per-runner terminal
 - One PTY subprocess per runner per mission, spawned via `portable-pty`.
 - Stdout streams to the frontend via a Tauri event (`session:{id}:out`).
-- Frontend renders with **xterm.js** to preserve ANSI colors, cursor control, and TUI layouts. A dumb `<pre>` will look broken for claude/codex.
-- Scrollback retained per session (cap at ~10k lines; overflow dumped to a per-session log file on disk).
-- Status chip per runner: `idle | running | waiting_for_input | blocked_on_human | crashed`. Derived from PTY state + last event.
-- Stdin input box so the human can type directly into any runner at any time.
-- Terminals stay alive across tab/selection switches — we don't re-create the xterm instance on hide, or we lose the ANSI state machine and scrollback.
+- Frontend renders with **xterm.js** to preserve ANSI colors, cursor control, and TUI layouts.
+- Scrollback retained per session (cap at ~10k lines; overflow dumped to a per-session log file).
+- Status chip per runner: `idle | running | waiting_for_input | blocked_on_human | crashed`.
+- Stdin input box so the human can type directly into any runner.
+- Terminals stay alive across tab/selection switches.
 
-### 6.5 Shared context (per mission)
+### 6.5 Signals — typed orchestrator-routable notifications
+- Runners emit via `runners signal <type> [--payload <json>]`.
+- Types are per-crew allowlisted (stored in `crews.signal_types`).
+- Payload is optional JSON for the orchestrator's decision logic.
+- Emitted signals appear as events in the coordination bus (see §6.7) and drive the orchestrator.
 
-Three layers, each with different semantics:
+### 6.6 Messages — flat prose stream per mission
+- Runners post via `runners msg post "<text>"`.
+- Read via `runners msg read [--since <ts>]` — returns all messages in the mission in ULID order.
+- No thread scoping in v0 — one flat stream per mission.
+- Messages are human-readable and runner-readable. They are the "what I think" layer; signals are the "please act" layer.
 
-#### 6.5.1 Mission brief (read-only)
-The goal for this mission. Defaults to `crew.goal`; user can override at mission start (`goal_override` on the mission row). Injected into each runner's system prompt at spawn.
+### 6.7 Coordination bus
+- Single append-only NDJSON file per mission at `$APPDATA/runners/crews/{crew_id}/missions/{mission_id}/events.ndjson`.
+- Both signals and messages are persisted as events with `kind: "signal"` or `kind: "message"`.
+- File is watched with the `notify` crate. Orchestrator and UI both subscribe.
+- Tailable with `tail -f` for debugging. Per-mission file solves log rotation implicitly.
 
-#### 6.5.2 Roster (read-only)
-Who else is on the crew and what they do. Auto-assembled at mission start from `crew.runners`. Each runner sees a rendered list of crewmates with their roles and a summary of their briefs, injected into its system prompt at spawn. This is how the Reviewer knows there's a Coder.
+### 6.8 `runners` CLI
 
-#### 6.5.3 Facts — the shared whiteboard (mutable)
-A key-value store any runner can read/write during the mission.
+```
+runners signal <type> [--payload <json>] [--correlation-id <id>] [--causation-id <id>]
+runners msg    post <text> [--correlation-id <id>] [--causation-id <id>]
+runners msg    read [--since <ts>]
+runners help
+```
 
-- Write: `runners ctx set <key> <value>`
-- Read: `runners ctx get <key>` or `runners ctx list`
-- Delete: `runners ctx unset <key>`
-- Last-writer-wins per key.
-- Flat namespace in v0 — no `ctx set foo.bar` convention yet; just `ctx set foo_bar`.
+One binary, two verbs. Reads context (crew, mission, runner, log path) from env vars injected at PTY spawn. Bundled with the app; dropped at `$APPDATA/runners/bin/runners` on first run; PATH is prepended for each session so agents can invoke it unqualified.
 
-Backed by the same NDJSON event log. `ctx set` emits a `fact_recorded` event. The orchestrator maintains an in-memory projection; `ctx get` reads through a local endpoint on the orchestrator (or re-scans the log). No second store. See §6.8.1 in `v0-arch.md` for mechanics.
+See `v0-arch.md` §5.3 for the full three-layer emission mechanism (system prompt → CLI on PATH → role brief examples).
 
-### 6.6 Event bus (inter-runner comm)
-- Single append-only **NDJSON** file per mission, at `$APPDATA/runners/crews/{crew_id}/missions/{mission_id}/events.ndjson`.
-- One line per event. Event schema:
-  ```json
-  {
-    "id": "ULID",
-    "ts": "2026-04-21T12:34:56.123Z",
-    "crew_id": "...",
-    "mission_id": "...",
-    "from": "coder",
-    "to": null,
-    "type": "review_requested",
-    "payload": { "...": "..." },
-    "correlation_id": null,
-    "causation_id": null
-  }
-  ```
-- File is watched with the `notify` crate. UI and orchestrator both subscribe.
-- File is tailable with `tail -f` for debugging. Deliberate.
-- One file per mission solves log rotation implicitly — each mission gets a fresh file.
-
-#### 6.6.1 How runners emit events — **[DECIDED]**
-
-CLI wrapper: a `runners` binary on PATH. When an agent executes `runners emit <type> --payload <json>`, it reads its context from env vars (`RUNNERS_CREW_ID`, `RUNNERS_MISSION_ID`, `RUNNERS_RUNNER_NAME`, `RUNNERS_EVENT_LOG`) and appends one JSON line to the current mission's event log.
-
-The agent learns to use this via its system prompt (which is composed by the backend to include the CLI's usage and the crew's allowed event types). See `v0-arch.md` §3.3 for the full three-layer emission mechanism.
-
-Alternatives considered and deferred:
-- MCP tool — revisit in v1 once MCP is ubiquitous in CLI agents.
-- Stdout parsing — fragile, interferes with TUI output.
-
-### 6.7 Orchestrator (rule-based)
-- Policy is per-crew, stored as JSON on the crew row. Shared across all missions of that crew.
-- In-memory state (pending asks, correlation tracking, fact projection) is per-mission; cleared on mission end.
+### 6.9 Orchestrator (rule-based)
+- Policy is per-crew, stored as JSON on the crew row. Shared across all missions.
+- In-memory state (pending asks, correlation tracking) is per-mission; cleared on mission end.
 - Policy is an ordered list of `{ when, do }` rules. First match wins. Schema:
   ```json
   [
-    { "when": { "type": "review_requested" },
+    { "when": { "signal": "review_requested" },
       "do": { "action": "inject_stdin", "target": "reviewer",
-              "template": "A review is pending. Please proceed." } },
-    { "when": { "type": "changes_requested" },
+              "template": "A review is pending — run `runners msg read` for context." } },
+    { "when": { "signal": "changes_requested" },
       "do": { "action": "ask_human",
               "prompt": "Reviewer requested changes. Accept or override?",
               "choices": ["accept", "override"] } },
-    { "when": { "type": "approved" },
-      "do": { "action": "notify_human", "message": "PR approved by reviewer." } }
+    { "when": { "signal": "approved" },
+      "do": { "action": "notify_human", "message": "Review approved." } }
   ]
   ```
 - Supported actions in v0:
   - `inject_stdin` — write a message into the target runner's stdin.
-  - `ask_human` — show a card in the HITL panel, wait for response, emit a follow-up event with the answer.
-  - `notify_human` — fire a toast, don't block.
-  - `pause_runner` / `resume_runner` — send SIGSTOP/SIGCONT to the target PTY.
-- No expressions, no scripting, no LLM. v0 is a lookup table.
+  - `ask_human` — show a card in the HITL panel, wait for response.
+  - `notify_human` — fire a toast.
+  - `pause_runner` / `resume_runner` — SIGSTOP/SIGCONT the target PTY.
+- Rules fire only on signals in v0. Messages don't drive routing (v0.x: mentions will).
 
-### 6.8 Human-in-the-loop panel
+### 6.10 Human-in-the-loop panel
 - Right-rail panel showing all pending `ask_human` cards for the current mission.
-- Each card shows: triggering event, orchestrator prompt, choices.
-- User clicks a choice → orchestrator writes a response event `{type: "human_response", correlation_id: <triggering event id>, choice: "accept"}` which any downstream rule can match.
-- Visible across all views so the user never misses one.
+- Each card shows: triggering signal, orchestrator prompt, choices.
+- User clicks a choice → orchestrator emits a `human_response` signal with `correlation_id = triggering signal's id` which downstream rules can match.
 - Cleared when the mission ends.
 
-### 6.9 Mission control UI
+### 6.11 Mission control UI
 
 Single screen per live mission. Layout:
 
@@ -194,21 +193,20 @@ Single screen per live mission. Layout:
 │          │  └───────────────────────────┘   │ │ [Accept] [Override]│ │
 │ + Spawn  │  > _                             │ └────────────────────┘ │
 │          │                                  │                        │
-│          │  Events (this runner)            │ Facts                  │
-│          │  12:34 fact_recorded pr_branch   │ pr_branch = feat/x     │
-│          │  12:35 emit review_requested     │ main_branch = main-dev │
-│          │  12:36 stdin injected            │                        │
-│          │                                  │ Event stream (all)     │
+│          │                                  │ Messages               │
+│          │  Signals (this mission)          │ coder  12:34           │
+│          │  12:34 review_requested          │  Branch feat/x ready…  │
+│          │  12:40 changes_requested         │ reviewer  12:38        │
+│          │  ...                             │  Line 47 auth.rs…      │
 └──────────┴──────────────────────────────────┴────────────────────────┘
 ```
 
 - **Left rail**: runner list with status dots. Click to focus.
-- **Main area**: focused runner's live terminal + that runner's event log below.
-- **Right rail**: HITL panel, live facts view (the shared whiteboard), and the global event timeline.
-- **[OPEN]**: interleaved terminal + events, or split? **Recommendation: split.** Events below the terminal, timestamp-aligned.
-- **[OPEN]**: side-by-side view of two runners' terminals. Deferrable to v0.x.
+- **Main area**: focused runner's live terminal + this mission's signal log below.
+- **Right rail**: HITL panel at the top, mission-wide messages stream below.
+- **[OPEN]** side-by-side view of two runners' terminals. Deferrable to v0.x.
 
-The **crew page** (not the mission page) lists past missions with status, start/stop times, and a one-line outcome summary pulled from the last few events.
+The **crew page** (not the mission page) lists past missions with status, start/stop times, and a one-line outcome summary pulled from the last few signals.
 
 ## 7. Data model
 
@@ -216,9 +214,9 @@ The **crew page** (not the mission page) lists past missions with status, start/
 crews (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL,
-  goal TEXT,                          -- default mission brief
+  goal TEXT,
   orchestrator_policy TEXT,           -- JSON
-  event_types TEXT,                   -- JSON array, CLI allowlist
+  signal_types TEXT,                  -- JSON array, CLI allowlist
   created_at TEXT, updated_at TEXT
 );
 
@@ -240,7 +238,7 @@ missions (
   id TEXT PRIMARY KEY,
   crew_id TEXT REFERENCES crews(id) ON DELETE CASCADE,
   status TEXT NOT NULL,               -- running | completed | aborted
-  goal_override TEXT,                 -- optional per-mission brief
+  goal_override TEXT,
   started_at TEXT NOT NULL,
   stopped_at TEXT
 );
@@ -254,39 +252,38 @@ sessions (
 );
 ```
 
-Events and facts live in the mission's NDJSON file, not in SQLite. SQLite is for config + session lifecycle only.
+Signals and messages live in the mission's NDJSON file, not in SQLite. SQLite is for config + session lifecycle only.
 
 ## 8. Tech boundaries
 
 - **Backend:** Rust, Tauri 2. PTY via `portable-pty`. File watching via `notify`. Persistence via `rusqlite` (WAL).
 - **Frontend:** React 19, TypeScript, Tailwind 4, xterm.js, React Router.
-- **Event log + facts:** NDJSON file per mission. No message broker, no WebSockets, no DB row stream.
-- **Orchestrator:** Rust module, runs in the Tauri backend, subscribes to the mission's event file via `notify`.
-- **`runners` CLI:** small Rust binary, bundled with the app, dropped at `$APPDATA/runners/bin/runners` on first run, PATH-prepended for each session.
+- **Coordination bus:** NDJSON file per mission.
+- **Orchestrator:** Rust module in the Tauri backend, subscribes to the mission's event file via `notify`.
+- **`runners` CLI:** small Rust binary, bundled with the app, dropped at `$APPDATA/runners/bin/runners`, PATH-prepended per session.
 
 ## 9. Open questions
 
-1. **Terminal + events visual layout** — interleaved or split. Recommendation: split.
-2. **Side-by-side runner terminals** in v0, or defer to v0.x.
-3. **How does the system prompt actually get passed** to each runtime? `claude-code` takes `--append-system-prompt`; `codex` has its own flag. The runtime enum in §6.2 should own this mapping.
-4. **Restart semantics** — if a runner crashes, auto-restart? v0 answer: no, surface the crash and let the human click Restart.
-5. **Event ordering guarantees** — single-writer per file should give us total order via append. Confirm `fs::OpenOptions::new().append(true)` writes <`PIPE_BUF` are atomic on macOS (they are, but document).
-6. **Fact namespacing** — flat or prefixed. v0 answer: flat.
-7. **Cross-mission memory** — v0 answer: no. Each mission starts empty.
+1. **Side-by-side runner terminals** in v0, or defer to v0.x.
+2. **How does the system prompt actually get passed** to each runtime? `claude-code` takes `--append-system-prompt`; `codex` has its own flag. Runtime enum owns the mapping.
+3. **Restart semantics** — if a runner crashes, auto-restart? v0: no.
+4. **Event ordering guarantees** — single-writer per line via `O_APPEND`. Document filesystem requirements (local POSIX).
+5. **Does `msg read` paginate?** v0: return everything, client can filter by `--since`.
+6. **Should the orchestrator include recent messages as context** when injecting stdin on a signal? Leaning yes — helpful for runners that don't immediately think to call `msg read`.
 
 ## 10. Risks
 
 - **PTY flakiness across platforms** — especially Windows. v0 targets macOS only; Linux best-effort; Windows deferred.
-- **TUI rendering in xterm.js** — claude/codex use rich TUIs. xterm.js is mature but some escape sequences may still render oddly. Budget time for tuning.
-- **Runners that don't know the `runners emit` / `runners ctx` conventions** — they can't coordinate. We need starter briefs / system-prompt snippets per runtime.
+- **TUI rendering in xterm.js** — claude/codex use rich TUIs. Budget time for tuning.
+- **Runners that don't know the `runners signal` / `runners msg` conventions** — they can't coordinate. Ship starter briefs / system-prompt snippets per runtime.
 
 ## 11. Done criteria
 
 v0 ships when:
 - [ ] A user can create a crew, spawn two runners, click Start Mission, and see two live terminals.
-- [ ] Runners can emit events via `runners emit` and the UI shows them in real time.
-- [ ] Runners can read/write facts via `runners ctx` and the UI shows the live fact whiteboard.
-- [ ] A rule-based policy can route an event into another runner's stdin.
+- [ ] Runners can emit signals via `runners signal` and the UI shows them in the signal log.
+- [ ] Runners can post and read messages via `runners msg`, and the UI shows the live messages pane.
+- [ ] A rule-based policy can route a signal into another runner's stdin.
 - [ ] A rule-based policy can pause the mission and ask the human a question, then resume based on the answer.
 - [ ] End Mission terminates all sessions, marks the mission completed, and the crew page shows it in history.
 - [ ] The Coder + Reviewer demo loop from §5 works end-to-end without the user touching a terminal outside the app.

--- a/docs/arch/v0-prd.md
+++ b/docs/arch/v0-prd.md
@@ -192,33 +192,37 @@ See `v0-arch.md` §5.3 for the full three-layer emission mechanism (system promp
 
 ### 6.11 Mission control UI
 
-Single screen per live mission. Layout:
+One screen per live mission. Surfaces and their responsibilities:
 
-```
-┌──────────────────────────────────────────────────────────────────────┐
-│ Feature Ship  •  Mission 2026-04-21 12:34    ▶ ⏸ ⏹    [End Mission]   │
-├──────────┬──────────────────────────────────┬────────────────────────┤
-│ Runners  │  ▌ Coder (running)               │ Pending asks           │
-│          │  ┌───────────────────────────┐   │ ┌────────────────────┐ │
-│ ● Coder  │  │ [xterm live output]       │   │ │ Reviewer requested │ │
-│ ○ Reviewer│ │                           │   │ │ changes.           │ │
-│          │  └───────────────────────────┘   │ │ [Accept] [Override]│ │
-│ + Spawn  │  > _                             │ └────────────────────┘ │
-│          │                                  │                        │
-│          │                                  │ Messages               │
-│          │  Signals (this mission)          │ coder  12:34           │
-│          │  12:34 review_requested          │  Branch feat/x ready…  │
-│          │  12:40 changes_requested         │ reviewer  12:38        │
-│          │  ...                             │  Line 47 auth.rs…      │
-└──────────┴──────────────────────────────────┴────────────────────────┘
-```
+- **Runner list** — every runner in the crew with a status indicator (`idle | running | waiting_for_input | blocked_on_human | crashed`). Selecting one focuses the main terminal area on it. Includes a control to spawn additional runners.
+- **Focused terminal** — the xterm.js view for the selected runner. Live PTY output with full TUI fidelity, stdin input for human takeover, and scrollback. Terminals stay alive across focus switches (§6.4).
+- **Signals pane** — chronological list of all signals emitted in this mission: timestamp, emitter, type. Scoped to the mission.
+- **HITL panel** — pending `ask_human` cards. Each card shows the triggering signal, the orchestrator's prompt, and choice buttons. Always visible so the operator never misses a pending decision.
+- **Messages pane** — every message in the mission (see §6.11.1 for visibility semantics and view modes).
+- **Mission header** — crew name, mission start time, global controls (Start/Pause/Stop, End Mission).
 
-- **Left rail**: runner list with status dots. Click to focus.
-- **Main area**: focused runner's live terminal + this mission's signal log below.
-- **Right rail**: HITL panel at the top, mission-wide messages stream below.
-- **[OPEN]** side-by-side view of two runners' terminals. Deferrable to v0.x.
+Side-by-side view of two runners' terminals is **[OPEN]** for v0 — deferrable to v0.x if it adds scope pressure.
 
-The **crew page** (not the mission page) lists past missions with status, start/stop times, and a one-line outcome summary pulled from the last few signals.
+#### 6.11.1 Message visibility — the human sees everything
+
+The operator is omniscient — the messages pane shows **every message in the mission**, regardless of addressing. Inbox scoping (broadcast + directed to me) applies to runners, not to the human. The human needs the full picture for oversight and debugging.
+
+Each message is labeled with direction: sender and recipient (or "all" for broadcast). Typical rows:
+
+- `coder → all` — a broadcast from the Coder.
+- `reviewer → coder` — a directed message from the Reviewer to the Coder.
+- `human → coder` — a message the operator sent via the UI (v0.x).
+
+The pane has two view modes, toggled at the pane header:
+
+- **All** (default) — flat chronological list of every message event in the mission.
+- **Inbox** — scoped to the currently-focused runner — shows only what that runner would get from `runners msg read` (broadcasts + directs addressed to it). Useful for debugging "did agent X actually see this message?"
+
+Clicking a message highlights any signal it correlates with (via `correlation_id` / `causation_id`) in the signals pane, so the operator can follow cause-and-effect threads across the mission.
+
+#### 6.11.2 Crew page
+
+The **crew page** (separate from the mission control screen) lists past missions with status, start/stop times, and a one-line outcome summary pulled from the last few signals.
 
 ## 7. Data model
 

--- a/docs/arch/v0-prd.md
+++ b/docs/arch/v0-prd.md
@@ -108,14 +108,14 @@ If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
 - A mission has: `id`, `crew_id`, `status` (running/completed/aborted), `goal_override` (optional per-mission brief overlay), `started_at`, `stopped_at`.
 - Crew page shows mission history: list of past missions with start time, duration, outcome summary.
 
-### 6.4 Live per-runner terminal
+### 6.4 Live per-runner terminal (with human takeover)
 - One PTY subprocess per runner per mission, spawned via `portable-pty`.
 - Stdout streams to the frontend via a Tauri event (`session:{id}:out`).
 - Frontend renders with **xterm.js** to preserve ANSI colors, cursor control, and TUI layouts.
 - Scrollback retained per session (cap at ~10k lines; overflow dumped to a per-session log file).
 - Status chip per runner: `idle | running | waiting_for_input | blocked_on_human | crashed`.
-- Stdin input box so the human can type directly into any runner.
-- Terminals stay alive across tab/selection switches.
+- **Human takeover, first-class.** The xterm pane is a real terminal, not a log viewer. At any moment the human can type directly into a runner's stdin — to answer a prompt, correct a bad plan, kill a runaway tool, or just chat with the agent mid-flight. Keystrokes including arrows, Enter, and Ctrl-C pass through untouched. Same writer path as the orchestrator's `inject_stdin`, so human and orchestrator are symmetric.
+- **Sessions outlive the UI.** Closing the mission control window does not kill sessions — agents keep running, events keep flowing, the orchestrator keeps routing. Re-opening re-attaches by fetching each session's scrollback ring. A session ends only on End Mission, child exit, or app quit. This means the human can close the monitor and still rely on the orchestrator + rules without cutting anyone out of the loop.
 
 ### 6.5 Signals — typed orchestrator-routable notifications
 - Runners emit via `runners signal <type> [--payload <json>]`.


### PR DESCRIPTION
## Summary

Drafts the v0 PRD and architecture docs for Runners at `docs/arch/v0-prd.md` and `docs/arch/v0-arch.md`. Establishes the domain model, coordination design, and UI scope for the first shippable version.

### Domain model

- **Configuration layer** (persistent): **Crew**, **Runner**, **Orchestrator Policy**.
- **Runtime layer** (mission-scoped): **Mission** as the container; **Sessions** (one PTY per runner per mission) as first-class members; the coordination bus; orchestrator in-memory state; shared context.
- A Mission is to a Crew what a Session is to a Runner: the *run* of a *configuration*.

### Coordination primitives

- **Signal** (v0) — typed, orchestrator-routable notifications. Verb grammar (`review_requested`, `approved`, `blocked`).
- **Message** (v0) — prose, broadcast (`runners msg post`) or directed (`runners msg post --to <runner>`).
- **Inbox** (v0) — projection over message events: `to=null OR to=my_name`. `runners msg read` returns the caller's inbox.
- **Thread** (v0.x), **Fact** (v0.x), **Mention** / **Reaction** (v1) — documented with milestone tags.

### Delivery model

Signals are orchestrator-routed and drive `inject_stdin`, `ask_human`, etc. Messages are pull-based — runners read them on convention (system-prompt habit) and on signal-driven wake-ups. When `inject_stdin` fires, the orchestrator automatically appends the recipient's unread inbox summary so an urgent signal carries the async conversation along with it. No auto-nudge on direct messages.

### Session ergonomics

- PTY-backed via `portable-pty`; xterm.js in the webview for full TUI fidelity.
- **Human takeover is first-class**: the xterm pane is a real terminal; keystrokes pass through untouched.
- **Sessions outlive the UI**: closing the mission window does not kill sessions — agents keep running, the orchestrator keeps routing.
- PTY master writer serialized behind a mutex so human and orchestrator writes don't interleave.

### Event transport

One append-only NDJSON file per mission at `$APPDATA/runners/crews/{crew_id}/missions/{mission_id}/events.ndjson`. Per-mission scoping solves log rotation, crash-replay, and deletion. Signals and messages are both persisted as events with a `kind` discriminator.

### How runners emit events

Three layers, answering "how does the agent know to append to the event log":
1. System prompt (composed at spawn) describes the `runners` CLI and allowed signal types.
2. CLI exists on PATH with crew/mission/runner identity in env vars.
3. Role briefs reinforce usage with concrete examples.

### CLI surface (v0)

```
runners signal <type> [--payload <json>] [--correlation-id <id>] [--causation-id <id>]
runners msg    post <text> [--to <runner>] [--correlation-id <id>] [--causation-id <id>]
runners msg    read [--since <ts>] [--from <runner>]
```

### UI (text-only spec)

Mission control surfaces: runner list, focused terminal, signals pane, HITL panel, messages pane. The human sees every message in the mission (omniscient); runners see only their inbox.

## Commits in this PR

- scaffold: Session as first-class runtime member of Mission
- coordination: split events into signals + messages; defer threads/facts
- human takeover: elevate to first-class; sessions outlive the UI
- direct messaging: `--to` + inbox concept
- inbox delivery: pull-based; auto-nudge replaced with enriched stdin injection
- UI: text-only spec for the messages pane with All / Inbox modes

## Test plan

- [ ] Read `docs/arch/v0-prd.md` end-to-end and confirm the user journey (§5) is coherent and achievable.
- [ ] Read `docs/arch/v0-arch.md` end-to-end and confirm the concept model (§2) aligns with the PRD's vocabulary.
- [ ] Verify that every "v0" feature in the PRD has a corresponding mechanism in the arch doc.
- [ ] Flag any v0 scope creep before implementation starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)