### PR TITLE
docs(impls): v0 MVP implementation plan

### DIFF
--- a/docs/arch/v0-arch.md
+++ b/docs/arch/v0-arch.md
@@ -103,6 +103,8 @@ The persistent "who's on the team and how they work together" record. A crew has
 
 **Every crew must have exactly one lead runner.** The lead is the human's counterpart in the crew: mission goals and broadcast human messages route to the lead by default, and the lead dispatches work to the other runners via directed messages. This is a hard invariant — a crew with zero runners or zero leads is invalid and cannot start a mission. The first runner added to a new crew becomes lead automatically; the user can reassign lead between existing runners, but cannot remove the lead runner without first designating a replacement. The lead is a routing convention, not a privileged capability: any runner can emit signals, post directed messages, and trigger orchestrator actions. Lead only governs *where inbound-from-human traffic lands by default*.
 
+**Lead is also the default HITL gateway.** When a worker needs human input, it does not ask the human directly — it sends a directed message to the lead, who decides whether to answer from their own context or escalate to the human via `ask_human`. If the lead escalates, the human's answer flows back through the lead, who forwards it to the original worker as another directed message. This keeps the human's attention focused on one interlocutor and lets the lead absorb, filter, or batch worker questions. See §5.5.0 for the protocol details (the `on_behalf_of` payload field and the forwarding flow). Workers *can* emit `ask_human` directly as a fallback — it's not forbidden at the protocol layer — but the default runner system prompt instructs them to route through the lead.
+
 Lifecycle: created by the user, edited freely, deleted when no longer needed. Persisted in SQLite.
 
 ### 2.3 Runner — *one configured agent*
@@ -533,7 +535,8 @@ Every action emits at least one audit signal. Each audit payload carries `trigge
     "question_id": "01HG...",                  // = this event's id; echoed here for convenience
     "triggered_by": <triggering-signal.id>,    // e.g. the changes_requested signal's id
     "prompt": "Reviewer requested changes. Accept or override?",
-    "choices": ["accept", "override"]
+    "choices": ["accept", "override"],
+    "on_behalf_of": "@impl"                    // optional; see "Lead-mediated asks" below
   }
 }
 
@@ -554,6 +557,29 @@ Causality is carried in-payload rather than on the envelope: `human_question.pay
 **Matching semantics for follow-up rules.** Downstream rules match `human_response` by choice value — `{ when: { signal: "human_response", payload: { choice: "accept" } }, do: ... }`. Matches any accept, regardless of which question triggered it.
 
 If two `ask_human` prompts are ever outstanding at once and we need to discriminate between them, v0.x will add richer matching (via the v0.x event-DAG fields). v0 ships the simple case; concurrent prompts are out of scope.
+
+**Lead-mediated asks (the canonical pattern).** By convention (§2.2), workers do not escalate to the human directly. When a worker needs human input, it posts a directed message to the lead:
+
+```
+runners msg post --to @lead "Should I add notify-debouncer-full? Pros: … Cons: …"
+```
+
+The orchestrator's built-in routing injects any directed message with `to: @lead` into the lead's stdin on arrival, so the lead sees it without polling. The lead then decides:
+
+1. **Answer from own context** — lead posts a directed message back to the worker. No human involvement. Done.
+2. **Escalate to human** — lead emits `ask_human` with `payload.on_behalf_of: "@impl"` (the original asker's handle) and a `prompt` that restates the worker's question for the human. The orchestrator renders the card; the UI uses `on_behalf_of` to show the attribution chain (e.g. *@impl → @architect → you*).
+
+When the human clicks a choice, `human_response` fires and the orchestrator injects the result into **the lead's stdin**, not the original worker's. The lead is responsible for forwarding the answer onward via a directed message:
+
+```
+runners msg post --to @impl "Human approved: use notify-debouncer-full."
+```
+
+This is not a new protocol — it is `ask_human` + directed messages composed. The only schema addition is the optional `on_behalf_of` field for UI attribution.
+
+**Why route through the lead.** The lead can absorb, filter, or batch worker questions, and the human's attention stays focused on one interlocutor. The tradeoff is added latency and the possibility of the lead paraphrasing the human's answer imprecisely — both acceptable for v0. The full chain is always visible in the event log for audit.
+
+**Worker-initiated asks.** A worker *may* emit `ask_human` directly (with no `on_behalf_of`); the orchestrator will route `human_response` back to that worker's stdin as in the direct flow. This is a fallback for cases where the lead is paused or unavailable and the system prompt explicitly permits it. It is not the default path.
 
 **Messages do not trigger orchestrator actions in v0.** The inbox is pull-based (§2.7.3). If a sender needs the recipient to drop everything, they emit a signal — signals are the urgent wake-up mechanism; direct messages are async conversation.
 

--- a/docs/arch/v0-arch.md
+++ b/docs/arch/v0-arch.md
@@ -691,7 +691,8 @@ One binary. Two verbs. Context always from env. No event-DAG flags in v0 — cau
 crews (
   id TEXT PRIMARY KEY,
   name TEXT NOT NULL,
-  goal TEXT,
+  purpose TEXT,                       -- short prose shown in Crew Detail; optional
+  goal TEXT,                          -- default mission goal
   orchestrator_policy TEXT,           -- JSON: [{ when, do }]
   signal_types TEXT,                  -- JSON array: allowlist
   created_at TEXT, updated_at TEXT
@@ -709,15 +710,22 @@ runners (
   working_dir TEXT,
   system_prompt TEXT,
   env_json TEXT,
+  lead INTEGER NOT NULL DEFAULT 0,    -- 0 or 1; see §2.2 lead invariant
+  position INTEGER NOT NULL,          -- ordering within the crew (0-based)
   created_at TEXT, updated_at TEXT,
   UNIQUE (crew_id, handle)
 );
 
+-- Enforces the lead invariant (§2.2): exactly one lead per crew.
+CREATE UNIQUE INDEX one_lead_per_crew ON runners(crew_id) WHERE lead = 1;
+
 missions (
   id TEXT PRIMARY KEY,
   crew_id TEXT REFERENCES crews(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,                -- short label shown in missions list + event log
   status TEXT NOT NULL,               -- running | completed | aborted
-  goal_override TEXT,
+  goal_override TEXT,                 -- null means inherit crews.goal
+  cwd TEXT,                           -- mission working dir; exposed as $MISSION_CWD
   started_at TEXT NOT NULL,
   stopped_at TEXT
 );
@@ -727,6 +735,7 @@ sessions (
   mission_id TEXT REFERENCES missions(id) ON DELETE CASCADE,
   runner_id TEXT REFERENCES runners(id) ON DELETE CASCADE,
   status TEXT NOT NULL,               -- running | stopped | crashed
+  pid INTEGER,                        -- OS process id once spawned; null while pending
   started_at TEXT, stopped_at TEXT
 );
 ```

--- a/docs/arch/v0-arch.md
+++ b/docs/arch/v0-arch.md
@@ -101,9 +101,9 @@ A mission is a container. Everything in the runtime column is either the contain
 
 The persistent "who's on the team and how they work together" record. A crew has a name, a default mission goal, a list of runners, an orchestrator policy, and a signal-type allowlist. It does not run. It is blueprint.
 
-**Every crew must have exactly one lead runner.** The lead is the human's counterpart in the crew: mission goals and broadcast human messages route to the lead by default, and the lead dispatches work to the other runners via directed messages. This is a hard invariant — a crew with zero runners or zero leads is invalid and cannot start a mission. The first runner added to a new crew becomes lead automatically; the user can reassign lead between existing runners, but cannot remove the lead runner without first designating a replacement. The lead is a routing convention, not a privileged capability: any runner can emit signals, post directed messages, and trigger orchestrator actions. Lead only governs *where inbound-from-human traffic lands by default*.
+**Every crew must have exactly one lead runner.** The lead is the human's counterpart in the crew: the mission goal and human-originated broadcast signals route to the lead by default, and the lead dispatches work to the other runners via directed messages. This is a hard invariant — a crew with zero runners or zero leads is invalid and cannot start a mission. The first runner added to a new crew becomes lead automatically; the user can reassign lead between existing runners, but cannot remove the lead runner without first designating a replacement. The lead is a routing convention, not a privileged capability: any runner can emit signals, post directed messages, and trigger orchestrator actions. Lead only governs *where inbound-from-human signals land by default*.
 
-**Lead is also the default HITL gateway.** When a worker needs human input, it does not ask the human directly — it sends a directed message to the lead, who decides whether to answer from their own context or escalate to the human via `ask_human`. If the lead escalates, the human's answer flows back through the lead, who forwards it to the original worker as another directed message. This keeps the human's attention focused on one interlocutor and lets the lead absorb, filter, or batch worker questions. See §5.5.0 for the protocol details (the `on_behalf_of` payload field and the forwarding flow). Workers *can* emit `ask_human` directly as a fallback — it's not forbidden at the protocol layer — but the default runner system prompt instructs them to route through the lead.
+**Lead is also the default HITL gateway.** When a worker needs human input, it does not ask the human directly — it emits an `ask_lead` signal whose payload carries the question. The orchestrator wakes the lead (signals trigger actions; messages don't — see §5.5.0), who decides whether to answer from their own context or escalate to the human via `ask_human`. If the lead escalates, the human's answer flows back to the lead, who forwards it to the original worker as a directed message that the worker picks up on its next `runners msg read`. This keeps the human's attention focused on one interlocutor and lets the lead absorb, filter, or batch worker questions. See §5.5.0 for the protocol details (the `ask_lead` signal, the `on_behalf_of` payload field on `ask_human`, and the forwarding flow). Workers *may* emit `ask_human` directly as a fallback — it's not forbidden at the protocol layer — but the default runner system prompt instructs them to go through the lead.
 
 Lifecycle: created by the user, edited freely, deleted when no longer needed. Persisted in SQLite.
 
@@ -558,24 +558,29 @@ Causality is carried in-payload rather than on the envelope: `human_question.pay
 
 If two `ask_human` prompts are ever outstanding at once and we need to discriminate between them, v0.x will add richer matching (via the v0.x event-DAG fields). v0 ships the simple case; concurrent prompts are out of scope.
 
-**Lead-mediated asks (the canonical pattern).** By convention (§2.2), workers do not escalate to the human directly. When a worker needs human input, it posts a directed message to the lead:
+**Lead-mediated asks (the canonical pattern).** By convention (§2.2), workers do not escalate to the human directly. The flow is entirely signal-driven — never message-triggered — so it does not violate the pull-based rule below.
 
-```
-runners msg post --to @lead "Should I add notify-debouncer-full? Pros: … Cons: …"
-```
+1. **Worker asks the lead.** Worker emits an `ask_lead` signal with the question in its payload:
 
-The orchestrator's built-in routing injects any directed message with `to: @lead` into the lead's stdin on arrival, so the lead sees it without polling. The lead then decides:
+   ```
+   runners signal ask_lead --payload '{"question": "Should I add notify-debouncer-full?", "context": "Pros: … Cons: …"}'
+   ```
 
-1. **Answer from own context** — lead posts a directed message back to the worker. No human involvement. Done.
-2. **Escalate to human** — lead emits `ask_human` with `payload.on_behalf_of: "@impl"` (the original asker's handle) and a `prompt` that restates the worker's question for the human. The orchestrator renders the card; the UI uses `on_behalf_of` to show the attribution chain (e.g. *@impl → @architect → you*).
+   `ask_lead` is a built-in signal type. Its built-in rule is `ask_lead → inject_stdin @lead` (payload rendered into the injection template). The worker's stdin stays blocked waiting; the lead wakes.
 
-When the human clicks a choice, `human_response` fires and the orchestrator injects the result into **the lead's stdin**, not the original worker's. The lead is responsible for forwarding the answer onward via a directed message:
+2. **Lead decides.**
+   - **Answer from own context.** Lead posts a directed message back to the worker via `runners msg post --to @impl "…"`. The worker picks it up on its next `runners msg read`. Pull-based; no new wake-up needed because the worker is already polling between turns per its system prompt.
+   - **Escalate to human.** Lead emits `ask_human` with `payload.on_behalf_of: "@impl"` (the original asker's handle) and a `prompt` that restates the question for the human. The orchestrator renders the card; the UI uses `on_behalf_of` to show the attribution chain (*@impl → @architect → you*).
 
-```
-runners msg post --to @impl "Human approved: use notify-debouncer-full."
-```
+3. **Human responds.** On click, `human_response` fires. The orchestrator injects the result into **the lead's stdin** (the lead was the asker of record for that `question_id`). The lead then forwards the answer onward via a directed message:
 
-This is not a new protocol — it is `ask_human` + directed messages composed. The only schema addition is the optional `on_behalf_of` field for UI attribution.
+   ```
+   runners msg post --to @impl "Human approved: use notify-debouncer-full."
+   ```
+
+   The worker picks up the answer on its next `runners msg read`.
+
+This is not a new protocol — it is `ask_lead` + `ask_human` + directed messages composed. The only schema additions are the `ask_lead` signal type and the optional `on_behalf_of` field on `human_question`.
 
 **Why route through the lead.** The lead can absorb, filter, or batch worker questions, and the human's attention stays focused on one interlocutor. The tradeoff is added latency and the possibility of the lead paraphrasing the human's answer imprecisely — both acceptable for v0. The full chain is always visible in the event log for audit.
 

--- a/docs/arch/v0-prd.md
+++ b/docs/arch/v0-prd.md
@@ -1,6 +1,11 @@
 # Runners — v0 PRD
 
 > Status: draft, open for feedback. Anything in **[OPEN]** is a decision we haven't taken yet.
+>
+> **Canonicity.** `docs/arch/v0-arch.md` is the source of truth for all protocol, schema, and event-model decisions. Where this PRD conflicts with the arch doc, the arch doc wins. Sections marked **⚠️ SUPERSEDED** below have been overtaken by arch updates and are kept only for historical context until the PRD is rewritten:
+> - §5 (Golden path) — the `changes_requested → ask_human → inject Coder` flow has been replaced by lead-mediated HITL (arch §2.2, §5.5.0).
+> - §6.8 (`runners` CLI) — the `--correlation-id` / `--causation-id` flags are dropped (arch §5.2).
+> - §6.11.1 — "clicking a message highlights correlated signals" relies on the dropped correlation fields.
 
 ## 1. Problem
 

--- a/docs/impls/v0-mvp.md
+++ b/docs/impls/v0-mvp.md
@@ -201,9 +201,9 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
   - Built-in rules always loaded:
     - `mission_goal → inject_stdin @lead` with a composed prompt including the goal, the crew roster, and coordination instructions (see arch §4 for the template).
     - `broadcast message from human → inject_stdin @lead` (lead-routing invariant).
-    - `directed message → inject_stdin @<to>` (any runner, any sender).
-    - `ask_human signal → emit human_question event + open card in UI`.
-    - `human_response event → inject_stdin to the original asker`.
+    - `directed message → inject_stdin @<to>` (any runner, any sender). This is how lead-mediated HITL works: a worker's "I need to ask the human…" message to `@lead` lands on lead's stdin immediately, and lead's forwarded answer lands on the worker's stdin the same way.
+    - `ask_human signal → emit human_question event + open card in UI`. If `payload.on_behalf_of` is present (the lead-mediated case), carry it into the `human_question` payload so the UI can render the attribution chain.
+    - `human_response event → inject_stdin to the runner that emitted the matching ask_human` — which is the lead in the lead-mediated flow, or the worker in the fallback direct flow. Orchestrator looks up the original asker by `question_id`.
   - Dispatch ledger (in-memory map of `triggering_event_id → handled`) so replay is idempotent.
   - Pending-ask map keyed by `question_id`.
 
@@ -240,7 +240,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 **Deliverables.**
 - `src/pages/MissionWorkspace.tsx` — subscribes to `event/appended`, renders the feed.
 - `src/components/EventFeed.tsx` — message / signal / `ask_human` card variants.
-- `src/components/AskHumanCard.tsx` — buttons emit a `human_response` signal.
+- `src/components/AskHumanCard.tsx` — buttons emit a `human_response` signal. If the underlying `human_question` carries `on_behalf_of`, render the attribution chain (e.g. *@impl → @architect → you*).
 - `src/components/MissionInput.tsx` — the Slack-channel input. Default `to: @<lead>`. `message` / `signal` mode toggle. Submitting calls a Tauri `human_post_message` command that writes to the log.
 - `src/components/RunnersRail.tsx` — list of sessions with status dot, `LEAD` badge, "open pty" action.
 - `src/components/RunnerTerminal.tsx` — xterm.js bound to the session output stream (popped out of the rail).

--- a/docs/impls/v0-mvp.md
+++ b/docs/impls/v0-mvp.md
@@ -8,13 +8,12 @@
 
 From a clean launch of the app, a user can:
 
-1. Create two runner templates (one `claude-code`, one `shell`) on the **Runners** page.
-2. Create a **Crew** of two slots (lead + worker) on the **Crews** / **Crew Detail** pages; the lead invariant is enforced end-to-end.
-3. Click **Start Mission**, fill the goal, and see the Mission workspace open with two live PTY sessions.
-4. Watch the lead runner receive the goal via stdin, draft a plan, and post a directed message to the worker; see the worker's reply in the feed.
-5. Receive an `ask_human` card from any runner, click **Approve**, and see the response injected back into that runner's stdin.
-6. Post a broadcast `@human` message and have it land on the lead by default.
-7. Close and reopen the mission; the feed replays and the orchestrator's in-memory state reconstructs.
+1. Create a **Crew** on the Crews page, then add two runners to it (one `claude-code` lead, one `shell` worker) on the **Crew Detail** page. Runners are crew-scoped — there is no shared "template" concept in v0 (per PRD §3). The lead invariant is enforced end-to-end.
+2. Click **Start Mission**, fill the goal, and see the Mission workspace open with two live PTY sessions.
+3. Watch the lead runner receive the goal via stdin, draft a plan, and post a directed message to the worker; see the worker pick it up on its next `runners msg read`.
+4. See a worker emit an `ask_lead` signal; watch the lead decide to escalate via `ask_human`; click **Approve** on the resulting card; see the lead receive the response and forward it to the worker.
+5. Post a broadcast human signal from the workspace input and have it land on the lead by default.
+6. Close and reopen the mission; the feed replays and the orchestrator's in-memory state reconstructs.
 
 Anything beyond this is explicitly v0.x or later.
 
@@ -68,16 +67,22 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 **Deliverables.**
 - `src-tauri/src/db.rs` — connection pool with WAL mode, `rusqlite` migrations runner, bootstrapped at app start.
 - Migration `0001_init.sql` creating:
-  - `crews(id, name, purpose, created_at, updated_at)`
-  - `runners(id, crew_id, handle, display_name, role, binary, args, cwd, system_prompt, lead, position, created_at, updated_at)` with:
-    - `UNIQUE(crew_id, handle)`
-    - `UNIQUE(crew_id) WHERE lead = 1` — the lead invariant from arch §2.3.
-    - `FOREIGN KEY(crew_id) REFERENCES crews(id) ON DELETE CASCADE`
-  - `missions(id, crew_id, title, goal, cwd, status, started_at, stopped_at)`
-- Rust types in `src-tauri/src/model.rs`: `Crew`, `Runner`, `Mission`, `Event`, `EventKind`, serde-derived.
+  - `crews(id, name, purpose, goal, orchestrator_policy, signal_types, created_at, updated_at)`. `purpose` is short prose; `goal` is the default mission goal; `orchestrator_policy` is a JSON blob (nullable / empty for MVP — C8 only uses built-ins but the column is reserved); `signal_types` is a JSON array of allowed signal type strings.
+  - `runners(id, crew_id, handle, display_name, role, runtime, command, args, cwd, env, system_prompt, lead, position, created_at, updated_at)` with:
+    - `runtime` = one of `claude-code`, `codex`, `aider`, `shell` (enum stored as TEXT).
+    - `command` + `args` are the spawn form; `env` is a JSON map merged onto the session env at spawn time.
+    - `UNIQUE(crew_id, handle)`.
+    - `FOREIGN KEY(crew_id) REFERENCES crews(id) ON DELETE CASCADE`.
+  - `missions(id, crew_id, title, goal, cwd, status, started_at, stopped_at)`.
+  - `sessions(id, mission_id, runner_id, handle, pid, status, started_at, stopped_at)` — persisted so the reopen path (see C7/C8 replay) can identify which runners were active. PTYs themselves are not restored across app restarts.
+- Separate partial index for the lead invariant (SQLite requires a standalone statement for partial uniqueness, not inline in `CREATE TABLE`):
+  ```sql
+  CREATE UNIQUE INDEX one_lead_per_crew ON runners(crew_id) WHERE lead = 1;
+  ```
+- Rust types in `src-tauri/src/model.rs`: `Crew`, `Runner`, `Mission`, `Session`, `Event`, `EventKind`, `SignalType`, serde-derived.
 - TS types in `src/lib/types.ts` hand-synced with Rust (we're not pulling in `ts-rs` yet — too much ceremony for the MVP).
 
-**Tests.** Constraint tests for the unique partial index: inserting two leads in one crew fails; inserting leads across crews succeeds.
+**Tests.** Constraint tests for the partial unique index: inserting two leads in one crew fails; inserting leads across crews succeeds. Round-trip tests for the JSON-blob columns (`orchestrator_policy`, `signal_types`, `env`).
 
 **Out of scope.** No Tauri commands yet — that's C2.
 
@@ -102,21 +107,22 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 
 ---
 
-## C3 — Config UI (Runners, Crews, Crew Detail, Add Slot)
+## C3 — Config UI (Crews, Crew Detail, Runner Detail, Add Slot)
 
 **Goal.** Wire the config CRUD to the wireframes in `design/runners-design.pen`. This is the first chunk a non-engineer can interact with.
 
+**Scope note — no top-level Runners page in MVP.** Runners are crew-scoped per PRD §3. The design file's standalone "Runners" list and "Runner Detail" frames are kept for a future v0.x surface (a cross-crew runner browser) but are *not* built in MVP. Runner CRUD happens inside Crew Detail via Add Slot and an inline edit drawer.
+
 **Deliverables.**
-- `src/pages/Runners.tsx` — list, create, edit runner templates (maps to the "Runners" frame).
-- `src/pages/RunnerDetail.tsx` — edit a runner's handle / binary / system prompt.
-- `src/pages/Crews.tsx` — crew cards.
-- `src/pages/CrewEditor.tsx` — Crew Detail with ordered slot list, `LEAD` badge, `Set as lead` action, drag-reorder.
-- `src/components/AddSlotModal.tsx` — modal form.
+- `src/pages/Crews.tsx` — crew cards (create, list, delete).
+- `src/pages/CrewEditor.tsx` — Crew Detail: ordered runner list within the crew, `LEAD` badge, `Set as lead` action, drag-reorder, delete-runner.
+- `src/components/AddSlotModal.tsx` — modal form: handle, runtime, command/args, cwd, system prompt. First runner in a crew is auto-lead (per C2).
+- `src/components/RunnerEditDrawer.tsx` — slide-over to edit an existing runner's fields in place. Reuses the Runner Detail frame's layout but inside Crew Detail context.
 - All pages call Tauri commands via a tiny `src/lib/api.ts` wrapper.
 
-**Manual test plan.** Create two runner templates, create a crew, add two slots, reassign lead, delete lead, confirm auto-promotion.
+**Manual test plan.** Create a crew, add two runners, reassign lead, delete lead, confirm auto-promotion to the next runner by `position`.
 
-**Out of scope.** Mission workspace, Start Mission modal. Slots' system-prompt override field renders but is a write-only stub until v0.x.
+**Out of scope.** Mission workspace, Start Mission modal. Standalone Runners list/detail pages (design exists, MVP does not build them).
 
 ---
 
@@ -198,12 +204,14 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 **Deliverables.**
 - `src-tauri/src/orchestrator/mod.rs`:
   - Policy loader (reads the crew's policy JSON).
-  - Built-in rules always loaded:
-    - `mission_goal → inject_stdin @lead` with a composed prompt including the goal, the crew roster, and coordination instructions (see arch §4 for the template).
-    - `broadcast message from human → inject_stdin @lead` (lead-routing invariant).
-    - `directed message → inject_stdin @<to>` (any runner, any sender). This is how lead-mediated HITL works: a worker's "I need to ask the human…" message to `@lead` lands on lead's stdin immediately, and lead's forwarded answer lands on the worker's stdin the same way.
-    - `ask_human signal → emit human_question event + open card in UI`. If `payload.on_behalf_of` is present (the lead-mediated case), carry it into the `human_question` payload so the UI can render the attribution chain.
-    - `human_response event → inject_stdin to the runner that emitted the matching ask_human` — which is the lead in the lead-mediated flow, or the worker in the fallback direct flow. Orchestrator looks up the original asker by `question_id`.
+  - Built-in rules — **all signal-driven** (per arch §5.5.0, messages never trigger orchestrator actions):
+    - `signal mission_goal → inject_stdin @lead` with a composed prompt including the goal, the crew roster, and coordination instructions (see arch §4 for the template).
+    - `signal human_broadcast (from: human, to: null) → inject_stdin @lead` with the text payload. The workspace input emits this signal when the user posts without a `--to`.
+    - `signal human_direct (from: human, to: <handle>) → inject_stdin @<handle>` with the text payload. Workspace input emits this when the user picks a `to:`.
+    - `signal ask_lead → inject_stdin @lead` with the payload rendered into the injection template. This is the worker-asks-lead half of the lead-mediated HITL flow.
+    - `signal ask_human → emit human_question event + open card in UI`. If `payload.on_behalf_of` is present (the lead-mediated case), carry it into the `human_question` payload so the UI can render the attribution chain.
+    - `signal human_response → inject_stdin to the runner that emitted the matching ask_human` — the lead in the lead-mediated flow, the worker in the fallback direct flow. Orchestrator looks up the original asker by `question_id`.
+  - Lead-forwards-answer back to worker and any runner-to-runner exchange are **directed messages**, not orchestrator actions — recipients see them on their next `runners msg read`. No `directed message → inject` rule in MVP.
   - Dispatch ledger (in-memory map of `triggering_event_id → handled`) so replay is idempotent.
   - Pending-ask map keyed by `question_id`.
 
@@ -241,7 +249,10 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 - `src/pages/MissionWorkspace.tsx` — subscribes to `event/appended`, renders the feed.
 - `src/components/EventFeed.tsx` — message / signal / `ask_human` card variants.
 - `src/components/AskHumanCard.tsx` — buttons emit a `human_response` signal. If the underlying `human_question` carries `on_behalf_of`, render the attribution chain (e.g. *@impl → @architect → you*).
-- `src/components/MissionInput.tsx` — the Slack-channel input. Default `to: @<lead>`. `message` / `signal` mode toggle. Submitting calls a Tauri `human_post_message` command that writes to the log.
+- `src/components/MissionInput.tsx` — the Slack-channel input. Default `to: @<lead>`. Submitting always emits a signal (not a message) so the orchestrator can wake the recipient, per arch §5.5.0:
+  - no `to:` → `signal human_broadcast { text }`.
+  - `to: @<handle>` → `signal human_direct { text, to: <handle> }`.
+  The UI label can still say "message" for user-facing clarity; the underlying event kind is `signal`.
 - `src/components/RunnersRail.tsx` — list of sessions with status dot, `LEAD` badge, "open pty" action.
 - `src/components/RunnerTerminal.tsx` — xterm.js bound to the session output stream (popped out of the rail).
 

--- a/docs/impls/v0-mvp.md
+++ b/docs/impls/v0-mvp.md
@@ -66,21 +66,9 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 
 **Deliverables.**
 - `src-tauri/src/db.rs` — connection pool with WAL mode, `rusqlite` migrations runner, bootstrapped at app start.
-- Migration `0001_init.sql` creating (field names match arch §5.2 / §6 data model exactly):
-  - `crews(id, name, purpose, goal, orchestrator_policy, signal_types, created_at, updated_at)`. `purpose` is short prose; `goal` is the default mission goal; `orchestrator_policy` is a JSON blob (nullable / empty for MVP — C8 only uses built-ins but the column is reserved); `signal_types` is a JSON array of allowed signal type strings.
-  - `runners(id, crew_id, handle, display_name, role, runtime, command, args_json, working_dir, env_json, system_prompt, lead, position, created_at, updated_at)` with:
-    - `runtime` = one of `claude-code`, `codex`, `aider`, `shell` (enum stored as TEXT).
-    - `command` + `args_json` are the spawn form; `env_json` is a JSON map merged onto the session env at spawn time; `working_dir` is the runner's PTY cwd override (null = use mission cwd).
-    - `UNIQUE(crew_id, handle)`.
-    - `FOREIGN KEY(crew_id) REFERENCES crews(id) ON DELETE CASCADE`.
-  - `missions(id, crew_id, title, goal_override, cwd, status, started_at, stopped_at)`. `goal_override` is nullable; when null, the mission inherits `crews.goal`.
-  - `sessions(id, mission_id, runner_id, handle, pid, status, started_at, stopped_at)` — persisted so the reopen path (see C7/C8 replay) can identify which runners were active. PTYs themselves are not restored across app restarts.
-- Separate partial index for the lead invariant (SQLite requires a standalone statement for partial uniqueness, not inline in `CREATE TABLE`):
-  ```sql
-  CREATE UNIQUE INDEX one_lead_per_crew ON runners(crew_id) WHERE lead = 1;
-  ```
+- Migration `0001_init.sql` — implements **arch §7.1 verbatim**, including the four tables (`crews`, `runners`, `missions`, `sessions`) and the `one_lead_per_crew` partial unique index. No additions, no renames. The plan used to list the columns inline; that list has been deleted to remove the two-source-of-truth risk the earlier review called out. Implementers copy §7.1 directly into `0001_init.sql`.
 - **Default signal-type allowlist.** Every new crew row is seeded with `signal_types = ["mission_goal", "human_said", "ask_lead", "ask_human", "human_question", "human_response", "inbox_read"]` — the full set of built-in types the MVP needs. Users can extend this list in v0.x; in MVP it is write-only from the DB layer. Without this seeding the CLI will reject the built-in signals at spawn time per arch §5.3 Layer 2.
-- Rust types in `src-tauri/src/model.rs`: `Crew`, `Runner`, `Mission`, `Session`, `Event`, `EventKind`, `SignalType`, serde-derived. Serde field attributes map Rust snake_case fields like `args`, `working_dir`, `env` to the DB/JSON column names `args_json`, `working_dir`, `env_json` consistently.
+- Rust types in `src-tauri/src/model.rs`: `Crew`, `Runner`, `Mission`, `Session`, `Event`, `EventKind`, `SignalType`, serde-derived. Serde field attributes map Rust-idiomatic snake_case (`args`, `env`) to the DB column names (`args_json`, `env_json`) where they differ.
 - TS types in `src/lib/types.ts` hand-synced with Rust (we're not pulling in `ts-rs` yet — too much ceremony for the MVP).
 
 **Tests.** Constraint tests for the partial unique index: inserting two leads in one crew fails; inserting leads across crews succeeds. Round-trip tests for the JSON-blob columns (`orchestrator_policy`, `signal_types`, `env`).
@@ -91,7 +79,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 
 ## C2 — Config CRUD (runners, crews, lead invariant)
 
-**Goal.** Tauri commands for managing runner templates and crews with the lead invariant enforced at the Rust layer in addition to the DB.
+**Goal.** Tauri commands for managing crews and their crew-scoped runners, with the lead invariant enforced at the Rust layer in addition to the DB.
 
 **Deliverables.**
 - `src-tauri/src/commands/crew.rs` — `crew_list`, `crew_create`, `crew_update`, `crew_delete`.

--- a/docs/impls/v0-mvp.md
+++ b/docs/impls/v0-mvp.md
@@ -66,20 +66,21 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 
 **Deliverables.**
 - `src-tauri/src/db.rs` — connection pool with WAL mode, `rusqlite` migrations runner, bootstrapped at app start.
-- Migration `0001_init.sql` creating:
+- Migration `0001_init.sql` creating (field names match arch §5.2 / §6 data model exactly):
   - `crews(id, name, purpose, goal, orchestrator_policy, signal_types, created_at, updated_at)`. `purpose` is short prose; `goal` is the default mission goal; `orchestrator_policy` is a JSON blob (nullable / empty for MVP — C8 only uses built-ins but the column is reserved); `signal_types` is a JSON array of allowed signal type strings.
-  - `runners(id, crew_id, handle, display_name, role, runtime, command, args, cwd, env, system_prompt, lead, position, created_at, updated_at)` with:
+  - `runners(id, crew_id, handle, display_name, role, runtime, command, args_json, working_dir, env_json, system_prompt, lead, position, created_at, updated_at)` with:
     - `runtime` = one of `claude-code`, `codex`, `aider`, `shell` (enum stored as TEXT).
-    - `command` + `args` are the spawn form; `env` is a JSON map merged onto the session env at spawn time.
+    - `command` + `args_json` are the spawn form; `env_json` is a JSON map merged onto the session env at spawn time; `working_dir` is the runner's PTY cwd override (null = use mission cwd).
     - `UNIQUE(crew_id, handle)`.
     - `FOREIGN KEY(crew_id) REFERENCES crews(id) ON DELETE CASCADE`.
-  - `missions(id, crew_id, title, goal, cwd, status, started_at, stopped_at)`.
+  - `missions(id, crew_id, title, goal_override, cwd, status, started_at, stopped_at)`. `goal_override` is nullable; when null, the mission inherits `crews.goal`.
   - `sessions(id, mission_id, runner_id, handle, pid, status, started_at, stopped_at)` — persisted so the reopen path (see C7/C8 replay) can identify which runners were active. PTYs themselves are not restored across app restarts.
 - Separate partial index for the lead invariant (SQLite requires a standalone statement for partial uniqueness, not inline in `CREATE TABLE`):
   ```sql
   CREATE UNIQUE INDEX one_lead_per_crew ON runners(crew_id) WHERE lead = 1;
   ```
-- Rust types in `src-tauri/src/model.rs`: `Crew`, `Runner`, `Mission`, `Session`, `Event`, `EventKind`, `SignalType`, serde-derived.
+- **Default signal-type allowlist.** Every new crew row is seeded with `signal_types = ["mission_goal", "human_said", "ask_lead", "ask_human", "human_question", "human_response", "inbox_read"]` — the full set of built-in types the MVP needs. Users can extend this list in v0.x; in MVP it is write-only from the DB layer. Without this seeding the CLI will reject the built-in signals at spawn time per arch §5.3 Layer 2.
+- Rust types in `src-tauri/src/model.rs`: `Crew`, `Runner`, `Mission`, `Session`, `Event`, `EventKind`, `SignalType`, serde-derived. Serde field attributes map Rust snake_case fields like `args`, `working_dir`, `env` to the DB/JSON column names `args_json`, `working_dir`, `env_json` consistently.
 - TS types in `src/lib/types.ts` hand-synced with Rust (we're not pulling in `ts-rs` yet — too much ceremony for the MVP).
 
 **Tests.** Constraint tests for the partial unique index: inserting two leads in one crew fails; inserting leads across crews succeeds. Round-trip tests for the JSON-blob columns (`orchestrator_policy`, `signal_types`, `env`).
@@ -150,7 +151,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 
 **Deliverables.**
 - `src-tauri/src/commands/mission.rs`:
-  - `mission_start(crew_id, title, goal, cwd)` — validates the crew has ≥1 runner and exactly one lead, creates the mission row, creates the mission dir, appends `mission_start` and `mission_goal` events to the log.
+  - `mission_start(crew_id, title, goal_override, cwd)` — validates the crew has ≥1 runner and exactly one lead, creates the mission row, creates the mission dir, exports the crew's `signal_types` column to `$APPDATA/runners/crews/{crew_id}/signal_types.json` (per arch §5.3 Layer 2 — the CLI reads this sidecar to validate emitted signal types), then appends `mission_start` and `mission_goal` events to the log.
   - `mission_stop(mission_id)` — marks the mission stopped, appends `mission_stopped`.
   - `mission_list`, `mission_get`.
 - Returns enough context to the frontend that C10 can navigate to the workspace.
@@ -204,12 +205,11 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 **Deliverables.**
 - `src-tauri/src/orchestrator/mod.rs`:
   - Policy loader (reads the crew's policy JSON).
-  - Built-in rules — **all signal-driven** (per arch §5.5.0, messages never trigger orchestrator actions):
+  - Built-in rules — **all signal-driven** (per arch §5.5.0, messages never trigger orchestrator actions). Per arch §5.2, signals always carry `to: null` in v0; any target lives in `payload.target`.
     - `signal mission_goal → inject_stdin @lead` with a composed prompt including the goal, the crew roster, and coordination instructions (see arch §4 for the template).
-    - `signal human_broadcast (from: human, to: null) → inject_stdin @lead` with the text payload. The workspace input emits this signal when the user posts without a `--to`.
-    - `signal human_direct (from: human, to: <handle>) → inject_stdin @<handle>` with the text payload. Workspace input emits this when the user picks a `to:`.
-    - `signal ask_lead → inject_stdin @lead` with the payload rendered into the injection template. This is the worker-asks-lead half of the lead-mediated HITL flow.
-    - `signal ask_human → emit human_question event + open card in UI`. If `payload.on_behalf_of` is present (the lead-mediated case), carry it into the `human_question` payload so the UI can render the attribution chain.
+    - `signal human_said (from: "human", payload: { text, target? }) → inject_stdin @payload.target if set, else @lead`. One signal type covers both broadcast and directed human input; routing is payload-driven, not envelope-driven. The workspace input emits this signal on Post.
+    - `signal ask_lead (from: <worker>, payload: { question, context }) → inject_stdin @lead` with the payload rendered into the injection template. The worker-asks-lead half of the lead-mediated HITL flow.
+    - `signal ask_human (from: <runner>, payload: { prompt, choices, on_behalf_of? }) → emit human_question event + open card in UI`. If `payload.on_behalf_of` is present (the lead-mediated case), carry it into the `human_question` payload so the UI can render the attribution chain.
     - `signal human_response → inject_stdin to the runner that emitted the matching ask_human` — the lead in the lead-mediated flow, the worker in the fallback direct flow. Orchestrator looks up the original asker by `question_id`.
   - Lead-forwards-answer back to worker and any runner-to-runner exchange are **directed messages**, not orchestrator actions — recipients see them on their next `runners msg read`. No `directed message → inject` rule in MVP.
   - Dispatch ledger (in-memory map of `triggering_event_id → handled`) so replay is idempotent.
@@ -249,10 +249,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 - `src/pages/MissionWorkspace.tsx` — subscribes to `event/appended`, renders the feed.
 - `src/components/EventFeed.tsx` — message / signal / `ask_human` card variants.
 - `src/components/AskHumanCard.tsx` — buttons emit a `human_response` signal. If the underlying `human_question` carries `on_behalf_of`, render the attribution chain (e.g. *@impl → @architect → you*).
-- `src/components/MissionInput.tsx` — the Slack-channel input. Default `to: @<lead>`. Submitting always emits a signal (not a message) so the orchestrator can wake the recipient, per arch §5.5.0:
-  - no `to:` → `signal human_broadcast { text }`.
-  - `to: @<handle>` → `signal human_direct { text, to: <handle> }`.
-  The UI label can still say "message" for user-facing clarity; the underlying event kind is `signal`.
+- `src/components/MissionInput.tsx` — the Slack-channel input. Default recipient in the UI is `@<lead>`. Submitting always emits a `signal human_said` (not a message event) so the orchestrator can wake the recipient, per arch §5.5.0. Signal envelope keeps `to: null` per arch §5.2; the picked recipient lives in `payload.target` (omitted for broadcast, set to the handle for directed). The UI label can still say "message" for user-facing clarity; the underlying event kind is `signal`.
 - `src/components/RunnersRail.tsx` — list of sessions with status dot, `LEAD` badge, "open pty" action.
 - `src/components/RunnerTerminal.tsx` — xterm.js bound to the session output stream (popped out of the rail).
 

--- a/docs/impls/v0-mvp.md
+++ b/docs/impls/v0-mvp.md
@@ -1,0 +1,287 @@
+# v0 MVP — Implementation Plan
+
+> Umbrella plan for the first end-to-end vertical slice of Runners. Ships as one feature branch (`feature/v0-mvp`) with **eleven** ordered chunks, each its own commit/PR merged into the feature branch. Once the slice is demo-able end to end, the feature branch squash-merges to `main`.
+>
+> Companion to `docs/arch/v0-arch.md` (architecture) and `docs/arch/v0-prd.md` (scope).
+
+## Definition of done (demo path)
+
+From a clean launch of the app, a user can:
+
+1. Create two runner templates (one `claude-code`, one `shell`) on the **Runners** page.
+2. Create a **Crew** of two slots (lead + worker) on the **Crews** / **Crew Detail** pages; the lead invariant is enforced end-to-end.
+3. Click **Start Mission**, fill the goal, and see the Mission workspace open with two live PTY sessions.
+4. Watch the lead runner receive the goal via stdin, draft a plan, and post a directed message to the worker; see the worker's reply in the feed.
+5. Receive an `ask_human` card from any runner, click **Approve**, and see the response injected back into that runner's stdin.
+6. Post a broadcast `@human` message and have it land on the lead by default.
+7. Close and reopen the mission; the feed replays and the orchestrator's in-memory state reconstructs.
+
+Anything beyond this is explicitly v0.x or later.
+
+## Out of scope for MVP
+
+- Windows support (macOS + Linux only for v0).
+- Threads / reactions / reply-to semantics beyond `--to <handle>`.
+- LLM-in-the-loop orchestrator rules (v0 is rule-based only; see arch §2.3).
+- Envelope-level `correlation_id` / `causation_id` fields (see arch §5.2).
+- Mission branching / forking / rewind.
+- Multi-device sync, auth, cloud persistence.
+- Per-slot system-prompt overrides in Crew Detail (the UI surface exists, but the prompt-override field is a stub that renders without effect until v0.x).
+
+## Chunking principles
+
+- Each chunk lands independently: `cargo check`, `cargo test`, and `pnpm tsc --noEmit` all pass after every merge into the feature branch.
+- A chunk is ~1 day of focused work, one coherent review.
+- Dependencies flow downstream only; no circular re-opens of earlier chunks.
+- Rust chunks ship with unit tests; UI chunks ship with a manual test checklist in the PR description.
+- Commit message format: `feat(<chunk-area>): <imperative summary>`. E.g. `feat(db): schema + shared types for v0`.
+
+## Dependency graph
+
+```
+  C1  schema + shared types
+    │
+    ├─► C2  config CRUD (runners, crews, lead invariant)
+    │     │
+    │     ├─► C3  config UI (Runners, Crews, Crew Detail, Add Slot)
+    │     │
+    │     └─► C5  mission lifecycle commands
+    │           │
+    │           ├─► C6  PTY session runtime ─► C9  `runners` CLI
+    │           │
+    │           └─► C7  event bus + notify watcher ─► C8  orchestrator v0
+    │
+    └─► C4  event log primitives  (feeds C5, C7, C9)
+
+  C10  mission workspace UI   (depends on C3, C7, C8)
+  C11  missions list + Start Mission modal   (depends on C3, C5, C10)
+```
+
+C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel after C5. Everything else is serial.
+
+---
+
+## C1 — Schema + shared types
+
+**Goal.** Lay down the SQLite schema and the Rust/TS type surface that every later chunk consumes.
+
+**Deliverables.**
+- `src-tauri/src/db.rs` — connection pool with WAL mode, `rusqlite` migrations runner, bootstrapped at app start.
+- Migration `0001_init.sql` creating:
+  - `crews(id, name, purpose, created_at, updated_at)`
+  - `runners(id, crew_id, handle, display_name, role, binary, args, cwd, system_prompt, lead, position, created_at, updated_at)` with:
+    - `UNIQUE(crew_id, handle)`
+    - `UNIQUE(crew_id) WHERE lead = 1` — the lead invariant from arch §2.3.
+    - `FOREIGN KEY(crew_id) REFERENCES crews(id) ON DELETE CASCADE`
+  - `missions(id, crew_id, title, goal, cwd, status, started_at, stopped_at)`
+- Rust types in `src-tauri/src/model.rs`: `Crew`, `Runner`, `Mission`, `Event`, `EventKind`, serde-derived.
+- TS types in `src/lib/types.ts` hand-synced with Rust (we're not pulling in `ts-rs` yet — too much ceremony for the MVP).
+
+**Tests.** Constraint tests for the unique partial index: inserting two leads in one crew fails; inserting leads across crews succeeds.
+
+**Out of scope.** No Tauri commands yet — that's C2.
+
+---
+
+## C2 — Config CRUD (runners, crews, lead invariant)
+
+**Goal.** Tauri commands for managing runner templates and crews with the lead invariant enforced at the Rust layer in addition to the DB.
+
+**Deliverables.**
+- `src-tauri/src/commands/crew.rs` — `crew_list`, `crew_create`, `crew_update`, `crew_delete`.
+- `src-tauri/src/commands/runner.rs` — `runner_list(crew_id)`, `runner_create`, `runner_update`, `runner_delete`, `runner_reorder(crew_id, ordered_ids)`, `runner_set_lead(runner_id)`.
+- Invariant rules encoded in Rust:
+  - First runner added to a crew is auto-lead.
+  - `runner_set_lead` runs in a transaction: unset old lead, set new lead, single commit.
+  - Deleting the lead while other runners remain auto-promotes the runner at the lowest `position`.
+  - Deleting the last runner of a crew is allowed (crew becomes empty, unstartable).
+
+**Tests.** `cargo test` covers: auto-lead on first insert, forbidden second lead, lead auto-promotion on delete, atomic reassign.
+
+**Out of scope.** UI, mission, PTY.
+
+---
+
+## C3 — Config UI (Runners, Crews, Crew Detail, Add Slot)
+
+**Goal.** Wire the config CRUD to the wireframes in `design/runners-design.pen`. This is the first chunk a non-engineer can interact with.
+
+**Deliverables.**
+- `src/pages/Runners.tsx` — list, create, edit runner templates (maps to the "Runners" frame).
+- `src/pages/RunnerDetail.tsx` — edit a runner's handle / binary / system prompt.
+- `src/pages/Crews.tsx` — crew cards.
+- `src/pages/CrewEditor.tsx` — Crew Detail with ordered slot list, `LEAD` badge, `Set as lead` action, drag-reorder.
+- `src/components/AddSlotModal.tsx` — modal form.
+- All pages call Tauri commands via a tiny `src/lib/api.ts` wrapper.
+
+**Manual test plan.** Create two runner templates, create a crew, add two slots, reassign lead, delete lead, confirm auto-promotion.
+
+**Out of scope.** Mission workspace, Start Mission modal. Slots' system-prompt override field renders but is a write-only stub until v0.x.
+
+---
+
+## C4 — Event log primitives
+
+**Goal.** Low-level NDJSON event log that every later chunk reads from or writes to.
+
+**Deliverables.**
+- `src-tauri/src/event_log/mod.rs`:
+  - `EventLog::open(mission_dir)` — opens `events.ndjson` with `O_APPEND | O_WRONLY | O_CREAT`.
+  - `EventLog::append(event)` — acquires `flock(LOCK_EX)`, writes a single `write(2)`, unlocks. One event = one line.
+  - `EventLog::read_from(offset)` — streaming parser used by the watcher.
+- `src-tauri/src/event_log/ulid.rs` — monotonic ULID generator (millisecond-sortable, collision-safe within the same ms).
+- Path helper: `$APPDATA/runners/crews/{crew_id}/missions/{mission_id}/events.ndjson`.
+
+**Tests.** Concurrent append from N threads never interleaves, ULID ordering is stable, parser round-trips all `EventKind` variants.
+
+**Out of scope.** The notify watcher itself (C7) — this chunk only ships the append + parse.
+
+---
+
+## C5 — Mission lifecycle commands
+
+**Goal.** Start and stop missions. No PTYs yet — this chunk is the bookkeeping layer.
+
+**Deliverables.**
+- `src-tauri/src/commands/mission.rs`:
+  - `mission_start(crew_id, title, goal, cwd)` — validates the crew has ≥1 runner and exactly one lead, creates the mission row, creates the mission dir, appends `mission_start` and `mission_goal` events to the log.
+  - `mission_stop(mission_id)` — marks the mission stopped, appends `mission_stopped`.
+  - `mission_list`, `mission_get`.
+- Returns enough context to the frontend that C10 can navigate to the workspace.
+
+**Tests.** Starting a crewless / leadless crew errors cleanly. `mission_start` writes the expected two opening events.
+
+**Out of scope.** Actually spawning runner processes — that's C6.
+
+---
+
+## C6 — PTY session runtime
+
+**Goal.** Spawn one PTY-backed session per runner for a running mission.
+
+**Deliverables.**
+- `src-tauri/src/session/manager.rs`:
+  - `SessionManager` owns `HashMap<SessionId, Session>`.
+  - `spawn(mission, runner)` — uses `portable-pty`, sets env (`RUNNERS_CREW_ID`, `RUNNERS_MISSION_ID`, `RUNNERS_RUNNER_HANDLE`, `RUNNERS_EVENT_LOG`, augmented `PATH` that puts the bundled `runners` CLI first).
+  - `inject_stdin(session_id, text)` — through a write channel.
+  - `pause(session_id)` (SIGSTOP on Unix), `resume(session_id)` (SIGCONT), `kill(session_id)`.
+- Reader thread per session: stdout/stderr → ring buffer (last N KB) → Tauri event `session/output`.
+- Hooks into C5 so `mission_start` spawns all sessions and `mission_stop` kills them.
+
+**Tests.** Spawn a `sh`, inject `echo hi`, read `hi` back. Pause/resume changes process state.
+
+**Out of scope.** xterm.js frontend — that's part of C10.
+
+---
+
+## C7 — Event bus + notify watcher
+
+**Goal.** Tail the mission's `events.ndjson` and broadcast events to the rest of the process.
+
+**Deliverables.**
+- `src-tauri/src/event_bus/mod.rs`:
+  - `EventBus::for_mission(mission)` — starts a `notify` watcher on the log file; on `Modify`, reads from last offset, parses new lines.
+  - Per-runner inbox projection: `events where to = null OR to = runner.handle`.
+  - Per-runner read watermark, driven by `inbox_read` signals (never inferred from `--since`).
+  - Emits Tauri events: `event/appended`, `inbox/updated`, `watermark/advanced`.
+
+**Tests.** Append events, watcher sees them, projections include/exclude the right rows.
+
+**Out of scope.** Orchestrator reactions to events — that's C8.
+
+---
+
+## C8 — Orchestrator v0
+
+**Goal.** The deterministic rule-based router that turns events into actions.
+
+**Deliverables.**
+- `src-tauri/src/orchestrator/mod.rs`:
+  - Policy loader (reads the crew's policy JSON).
+  - Built-in rules always loaded:
+    - `mission_goal → inject_stdin @lead` with a composed prompt including the goal, the crew roster, and coordination instructions (see arch §4 for the template).
+    - `broadcast message from human → inject_stdin @lead` (lead-routing invariant).
+    - `directed message → inject_stdin @<to>` (any runner, any sender).
+    - `ask_human signal → emit human_question event + open card in UI`.
+    - `human_response event → inject_stdin to the original asker`.
+  - Dispatch ledger (in-memory map of `triggering_event_id → handled`) so replay is idempotent.
+  - Pending-ask map keyed by `question_id`.
+
+**Tests.** Each built-in rule fires exactly once. Replay after reopen reconstructs state from the log. `human_response` without a matching `human_question` is dropped with a log warning, not panic.
+
+**Out of scope.** LLM policy, user-authored rules. MVP ships only the built-ins plus a no-op policy slot.
+
+---
+
+## C9 — `runners` CLI binary
+
+**Goal.** The binary each runner's PTY calls to post events. Without this, runners can't talk to the log.
+
+**Deliverables.**
+- `cli/` crate in the workspace: `runners` binary.
+- Resolves envelope fields from env vars set by C6.
+- Commands:
+  - `runners signal <type> [--payload <json>]`
+  - `runners msg post <text> [--to <handle>]`
+  - `runners msg read [--since <ts>] [--from <handle>]` — emits `inbox_read` signal with `payload.up_to = max ULID`.
+  - `runners help`.
+- Reuses `event_log` crate from C4 directly (shared crate, not duplicated code).
+
+**Tests.** Integration test: spawn a shell with the env a real session would have, run CLI commands, assert events land in the ndjson.
+
+**Out of scope.** Any form of direct-to-orchestrator RPC — everything goes through the log.
+
+---
+
+## C10 — Mission workspace UI
+
+**Goal.** Render the live mission in the design's "Mission workspace" frame.
+
+**Deliverables.**
+- `src/pages/MissionWorkspace.tsx` — subscribes to `event/appended`, renders the feed.
+- `src/components/EventFeed.tsx` — message / signal / `ask_human` card variants.
+- `src/components/AskHumanCard.tsx` — buttons emit a `human_response` signal.
+- `src/components/MissionInput.tsx` — the Slack-channel input. Default `to: @<lead>`. `message` / `signal` mode toggle. Submitting calls a Tauri `human_post_message` command that writes to the log.
+- `src/components/RunnersRail.tsx` — list of sessions with status dot, `LEAD` badge, "open pty" action.
+- `src/components/RunnerTerminal.tsx` — xterm.js bound to the session output stream (popped out of the rail).
+
+**Manual test plan.** End-to-end demo path from the "Definition of done" section.
+
+**Out of scope.** The Start Mission modal itself — that's C11.
+
+---
+
+## C11 — Missions list + Start Mission modal
+
+**Goal.** The entrypoint to everything C10 renders. The final chunk that closes the loop.
+
+**Deliverables.**
+- `src/pages/Missions.tsx` — Active / Past tabs, mission rows, status dot, "pending ask" flag derived from orchestrator state.
+- `src/components/StartMissionModal.tsx` — crew picker, title, goal textarea, cwd with `Browse…`, Advanced collapse (stubbed).
+- Navigation: Start → call `mission_start` → route to `/missions/:id`.
+
+**Manual test plan.** From Home, pick a crew, start a mission, land on the workspace, interact, close, reopen from Missions list.
+
+**Out of scope.** Mission archive / search / filter — deferred.
+
+---
+
+## Commit message convention (all chunks)
+
+```
+feat(<area>): <imperative summary>
+
+<body — what changed and why, mentioning the chunk letter>
+
+Part of the v0 MVP umbrella. See docs/impls/v0-mvp.md.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+Areas: `db`, `commands`, `ui`, `event-log`, `session`, `event-bus`, `orchestrator`, `cli`, `mission`.
+
+## Branching
+
+- Feature branch: `feature/v0-mvp`, branched from `main`.
+- Each chunk PR targets `feature/v0-mvp`, merged with `--squash --delete-branch`.
+- Once C11 lands and the demo path passes, `feature/v0-mvp` squash-merges to `main` with a summary commit message.


### PR DESCRIPTION
## Summary
- Adds \`docs/impls/v0-mvp.md\` — umbrella plan for the v0 MVP.
- Breaks the first end-to-end vertical slice into **11 chunks** (C1–C11) with a clear dependency graph; each chunk is its own squash-merged PR into a shared \`feature/v0-mvp\` branch.
- Documents the demo "definition of done" (lead dispatches → worker replies → ask_human roundtrip → reopen + replay), explicit out-of-scope list, and commit / branching conventions.

## Test plan
- [ ] Skim \`docs/impls/v0-mvp.md\` and confirm the chunking feels right before C1 starts
- [ ] Sanity-check the out-of-scope list against \`v0-prd.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)