### PR TITLE
ci: GitHub Actions PR workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, "feature/**"]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec tsc --noEmit
+      - run: pnpm run lint
+
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: src-tauri
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri
+      # Tauri 2 on Linux needs webkit2gtk and friends even for `cargo check`
+      # because tauri-runtime-wry links against them.
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
+      - run: cargo fmt --check
+      - run: cargo clippy --all-targets -- -D warnings
+      - run: cargo check
+      - run: cargo test


### PR DESCRIPTION
## Summary

Adds `.github/workflows/ci.yaml` so every sub-PR (into \`feature/v0-mvp\` or \`main\`) is gated by the same checks we run locally via \`make test\` + \`make check\`.

- **Frontend job**: \`pnpm install --frozen-lockfile\` → \`pnpm exec tsc --noEmit\` → \`pnpm run lint\`.
- **Backend job**: \`cargo fmt --check\` → \`cargo clippy --all-targets -D warnings\` → \`cargo check\` → \`cargo test\`.

Triggers on PRs into \`main\` or any \`feature/**\` branch. \`concurrency\` group cancels superseded runs on the same ref.

Patterned after quill's \`.github/workflows/ci.yaml\`, adapted for:
- **pnpm** — runners uses \`pnpm-lock.yaml\`, so the workflow uses \`pnpm/action-setup@v4\` + \`cache: pnpm\` instead of npm.
- **Stricter Rust gate** — adds \`cargo fmt --check\` (missed-format was a prior reviewer finding), runs \`cargo test\` (full suite) instead of \`--lib\` since we'll add integration tests in C6 and C9.
- **Linux system deps** — \`libwebkit2gtk-4.1-dev\`, \`libgtk-3-dev\`, \`libayatana-appindicator3-dev\`, \`librsvg2-dev\`: tauri-runtime-wry links against them even for \`cargo check\` on Ubuntu.

## Test plan

- [x] \`cargo fmt --check\` locally
- [x] \`cargo clippy --all-targets -- -D warnings\` locally — clean
- [x] \`pnpm run lint\` locally — clean
- [x] \`cargo test\` + \`pnpm exec tsc --noEmit\` locally — clean
- [ ] Verify CI passes on this PR and on #7 (C2) once it rebases/picks this up

🤖 Generated with [Claude Code](https://claude.com/claude-code)