### PR TITLE
feat(session): PTY session runtime + debug page (C6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3280,6 +3280,7 @@ name = "runners"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "libc",
  "portable-pty",
  "r2d2",
  "r2d2_sqlite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,6 +829,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -875,7 +881,7 @@ dependencies = [
  "rustc_version",
  "toml 0.9.12+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -1001,8 +1007,19 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "rustc_version",
+]
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
 ]
 
 [[package]]
@@ -1842,6 +1859,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ioctl-rs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2007,6 +2033,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,6 +2187,15 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
@@ -2245,6 +2286,20 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nix"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset 0.6.5",
+ "pin-utils",
+]
 
 [[package]]
 name = "nodrop"
@@ -2717,6 +2772,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "piper"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,6 +2832,27 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "portable-pty"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806ee80c2a03dbe1a9fb9534f8d19e4c0546b790cde8fd1fea9d6390644cb0be"
+dependencies = [
+ "anyhow",
+ "bitflags 1.3.2",
+ "downcast-rs",
+ "filedescriptor",
+ "lazy_static",
+ "libc",
+ "log",
+ "nix",
+ "serial",
+ "shared_library",
+ "shell-words",
+ "winapi",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -3198,6 +3280,7 @@ name = "runners"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "portable-pty",
  "r2d2",
  "r2d2_sqlite",
  "runners-core",
@@ -3528,6 +3611,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1237a96570fc377c13baa1b88c7589ab66edced652e43ffb17088f003db3e86"
+dependencies = [
+ "serial-core",
+ "serial-unix",
+ "serial-windows",
+]
+
+[[package]]
+name = "serial-core"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f46209b345401737ae2125fe5b19a77acce90cd53e1658cda928e4fe9a64581"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "serial-unix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03fbca4c9d866e24a459cbca71283f545a37f8e3e002ad8c70593871453cab7"
+dependencies = [
+ "ioctl-rs",
+ "libc",
+ "serial-core",
+ "termios",
+]
+
+[[package]]
+name = "serial-windows"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15c6d3b776267a75d31bbdfd5d36c0ca051251caafc285827052bc53bcdc8162"
+dependencies = [
+ "libc",
+ "serial-core",
+]
+
+[[package]]
 name = "serialize-to-javascript"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3589,6 +3714,22 @@ dependencies = [
  "sigchld",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "shared_library"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9e7e0f2bfae24d8a5b5a66c5b257a83c7412304311512a0c054cd5e619da11"
+dependencies = [
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -4258,6 +4399,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termios"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5d9cf598a6d7ce700a4e6a9199da127e6819a61e64b68609683cc9a01b5683a"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4592,7 +4742,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
- "memoffset",
+ "memoffset 0.9.1",
  "tempfile",
  "windows-sys 0.61.2",
 ]
@@ -5467,6 +5617,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,3 +31,4 @@ ulid = { workspace = true }
 # Regular dep (not dev-only) because the sidecar writer needs
 # NamedTempFile::persist for a Windows-safe atomic replace.
 tempfile = "3"
+portable-pty = "0.8"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,3 +32,8 @@ ulid = { workspace = true }
 # NamedTempFile::persist for a Windows-safe atomic replace.
 tempfile = "3"
 portable-pty = "0.8"
+
+# Unix-only: SIGTERM/SIGKILL escalation inside SessionManager::kill. Windows
+# gets a different path in a future chunk (v0 scope is macOS + Linux).
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -331,15 +331,15 @@ pub async fn mission_start(
         start(&mut conn, &state.app_data_dir, input)?
     };
 
-    // Mission row + opening events are durable — spawn one PTY per runner.
-    // If a spawn fails, we propagate the error but leave the mission and any
-    // successfully-spawned sessions alone so the operator can inspect and
-    // recover. A stricter all-or-nothing policy belongs in a future chunk
-    // once session restart / abort semantics exist.
+    // Mission row + opening events are durable. Now spawn one PTY per
+    // runner. This loop is **all-or-nothing**: if any spawn fails we kill
+    // the sessions we already created, flip the mission to `aborted`, and
+    // return the error. Without this the caller could see "err" while the
+    // crew still has half a live mission that blocks future starts via
+    // the one-live-mission-per-crew invariant.
     //
     // Post-C5.5a the roster lives in `crew_runners`, so we join through it
-    // instead of listing global runners. Each `CrewRunner` carries the
-    // runner row we need to spawn plus the per-crew slot metadata we don't.
+    // instead of listing global runners.
     let roster = {
         let conn = state.db.get()?;
         crew_runner::list(&conn, &out.mission.crew_id)?
@@ -348,24 +348,40 @@ pub async fn mission_start(
         event_log::events_path(&state.app_data_dir, &out.mission.crew_id, &out.mission.id);
     let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app.clone()));
     for member in roster {
-        state.sessions.spawn(
+        let spawn_res = state.sessions.spawn(
             &out.mission,
             &member.runner,
+            &state.app_data_dir,
             events_log_path.clone(),
             state.db.clone(),
             Arc::clone(&emitter),
-        )?;
+        );
+        if let Err(e) = spawn_res {
+            // Rollback: kill the sessions that did start, mark the mission
+            // aborted so the crew isn't stuck behind a phantom `running`,
+            // then surface the original spawn error.
+            let _ = state.sessions.kill_all_for_mission(&out.mission.id);
+            if let Ok(conn) = state.db.get() {
+                let _ = conn.execute(
+                    "UPDATE missions
+                        SET status = 'aborted', stopped_at = ?1
+                      WHERE id = ?2",
+                    rusqlite::params![Utc::now().to_rfc3339(), out.mission.id],
+                );
+            }
+            return Err(e);
+        }
     }
     Ok(out)
 }
 
 #[tauri::command]
 pub async fn mission_stop(state: State<'_, AppState>, id: String) -> Result<Mission> {
-    // Kill live sessions first so their reader threads drain before we flip
-    // the mission row. A fully parallel shutdown is fine too, but this
-    // ordering keeps the event log ordering sane: all `session/exit`s land
-    // before `mission_stopped`.
-    let _ = state.sessions.kill_all_for_mission(&id);
+    // Kill first, then flip the mission row. `kill_all_for_mission` blocks
+    // until every reader thread has joined — which means every child has
+    // been reaped and every `sessions` row has reached a terminal status.
+    // Only then is it honest to call the mission `completed`.
+    state.sessions.kill_all_for_mission(&id)?;
     let mut conn = state.db.get()?;
     stop(&mut conn, &state.app_data_dir, &id)
 }

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -320,14 +320,52 @@ fn write_signal_types_sidecar(
 #[tauri::command]
 pub async fn mission_start(
     state: State<'_, AppState>,
+    app: tauri::AppHandle,
     input: StartMissionInput,
 ) -> Result<StartMissionOutput> {
-    let mut conn = state.db.get()?;
-    start(&mut conn, &state.app_data_dir, input)
+    use crate::session::manager::{SessionEvents, TauriSessionEvents};
+    use std::sync::Arc;
+
+    let out = {
+        let mut conn = state.db.get()?;
+        start(&mut conn, &state.app_data_dir, input)?
+    };
+
+    // Mission row + opening events are durable — spawn one PTY per runner.
+    // If a spawn fails, we propagate the error but leave the mission and any
+    // successfully-spawned sessions alone so the operator can inspect and
+    // recover. A stricter all-or-nothing policy belongs in a future chunk
+    // once session restart / abort semantics exist.
+    //
+    // Post-C5.5a the roster lives in `crew_runners`, so we join through it
+    // instead of listing global runners. Each `CrewRunner` carries the
+    // runner row we need to spawn plus the per-crew slot metadata we don't.
+    let roster = {
+        let conn = state.db.get()?;
+        crew_runner::list(&conn, &out.mission.crew_id)?
+    };
+    let events_log_path =
+        event_log::events_path(&state.app_data_dir, &out.mission.crew_id, &out.mission.id);
+    let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app.clone()));
+    for member in roster {
+        state.sessions.spawn(
+            &out.mission,
+            &member.runner,
+            events_log_path.clone(),
+            state.db.clone(),
+            Arc::clone(&emitter),
+        )?;
+    }
+    Ok(out)
 }
 
 #[tauri::command]
 pub async fn mission_stop(state: State<'_, AppState>, id: String) -> Result<Mission> {
+    // Kill live sessions first so their reader threads drain before we flip
+    // the mission row. A fully parallel shutdown is fine too, but this
+    // ordering keeps the event log ordering sane: all `session/exit`s land
+    // before `mission_stopped`.
+    let _ = state.sessions.kill_all_for_mission(&id);
     let mut conn = state.db.get()?;
     stop(&mut conn, &state.app_data_dir, &id)
 }

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -8,3 +8,4 @@ pub mod crew;
 pub mod crew_runner;
 pub mod mission;
 pub mod runner;
+pub mod session;

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -1,0 +1,107 @@
+// Session Tauri commands — thin wrappers over `session::SessionManager`.
+//
+// Spawn happens inside `mission_start` (see `commands::mission`), so there's
+// no `session_spawn` here. The commands below let the frontend:
+//   - list persisted sessions for a mission (including ones that have exited)
+//   - inject bytes into a live session's stdin
+//   - kill a live session
+//
+// `session/output` and `session/exit` events flow from the PTY reader threads
+// directly via `AppHandle::emit`; the frontend subscribes without going
+// through a command.
+
+use rusqlite::{params, Row};
+use serde::{Deserialize, Serialize};
+use tauri::State;
+
+use crate::{
+    error::Result,
+    model::{Session, SessionStatus, Timestamp},
+    AppState,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionRow {
+    #[serde(flatten)]
+    pub session: Session,
+    /// Handle of the runner this session instantiates — denormalized so the
+    /// frontend can render `@coder`-style labels without a second lookup.
+    pub handle: String,
+}
+
+fn row_to_session(row: &Row<'_>) -> rusqlite::Result<SessionRow> {
+    let status: String = row.get("status")?;
+    let started_at: Option<String> = row.get("started_at")?;
+    let stopped_at: Option<String> = row.get("stopped_at")?;
+
+    let status = match status.as_str() {
+        "running" => SessionStatus::Running,
+        "stopped" => SessionStatus::Stopped,
+        "crashed" => SessionStatus::Crashed,
+        other => {
+            return Err(rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Text,
+                format!("unknown session status {other:?}").into(),
+            ))
+        }
+    };
+    let parse_ts = |s: String| -> rusqlite::Result<Timestamp> {
+        s.parse().map_err(|e: chrono::ParseError| {
+            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+        })
+    };
+    Ok(SessionRow {
+        session: Session {
+            id: row.get("id")?,
+            mission_id: row.get("mission_id")?,
+            runner_id: row.get("runner_id")?,
+            cwd: row.get("cwd")?,
+            status,
+            pid: row.get("pid")?,
+            started_at: started_at.map(parse_ts).transpose()?,
+            stopped_at: stopped_at.map(parse_ts).transpose()?,
+        },
+        handle: row.get("handle")?,
+    })
+}
+
+#[tauri::command]
+pub async fn session_list(
+    state: State<'_, AppState>,
+    mission_id: String,
+) -> Result<Vec<SessionRow>> {
+    // Order by the crew-scoped position of the runner within this mission's
+    // crew, so the UI renders sessions in the same slot order as the Crew
+    // Detail roster. `runners` is globally scoped post-C5.5a so we join
+    // through `missions` + `crew_runners` to get the crew-local position.
+    let conn = state.db.get()?;
+    let mut stmt = conn.prepare(
+        "SELECT s.id, s.mission_id, s.runner_id, s.cwd, s.status, s.pid,
+                s.started_at, s.stopped_at, r.handle
+           FROM sessions s
+           JOIN runners r ON r.id = s.runner_id
+           JOIN missions m ON m.id = s.mission_id
+           LEFT JOIN crew_runners cr
+                  ON cr.crew_id = m.crew_id AND cr.runner_id = s.runner_id
+          WHERE s.mission_id = ?1
+          ORDER BY cr.position ASC, s.started_at ASC",
+    )?;
+    let rows = stmt.query_map(params![mission_id], row_to_session)?;
+    rows.collect::<rusqlite::Result<Vec<_>>>()
+        .map_err(Into::into)
+}
+
+#[tauri::command]
+pub async fn session_inject_stdin(
+    state: State<'_, AppState>,
+    session_id: String,
+    text: String,
+) -> Result<()> {
+    state.sessions.inject_stdin(&session_id, text.as_bytes())
+}
+
+#[tauri::command]
+pub async fn session_kill(state: State<'_, AppState>, session_id: String) -> Result<()> {
+    state.sessions.kill(&session_id)
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -7,15 +7,19 @@ mod orchestrator;
 mod session;
 
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use tauri::Manager;
 
 pub struct AppState {
-    pub db: db::DbPool,
+    pub db: Arc<db::DbPool>,
     /// Root of the app's per-user data tree — `$APPDATA/runners/` on real
     /// installs, a tempdir in tests. Mission commands resolve event-log paths
     /// relative to this via `runners_core::event_log::path`.
     pub app_data_dir: PathBuf,
+    /// Live per-mission PTY sessions. Created at app start, shared across
+    /// all Tauri commands and the reader threads they spawn.
+    pub sessions: Arc<session::SessionManager>,
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -30,10 +34,11 @@ pub fn run() {
             let app_data_dir = app.path().app_data_dir()?;
             std::fs::create_dir_all(&app_data_dir)?;
             let db_path = app_data_dir.join("runners.db");
-            let pool = db::open_pool(&db_path)?;
+            let pool = Arc::new(db::open_pool(&db_path)?);
             app.manage(AppState {
                 db: pool,
                 app_data_dir,
+                sessions: session::SessionManager::new(),
             });
             Ok(())
         })
@@ -58,6 +63,9 @@ pub fn run() {
             commands::mission::mission_stop,
             commands::mission::mission_list,
             commands::mission::mission_get,
+            commands::session::session_list,
+            commands::session::session_inject_stdin,
+            commands::session::session_kill,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -194,21 +194,25 @@ impl SessionManager {
         drop(pair.slave);
 
         let pid = child.process_id();
-        let reader = pair
-            .master
-            .try_clone_reader()
-            .map_err(|e| Error::msg(format!("clone reader: {e}")))?;
-        let writer = pair
-            .master
-            .take_writer()
-            .map_err(|e| Error::msg(format!("take writer: {e}")))?;
 
+        // Everything between `spawn_command` and the live-map insert is
+        // fallible (`try_clone_reader`, `take_writer`, `sessions` INSERT).
+        // If any of it errors we'd otherwise leak the running child — the
+        // session isn't in the map yet, so `mission_start`'s rollback can't
+        // see it and nothing else ever reaps it. Group the fallible work in
+        // an IIFE so a single error handler can kill + wait the child on
+        // every post-spawn failure path.
         let session_id = ulid::Ulid::new().to_string();
         let started_at = Utc::now().to_rfc3339();
-
-        // Persist the row *before* handing the session out; if the insert
-        // fails we want the caller to see the error before it sees events.
-        {
+        let setup_res: Result<(Box<dyn Read + Send>, Box<dyn Write + Send>)> = (|| {
+            let reader = pair
+                .master
+                .try_clone_reader()
+                .map_err(|e| Error::msg(format!("clone reader: {e}")))?;
+            let writer = pair
+                .master
+                .take_writer()
+                .map_err(|e| Error::msg(format!("take writer: {e}")))?;
             let conn = pool.get()?;
             conn.execute(
                 "INSERT INTO sessions
@@ -216,7 +220,19 @@ impl SessionManager {
                  VALUES (?1, ?2, ?3, 'running', ?4, ?5)",
                 params![session_id, mission.id, runner.id, pid, started_at],
             )?;
-        }
+            Ok((reader, writer))
+        })();
+        let (reader, writer) = match setup_res {
+            Ok(rw) => rw,
+            Err(e) => {
+                // Reap the orphan. `kill` signals SIGTERM/Windows equivalent;
+                // `wait` blocks until the child is gone so the caller isn't
+                // racing against a live PID when it retries.
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(e);
+            }
+        };
 
         // Insert into the live map BEFORE starting the reader thread.
         // A short-lived child (e.g. `sh -c "echo hi"`) can exit within
@@ -658,6 +674,56 @@ mod tests {
         let mgr = SessionManager::new();
         let err = mgr.inject_stdin("nope", b"x").unwrap_err();
         assert!(format!("{err}").contains("session not found"));
+    }
+
+    #[test]
+    fn spawn_failure_after_spawn_command_reaps_the_child() {
+        // Force the `sessions` INSERT to fail by dropping the table after the
+        // pool is built. Without the post-spawn cleanup, the child would keep
+        // running after `spawn` returns Err because nothing knows about it.
+        let pool = pool_with_schema();
+        let mission = mission();
+        let mut runner = runner("/bin/cat", &[]);
+        insert_crew_runner(&pool, &mission.id, &runner.id);
+        runner.id = {
+            let conn = pool.get().unwrap();
+            conn.query_row("SELECT id FROM runners LIMIT 1", [], |r| r.get(0))
+                .unwrap()
+        };
+        let fresh_mission_id: String = {
+            let conn = pool.get().unwrap();
+            conn.query_row("SELECT id FROM missions LIMIT 1", [], |r| r.get(0))
+                .unwrap()
+        };
+        let mission = Mission {
+            id: fresh_mission_id,
+            ..mission
+        };
+
+        // Break the schema so the next INSERT fails.
+        pool.get()
+            .unwrap()
+            .execute("DROP TABLE sessions", [])
+            .unwrap();
+
+        let mgr = SessionManager::new();
+        let err = mgr
+            .spawn(
+                &mission,
+                &runner,
+                std::path::Path::new("/tmp"),
+                PathBuf::from("/dev/null"),
+                Arc::clone(&pool),
+                capture(),
+            )
+            .unwrap_err();
+        // The error must surface the DB failure, not a spawn failure.
+        assert!(
+            format!("{err}").contains("sessions") || format!("{err}").contains("no such table"),
+            "unexpected error: {err}"
+        );
+        // No live session left behind.
+        assert!(mgr.sessions.lock().unwrap().is_empty());
     }
 
     #[test]

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1,0 +1,582 @@
+// Per-runner PTY session runtime.
+//
+// One `Session` = one `portable_pty` child running the runner's CLI agent. The
+// SessionManager holds the map of live sessions so Tauri commands can look
+// them up by id (for stdin injection, pause/resume, kill). Each session owns:
+//
+//   - A `MasterPty` handle (Tauri process side). The slave end is closed
+//     immediately after spawn — we never read from it.
+//   - A reader thread that drains the PTY and emits `session/output` Tauri
+//     events. When the reader hits EOF (child exited, signaled, or we killed
+//     it), it reaps the child, emits `session/exit`, and updates the DB row.
+//   - A writer behind a Mutex for `inject_stdin`.
+//
+// Drop behavior: killing the app process drops the SessionManager, which
+// drops every `SessionHandle`, which drops each `Child`. `portable-pty`'s
+// Child wrappers on Unix do not SIGKILL on drop — we take care of this in
+// `SessionManager::kill_all` at app shutdown (future work; for MVP the
+// child inherits our process group and dies when we exit).
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+use chrono::Utc;
+use portable_pty::{CommandBuilder, MasterPty, PtySize};
+use rusqlite::params;
+use serde::Serialize;
+
+use crate::db::DbPool;
+use crate::error::{Error, Result};
+use crate::model::{Mission, Runner};
+
+/// Decouples the PTY layer from Tauri so the reader thread can be unit-tested
+/// with a fake. Prod wraps an `AppHandle::emit`; tests use a no-op or a
+/// channel-capture impl.
+pub trait SessionEvents: Send + Sync + 'static {
+    fn output(&self, ev: &OutputEvent);
+    fn exit(&self, ev: &ExitEvent);
+}
+
+/// Emitter for the real Tauri app — emits `session/output` and `session/exit`.
+pub struct TauriSessionEvents(pub tauri::AppHandle);
+
+impl SessionEvents for TauriSessionEvents {
+    fn output(&self, ev: &OutputEvent) {
+        use tauri::Emitter;
+        let _ = self.0.emit("session/output", ev);
+    }
+    fn exit(&self, ev: &ExitEvent) {
+        use tauri::Emitter;
+        let _ = self.0.emit("session/exit", ev);
+    }
+}
+
+/// Contents of `session/output` events emitted to the frontend. The raw PTY
+/// bytes are base64-encoded so the event payload is valid JSON regardless of
+/// what the child wrote (ANSI escapes, non-UTF-8, etc.). The frontend decodes
+/// before feeding xterm.js.
+#[derive(Debug, Clone, Serialize)]
+pub struct OutputEvent {
+    pub session_id: String,
+    pub mission_id: String,
+    /// Lossy UTF-8 of the chunk — good enough for the MVP debug page. xterm.js
+    /// integration in C10 will switch this to base64 bytes.
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExitEvent {
+    pub session_id: String,
+    pub mission_id: String,
+    pub exit_code: Option<i32>,
+    pub success: bool,
+}
+
+/// Row returned to the frontend after a spawn. Subset of the DB `sessions`
+/// row with the runner handle denormalized so the debug page can render
+/// `@coder`-style labels without a separate lookup.
+#[derive(Debug, Clone, Serialize)]
+pub struct SpawnedSession {
+    pub id: String,
+    pub mission_id: String,
+    pub runner_id: String,
+    pub handle: String,
+    pub pid: Option<u32>,
+}
+
+struct SessionHandle {
+    // Kept for debugging and future kill-by-pid / identity checks.
+    #[allow(dead_code)]
+    id: String,
+    mission_id: String,
+    /// Retained so the master PTY isn't dropped early; without this the
+    /// child's stdin/stdout would be closed the moment `spawn` returns.
+    #[allow(dead_code)]
+    master: Box<dyn MasterPty + Send>,
+    writer: Mutex<Box<dyn Write + Send>>,
+    /// Process id of the spawned child — used by a future pause/resume path
+    /// (SIGSTOP/SIGCONT via libc) that's out of scope for C6.
+    #[allow(dead_code)]
+    pid: Option<u32>,
+}
+
+pub struct SessionManager {
+    sessions: Mutex<HashMap<String, SessionHandle>>,
+}
+
+impl SessionManager {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            sessions: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Spawn one PTY child for `runner` as part of `mission`. Persists a
+    /// `sessions` row, starts the reader thread, and returns a summary for
+    /// the frontend.
+    pub fn spawn(
+        self: &Arc<Self>,
+        mission: &Mission,
+        runner: &Runner,
+        events_log_path: PathBuf,
+        pool: Arc<DbPool>,
+        events: Arc<dyn SessionEvents>,
+    ) -> Result<SpawnedSession> {
+        let pty_system = portable_pty::native_pty_system();
+        let pair = pty_system
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| Error::msg(format!("openpty: {e}")))?;
+
+        let mut cmd = CommandBuilder::new(&runner.command);
+        cmd.args(&runner.args);
+
+        // Working directory: runner override if set, else mission cwd, else
+        // inherit parent's. `CommandBuilder::cwd` requires a concrete path.
+        if let Some(wd) = runner.working_dir.as_deref() {
+            cmd.cwd(wd);
+        } else if let Some(wd) = mission.cwd.as_deref() {
+            cmd.cwd(wd);
+        }
+
+        // Env — start from the runner's map (so the user can override /
+        // clear things they need), then layer the system-assigned vars on
+        // top so they can't be accidentally shadowed.
+        for (k, v) in &runner.env {
+            cmd.env(k, v);
+        }
+        cmd.env("RUNNERS_CREW_ID", &mission.crew_id);
+        cmd.env("RUNNERS_MISSION_ID", &mission.id);
+        cmd.env("RUNNERS_RUNNER_HANDLE", &runner.handle);
+        cmd.env(
+            "RUNNERS_EVENT_LOG",
+            events_log_path.to_string_lossy().to_string(),
+        );
+        if let Some(wd) = mission.cwd.as_deref() {
+            cmd.env("MISSION_CWD", wd);
+        }
+
+        let mut child = pair
+            .slave
+            .spawn_command(cmd)
+            .map_err(|e| Error::msg(format!("spawn {}: {e}", runner.command)))?;
+        // Closing the slave on our side means child is the only holder and
+        // our reader sees EOF the moment the child dies.
+        drop(pair.slave);
+
+        let pid = child.process_id();
+        let reader = pair
+            .master
+            .try_clone_reader()
+            .map_err(|e| Error::msg(format!("clone reader: {e}")))?;
+        let writer = pair
+            .master
+            .take_writer()
+            .map_err(|e| Error::msg(format!("take writer: {e}")))?;
+
+        let session_id = ulid::Ulid::new().to_string();
+        let started_at = Utc::now().to_rfc3339();
+
+        // Persist the row *before* handing the session out; if the insert
+        // fails we want the caller to see the error before it sees events.
+        {
+            let conn = pool.get()?;
+            conn.execute(
+                "INSERT INTO sessions
+                    (id, mission_id, runner_id, status, pid, started_at)
+                 VALUES (?1, ?2, ?3, 'running', ?4, ?5)",
+                params![session_id, mission.id, runner.id, pid, started_at],
+            )?;
+        }
+
+        // Spawn the reader thread. On EOF it reaps the child, emits exit,
+        // updates the row, and removes the session from the in-memory map.
+        {
+            let session_id_t = session_id.clone();
+            let mission_id_t = mission.id.clone();
+            let events_t = Arc::clone(&events);
+            let manager_t: Arc<SessionManager> = Arc::clone(self);
+            let pool_t: Arc<DbPool> = Arc::clone(&pool);
+            thread::spawn(move || {
+                let exit = drain_pty_and_reap(
+                    reader,
+                    &mut *child,
+                    &session_id_t,
+                    &mission_id_t,
+                    events_t.as_ref(),
+                );
+                let _ = manager_t.forget(&session_id_t);
+                if let Ok(conn) = pool_t.get() {
+                    let _ = conn.execute(
+                        "UPDATE sessions
+                            SET status = ?1, stopped_at = ?2
+                          WHERE id = ?3",
+                        params![
+                            if exit.success { "stopped" } else { "crashed" },
+                            Utc::now().to_rfc3339(),
+                            session_id_t,
+                        ],
+                    );
+                }
+                events_t.exit(&exit);
+            });
+        }
+
+        // Insert into the live map.
+        self.sessions.lock().unwrap().insert(
+            session_id.clone(),
+            SessionHandle {
+                id: session_id.clone(),
+                mission_id: mission.id.clone(),
+                master: pair.master,
+                writer: Mutex::new(writer),
+                pid,
+            },
+        );
+
+        Ok(SpawnedSession {
+            id: session_id,
+            mission_id: mission.id.clone(),
+            runner_id: runner.id.clone(),
+            handle: runner.handle.clone(),
+            pid,
+        })
+    }
+
+    /// Write raw bytes to the session's stdin.
+    pub fn inject_stdin(&self, session_id: &str, bytes: &[u8]) -> Result<()> {
+        let sessions = self.sessions.lock().unwrap();
+        let handle = sessions
+            .get(session_id)
+            .ok_or_else(|| Error::msg(format!("session not found: {session_id}")))?;
+        let mut writer = handle.writer.lock().unwrap();
+        writer.write_all(bytes)?;
+        writer.flush()?;
+        Ok(())
+    }
+
+    /// Kill the child. Reader thread will see EOF and clean up the row + map.
+    pub fn kill(&self, session_id: &str) -> Result<()> {
+        let mut sessions = self.sessions.lock().unwrap();
+        if let Some(handle) = sessions.remove(session_id) {
+            // Dropping the master PTY signals the child by closing stdin /
+            // hanging up the terminal; on Unix this SIGHUP-equivalent, which
+            // for well-behaved shells and interpreters is enough to exit.
+            // portable-pty doesn't expose a portable `kill` on the master,
+            // and we don't have the Child here — we intentionally transferred
+            // ownership into the reader thread. For MVP this is fine; a
+            // harder-kill path (via libc + stored pid) lands with C8.
+            drop(handle);
+        }
+        Ok(())
+    }
+
+    /// Kill every live session; used on mission_stop and at app shutdown.
+    pub fn kill_all_for_mission(&self, mission_id: &str) -> Result<()> {
+        let ids: Vec<String> = {
+            let sessions = self.sessions.lock().unwrap();
+            sessions
+                .values()
+                .filter(|s| s.mission_id == mission_id)
+                .map(|s| s.id.clone())
+                .collect()
+        };
+        for id in ids {
+            self.kill(&id)?;
+        }
+        Ok(())
+    }
+
+    fn forget(&self, session_id: &str) -> Result<()> {
+        self.sessions.lock().unwrap().remove(session_id);
+        Ok(())
+    }
+}
+
+/// Pumps PTY output → `session/output` events, then waits for the child to
+/// exit. Returns the exit summary that the caller emits as `session/exit`.
+fn drain_pty_and_reap(
+    mut reader: Box<dyn Read + Send>,
+    child: &mut (dyn portable_pty::Child + Send),
+    session_id: &str,
+    mission_id: &str,
+    events: &dyn SessionEvents,
+) -> ExitEvent {
+    let mut buf = [0u8; 4096];
+    loop {
+        match reader.read(&mut buf) {
+            Ok(0) => break,
+            Ok(n) => {
+                let chunk = String::from_utf8_lossy(&buf[..n]).into_owned();
+                events.output(&OutputEvent {
+                    session_id: session_id.into(),
+                    mission_id: mission_id.into(),
+                    text: chunk,
+                });
+            }
+            Err(_) => break,
+        }
+    }
+    let (exit_code, success) = match child.wait() {
+        Ok(status) => {
+            let code = status.exit_code() as i32;
+            (Some(code), status.success())
+        }
+        Err(_) => (None, false),
+    };
+    ExitEvent {
+        session_id: session_id.into(),
+        mission_id: mission_id.into(),
+        exit_code,
+        success,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // These tests don't touch Tauri — they hit the PTY layer directly. We
+    // build a minimal `Runner` row, skip the DB (the SessionManager writes
+    // to DB on spawn), and cover: spawn-echo-readback, inject-stdin-roundtrip,
+    // and exit-emits-correct-status. For DB coverage we use the app's
+    // file-backed pool helper.
+
+    use crate::db;
+    use crate::model::{MissionStatus, Runner};
+    use std::collections::HashMap;
+    use std::sync::Mutex;
+    use std::time::{Duration, Instant};
+
+    /// Test emitter that just records every event. Replaces the Tauri
+    /// `AppHandle` in unit tests — no runtime dependency.
+    #[derive(Default)]
+    struct Capture {
+        output: Mutex<Vec<OutputEvent>>,
+        exit: Mutex<Vec<ExitEvent>>,
+    }
+    impl SessionEvents for Capture {
+        fn output(&self, ev: &OutputEvent) {
+            self.output.lock().unwrap().push(ev.clone());
+        }
+        fn exit(&self, ev: &ExitEvent) {
+            self.exit.lock().unwrap().push(ev.clone());
+        }
+    }
+
+    fn runner(command: &str, args: &[&str]) -> Runner {
+        Runner {
+            id: ulid::Ulid::new().to_string(),
+            handle: "tester".into(),
+            display_name: "Tester".into(),
+            role: "test".into(),
+            runtime: "shell".into(),
+            command: command.into(),
+            args: args.iter().map(|s| s.to_string()).collect(),
+            working_dir: None,
+            system_prompt: None,
+            env: HashMap::new(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn mission() -> Mission {
+        Mission {
+            id: ulid::Ulid::new().to_string(),
+            crew_id: "crew-ignored-in-tests".into(),
+            title: "t".into(),
+            status: MissionStatus::Running,
+            goal_override: None,
+            cwd: None,
+            started_at: Utc::now(),
+            stopped_at: None,
+        }
+    }
+
+    fn capture() -> Arc<Capture> {
+        Arc::new(Capture::default())
+    }
+
+    fn pool_with_schema() -> Arc<DbPool> {
+        let tmp = tempfile::tempdir().unwrap();
+        // Leak the tempdir so the DB file outlives this fn; fine in tests.
+        let path = tmp.path().join("c6.db");
+        std::mem::forget(tmp);
+        Arc::new(db::open_pool(&path).unwrap())
+    }
+
+    fn insert_crew_runner(pool: &DbPool, mission_id: &str, runner_id: &str) {
+        // Satisfy the FKs the `sessions` INSERT needs (crew, global runner,
+        // crew membership, mission). Post-C5.5a, `runners` is global and
+        // membership is on `crew_runners` — keep this helper aligned with
+        // the live schema so spawn tests stay honest.
+        let conn = pool.get().unwrap();
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO crews (id, name, created_at, updated_at)
+             VALUES ('c', 'c', ?1, ?1)",
+            params![now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO runners
+                (id, handle, display_name, role, runtime, command,
+                 args_json, working_dir, system_prompt, env_json,
+                 created_at, updated_at)
+             VALUES (?1, 't', 'T', 'test', 'shell', '/bin/sh',
+                     NULL, NULL, NULL, NULL, ?2, ?2)",
+            params![runner_id, now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO crew_runners
+                (crew_id, runner_id, position, lead, added_at)
+             VALUES ('c', ?1, 0, 1, ?2)",
+            params![runner_id, now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO missions (id, crew_id, title, status, started_at)
+             VALUES (?1, 'c', 't', 'running', ?2)",
+            params![mission_id, now],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn spawn_echo_roundtrip() {
+        // Spawn `sh -c "echo hi && exit"`; assert the exit event fires with
+        // success=true. We skip output inspection because the Tauri mock app
+        // doesn't let us subscribe to events from a test.
+        let pool = pool_with_schema();
+        let mission = mission();
+        let mut runner = runner("/bin/sh", &["-c", "echo hi"]);
+        insert_crew_runner(&pool, &mission.id, &runner.id);
+        runner.id = {
+            let conn = pool.get().unwrap();
+            let id: String = conn
+                .query_row("SELECT id FROM runners LIMIT 1", [], |r| r.get(0))
+                .unwrap();
+            id
+        };
+        let fresh_mission_id = {
+            let conn = pool.get().unwrap();
+            let id: String = conn
+                .query_row("SELECT id FROM missions LIMIT 1", [], |r| r.get(0))
+                .unwrap();
+            id
+        };
+        let mission = Mission {
+            id: fresh_mission_id,
+            ..mission
+        };
+
+        let mgr = SessionManager::new();
+        let spawned = mgr
+            .spawn(
+                &mission,
+                &runner,
+                PathBuf::from("/dev/null"),
+                Arc::clone(&pool),
+                capture(),
+            )
+            .unwrap();
+        assert!(spawned.pid.is_some());
+
+        // Poll the DB until the reader thread has marked the session stopped.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let final_status = loop {
+            let conn = pool.get().unwrap();
+            let status: String = conn
+                .query_row(
+                    "SELECT status FROM sessions WHERE id = ?1",
+                    params![spawned.id],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            if status != "running" {
+                break status;
+            }
+            if Instant::now() > deadline {
+                panic!("session never exited");
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        };
+        assert_eq!(final_status, "stopped");
+    }
+
+    #[test]
+    fn inject_stdin_roundtrip() {
+        // Spawn `cat`, inject "hello\n", then kill. `cat` reads until stdin
+        // closes; killing the session drops the master PTY, which on Unix
+        // hangs up and `cat` sees EOF.
+        let pool = pool_with_schema();
+        let mission = mission();
+        let mut runner = runner("/bin/cat", &[]);
+        insert_crew_runner(&pool, &mission.id, &runner.id);
+        runner.id = {
+            let conn = pool.get().unwrap();
+            conn.query_row("SELECT id FROM runners LIMIT 1", [], |r| r.get(0))
+                .unwrap()
+        };
+        let fresh_mission_id = {
+            let conn = pool.get().unwrap();
+            conn.query_row("SELECT id FROM missions LIMIT 1", [], |r| r.get(0))
+                .unwrap()
+        };
+        let mission = Mission {
+            id: fresh_mission_id,
+            ..mission
+        };
+
+        let mgr = SessionManager::new();
+        let spawned = mgr
+            .spawn(
+                &mission,
+                &runner,
+                PathBuf::from("/dev/null"),
+                Arc::clone(&pool),
+                capture(),
+            )
+            .unwrap();
+        mgr.inject_stdin(&spawned.id, b"hello\n").unwrap();
+        // Brief wait so `cat` echoes before we hang up.
+        std::thread::sleep(Duration::from_millis(100));
+        mgr.kill(&spawned.id).unwrap();
+
+        // After kill, reader thread exits and updates the row.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            let conn = pool.get().unwrap();
+            let status: String = conn
+                .query_row(
+                    "SELECT status FROM sessions WHERE id = ?1",
+                    params![spawned.id],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            if status != "running" {
+                break;
+            }
+            if Instant::now() > deadline {
+                panic!("session never exited after kill");
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+
+    #[test]
+    fn inject_stdin_on_unknown_session_errors_cleanly() {
+        let mgr = SessionManager::new();
+        let err = mgr.inject_stdin("nope", b"x").unwrap_err();
+        assert!(format!("{err}").contains("session not found"));
+    }
+}

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -19,7 +19,7 @@
 
 use std::collections::HashMap;
 use std::io::{Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::thread;
 
@@ -92,15 +92,17 @@ struct SessionHandle {
     #[allow(dead_code)]
     id: String,
     mission_id: String,
-    /// Retained so the master PTY isn't dropped early; without this the
-    /// child's stdin/stdout would be closed the moment `spawn` returns.
-    #[allow(dead_code)]
-    master: Box<dyn MasterPty + Send>,
+    /// Optionally holds the master PTY. `kill` takes it to drop-close the
+    /// terminal (signals the child's SIGHUP) before signaling/joining.
+    master: Option<Box<dyn MasterPty + Send>>,
     writer: Mutex<Box<dyn Write + Send>>,
-    /// Process id of the spawned child — used by a future pause/resume path
-    /// (SIGSTOP/SIGCONT via libc) that's out of scope for C6.
-    #[allow(dead_code)]
+    /// OS process id of the spawned child. Used by `kill` to escalate
+    /// SIGTERM → SIGKILL if the PTY hangup alone doesn't reap the child.
     pid: Option<u32>,
+    /// Handle for the reader thread that drains the PTY + reaps the child.
+    /// `kill` joins on it so the caller is guaranteed the `sessions` row is
+    /// in a terminal status by the time we return.
+    reader: Option<thread::JoinHandle<()>>,
 }
 
 pub struct SessionManager {
@@ -117,10 +119,16 @@ impl SessionManager {
     /// Spawn one PTY child for `runner` as part of `mission`. Persists a
     /// `sessions` row, starts the reader thread, and returns a summary for
     /// the frontend.
+    ///
+    /// `app_data_dir` is the root of `$APPDATA/runners/` so we can prepend
+    /// `<app_data_dir>/bin` onto the child's PATH — arch §5.3 Layer 2 and
+    /// v0-mvp.md C9 both require the bundled `runners` CLI to win over any
+    /// system binary with the same name.
     pub fn spawn(
         self: &Arc<Self>,
         mission: &Mission,
         runner: &Runner,
+        app_data_dir: &Path,
         events_log_path: PathBuf,
         pool: Arc<DbPool>,
         events: Arc<dyn SessionEvents>,
@@ -152,6 +160,20 @@ impl SessionManager {
         for (k, v) in &runner.env {
             cmd.env(k, v);
         }
+        // Prepend the bundled CLI directory to PATH so `runners` on the
+        // child's PATH resolves to our drop (C9 installs it here) before
+        // any system binary with the same name. Inherit the parent PATH
+        // as the tail — if nothing else, agents need `sh`, `git`, `node`.
+        let bin_dir = app_data_dir.join("bin");
+        let sep = if cfg!(windows) { ';' } else { ':' };
+        let parent_path = std::env::var_os("PATH").unwrap_or_default();
+        let mut new_path = std::ffi::OsString::from(bin_dir.as_os_str());
+        if !parent_path.is_empty() {
+            new_path.push(std::ffi::OsString::from(sep.to_string()));
+            new_path.push(parent_path);
+        }
+        cmd.env("PATH", new_path);
+
         cmd.env("RUNNERS_CREW_ID", &mission.crew_id);
         cmd.env("RUNNERS_MISSION_ID", &mission.id);
         cmd.env("RUNNERS_RUNNER_HANDLE", &runner.handle);
@@ -196,9 +218,31 @@ impl SessionManager {
             )?;
         }
 
-        // Spawn the reader thread. On EOF it reaps the child, emits exit,
-        // updates the row, and removes the session from the in-memory map.
-        {
+        // Insert into the live map BEFORE starting the reader thread.
+        // A short-lived child (e.g. `sh -c "echo hi"`) can exit within
+        // microseconds — if we spawned the thread first, its `forget()`
+        // call could run before the insert and leave a stale live handle
+        // for an already-dead session. Handle parts that the reader thread
+        // needs ownership of (child, reader pipe) stay out of the map;
+        // parts the Tauri commands need (master, writer, pid) go in.
+        self.sessions.lock().unwrap().insert(
+            session_id.clone(),
+            SessionHandle {
+                id: session_id.clone(),
+                mission_id: mission.id.clone(),
+                master: Some(pair.master),
+                writer: Mutex::new(writer),
+                pid,
+                reader: None, // populated immediately below
+            },
+        );
+
+        // Spawn the reader thread. On EOF it reaps the child, updates the
+        // DB row, removes the session from the in-memory map, and emits
+        // the `exit` event. `kill` joins this handle to guarantee the
+        // mission_stop → mission_completed transition never races ahead of
+        // the actual child reap.
+        let reader_handle = {
             let session_id_t = session_id.clone();
             let mission_id_t = mission.id.clone();
             let events_t = Arc::clone(&events);
@@ -226,20 +270,15 @@ impl SessionManager {
                     );
                 }
                 events_t.exit(&exit);
-            });
-        }
+            })
+        };
 
-        // Insert into the live map.
-        self.sessions.lock().unwrap().insert(
-            session_id.clone(),
-            SessionHandle {
-                id: session_id.clone(),
-                mission_id: mission.id.clone(),
-                master: pair.master,
-                writer: Mutex::new(writer),
-                pid,
-            },
-        );
+        // Attach the reader handle. We raced to insert-first so the reader
+        // may already be draining by the time we land here — that's fine,
+        // it doesn't touch this slot.
+        if let Some(h) = self.sessions.lock().unwrap().get_mut(&session_id) {
+            h.reader = Some(reader_handle);
+        }
 
         Ok(SpawnedSession {
             id: session_id,
@@ -262,23 +301,62 @@ impl SessionManager {
         Ok(())
     }
 
-    /// Kill the child. Reader thread will see EOF and clean up the row + map.
+    /// Kill the child and wait for the reader thread to reap it.
+    ///
+    /// Sequence:
+    ///   1. Remove the handle from the live map (no further `inject_stdin` /
+    ///      `kill` can target it).
+    ///   2. Drop the master PTY — the child receives SIGHUP and well-behaved
+    ///      programs exit; the reader thread's `read()` returns 0.
+    ///   3. On Unix, belt-and-suspenders: signal SIGTERM (then SIGKILL after
+    ///      200 ms) so a child that ignores SIGHUP can't stall the reader.
+    ///   4. Join the reader thread. It waits the child, updates the DB row
+    ///      to stopped/crashed, emits `session/exit`. Only after this
+    ///      returns is the caller allowed to consider the session dead —
+    ///      which is what `mission_stop` needs in order to flip the mission
+    ///      row without lying about termination.
     pub fn kill(&self, session_id: &str) -> Result<()> {
-        let mut sessions = self.sessions.lock().unwrap();
-        if let Some(handle) = sessions.remove(session_id) {
-            // Dropping the master PTY signals the child by closing stdin /
-            // hanging up the terminal; on Unix this SIGHUP-equivalent, which
-            // for well-behaved shells and interpreters is enough to exit.
-            // portable-pty doesn't expose a portable `kill` on the master,
-            // and we don't have the Child here — we intentionally transferred
-            // ownership into the reader thread. For MVP this is fine; a
-            // harder-kill path (via libc + stored pid) lands with C8.
-            drop(handle);
+        let (pid, master, reader) = {
+            let mut sessions = self.sessions.lock().unwrap();
+            match sessions.remove(session_id) {
+                Some(mut h) => (h.pid, h.master.take(), h.reader.take()),
+                None => return Ok(()),
+            }
+        };
+
+        // Step 2: hang up the terminal. For most children this alone is
+        // enough. We drop before sending signals so the child's next I/O
+        // fails instead of blocking indefinitely.
+        drop(master);
+
+        // Step 3: Unix-only hard-kill escalation.
+        #[cfg(unix)]
+        if let Some(pid) = pid {
+            // SAFETY: `pid` came from `Child::process_id()` on a child we
+            // just started; it hasn't been reaped yet because the reader
+            // thread holds the only `Child` reference. `kill(2)` with an
+            // unknown pid is a no-op returning ESRCH which we ignore.
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGTERM);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(200));
+            unsafe {
+                libc::kill(pid as libc::pid_t, libc::SIGKILL);
+            }
+        }
+        #[cfg(not(unix))]
+        let _ = pid; // Windows path lands with a future chunk.
+
+        // Step 4: wait for the reader to reap + update the DB + emit exit.
+        if let Some(h) = reader {
+            let _ = h.join();
         }
         Ok(())
     }
 
     /// Kill every live session; used on mission_stop and at app shutdown.
+    /// Returns only after all reader threads have joined — callers rely on
+    /// that for the "no live sessions after we return" contract.
     pub fn kill_all_for_mission(&self, mission_id: &str) -> Result<()> {
         let ids: Vec<String> = {
             let sessions = self.sessions.lock().unwrap();
@@ -484,6 +562,7 @@ mod tests {
             .spawn(
                 &mission,
                 &runner,
+                std::path::Path::new("/tmp"),
                 PathBuf::from("/dev/null"),
                 Arc::clone(&pool),
                 capture(),
@@ -542,6 +621,7 @@ mod tests {
             .spawn(
                 &mission,
                 &runner,
+                std::path::Path::new("/tmp"),
                 PathBuf::from("/dev/null"),
                 Arc::clone(&pool),
                 capture(),
@@ -578,5 +658,58 @@ mod tests {
         let mgr = SessionManager::new();
         let err = mgr.inject_stdin("nope", b"x").unwrap_err();
         assert!(format!("{err}").contains("session not found"));
+    }
+
+    #[test]
+    fn kill_blocks_until_session_row_is_terminal() {
+        // mission_stop relies on this contract: kill must return only after
+        // the reader thread has updated the DB row to stopped/crashed.
+        let pool = pool_with_schema();
+        let mission = mission();
+        let mut runner = runner("/bin/cat", &[]);
+        insert_crew_runner(&pool, &mission.id, &runner.id);
+        runner.id = {
+            let conn = pool.get().unwrap();
+            conn.query_row("SELECT id FROM runners LIMIT 1", [], |r| r.get(0))
+                .unwrap()
+        };
+        let fresh_mission_id: String = {
+            let conn = pool.get().unwrap();
+            conn.query_row("SELECT id FROM missions LIMIT 1", [], |r| r.get(0))
+                .unwrap()
+        };
+        let mission = Mission {
+            id: fresh_mission_id,
+            ..mission
+        };
+
+        let mgr = SessionManager::new();
+        let spawned = mgr
+            .spawn(
+                &mission,
+                &runner,
+                std::path::Path::new("/tmp"),
+                PathBuf::from("/dev/null"),
+                Arc::clone(&pool),
+                capture(),
+            )
+            .unwrap();
+
+        // kill must synchronize on the reader; immediately after it returns,
+        // the DB row should already be terminal (no polling).
+        mgr.kill(&spawned.id).unwrap();
+
+        let conn = pool.get().unwrap();
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM sessions WHERE id = ?1",
+                params![spawned.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(
+            status != "running",
+            "kill returned while session still running: {status}"
+        );
     }
 }

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -1,2 +1,9 @@
 // Session runtime — spawns and controls each runner's local CLI process
-// (claude, codex, ...) via a pseudo-terminal. TODO: implement with portable-pty.
+// via a pseudo-terminal (portable-pty). See docs/impls/v0-mvp.md §C6.
+//
+// The `manager` submodule owns the per-process PTY machinery. The app wires
+// it into AppState and calls into it from mission/session Tauri commands.
+
+pub mod manager;
+
+pub use manager::SessionManager;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import Crews from "./pages/Crews";
 import CrewEditor from "./pages/CrewEditor";
+import Debug from "./pages/Debug";
 
 export default function App() {
   return (
@@ -9,6 +10,8 @@ export default function App() {
         <Route path="/" element={<Navigate to="/crews" replace />} />
         <Route path="/crews" element={<Crews />} />
         <Route path="/crews/:crewId" element={<CrewEditor />} />
+        {/* Scratch page for C6 PTY validation — remove when C10 lands. */}
+        <Route path="/debug" element={<Debug />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@ type NavItem = {
 const NAV: NavItem[] = [
   { to: "/crews", label: "Crew", enabled: true },
   { to: "/missions", label: "Mission", enabled: false, hint: "Coming with C11" },
+  { to: "/debug", label: "Debug", enabled: true, hint: "C6 PTY scratch page" },
 ];
 
 export function Sidebar() {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -3,7 +3,7 @@
 // Tauri auto-converts top-level arg names between camelCase (JS) and
 // snake_case (Rust), so `crewId` here maps to `crew_id` in the Rust
 // handlers. Nested struct fields pass through unchanged — `input` objects
-// match the Rust struct shapes in src-tauri/src/commands/{crew,runner,crew_runner,mission}.rs,
+// match the Rust struct shapes in src-tauri/src/commands/{crew,runner,crew_runner,mission,session}.rs,
 // mirrored by src/lib/types.ts.
 
 import { invoke } from "@tauri-apps/api/core";
@@ -17,11 +17,17 @@ import type {
   Mission,
   Runner,
   RunnerActivity,
+  Session,
   StartMissionInput,
   StartMissionOutput,
   UpdateCrewInput,
   UpdateRunnerInput,
 } from "./types";
+
+/** Session row joined with the runner's handle for UI labels. */
+export interface SessionRow extends Session {
+  handle: string;
+}
 
 export const api = {
   crew: {
@@ -61,5 +67,12 @@ export const api = {
     start: (input: StartMissionInput) =>
       invoke<StartMissionOutput>("mission_start", { input }),
     stop: (id: string) => invoke<Mission>("mission_stop", { id }),
+  },
+  session: {
+    list: (missionId: string) =>
+      invoke<SessionRow[]>("session_list", { missionId }),
+    injectStdin: (sessionId: string, text: string) =>
+      invoke<void>("session_inject_stdin", { sessionId, text }),
+    kill: (sessionId: string) => invoke<void>("session_kill", { sessionId }),
   },
 };

--- a/src/pages/Debug.tsx
+++ b/src/pages/Debug.tsx
@@ -1,0 +1,286 @@
+// Scratch page for C6 — lets you kick off a mission on any crew and watch
+// the raw PTY output stream back from each session. Delete once C10 (mission
+// workspace) lands. Intentionally minimal: no styling polish, no xterm.js,
+// no scrollback management. Just prove the bytes flow end to end.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { listen } from "@tauri-apps/api/event";
+
+import type { Crew, Mission, SessionStatus } from "../lib/types";
+import { api, SessionRow } from "../lib/api";
+
+interface OutputEvent {
+  session_id: string;
+  mission_id: string;
+  text: string;
+}
+
+interface ExitEvent {
+  session_id: string;
+  mission_id: string;
+  exit_code: number | null;
+  success: boolean;
+}
+
+interface SessionPane {
+  row: SessionRow;
+  output: string;
+  status: SessionStatus;
+  exitCode: number | null;
+}
+
+export default function Debug() {
+  const [crews, setCrews] = useState<Crew[]>([]);
+  const [crewId, setCrewId] = useState<string>("");
+  const [title, setTitle] = useState("scratch mission");
+  const [goal, setGoal] = useState("");
+  const [cwd, setCwd] = useState("");
+  const [mission, setMission] = useState<Mission | null>(null);
+  const [sessions, setSessions] = useState<Record<string, SessionPane>>({});
+  const [err, setErr] = useState<string | null>(null);
+  const [inputs, setInputs] = useState<Record<string, string>>({});
+  const missionIdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    void api.crew.list().then((items) => {
+      setCrews(items.map((i) => i));
+      if (items[0]) setCrewId(items[0].id);
+    });
+  }, []);
+
+  // Subscribe once on mount; filter events by the current mission id so
+  // multiple sequential starts don't bleed old output into a new run.
+  useEffect(() => {
+    let outputUnlisten: (() => void) | null = null;
+    let exitUnlisten: (() => void) | null = null;
+
+    void listen<OutputEvent>("session/output", (event) => {
+      if (event.payload.mission_id !== missionIdRef.current) return;
+      setSessions((prev) => {
+        const pane = prev[event.payload.session_id];
+        if (!pane) return prev;
+        return {
+          ...prev,
+          [event.payload.session_id]: {
+            ...pane,
+            output: (pane.output + event.payload.text).slice(-16_000),
+          },
+        };
+      });
+    }).then((fn) => {
+      outputUnlisten = fn;
+    });
+
+    void listen<ExitEvent>("session/exit", (event) => {
+      if (event.payload.mission_id !== missionIdRef.current) return;
+      setSessions((prev) => {
+        const pane = prev[event.payload.session_id];
+        if (!pane) return prev;
+        return {
+          ...prev,
+          [event.payload.session_id]: {
+            ...pane,
+            status: event.payload.success ? "stopped" : "crashed",
+            exitCode: event.payload.exit_code,
+          },
+        };
+      });
+    }).then((fn) => {
+      exitUnlisten = fn;
+    });
+
+    return () => {
+      outputUnlisten?.();
+      exitUnlisten?.();
+    };
+  }, []);
+
+  async function start() {
+    setErr(null);
+    setSessions({});
+    try {
+      const out = await api.mission.start({
+        crew_id: crewId,
+        title,
+        goal_override: goal || null,
+        cwd: cwd || null,
+      });
+      setMission(out.mission);
+      missionIdRef.current = out.mission.id;
+
+      // Give the backend a beat to insert rows + spawn.
+      await new Promise((r) => setTimeout(r, 50));
+      const rows = await api.session.list(out.mission.id);
+      const seeded: Record<string, SessionPane> = {};
+      for (const row of rows) {
+        seeded[row.id] = {
+          row,
+          output: "",
+          status: row.status,
+          exitCode: null,
+        };
+      }
+      setSessions(seeded);
+    } catch (e) {
+      setErr(String(e));
+    }
+  }
+
+  async function stopMission() {
+    if (!mission) return;
+    try {
+      const m = await api.mission.stop(mission.id);
+      setMission(m);
+    } catch (e) {
+      setErr(String(e));
+    }
+  }
+
+  async function inject(sessionId: string) {
+    const text = inputs[sessionId];
+    if (!text) return;
+    try {
+      await api.session.injectStdin(sessionId, text + "\n");
+      setInputs({ ...inputs, [sessionId]: "" });
+    } catch (e) {
+      setErr(String(e));
+    }
+  }
+
+  const paneList = useMemo(() => Object.values(sessions), [sessions]);
+
+  return (
+    <div className="min-h-screen bg-neutral-50 p-6 font-mono text-sm text-neutral-900">
+      <div className="mx-auto max-w-5xl space-y-4">
+        <header className="flex items-baseline justify-between">
+          <h1 className="text-lg font-semibold">C6 Debug — PTY scratch</h1>
+          <a href="#/crews" className="text-xs text-blue-600 underline">
+            back to crews
+          </a>
+        </header>
+
+        <section className="space-y-2 rounded border border-neutral-300 bg-white p-4">
+          <div className="grid grid-cols-2 gap-3">
+            <label className="flex flex-col gap-1 text-xs text-neutral-600">
+              Crew
+              <select
+                value={crewId}
+                onChange={(e) => setCrewId(e.target.value)}
+                className="rounded border border-neutral-300 bg-white p-1 text-sm"
+              >
+                {crews.map((c) => (
+                  <option key={c.id} value={c.id}>
+                    {c.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1 text-xs text-neutral-600">
+              Title
+              <input
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                className="rounded border border-neutral-300 bg-white p-1 text-sm"
+              />
+            </label>
+            <label className="col-span-2 flex flex-col gap-1 text-xs text-neutral-600">
+              Goal (optional — falls back to crew default)
+              <input
+                value={goal}
+                onChange={(e) => setGoal(e.target.value)}
+                className="rounded border border-neutral-300 bg-white p-1 text-sm"
+              />
+            </label>
+            <label className="col-span-2 flex flex-col gap-1 text-xs text-neutral-600">
+              Working directory (optional — $MISSION_CWD)
+              <input
+                value={cwd}
+                onChange={(e) => setCwd(e.target.value)}
+                placeholder="/Users/you/projects/foo"
+                className="rounded border border-neutral-300 bg-white p-1 text-sm"
+              />
+            </label>
+          </div>
+          <div className="flex gap-2">
+            <button
+              onClick={() => void start()}
+              disabled={!crewId || !title}
+              className="rounded bg-neutral-900 px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-40"
+            >
+              Start mission
+            </button>
+            {mission && mission.status === "running" && (
+              <button
+                onClick={() => void stopMission()}
+                className="rounded border border-neutral-300 bg-white px-3 py-1.5 text-xs font-semibold"
+              >
+                Stop
+              </button>
+            )}
+            {mission && (
+              <span className="ml-auto self-center text-xs text-neutral-500">
+                mission {mission.id.slice(-6)} · {mission.status}
+              </span>
+            )}
+          </div>
+          {err && (
+            <pre className="whitespace-pre-wrap rounded bg-red-50 p-2 text-xs text-red-700">
+              {err}
+            </pre>
+          )}
+        </section>
+
+        <section className="space-y-3">
+          {paneList.length === 0 && (
+            <p className="text-xs text-neutral-500">
+              Pick a crew and click <em>Start mission</em> — one pane per runner will appear.
+            </p>
+          )}
+          {paneList.map((pane) => (
+            <div key={pane.row.id} className="rounded border border-neutral-300 bg-white">
+              <div className="flex items-center justify-between border-b border-neutral-200 bg-neutral-100 px-3 py-1.5 text-xs">
+                <span className="font-semibold">@{pane.row.handle}</span>
+                <span className="text-neutral-500">
+                  pid {pane.row.pid ?? "?"} · {pane.status}
+                  {pane.exitCode != null ? ` · exit ${pane.exitCode}` : ""}
+                </span>
+              </div>
+              <pre className="max-h-80 overflow-auto whitespace-pre-wrap bg-neutral-900 p-3 text-xs leading-tight text-neutral-100">
+                {pane.output || "(no output yet)"}
+              </pre>
+              <div className="flex gap-1 border-t border-neutral-200 p-2">
+                <input
+                  value={inputs[pane.row.id] ?? ""}
+                  onChange={(e) =>
+                    setInputs({ ...inputs, [pane.row.id]: e.target.value })
+                  }
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") void inject(pane.row.id);
+                  }}
+                  placeholder="stdin (hit ↵ to inject with newline)"
+                  className="flex-1 rounded border border-neutral-300 bg-white p-1 text-xs"
+                  disabled={pane.status !== "running"}
+                />
+                <button
+                  onClick={() => void inject(pane.row.id)}
+                  disabled={pane.status !== "running" || !inputs[pane.row.id]}
+                  className="rounded bg-neutral-900 px-2 py-1 text-xs font-semibold text-white disabled:opacity-40"
+                >
+                  Send
+                </button>
+                <button
+                  onClick={() => void api.session.kill(pane.row.id)}
+                  disabled={pane.status !== "running"}
+                  className="rounded border border-neutral-300 bg-white px-2 py-1 text-xs font-semibold disabled:opacity-40"
+                >
+                  Kill
+                </button>
+              </div>
+            </div>
+          ))}
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- \`session::SessionManager\` spawns a PTY child per runner via portable-pty. Env vars (RUNNERS_CREW_ID / MISSION_ID / RUNNER_HANDLE / EVENT_LOG + \$MISSION_CWD) are set at spawn time so C9's CLI can pick them up.
- One reader thread per session pumps bytes → \`SessionEvents::output\`, waits the child on EOF, updates the \`sessions\` row to stopped/crashed, and emits \`SessionEvents::exit\`.
- \`SessionEvents\` trait decouples the PTY layer from Tauri so tests run with a capture fake. Prod uses \`TauriSessionEvents(AppHandle)\` → \`session/output\` + \`session/exit\` Tauri events.
- \`mission_start\` now spawns one PTY per runner; \`mission_stop\` kills them before flipping the mission row.
- **Debug page at \`/debug\`** (scratch, to be removed when C10 lands) — picks a crew, starts a mission, renders one pane per runner with live output + stdin input + kill button. Exists so runtime reality surfaces before the polished workspace UI goes in.

## Test plan
- [x] \`cargo test --workspace\` — 57 passing (3 new PTY tests: end-to-end echo, cat + stdin roundtrip, unknown-session error).
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`pnpm tsc --noEmit\` + \`pnpm lint\` clean.
- [ ] Manual: \`make dev\` → navigate to \`/debug\`, pick a crew with \`/bin/sh\` as a runner command, start mission, send \`echo hi\`, see output stream back, kill, see exit land. Then try a real agent (\`claude-code\`, \`codex\`) to derisk C10.

Part of the v0 MVP umbrella (C6). See \`docs/impls/v0-mvp.md\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)