### PR TITLE
feat(event-bus): notify watcher + per-runner inbox projection (C7)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1023,6 +1023,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1100,6 +1111,15 @@ checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1859,6 +1879,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8069d3ec154eb856955c1c0fbffefbf5f3c40a104ec912d4797314c1801abff"
+dependencies = [
+ "bitflags 1.3.2",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ioctl-rs"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2021,6 +2061,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
 name = "kuchikiki"
 version = "0.8.8-speedreader"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2090,7 +2150,10 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
+ "bitflags 2.11.1",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2221,6 +2284,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -2306,6 +2381,25 @@ name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "notify"
+version = "6.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6205bd8bb1e454ad2e27422015fb5e4f2bcc7e08fa8f27058670d208324a4d2d"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossbeam-channel",
+ "filetime",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 0.8.11",
+ "walkdir",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "num-conv"
@@ -2561,7 +2655,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -2793,6 +2887,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -3158,6 +3258,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3281,6 +3390,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "libc",
+ "notify",
  "portable-pty",
  "r2d2",
  "r2d2_sqlite",
@@ -3824,7 +3934,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-quartz-core",
  "raw-window-handle",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "tracing",
  "wasm-bindgen",
  "web-sys",
@@ -4497,7 +4607,7 @@ checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.0",
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
@@ -5364,6 +5474,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -5402,6 +5521,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5463,6 +5597,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5481,6 +5621,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5496,6 +5642,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5529,6 +5681,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5544,6 +5702,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5565,6 +5729,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5580,6 +5750,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/crates/runners-core/src/event_log/log.rs
+++ b/crates/runners-core/src/event_log/log.rs
@@ -262,10 +262,27 @@ impl EventLog {
                 continue;
             }
             match serde_json::from_slice::<Event>(line) {
-                Ok(event) => out.push(LogEntry {
-                    next_offset: pos,
-                    event,
-                }),
+                Ok(event) => {
+                    // Validate the id is a real ULID — `Event.id` is just a
+                    // String at the type level, so serde will happily accept
+                    // `"id":"zzzz"`. Letting it through would corrupt the
+                    // bus's lex-sorted inbox state: a junk id like "zzzz"
+                    // sorts after every real ULID, so a later legitimate
+                    // event would silently look "older" and get treated as
+                    // already-read by `up_to` watermarks.
+                    if event.id.parse::<ulid::Ulid>().is_err() {
+                        skipped.push(SkipReport {
+                            offset: line_start,
+                            next_offset: pos,
+                            error: format!("event id {:?} is not a valid ULID", event.id),
+                        });
+                        continue;
+                    }
+                    out.push(LogEntry {
+                        next_offset: pos,
+                        event,
+                    });
+                }
                 Err(e) => {
                     skipped.push(SkipReport {
                         offset: line_start,
@@ -632,6 +649,44 @@ mod tests {
             "next id {} not > prior valid id {}",
             next.id,
             committed
+        );
+    }
+
+    #[test]
+    fn read_from_lossy_skips_lines_whose_id_is_not_a_ulid() {
+        // Regression: `Event.id` is just a `String` at the type level, so
+        // serde happily accepts `"id":"zzzz"`. The bus stores ids in a
+        // lex-sorted projection — a junk id like "zzzz" sorts past every
+        // real ULID and would make later legitimate events look already-
+        // read. Demote to SkipReport so this never reaches the bus.
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let log = EventLog::open(dir.path()).unwrap();
+        let good_a = log.append(draft_signal("ask_lead")).unwrap();
+        // Hand-write a complete JSON line whose id field is the wrong shape.
+        {
+            let mut f = OpenOptions::new()
+                .append(true)
+                .open(dir.path().join(EVENTS_FILENAME))
+                .unwrap();
+            f.write_all(
+                b"{\"id\":\"zzzz\",\"ts\":\"2026-04-26T00:00:00Z\",\"crew_id\":\"c\",\
+                  \"mission_id\":\"m\",\"kind\":\"signal\",\"from\":\"x\",\"to\":null,\
+                  \"type\":\"ask_lead\",\"payload\":{}}\n",
+            )
+            .unwrap();
+        }
+        let good_b = log.append(draft_signal("ask_lead")).unwrap();
+
+        let (entries, skipped) = log.read_from_lossy(0).unwrap();
+        assert_eq!(entries.len(), 2, "two valid events must come through");
+        assert_eq!(entries[0].event.id, good_a.id);
+        assert_eq!(entries[1].event.id, good_b.id);
+        assert_eq!(skipped.len(), 1, "the malformed-id line must be a skip");
+        assert!(
+            skipped[0].error.contains("not a valid ULID"),
+            "skip should explain why; got {:?}",
+            skipped[0].error
         );
     }
 

--- a/crates/runners-core/src/event_log/log.rs
+++ b/crates/runners-core/src/event_log/log.rs
@@ -230,11 +230,17 @@ impl EventLog {
         let mut out = Vec::new();
         let mut skipped = Vec::new();
         let mut pos = offset;
-        let mut buf = String::new();
+        let mut buf: Vec<u8> = Vec::new();
         loop {
             let line_start = pos;
             buf.clear();
-            let n = reader.read_line(&mut buf)?;
+            // Use byte-level reads. `read_line` would Err on the first
+            // non-UTF-8 byte and that error would propagate out of `tick`,
+            // freezing the bus on the same offset forever. NDJSON expects
+            // UTF-8, but a buggy writer that emits raw bytes must surface
+            // as a SkipReport — not as a poison pill that hides every
+            // event after it.
+            let n = reader.read_until(b'\n', &mut buf)?;
             if n == 0 {
                 break;
             }
@@ -242,14 +248,20 @@ impl EventLog {
             // A line without a trailing '\n' is incomplete (writer crashed
             // or torn write). Don't advance past it — the next tick should
             // re-attempt once the writer finishes the line.
-            if !buf.ends_with('\n') {
+            if buf.last() != Some(&b'\n') {
                 break;
             }
-            let trimmed = buf.trim_end_matches(['\n', '\r']);
-            if trimmed.is_empty() {
+            // Trim the terminator (and an optional preceding '\r') without
+            // requiring valid UTF-8.
+            let mut end = buf.len() - 1;
+            if end > 0 && buf[end - 1] == b'\r' {
+                end -= 1;
+            }
+            let line = &buf[..end];
+            if line.is_empty() {
                 continue;
             }
-            match serde_json::from_str::<Event>(trimmed) {
+            match serde_json::from_slice::<Event>(line) {
                 Ok(event) => out.push(LogEntry {
                     next_offset: pos,
                     event,
@@ -620,6 +632,37 @@ mod tests {
             "next id {} not > prior valid id {}",
             next.id,
             committed
+        );
+    }
+
+    #[test]
+    fn read_from_lossy_skips_non_utf8_lines_too() {
+        // Regression: `read_line` requires UTF-8 and Errs out on the first
+        // non-UTF-8 line, which would propagate up through the bus's tick
+        // and freeze the offset. `read_until` with byte-level parsing
+        // demotes that to a SkipReport.
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let log = EventLog::open(dir.path()).unwrap();
+        let good_a = log.append(draft_signal("ask_lead")).unwrap();
+        // Hand-write a complete-but-invalid-UTF-8 line directly.
+        {
+            let mut f = OpenOptions::new()
+                .append(true)
+                .open(dir.path().join(EVENTS_FILENAME))
+                .unwrap();
+            f.write_all(b"\xff\xfe garbage\n").unwrap();
+        }
+        let good_b = log.append(draft_signal("ask_lead")).unwrap();
+
+        let (entries, skipped) = log.read_from_lossy(0).unwrap();
+        assert_eq!(entries.len(), 2, "both good events surface");
+        assert_eq!(entries[0].event.id, good_a.id);
+        assert_eq!(entries[1].event.id, good_b.id);
+        assert_eq!(skipped.len(), 1, "exactly one skip report");
+        assert!(
+            skipped[0].next_offset > skipped[0].offset,
+            "skip must advance past the bad bytes"
         );
     }
 

--- a/crates/runners-core/src/event_log/log.rs
+++ b/crates/runners-core/src/event_log/log.rs
@@ -409,6 +409,15 @@ fn parse_id(line: &[u8]) -> Result<String> {
         id: String,
     }
     let t: Tail = serde_json::from_slice(line)?;
+    // Validate ULID shape, not just "string-typed `id` field exists". Without
+    // this, a line like `{"id":"not-a-ulid"}` parses cleanly here but blows
+    // up later when `EventLog::open` calls `raise_floor_from_str` — which
+    // would prevent the bus from ever mounting on a corrupted log. Treat
+    // shape failure the same as a JSON parse failure so `last_id_in_file`
+    // walks back to the last *valid* line instead of bailing out.
+    if t.id.parse::<ulid::Ulid>().is_err() {
+        return Err(Error::msg(format!("id {:?} is not a valid ULID", t.id)));
+    }
     Ok(t.id)
 }
 
@@ -576,6 +585,42 @@ mod tests {
         let entries = log.read_from(0).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].event.id, evt.id);
+    }
+
+    #[test]
+    fn open_survives_tail_line_with_non_ulid_id() {
+        // Regression for review finding: a complete JSON line whose `id`
+        // field is the wrong shape (parses as a String but isn't a valid
+        // ULID) used to make `EventLog::open` fail at
+        // `raise_floor_from_str`. The bus could then never mount on a
+        // corrupted log, defeating the whole point of `read_from_lossy`.
+        // `last_id_in_file` must walk back to the last *valid* line.
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let committed = {
+            let log = EventLog::open(dir.path()).unwrap();
+            log.append(draft_signal("ask_lead")).unwrap().id
+        };
+        // Append a complete, parseable, but malformed-id line.
+        {
+            let mut f = OpenOptions::new()
+                .append(true)
+                .open(dir.path().join(EVENTS_FILENAME))
+                .unwrap();
+            f.write_all(b"{\"id\":\"not-a-ulid\"}\n").unwrap();
+        }
+
+        // Open must succeed: walk back past the bad line, recover the prior id.
+        let log = EventLog::open(dir.path()).unwrap();
+
+        // The next append must use a ULID strictly greater than the prior valid id.
+        let next = log.append(draft_signal("ask_lead")).unwrap();
+        assert!(
+            next.id > committed,
+            "next id {} not > prior valid id {}",
+            next.id,
+            committed
+        );
     }
 
     #[test]

--- a/crates/runners-core/src/event_log/log.rs
+++ b/crates/runners-core/src/event_log/log.rs
@@ -49,6 +49,18 @@ pub struct LogEntry {
     pub event: Event,
 }
 
+/// One malformed line surfaced by `read_from_lossy`. The C7 watcher logs
+/// these and skips past them so a single bad line can't freeze the bus.
+#[derive(Debug, Clone)]
+pub struct SkipReport {
+    /// Byte offset where the skipped line started.
+    pub offset: u64,
+    /// Byte offset just past the skipped line's terminating newline. Pass
+    /// as the next `offset` to resume after the corruption.
+    pub next_offset: u64,
+    pub error: String,
+}
+
 impl EventLog {
     /// Opens (creating if needed) the events file inside `mission_dir`.
     /// The directory is created recursively.
@@ -201,6 +213,59 @@ impl EventLog {
         Ok(out)
     }
 
+    /// Like `read_from`, but skips lines that fail to parse instead of
+    /// aborting. Returns successfully-parsed entries and a separate vec of
+    /// skip reports (offset + reason) so the caller can log a warning. Used
+    /// by the C7 watcher: a single corrupted line — say from a buggy CLI
+    /// release someone shipped — must not poison the bus and freeze every
+    /// downstream subscriber on the same offset forever.
+    ///
+    /// IO errors (file truncated, read failed) still propagate — those are
+    /// not per-line corruption and re-trying makes sense.
+    pub fn read_from_lossy(&self, offset: u64) -> Result<(Vec<LogEntry>, Vec<SkipReport>)> {
+        let mut file = File::open(&self.path)?;
+        file.seek(SeekFrom::Start(offset))?;
+        let mut reader = BufReader::new(file);
+
+        let mut out = Vec::new();
+        let mut skipped = Vec::new();
+        let mut pos = offset;
+        let mut buf = String::new();
+        loop {
+            let line_start = pos;
+            buf.clear();
+            let n = reader.read_line(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            pos += n as u64;
+            // A line without a trailing '\n' is incomplete (writer crashed
+            // or torn write). Don't advance past it — the next tick should
+            // re-attempt once the writer finishes the line.
+            if !buf.ends_with('\n') {
+                break;
+            }
+            let trimmed = buf.trim_end_matches(['\n', '\r']);
+            if trimmed.is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<Event>(trimmed) {
+                Ok(event) => out.push(LogEntry {
+                    next_offset: pos,
+                    event,
+                }),
+                Err(e) => {
+                    skipped.push(SkipReport {
+                        offset: line_start,
+                        next_offset: pos,
+                        error: e.to_string(),
+                    });
+                }
+            }
+        }
+        Ok((out, skipped))
+    }
+
     /// Truncate off any non-newline-terminated bytes at the end of the file.
     ///
     /// A well-behaved writer always finishes with `\n`. A crashed writer can
@@ -261,18 +326,18 @@ impl EventLog {
         Ok(())
     }
 
-    /// Reads the `id` field of the last complete JSON line in the file without
-    /// loading the whole log. Scans backward from EOF for the preceding newline,
-    /// then parses just that line.
+    /// Reads the `id` field of the most recent JSON line that parses
+    /// cleanly. Skips malformed lines by walking further back so a single
+    /// corrupt line doesn't poison the floor (which would block every
+    /// subsequent `append`) — the C7 watcher's "bad line doesn't poison
+    /// the bus" contract has to extend to the writer side too, otherwise
+    /// open + append both fail and the bus has nothing to read.
     fn last_id_in_file(file: &File) -> Result<Option<String>> {
         let len = file.metadata()?.len();
         if len == 0 {
             return Ok(None);
         }
 
-        // Walk back from EOF in small chunks looking for the *second-to-last*
-        // '\n' (the boundary before the final line). For typical event sizes
-        // (< 4 KB) a single 4 KB read is enough.
         let chunk_size: u64 = 4096;
         let mut end = len;
         let mut line_bytes: Vec<u8> = Vec::new();
@@ -293,25 +358,39 @@ impl EventLog {
             }
             buf.truncate(read);
 
-            // Combine with any bytes we already stitched from a later chunk.
             buf.extend_from_slice(&line_bytes);
             line_bytes = buf;
 
-            // Drop a trailing newline that marks the end of the last line.
             if line_bytes.last() == Some(&b'\n') {
                 line_bytes.pop();
             }
 
-            // Find the newline that precedes the final line. If present, that's
-            // the boundary; everything after it is the last line.
-            if let Some(pos) = line_bytes.iter().rposition(|&b| b == b'\n') {
-                let last = &line_bytes[pos + 1..];
-                return parse_id(last).map(Some);
+            // Try parsing successively-earlier lines from the bytes we've
+            // accumulated so far. If one parses, that's our floor. If none
+            // do, fetch another chunk and retry — a malformed line at the
+            // tail must not fail-fast the way it used to.
+            loop {
+                let candidate_start = match line_bytes.iter().rposition(|&b| b == b'\n') {
+                    Some(pos) => pos + 1,
+                    None if start == 0 => 0,
+                    None => break, // need more bytes from earlier in the file
+                };
+                let candidate = &line_bytes[candidate_start..];
+                if let Ok(id) = parse_id(candidate) {
+                    return Ok(Some(id));
+                }
+                if candidate_start == 0 {
+                    // We've exhausted this buffer's lines and we already
+                    // reached the file head. No valid id anywhere.
+                    return Ok(None);
+                }
+                // Drop the bad candidate (and the newline before it) and
+                // retry against the line that precedes it.
+                line_bytes.truncate(candidate_start - 1);
             }
-            // Otherwise scan further back.
+
             if start == 0 {
-                // Entire file is one line.
-                return parse_id(&line_bytes).map(Some);
+                return Ok(None);
             }
             end = start;
         }
@@ -497,6 +576,46 @@ mod tests {
         let entries = log.read_from(0).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].event.id, evt.id);
+    }
+
+    #[test]
+    fn read_from_lossy_skips_bad_lines_and_advances_past_them() {
+        // Regression for the C7 watcher freeze: `read_from` aborts the whole
+        // call on the first parse error, leaving the consumer's offset stuck
+        // and re-reading the same bad bytes forever. `read_from_lossy` must
+        // skip the bad line, surface a SkipReport, and let later good lines
+        // through.
+        use std::io::Write;
+        let dir = tempfile::tempdir().unwrap();
+        let log = EventLog::open(dir.path()).unwrap();
+        let good_a = log.append(draft_signal("ask_lead")).unwrap();
+
+        // Hand-write a malformed-but-newline-terminated line directly into
+        // the file. Append-only writers never produce these in practice, but
+        // a buggy CLI release or a manual edit could.
+        {
+            let mut f = OpenOptions::new()
+                .append(true)
+                .open(dir.path().join(EVENTS_FILENAME))
+                .unwrap();
+            f.write_all(b"this is not json\n").unwrap();
+        }
+
+        let good_b = log.append(draft_signal("ask_lead")).unwrap();
+
+        let (entries, skipped) = log.read_from_lossy(0).unwrap();
+        assert_eq!(entries.len(), 2, "both good events must be returned");
+        assert_eq!(entries[0].event.id, good_a.id);
+        assert_eq!(entries[1].event.id, good_b.id);
+        assert_eq!(skipped.len(), 1, "exactly one skip report");
+        assert!(
+            skipped[0].next_offset > skipped[0].offset,
+            "skip must advance past the bad line"
+        );
+        // Resuming after the second good entry yields nothing — i.e. the
+        // skip's bytes were truly past us.
+        let (more, _) = log.read_from_lossy(entries[1].next_offset).unwrap();
+        assert!(more.is_empty());
     }
 
     #[test]

--- a/crates/runners-core/src/event_log/mod.rs
+++ b/crates/runners-core/src/event_log/mod.rs
@@ -6,6 +6,6 @@ pub mod log;
 pub mod path;
 pub mod ulid;
 
-pub use log::{EventLog, LogEntry};
+pub use log::{EventLog, LogEntry, SkipReport};
 pub use path::{crew_dir, events_path, mission_dir, signal_types_path, EVENTS_FILENAME};
 pub use ulid::UlidGen;

--- a/design/runners-design.pen
+++ b/design/runners-design.pen
@@ -47,6 +47,25 @@
             },
             {
               "type": "frame",
+              "id": "I1QUL",
+              "name": "nav_r_c",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "padding": 10,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "OVpMo",
+                  "fill": "#555",
+                  "content": "Runner",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
               "id": "rKqtG",
               "name": "nav_c_c",
               "width": "fill_container",
@@ -576,7 +595,7 @@
       "type": "frame",
       "id": "MLhv8",
       "x": 15,
-      "y": 1206,
+      "y": 1342,
       "name": "Missions page",
       "width": 1440,
       "height": 900,
@@ -615,6 +634,25 @@
               "id": "yzcM8",
               "width": "fill_container",
               "height": 24
+            },
+            {
+              "type": "frame",
+              "id": "7wKNx",
+              "name": "nav_r_m",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "padding": 10,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "y3maC",
+                  "fill": "#555",
+                  "content": "Runner",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
             },
             {
               "type": "frame",
@@ -1058,7 +1096,7 @@
       "type": "frame",
       "id": "XCm1k",
       "x": 1547,
-      "y": 1206,
+      "y": 1342,
       "name": "Mission workspace",
       "width": 1440,
       "height": 900,
@@ -1097,6 +1135,25 @@
               "id": "h4Zba",
               "width": "fill_container",
               "height": 24
+            },
+            {
+              "type": "frame",
+              "id": "8LyoK",
+              "name": "nav_r_w",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "padding": 10,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "HF2KL",
+                  "fill": "#555",
+                  "content": "Runner",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
             },
             {
               "type": "frame",
@@ -2304,6 +2361,25 @@
               "id": "ILof0",
               "width": "fill_container",
               "height": 24
+            },
+            {
+              "type": "frame",
+              "id": "vuPTr",
+              "name": "nav_r_cd",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "padding": 10,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "26t1h",
+                  "fill": "#555",
+                  "content": "Runner",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
             },
             {
               "type": "frame",
@@ -4026,7 +4102,7 @@
       "type": "frame",
       "id": "rMw15",
       "x": 15,
-      "y": 2279,
+      "y": 2415,
       "name": "Start Mission modal",
       "width": 1440,
       "height": 900,
@@ -4568,6 +4644,2243 @@
                           "fontFamily": "Inter",
                           "fontSize": 13,
                           "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "2Oecf",
+      "x": 3124,
+      "y": 1342,
+      "name": "Runners page",
+      "width": 1440,
+      "height": 900,
+      "fill": "#FAFAFA",
+      "cornerRadius": 12,
+      "children": [
+        {
+          "type": "frame",
+          "id": "AkMQ4",
+          "name": "Sidebar",
+          "width": 240,
+          "height": "fill_container",
+          "fill": "#F2F2F2",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "#E5E5E5"
+          },
+          "layout": "vertical",
+          "gap": 4,
+          "padding": 20,
+          "children": [
+            {
+              "type": "text",
+              "id": "RRY3B",
+              "fill": "#111",
+              "content": "runners",
+              "fontFamily": "Inter",
+              "fontSize": 18,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "MK3Fg",
+              "width": "fill_container",
+              "height": 24
+            },
+            {
+              "type": "frame",
+              "id": "6HxH0",
+              "name": "nav_r_r",
+              "width": "fill_container",
+              "fill": "#E5E5E5",
+              "cornerRadius": 6,
+              "padding": 10,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "kxfC3",
+                  "fill": "#111",
+                  "content": "Runner",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "HisGb",
+              "name": "nav_c_r",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "padding": 10,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "fD5Ci",
+                  "fill": "#555",
+                  "content": "Crew",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Aigic",
+              "name": "nav_m_r",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "padding": 10,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "eju8x",
+                  "fill": "#555",
+                  "content": "Mission",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Y2idh",
+          "name": "Main",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "#FAFAFA",
+          "layout": "vertical",
+          "gap": 24,
+          "padding": 32,
+          "children": [
+            {
+              "type": "frame",
+              "id": "CEOcu",
+              "name": "header_r",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "3WBmL",
+                  "name": "htitles_r",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "CUR1p",
+                      "fill": "#111",
+                      "content": "Runners",
+                      "fontFamily": "Inter",
+                      "fontSize": 24,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "7oj2H",
+                      "fill": "#777",
+                      "content": "Reusable CLI agents — pick one for a crew slot or chat directly.",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "54f1f",
+                  "name": "newbtn_r",
+                  "fill": "#111",
+                  "cornerRadius": 6,
+                  "padding": [
+                    10,
+                    14
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "GH8jB",
+                      "fill": "#FFF",
+                      "content": "+ New runner",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zUnn9",
+              "name": "List",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "KhgbU",
+                  "name": "Runner card 1",
+                  "width": "fill_container",
+                  "fill": "#FFF",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#E5E5E5"
+                  },
+                  "gap": 20,
+                  "padding": 20,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "PsE2g",
+                      "name": "r1_left",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "4soM7",
+                          "name": "top1",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "lDQQg",
+                              "fill": "#111",
+                              "content": "@architect",
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "ucayL",
+                              "name": "runtime1",
+                              "fill": "#F2F2F2",
+                              "cornerRadius": 999,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "UccTX",
+                                  "fill": "#555",
+                                  "content": "claude-code",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "bbucE",
+                          "fill": "#777",
+                          "content": "Plans features and splits work into tasks for implementers.",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "3m5zp",
+                          "name": "meta1",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "aExuz",
+                              "fill": "#888",
+                              "content": "$ claude",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "mSe4o",
+                              "fill": "#CCC",
+                              "content": "·",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "8jdtN",
+                              "fill": "#888",
+                              "content": "in 2 crews",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "a0qfS",
+                      "name": "r1_right",
+                      "layout": "vertical",
+                      "gap": 10,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "WMNuB",
+                          "name": "badges1",
+                          "gap": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "KFwPc",
+                              "name": "sb1",
+                              "fill": "#F0FDF4",
+                              "cornerRadius": 999,
+                              "gap": 6,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "F2Htx",
+                                  "fill": "#22C55E",
+                                  "width": 6,
+                                  "height": 6
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "vprwB",
+                                  "fill": "#15803D",
+                                  "content": "2 sessions",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Durd5",
+                              "name": "mb1",
+                              "fill": "#EFF6FF",
+                              "cornerRadius": 999,
+                              "gap": 6,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "E811z",
+                                  "fill": "#1D4ED8",
+                                  "content": "1 mission",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "yfbFr",
+                          "name": "acts1",
+                          "gap": 12,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "7w66b",
+                              "fill": "#0066CC",
+                              "content": "Edit",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "hWIdb",
+                              "fill": "#0066CC",
+                              "content": "Chat",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "UWySw",
+                              "fill": "#B42318",
+                              "content": "Delete",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "dS2t0",
+                  "name": "Runner card 2",
+                  "width": "fill_container",
+                  "fill": "#FFF",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#E5E5E5"
+                  },
+                  "gap": 20,
+                  "padding": 20,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "DBUbz",
+                      "name": "r2_left",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Qu0WM",
+                          "name": "top2",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "iUnXb",
+                              "fill": "#111",
+                              "content": "@impl",
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Os3Zx",
+                              "name": "rt2",
+                              "fill": "#F2F2F2",
+                              "cornerRadius": 999,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "1LbY6",
+                                  "fill": "#555",
+                                  "content": "codex",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "qpP5T",
+                          "fill": "#777",
+                          "content": "Implements feature modules end-to-end. Reports to @architect.",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "jnwhd",
+                          "name": "m2",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "nGuGQ",
+                              "fill": "#888",
+                              "content": "$ codex --no-confirm",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "pM3tW",
+                              "fill": "#CCC",
+                              "content": "·",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "e8MID",
+                              "fill": "#888",
+                              "content": "in 1 crew",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WgI1I",
+                      "name": "r2_right",
+                      "layout": "vertical",
+                      "gap": 10,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "gf28z",
+                          "name": "b2",
+                          "gap": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "lkpPm",
+                              "name": "sb2",
+                              "fill": "#F0FDF4",
+                              "cornerRadius": 999,
+                              "gap": 6,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "9mnSG",
+                                  "fill": "#22C55E",
+                                  "width": 6,
+                                  "height": 6
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "I6kBj",
+                                  "fill": "#15803D",
+                                  "content": "1 session",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "JWNWX",
+                              "name": "mb2",
+                              "fill": "#EFF6FF",
+                              "cornerRadius": 999,
+                              "gap": 6,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "1Nnpr",
+                                  "fill": "#1D4ED8",
+                                  "content": "1 mission",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Ne1W7",
+                          "name": "a2",
+                          "gap": 12,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "DnvA8",
+                              "fill": "#0066CC",
+                              "content": "Edit",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "RypQt",
+                              "fill": "#0066CC",
+                              "content": "Chat",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "EhYDb",
+                              "fill": "#B42318",
+                              "content": "Delete",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "bSwub",
+                  "name": "Runner card 3",
+                  "width": "fill_container",
+                  "fill": "#FFF",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#E5E5E5"
+                  },
+                  "gap": 20,
+                  "padding": 20,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "cXCYt",
+                      "name": "r3_left",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "V14BS",
+                          "name": "top3",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "mlfzu",
+                              "fill": "#111",
+                              "content": "@reviewer",
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "M6YZG",
+                              "name": "rt3",
+                              "fill": "#F2F2F2",
+                              "cornerRadius": 999,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "YPNA4",
+                                  "fill": "#555",
+                                  "content": "aider",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "Jn2Z9",
+                          "fill": "#777",
+                          "content": "Reviews diffs, reports blockers back to architect.",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Xk39O",
+                          "name": "m3",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "30AyQ",
+                              "fill": "#888",
+                              "content": "$ aider --auto",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "Uv8Ii",
+                              "fill": "#CCC",
+                              "content": "·",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "NoEjb",
+                              "fill": "#888",
+                              "content": "in 2 crews",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "XdjZc",
+                      "name": "r3_right",
+                      "layout": "vertical",
+                      "gap": 10,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "BaGhs",
+                          "name": "b3",
+                          "gap": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "ustEG",
+                              "name": "idle3",
+                              "fill": "#FAFAFA",
+                              "cornerRadius": 999,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#E5E5E5"
+                              },
+                              "gap": 6,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "bunRb",
+                                  "fill": "#888",
+                                  "content": "idle",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Q0BAk",
+                          "name": "a3",
+                          "gap": 12,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "gbutm",
+                              "fill": "#0066CC",
+                              "content": "Edit",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "bjc4r",
+                              "fill": "#0066CC",
+                              "content": "Chat",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "efwTa",
+                              "fill": "#B42318",
+                              "content": "Delete",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HTVTB",
+                  "name": "Runner card 4",
+                  "width": "fill_container",
+                  "fill": "#FFF",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#E5E5E5"
+                  },
+                  "gap": 20,
+                  "padding": 20,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "TRwXv",
+                      "name": "r4_left",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "iTgIz",
+                          "name": "top4",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "XgpcG",
+                              "fill": "#111",
+                              "content": "@ops",
+                              "fontFamily": "Inter",
+                              "fontSize": 16,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Zy3Ff",
+                              "name": "rt4",
+                              "fill": "#F2F2F2",
+                              "cornerRadius": 999,
+                              "padding": [
+                                3,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "wxb1G",
+                                  "fill": "#555",
+                                  "content": "claude-code",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "u5SOB",
+                          "fill": "#777",
+                          "content": "Runs migrations and deploys. Orphan runner — not in any crew.",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "quMFn",
+                          "name": "m4",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "R1S9E",
+                              "fill": "#888",
+                              "content": "$ claude --dangerously-skip-permissions",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "ze2hH",
+                              "fill": "#CCC",
+                              "content": "·",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "9gcED",
+                              "fill": "#A16207",
+                              "content": "orphan",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "iae0J",
+                      "name": "r4_right",
+                      "layout": "vertical",
+                      "gap": 10,
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "DAlGU",
+                          "name": "b4",
+                          "gap": 6,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "wHoIi",
+                              "name": "sb4",
+                              "fill": "#F0FDF4",
+                              "cornerRadius": 999,
+                              "gap": 6,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "zC5JR",
+                                  "fill": "#22C55E",
+                                  "width": 6,
+                                  "height": 6
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Jcudw",
+                                  "fill": "#15803D",
+                                  "content": "1 session",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "hCg71",
+                          "name": "a4",
+                          "gap": 12,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Sd7OF",
+                              "fill": "#0066CC",
+                              "content": "Edit",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "LBCpr",
+                              "fill": "#0066CC",
+                              "content": "Chat",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "h8oJ9",
+                              "fill": "#B42318",
+                              "content": "Delete",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "6D752",
+                  "name": "Runner card empty",
+                  "width": "fill_container",
+                  "fill": "#FAFAFA",
+                  "cornerRadius": 8,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#D0D0D0"
+                  },
+                  "layout": "vertical",
+                  "gap": 8,
+                  "padding": 20,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "CzQM1",
+                      "fill": "#888",
+                      "content": "+ Add another runner",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "text",
+                      "id": "AtPUr",
+                      "fill": "#AAA",
+                      "content": "Reusable across crews and direct chat sessions.",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "ocAFJ",
+      "x": 1547,
+      "y": 2415,
+      "name": "Runner Detail page",
+      "width": 1440,
+      "height": 900,
+      "fill": "#FAFAFA",
+      "cornerRadius": 12,
+      "children": [
+        {
+          "type": "frame",
+          "id": "pgAEV",
+          "name": "Sidebar",
+          "width": 240,
+          "height": "fill_container",
+          "fill": "#F2F2F2",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "#E5E5E5"
+          },
+          "layout": "vertical",
+          "gap": 4,
+          "padding": 20,
+          "children": [
+            {
+              "type": "text",
+              "id": "A1fwx",
+              "fill": "#111",
+              "content": "runners",
+              "fontFamily": "Inter",
+              "fontSize": 18,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "mVkRh",
+              "width": "fill_container",
+              "height": 24
+            },
+            {
+              "type": "frame",
+              "id": "5k47O",
+              "name": "nav_r_rd",
+              "width": "fill_container",
+              "fill": "#E5E5E5",
+              "cornerRadius": 6,
+              "padding": 10,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "OtXRI",
+                  "fill": "#111",
+                  "content": "Runner",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ZuqMW",
+              "name": "nav_c_rd",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "padding": 10,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "BFg0Q",
+                  "fill": "#555",
+                  "content": "Crew",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "wZoEH",
+              "name": "nav_m_rd",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "padding": 10,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "fASBZ",
+                  "fill": "#555",
+                  "content": "Mission",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "VObYw",
+              "width": "fill_container",
+              "height": 16
+            },
+            {
+              "type": "text",
+              "id": "QkkjK",
+              "fill": "#AAA",
+              "content": "ROSTER",
+              "fontFamily": "Inter",
+              "fontSize": 10,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "ctEUy",
+              "name": "roster_active",
+              "width": "fill_container",
+              "fill": "#FFF",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#E5E5E5"
+              },
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "MfAVE",
+                  "fill": "#22C55E",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "prtiY",
+                  "fill": "#111",
+                  "content": "@architect",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "mjpK5",
+              "name": "roster2",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "yrCoP",
+                  "fill": "#D4D4D4",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "1D9Hm",
+                  "fill": "#555",
+                  "content": "@impl",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "drk7I",
+              "name": "roster3",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "iNQiK",
+                  "fill": "#D4D4D4",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "DfQXb",
+                  "fill": "#555",
+                  "content": "@reviewer",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "e8HJZ",
+              "name": "roster4",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "J0gjT",
+                  "fill": "#D4D4D4",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "A68mI",
+                  "fill": "#555",
+                  "content": "@ops",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "19EuL",
+          "name": "Main",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "#FAFAFA",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "50vXx",
+              "name": "Topbar",
+              "width": "fill_container",
+              "fill": "#FFF",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#E5E5E5"
+              },
+              "gap": 16,
+              "padding": [
+                16,
+                32
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "FStpK",
+                  "name": "tb_left",
+                  "width": "fill_container",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "B33UN",
+                      "fill": "#777",
+                      "content": "← Runners",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "ihwKq",
+                      "fill": "#CCC",
+                      "content": "/",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "GdxrI",
+                      "fill": "#111",
+                      "content": "@architect",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "i0WXS",
+                      "name": "rtpill",
+                      "fill": "#F2F2F2",
+                      "cornerRadius": 999,
+                      "padding": [
+                        3,
+                        8
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "vt10S",
+                          "fill": "#555",
+                          "content": "claude-code",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "gCED8",
+                  "name": "tb_right",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "pIEkv",
+                      "name": "edit",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#E5E5E5"
+                      },
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "y0e4Q",
+                          "fill": "#111",
+                          "content": "Edit",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "yPpD9",
+                      "name": "chat",
+                      "fill": "#111",
+                      "cornerRadius": 6,
+                      "padding": [
+                        8,
+                        14
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "PqA30",
+                          "fill": "#FFF",
+                          "content": "Chat now",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "jFGZX",
+              "name": "content_rd",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 24,
+              "padding": 32,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Oh8OA",
+                  "name": "head",
+                  "layout": "vertical",
+                  "gap": 6,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "yyLQ4",
+                      "fill": "#111",
+                      "content": "@architect",
+                      "fontFamily": "Inter",
+                      "fontSize": 28,
+                      "fontWeight": "700"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Ws0zq",
+                      "fill": "#777",
+                      "textGrowth": "fixed-width",
+                      "width": 880,
+                      "content": "Plans features and splits work into tasks for implementers.",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "zHiU9",
+                      "name": "mr",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "yW1M3",
+                          "fill": "#555",
+                          "content": "$ claude",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ETuBY",
+                          "fill": "#CCC",
+                          "content": "·",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "0vrnH",
+                          "fill": "#555",
+                          "content": "in 2 crews: runners-feature, runners-ops",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "EyBUf",
+                  "name": "cols",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "gap": 24,
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "n11UB",
+                      "name": "colL",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 16,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "FUbuW",
+                          "name": "PromptCard",
+                          "width": "fill_container",
+                          "fill": "#FFF",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#E5E5E5"
+                          },
+                          "layout": "vertical",
+                          "gap": 12,
+                          "padding": 20,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "C9mYB",
+                              "name": "ph",
+                              "width": "fill_container",
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "GR2ZV",
+                                  "name": "phl",
+                                  "layout": "vertical",
+                                  "gap": 2,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "pOoRk",
+                                      "fill": "#111",
+                                      "content": "Default system prompt",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 14,
+                                      "fontWeight": "600"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "yHI4n",
+                                      "fill": "#888",
+                                      "content": "Used whenever this runner spawns. Override per-slot inside crews.",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "aziHU",
+                                  "fill": "#0066CC",
+                                  "content": "Edit",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "rZUml",
+                              "name": "pbody",
+                              "width": "fill_container",
+                              "fill": "#FAFAFA",
+                              "cornerRadius": 6,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#E5E5E5"
+                              },
+                              "padding": 16,
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "qgkZZ",
+                                  "fill": "#333",
+                                  "textGrowth": "fixed-width",
+                                  "width": "fill_container",
+                                  "content": "You are the architect for the runners crew.\n\nWhen a mission starts, decompose the goal into 3–6 tasks and assign each to an @handle in the crew. Use task.assign events.\n\nWatch for blockers from @impl and @reviewer; resolve with task.adjust events. Hand off to a human only when blocked > 2 cycles.",
+                                  "lineHeight": 1.5,
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "gh86j",
+                          "name": "CrewsCard",
+                          "width": "fill_container",
+                          "fill": "#FFF",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#E5E5E5"
+                          },
+                          "layout": "vertical",
+                          "gap": 12,
+                          "padding": 20,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "FGIbf",
+                              "name": "ch",
+                              "width": "fill_container",
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "qIcLv",
+                                  "fill": "#111",
+                                  "content": "Crews using this runner",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 14,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "C4gDm",
+                                  "fill": "#888",
+                                  "content": "2",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "28uIQ",
+                              "name": "crow1",
+                              "width": "fill_container",
+                              "cornerRadius": 6,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#E5E5E5"
+                              },
+                              "padding": [
+                                10,
+                                12
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "Vr5YN",
+                                  "name": "crl1",
+                                  "gap": 10,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "G5dW9",
+                                      "fill": "#111",
+                                      "content": "runners-feature",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "500"
+                                    },
+                                    {
+                                      "type": "frame",
+                                      "id": "f8It7",
+                                      "name": "lead",
+                                      "fill": "#FEF3C7",
+                                      "cornerRadius": 999,
+                                      "padding": [
+                                        2,
+                                        8
+                                      ],
+                                      "children": [
+                                        {
+                                          "type": "text",
+                                          "id": "lT2xJ",
+                                          "fill": "#92400E",
+                                          "content": "LEAD",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 10,
+                                          "fontWeight": "600",
+                                          "letterSpacing": 0.5
+                                        }
+                                      ]
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "I6BM9",
+                                  "fill": "#0066CC",
+                                  "content": "Open →",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "s99aL",
+                              "name": "crow2",
+                              "width": "fill_container",
+                              "cornerRadius": 6,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#E5E5E5"
+                              },
+                              "padding": [
+                                10,
+                                12
+                              ],
+                              "justifyContent": "space_between",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "ycm9m",
+                                  "fill": "#111",
+                                  "content": "runners-ops",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 13,
+                                  "fontWeight": "500"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "lsJcp",
+                                  "fill": "#0066CC",
+                                  "content": "Open →",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "9DJ5W",
+                      "name": "colR",
+                      "width": 340,
+                      "layout": "vertical",
+                      "gap": 16,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "r9D9b",
+                          "name": "ActivityCard",
+                          "width": "fill_container",
+                          "fill": "#FFF",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#E5E5E5"
+                          },
+                          "layout": "vertical",
+                          "gap": 14,
+                          "padding": 20,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "AEHJd",
+                              "fill": "#111",
+                              "content": "Activity",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "EkIW7",
+                              "name": "stats",
+                              "width": "fill_container",
+                              "gap": 12,
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "RYnYP",
+                                  "name": "s1",
+                                  "width": "fill_container",
+                                  "fill": "#FAFAFA",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#E5E5E5"
+                                  },
+                                  "layout": "vertical",
+                                  "gap": 4,
+                                  "padding": 12,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "W5JSz",
+                                      "fill": "#111",
+                                      "content": "2",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 22,
+                                      "fontWeight": "700"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "V2zZJ",
+                                      "fill": "#777",
+                                      "content": "sessions",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "4PDJa",
+                                  "name": "s2",
+                                  "width": "fill_container",
+                                  "fill": "#FAFAFA",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#E5E5E5"
+                                  },
+                                  "layout": "vertical",
+                                  "gap": 4,
+                                  "padding": 12,
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "Q827g",
+                                      "fill": "#111",
+                                      "content": "1",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 22,
+                                      "fontWeight": "700"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "Y42O4",
+                                      "fill": "#777",
+                                      "content": "missions",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "hZFQ8",
+                              "name": "divider",
+                              "width": "fill_container",
+                              "height": 1,
+                              "fill": "#E5E5E5"
+                            },
+                            {
+                              "type": "text",
+                              "id": "1s0bQ",
+                              "fill": "#AAA",
+                              "content": "OPEN SESSIONS",
+                              "fontFamily": "Inter",
+                              "fontSize": 10,
+                              "fontWeight": "600",
+                              "letterSpacing": 1
+                            },
+                            {
+                              "type": "frame",
+                              "id": "8kFTa",
+                              "name": "sess1",
+                              "width": "fill_container",
+                              "cornerRadius": 6,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#E5E5E5"
+                              },
+                              "layout": "vertical",
+                              "gap": 4,
+                              "padding": [
+                                8,
+                                10
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "6im4i",
+                                  "name": "ss1",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "WxB1b",
+                                      "name": "ss1l",
+                                      "gap": 6,
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "ellipse",
+                                          "id": "x4P29",
+                                          "fill": "#22C55E",
+                                          "width": 6,
+                                          "height": 6
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "PDI15",
+                                          "fill": "#111",
+                                          "content": "direct chat",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "FoJdf",
+                                      "fill": "#888",
+                                      "content": "3m ago",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "33a0c",
+                                  "fill": "#888",
+                                  "content": "~/work/runners",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "NVSl9",
+                              "name": "sess2",
+                              "width": "fill_container",
+                              "cornerRadius": 6,
+                              "stroke": {
+                                "align": "inside",
+                                "thickness": 1,
+                                "fill": "#E5E5E5"
+                              },
+                              "layout": "vertical",
+                              "gap": 4,
+                              "padding": [
+                                8,
+                                10
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "Bs7mK",
+                                  "name": "ss2",
+                                  "width": "fill_container",
+                                  "justifyContent": "space_between",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "frame",
+                                      "id": "8IGgH",
+                                      "name": "ss2l",
+                                      "gap": 6,
+                                      "alignItems": "center",
+                                      "children": [
+                                        {
+                                          "type": "ellipse",
+                                          "id": "PkI2W",
+                                          "fill": "#22C55E",
+                                          "width": 6,
+                                          "height": 6
+                                        },
+                                        {
+                                          "type": "text",
+                                          "id": "cvSWy",
+                                          "fill": "#111",
+                                          "content": "runners-eta",
+                                          "fontFamily": "Inter",
+                                          "fontSize": 12,
+                                          "fontWeight": "500"
+                                        }
+                                      ]
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "1SOLs",
+                                      "fill": "#888",
+                                      "content": "21m ago",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 11,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "lbk2a",
+                                  "fill": "#888",
+                                  "content": "mission · Investigate latency spike",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "katFd",
+                              "fill": "#999",
+                              "content": "Last active 3 minutes ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "k9z4O",
+                          "name": "MetaCard",
+                          "width": "fill_container",
+                          "fill": "#FFF",
+                          "cornerRadius": 8,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#E5E5E5"
+                          },
+                          "layout": "vertical",
+                          "gap": 10,
+                          "padding": 20,
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "sEcUZ",
+                              "fill": "#111",
+                              "content": "Details",
+                              "fontFamily": "Inter",
+                              "fontSize": 14,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "ghIUg",
+                              "name": "mr1",
+                              "width": "fill_container",
+                              "justifyContent": "space_between",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "8KIwo",
+                                  "fill": "#888",
+                                  "content": "Handle",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "nJr0v",
+                                  "fill": "#111",
+                                  "content": "@architect",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "z6e9x",
+                              "name": "mr2",
+                              "width": "fill_container",
+                              "justifyContent": "space_between",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "5ASnP",
+                                  "fill": "#888",
+                                  "content": "Runtime",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "VDPFh",
+                                  "fill": "#111",
+                                  "content": "claude-code",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Np7mh",
+                              "name": "mr3",
+                              "width": "fill_container",
+                              "justifyContent": "space_between",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "tXnjJ",
+                                  "fill": "#888",
+                                  "content": "Created",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "fZ2Lj",
+                                  "fill": "#111",
+                                  "content": "Apr 18, 2026",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "yWXJE",
+                              "name": "mr4",
+                              "width": "fill_container",
+                              "justifyContent": "space_between",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "wWJ5b",
+                                  "fill": "#888",
+                                  "content": "ID",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "IU4Kj",
+                                  "fill": "#111",
+                                  "content": "rnr_a3f2c1",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
                         }
                       ]
                     }

--- a/docs/arch/v0-arch.md
+++ b/docs/arch/v0-arch.md
@@ -109,18 +109,18 @@ Lifecycle: created by the user, edited freely, deleted when no longer needed. Pe
 
 ### 2.3 Runner — *one configured agent*
 
-An individual CLI agent within a crew: what binary to run, with what args, in what working directory, with what system prompt (the role's brief). Persistent config. A runner doesn't run either; it describes a process that will be spawned when a mission starts.
+An individual CLI agent: what binary to run, with what args, in what working directory, with what system prompt (the role's brief). Persistent config. A runner doesn't run on its own; it describes a process that will be spawned — either as a session inside a mission (the normal path), or as a standalone direct-chat session (see §2.6).
 
 A runner has two identifying fields:
 
-- **`handle`** — a lowercase slug (e.g. `coder`, `reviewer`, `tester`). Required, immutable once set, unique within the crew. Used everywhere addressing is needed: as `from` and `to` in events, as `--to <handle>` on the CLI, and in policy rules. Handles are what runners call each other by.
+- **`handle`** — a lowercase slug (e.g. `coder`, `reviewer`, `tester`). Required, immutable once set, **globally unique** across the app. Used everywhere addressing is needed: as `from` and `to` in events, as `--to <handle>` on the CLI, and in policy rules. Global uniqueness means `@impl` names the same runner whether it's seen in crew A's event log or crew B's.
 - **`display_name`** — a free-form label for the UI (e.g. "Coder", "Lead Reviewer"). Editable; not used in event fields or addressing.
 
 Keeping these separate means renaming a runner for the UI doesn't break briefs, rules, or historical events. `handle` is the identity; `display_name` is just presentation.
 
-A runner belongs to exactly one crew. Examples: `coder` (claude-code), `reviewer` (claude-code), `tester` (shell).
+**Runners are top-level config; crews compose them.** A runner is its own entity, not a child of a crew. The same runner can be a member of multiple crews — `@architect` can sit in `runners-feature` and `runners-ops` simultaneously. Crew membership lives in the `crew_runners` join table, which carries the per-crew `position` and `lead` flag (see §7.1). This is a deliberate post-C3 product change: a user typically curates a small stable of runners and reuses them across crews and ad-hoc direct chats; tying a runner to a single crew would force them to clone configs every time.
 
-Exactly one runner in a crew carries the `lead` flag (see §2.2). The orchestrator treats the lead as the default recipient of human broadcast messages and the mission-goal inject at startup; other runners receive traffic only when directly addressed. The flag lives on the runner record in SQLite, enforced by a unique partial index: `UNIQUE(crew_id) WHERE lead = 1`.
+Exactly one runner per crew carries the per-crew `lead` flag (see §2.2). The orchestrator treats the lead as the default recipient of human broadcast messages and the mission-goal inject at startup; other crew members receive traffic only when directly addressed. The flag lives on `crew_runners`, enforced by a unique partial index: `UNIQUE(crew_id) WHERE lead = 1`. Lead is per-crew, not per-runner — the same runner can be lead in one crew and a worker in another.
 
 ### 2.4 Orchestrator Policy — *the crew's decision rules*
 
@@ -145,11 +145,14 @@ This framing matters: when we say "the coordination bus is mission-scoped" or "t
 
 v0 constraint: a crew can have at most one live mission at a time. A crew can have many historical missions.
 
-### 2.6 Session — *one runner's PTY process, running inside a mission*
+### 2.6 Session — *one runner's PTY process*
 
 The runtime instance of a Runner. A Session is to a Runner what a Mission is to a Crew: the *run* of a *configuration*.
 
-A session exists if and only if a mission exists. One runner × one mission = one session. When the mission starts, each runner in the crew gets a session spawned for it. When the mission ends, every session in that mission is killed. A session cannot outlive its mission; a session cannot exist without one.
+A session has two flavors, distinguished by whether `mission_id` is set:
+
+- **Mission session** — spawned when a mission starts; one session per crew member. It dies with the mission. The runner participates in the crew's coordination bus, sees broadcasts, can receive `inject_stdin` from the orchestrator, etc. This is the path the v0 demo flow exercises.
+- **Direct-chat session** — spawned ad-hoc from the Runners page (see §2.3) without a parent mission. `mission_id` is null and the working directory lives on the session row directly. The runner is **not on any coordination bus** — there's no event log, no orchestrator, no inbox; it's just a one-on-one PTY between the human and the runner's CLI. Useful for "I just want to ask `@architect` something quickly" without spinning up a full crew.
 
 A session owns:
 - A PTY master handle (the only object in the system with a file descriptor to a running child process).
@@ -700,8 +703,7 @@ crews (
 
 runners (
   id TEXT PRIMARY KEY,
-  crew_id TEXT REFERENCES crews(id) ON DELETE CASCADE,
-  handle TEXT NOT NULL,               -- lowercase slug, immutable, unique within crew
+  handle TEXT NOT NULL UNIQUE,        -- globally unique slug; see §2.3
   display_name TEXT NOT NULL,         -- free-form UI label
   role TEXT NOT NULL,
   runtime TEXT NOT NULL,
@@ -710,18 +712,27 @@ runners (
   working_dir TEXT,
   system_prompt TEXT,
   env_json TEXT,
-  lead INTEGER NOT NULL DEFAULT 0,    -- 0 or 1; see §2.2 lead invariant
-  position INTEGER NOT NULL,          -- ordering within the crew (0-based)
-  created_at TEXT, updated_at TEXT,
-  UNIQUE (crew_id, handle)
+  created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+);
+
+-- Crew membership lives here, not on `runners`. One runner can join many
+-- crews; `lead` and `position` are per-crew (§2.3).
+crew_runners (
+  crew_id TEXT NOT NULL REFERENCES crews(id) ON DELETE CASCADE,
+  runner_id TEXT NOT NULL REFERENCES runners(id) ON DELETE CASCADE,
+  position INTEGER NOT NULL,
+  lead INTEGER NOT NULL DEFAULT 0,
+  added_at TEXT NOT NULL,
+  PRIMARY KEY (crew_id, runner_id),
+  UNIQUE (crew_id, position)
 );
 
 -- Enforces the lead invariant (§2.2): exactly one lead per crew.
-CREATE UNIQUE INDEX one_lead_per_crew ON runners(crew_id) WHERE lead = 1;
+CREATE UNIQUE INDEX one_lead_per_crew ON crew_runners(crew_id) WHERE lead = 1;
 
 missions (
   id TEXT PRIMARY KEY,
-  crew_id TEXT REFERENCES crews(id) ON DELETE CASCADE,
+  crew_id TEXT NOT NULL REFERENCES crews(id) ON DELETE CASCADE,
   title TEXT NOT NULL,                -- short label shown in missions list + event log
   status TEXT NOT NULL,               -- running | completed | aborted
   goal_override TEXT,                 -- null means inherit crews.goal
@@ -732,8 +743,12 @@ missions (
 
 sessions (
   id TEXT PRIMARY KEY,
-  mission_id TEXT REFERENCES missions(id) ON DELETE CASCADE,
-  runner_id TEXT REFERENCES runners(id) ON DELETE CASCADE,
+  -- Nullable: direct-chat sessions exist without a mission (§2.6). For
+  -- mission sessions, deleting the mission detaches the session
+  -- (`SET NULL`) so historical session rows survive for activity stats.
+  mission_id TEXT REFERENCES missions(id) ON DELETE SET NULL,
+  runner_id TEXT NOT NULL REFERENCES runners(id) ON DELETE CASCADE,
+  cwd TEXT,                           -- working dir; carried for direct-chat sessions
   status TEXT NOT NULL,               -- running | stopped | crashed
   pid INTEGER,                        -- OS process id once spawned; null while pending
   started_at TEXT, stopped_at TEXT

--- a/docs/arch/v0-prd.md
+++ b/docs/arch/v0-prd.md
@@ -97,10 +97,10 @@ If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
 - A crew has: `name`, `goal` (default mission brief), list of runners, orchestrator policy, signal-type allowlist.
 - Persisted in SQLite.
 
-### 6.2 Runner CRUD (scoped to a crew)
-- Spawn, edit, remove runners within a crew.
+### 6.2 Runner CRUD (top-level, shared across crews)
+- Create, edit, delete runners as standalone config; add or remove a runner's membership in a given crew via `crew_runners`. The same runner can sit in multiple crews simultaneously (post-C5.5a).
 - A runner has:
-  - `handle` — lowercase slug (e.g. `coder`). Immutable once set; unique within the crew. Used everywhere addressing is needed (`from`/`to` in events, `--to <handle>` on the CLI, policy rules).
+  - `handle` — lowercase slug (e.g. `coder`). Immutable once set; **globally unique** across the app. Used everywhere addressing is needed (`from`/`to` in events, `--to <handle>` on the CLI, policy rules) so `@coder` names the same runner everywhere it appears.
   - `display_name` — free-form UI label (e.g. "Coder", "Lead Reviewer"). Editable; presentation-only.
   - `role` — short label, e.g. "implementation".
   - `runtime` — enum: `claude-code | codex | shell`. Adds the right default `command` + `args`.

--- a/docs/impls/v0-mvp.md
+++ b/docs/impls/v0-mvp.md
@@ -8,7 +8,7 @@
 
 From a clean launch of the app, a user can:
 
-1. Create a **Crew** on the Crews page, then add two runners to it (one `claude-code` lead, one `shell` worker) on the **Crew Detail** page. Runners are crew-scoped — there is no shared "template" concept in v0 (per PRD §3). The lead invariant is enforced end-to-end.
+1. Create a **Crew** on the Crews page, then add two runners to it (one `claude-code` lead, one `shell` worker) on the **Crew Detail** page. Per C5.5a, runners are top-level config and shared across crews — adding a runner to a crew creates a `crew_runners` membership row, not a new runner. The lead invariant is per-crew (one lead per crew, enforced via partial unique index on `crew_runners`) and is checked end-to-end.
 2. Click **Start Mission**, fill the goal, and see the Mission workspace open with two live PTY sessions.
 3. Watch the lead runner receive the goal via stdin, draft a plan, and post a directed message to the worker; see the worker pick it up on its next `runners msg read`.
 4. See a worker emit an `ask_lead` signal; watch the lead decide to escalate via `ask_human`; click **Approve** on the resulting card; see the lead receive the response and forward it to the worker.
@@ -80,18 +80,22 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 
 ## C2 — Config CRUD (runners, crews, lead invariant)
 
-**Goal.** Tauri commands for managing crews and their crew-scoped runners, with the lead invariant enforced at the Rust layer in addition to the DB.
+**Goal.** Tauri commands for managing crews and (top-level, sharable) runners, with the per-crew lead invariant enforced at the Rust layer in addition to the DB.
+
+**Note (post-C5.5a).** This section was originally written for the per-crew runner model. C5.5a moved runner CRUD onto the global `runners` table and put crew membership on `crew_runners`; the live commands match that shape. The descriptions below reflect what actually shipped.
 
 **Deliverables.**
 - `src-tauri/src/commands/crew.rs` — `crew_list`, `crew_create`, `crew_update`, `crew_delete`.
-- `src-tauri/src/commands/runner.rs` — `runner_list(crew_id)`, `runner_create`, `runner_update`, `runner_delete`, `runner_reorder(crew_id, ordered_ids)`, `runner_set_lead(runner_id)`.
+- `src-tauri/src/commands/runner.rs` — `runner_list` (global, no crew arg), `runner_get`, `runner_create`, `runner_update`, `runner_delete`, `runner_activity`. Runners exist independently of any crew.
+- `src-tauri/src/commands/crew_runner.rs` — membership commands: `crew_list_runners(crew_id)`, `crew_add_runner(crew_id, runner_id)`, `crew_remove_runner(crew_id, runner_id)`, `crew_set_lead(crew_id, runner_id)`, `crew_reorder(crew_id, ordered_runner_ids)`.
 - Invariant rules encoded in Rust:
-  - First runner added to a crew is auto-lead.
-  - `runner_set_lead` runs in a transaction: unset old lead, set new lead, single commit.
-  - Deleting the lead while other runners remain auto-promotes the runner at the lowest `position`.
-  - Deleting the last runner of a crew is allowed (crew becomes empty, unstartable).
+  - First runner added to a crew is auto-lead (membership-level, not runner-level).
+  - `crew_set_lead` runs in a transaction: unset old lead, set new lead, single commit.
+  - Removing the lead from a crew while other members remain auto-promotes the runner at the lowest `position`.
+  - Removing the last member of a crew is allowed (crew becomes empty, unstartable).
+  - Deleting a runner globally cascades through `crew_runners` (`ON DELETE CASCADE`); deleting a crew cascades through `crew_runners` but **does not** delete the runner row itself.
 
-**Tests.** `cargo test` covers: auto-lead on first insert, forbidden second lead, lead auto-promotion on delete, atomic reassign.
+**Tests.** `cargo test` covers: auto-lead on first membership insert, forbidden second lead per crew, lead auto-promotion on remove, atomic reassign, runner survives crew delete, same runner can join multiple crews and be lead in each independently.
 
 **Out of scope.** UI, mission, PTY.
 

--- a/docs/impls/v0-mvp.md
+++ b/docs/impls/v0-mvp.md
@@ -116,7 +116,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 
 **Manual test plan.** Create a crew, add two runners, reassign lead, delete lead, confirm auto-promotion to the next runner by `position`.
 
-**Out of scope.** Mission workspace, Start Mission modal. Standalone Runners list/detail pages (design exists, MVP does not build them).
+**Out of scope.** Mission workspace, Start Mission modal. The standalone Runners list / Runner Detail pages (frames `2Oecf` and `ocAFJ` in the design) ship in **C8.5**, not C3.
 
 ---
 

--- a/docs/impls/v0-mvp.md
+++ b/docs/impls/v0-mvp.md
@@ -46,7 +46,8 @@ Anything beyond this is explicitly v0.x or later.
     │     │
     │     └─► C5  mission lifecycle commands
     │           │
-    │           ├─► C6  PTY session runtime ─► C9  `runners` CLI
+    │           ├─► C6  PTY session runtime ─► C9    `runners` CLI
+    │           │                          └─► C8.5  Runners page + Runner Detail + direct chat
     │           │
     │           └─► C7  event bus + notify watcher ─► C8  orchestrator v0
     │
@@ -56,7 +57,7 @@ Anything beyond this is explicitly v0.x or later.
   C11  missions list + Start Mission modal   (depends on C3, C5, C10)
 ```
 
-C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel after C5. Everything else is serial.
+C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel after C5. C8 (orchestrator) and C8.5 (Runners page) are peers — both depend on C6, neither depends on the other, so they can ship in either order.
 
 ---
 
@@ -100,7 +101,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 
 **Goal.** Wire the config CRUD to the wireframes in `design/runners-design.pen`. This is the first chunk a non-engineer can interact with.
 
-**Scope note — no top-level Runners page in MVP.** Runners are crew-scoped per PRD §3. The design file's standalone "Runners" list and "Runner Detail" frames are kept for a future v0.x surface (a cross-crew runner browser) but are *not* built in MVP. Runner CRUD happens inside Crew Detail via Add Slot and an inline edit drawer.
+**Scope note — Runners are top-level in MVP, but the dedicated Runners pages land in C8.5.** C5.5a (`v0-mvp-c5-5-shared-runners.md`) already moved runners out from under crews and made the same runner shareable across crews; the data model has no notion of "crew-scoped runner" anymore. C3 still does runner CRUD inside Crew Detail (Add Slot + edit drawer) because that's the path the demo flow needs. The standalone Runners list and Runner Detail frames in `design/runners-design.pen` (`2Oecf`, `ocAFJ`) are built in C8.5 (sibling chunk of C8 orchestrator).
 
 **Deliverables.**
 - `src/pages/Crews.tsx` — crew cards (create, list, delete).
@@ -206,6 +207,42 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 **Tests.** Each built-in rule fires exactly once. Replay after reopen reconstructs state from the log. `human_response` without a matching `human_question` is dropped with a log warning, not panic.
 
 **Out of scope.** LLM policy, user-authored rules. MVP ships only the built-ins plus a no-op policy slot.
+
+---
+
+## C8.5 — Runners page + Runner Detail + direct chat
+
+**Goal.** Promote runners to a top-level UI surface, mirroring the design's `2Oecf` (Runners list) and `ocAFJ` (Runner Detail) frames, plus a "Chat now" path that exercises the direct-chat session shape C5.5a already baked into the schema. Without this chunk, runners that aren't in any crew are invisible and the user can never spawn a runner without going through a full mission.
+
+**Why it sits at C8.5.** Sibling/parallel to C8 (orchestrator) — both depend on C6 and neither depends on the other, following the C5.5a precedent for inserted chunks. The orchestrator and the Runners page can ship in either order; this just records that the work is part of v0-mvp, not deferred.
+
+**Scope-shift context.** Originally cut from MVP under the C3 "no top-level Runners page" scope note, now restored: the C5.5a schema work is wasted UI-side until this lands.
+
+**Deliverables.**
+- **Backend.**
+  - `commands/runner.rs::runner_list_with_activity()` — extends the existing `runner_list` to include `running_session_count` (from `sessions WHERE status = 'running'`) and `open_mission_count` (from `crew_runners ⨝ missions WHERE status = 'running'`). The Runners list cards need both counters.
+  - `commands/runner.rs::runner_get_by_handle(handle)` — used by `/runners/:handle` so the URL is stable across runner-id rotations.
+  - `commands/session.rs::session_start_direct(runner_id, cwd)` — inserts a `sessions` row with `mission_id = NULL` and the chosen `cwd`, then spawns through the existing `SessionManager::spawn` path. Differences from the mission flavor: no `RUNNERS_MISSION_ID`, `RUNNERS_EVENT_LOG`, or `RUNNERS_CREW_ID` env vars are set, and the runner does not join any event bus or orchestrator. The `runners` CLI must no-op gracefully when those vars are absent (small change in C9-land — the CLI errors today on `RUNNERS_EVENT_LOG`-not-set, which would crash a direct-chat agent the moment it tries to emit an event).
+  - Live activity events: `SessionManager` emits `runner/activity { runner_id, running_sessions, open_missions }` on every spawn, reap, and kill so the Runners list and Runner Detail can update without polling.
+- **Frontend.**
+  - `src/components/Sidebar.tsx` — flip the placeholder Runner item to an enabled `NavLink to="/runners"`. Order in the design is Runner / Crew / Mission, top to bottom.
+  - `src/pages/Runners.tsx` — vertical stack of `RunnerCard`s, header with `+ New runner`, dashed empty-state card. Same visual vocabulary as `Crews.tsx`. Subscribes to `runner/activity` for live counters.
+  - `src/components/CreateRunnerModal.tsx` — extracted from `CrewEditor.tsx`'s anonymous "Add Slot" modal so both surfaces reuse one component. The Crew Detail flow keeps adding *existing* runners through Add Slot, plus this same modal as a "create new" affordance.
+  - `src/pages/RunnerDetail.tsx` (`/runners/:handle`) — two columns matching `ocAFJ`: left has `Default system prompt` (with the same edit-drawer behavior C3 ships) and `Crews using this runner` (LEAD badge per row, deep-link into Crew Detail); right has `Activity` (counts + clickable list of open sessions) and `Details` (handle, runtime, created, ID). Header shows breadcrumb `Runners › @handle`, role badge, and two actions: `Edit` (opens `RunnerEditDrawer`) and `Chat now`.
+  - **Chat now flow.** Opens a small dialog asking for working directory (defaulting to the runner's own `working_dir` if set), calls `session_start_direct`, then routes to a new pane modeled on the C6 debug page minus the mission/runners-rail concepts. Route shape `/runners/:handle/chat/:sessionId` so multiple direct chats can stay open across runners.
+
+**Tests.**
+- Backend: `runner_list_with_activity` returns zero counters for a brand-new runner; reflects running mission sessions; reflects direct-chat sessions independently. Deleting a mission must leave its session row counted under the runner (per `sessions.mission_id ON DELETE SET NULL`) until the session itself is reaped.
+- Backend: `session_start_direct` against `/bin/cat` → row has `mission_id IS NULL`, stdin injection round-trips, kill reaps cleanly, status reaches `stopped`. Concurrent direct chats on the same runner work and don't fight for the runner's `working_dir`.
+- Backend: starting a direct session does **not** affect mission invariants — a crew that already has a live mission can still be inspected, and a direct chat does not block its lead's other crew from starting a new mission.
+- Frontend: `/runners` renders with mocked activity payloads; sidebar routing; opening Runner Detail; round-trip the edit drawer; clicking a crew row navigates to `/crews/{id}`; Chat now opens the chat pane and bytes flow.
+
+**Out of scope.**
+- A persistent transcript log per direct-chat session. Direct chats are ephemeral by design — the C6 scrollback ring is the only memory. A real transcript would need its own append-only store and is deferred to v0.x.
+- Renaming a `handle`. Globally-unique handles + cross-crew membership make immutability load-bearing — renaming would silently change `from`/`to` semantics on every historical event. Runner Detail surfaces only `display_name` as editable; a tooltip on `handle` explains why it's locked.
+- Cross-window sync for activity counters. We don't ship multi-window in MVP.
+
+**Manual test plan.** From the sidebar's Runner item, land on Runners list; verify activity badges; create a fresh runner from the Runners page (not from inside a crew); open its detail; verify the empty Crews-using-this-runner section; click Chat now; type a command into the runner's CLI and see output; close the chat; check that the activity counter on the list page dropped back to zero.
 
 ---
 

--- a/docs/tests/v0-mvp-tests.md
+++ b/docs/tests/v0-mvp-tests.md
@@ -333,7 +333,7 @@ Expected: positions persist (refresh to confirm); `LEAD` badge still attached to
 ### Known gaps — do NOT verify in C3
 
 - Per-slot system-prompt override: UI field exists but is a stub until v0.x — typing stores the value but it has no effect at runtime.
-- Standalone Runners list / Runner Detail pages: not built in MVP.
+- Standalone Runners list / Runner Detail pages: built in **C8.5**, not C3. Verify under that chunk's manual-test plan.
 - Mission workspace behavior: C10.
 - Start Mission: C11.
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -32,6 +32,10 @@ ulid = { workspace = true }
 # NamedTempFile::persist for a Windows-safe atomic replace.
 tempfile = "3"
 portable-pty = "0.8"
+# Filesystem watcher for the per-mission event-log tail (C7). The
+# `macos_fsevent` backend is the default on macOS; on Linux it falls back to
+# inotify, on Windows to ReadDirectoryChangesW.
+notify = "6"
 
 # Unix-only: SIGTERM/SIGKILL escalation inside SessionManager::kill. Windows
 # gets a different path in a future chunk (v0 scope is macOS + Linux).

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -323,6 +323,7 @@ pub async fn mission_start(
     app: tauri::AppHandle,
     input: StartMissionInput,
 ) -> Result<StartMissionOutput> {
+    use crate::event_bus::{BusEmitter, TauriBusEvents};
     use crate::session::manager::{SessionEvents, TauriSessionEvents};
     use std::sync::Arc;
 
@@ -346,6 +347,36 @@ pub async fn mission_start(
     };
     let events_log_path =
         event_log::events_path(&state.app_data_dir, &out.mission.crew_id, &out.mission.id);
+
+    // Mount the event-bus watcher *before* spawning sessions. The opening
+    // events are already on disk (start() emitted them under the same DB
+    // tx), so the bus's initial replay will pick up `mission_start` and
+    // `mission_goal` and surface them to the UI. Mounting before spawn
+    // also means anything a runner writes to the log on startup is
+    // observed without a race against the watcher attaching.
+    let mission_dir =
+        event_log::mission_dir(&state.app_data_dir, &out.mission.crew_id, &out.mission.id);
+    let roster_handles: Vec<String> = roster.iter().map(|m| m.runner.handle.clone()).collect();
+    let bus_emitter: Arc<dyn BusEmitter> = Arc::new(TauriBusEvents(app.clone()));
+    if let Err(e) = state.buses.mount(
+        out.mission.id.clone(),
+        &mission_dir,
+        &roster_handles,
+        bus_emitter,
+    ) {
+        // Roll back the mission row so the crew isn't stuck behind a
+        // phantom `running` if the watcher couldn't attach.
+        if let Ok(conn) = state.db.get() {
+            let _ = conn.execute(
+                "UPDATE missions
+                    SET status = 'aborted', stopped_at = ?1
+                  WHERE id = ?2",
+                rusqlite::params![Utc::now().to_rfc3339(), out.mission.id],
+            );
+        }
+        return Err(e);
+    }
+
     let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app.clone()));
     for member in roster {
         let spawn_res = state.sessions.spawn(
@@ -357,10 +388,11 @@ pub async fn mission_start(
             Arc::clone(&emitter),
         );
         if let Err(e) = spawn_res {
-            // Rollback: kill the sessions that did start, mark the mission
-            // aborted so the crew isn't stuck behind a phantom `running`,
-            // then surface the original spawn error.
+            // Rollback: kill the sessions that did start, drop the bus,
+            // mark the mission aborted so the crew isn't stuck behind a
+            // phantom `running`, then surface the original spawn error.
             let _ = state.sessions.kill_all_for_mission(&out.mission.id);
+            state.buses.unmount(&out.mission.id);
             if let Ok(conn) = state.db.get() {
                 let _ = conn.execute(
                     "UPDATE missions
@@ -383,7 +415,12 @@ pub async fn mission_stop(state: State<'_, AppState>, id: String) -> Result<Miss
     // Only then is it honest to call the mission `completed`.
     state.sessions.kill_all_for_mission(&id)?;
     let mut conn = state.db.get()?;
-    stop(&mut conn, &state.app_data_dir, &id)
+    let mission = stop(&mut conn, &state.app_data_dir, &id)?;
+    // Drop the bus *after* the terminal `mission_stopped` event is on
+    // disk, so the watcher gets one last tick and clients see it before
+    // the bus tears down. unmount() is idempotent and never fails.
+    state.buses.unmount(&id);
+    Ok(mission)
 }
 
 #[tauri::command]

--- a/src-tauri/src/event_bus/mod.rs
+++ b/src-tauri/src/event_bus/mod.rs
@@ -287,10 +287,27 @@ impl BusState {
     /// Drain whatever new lines are on disk and project them through the
     /// emitter. Called both on initial mount (from offset 0) and on every
     /// notify ping.
+    ///
+    /// Uses `read_from_lossy` so a single malformed complete line is logged
+    /// and skipped, never re-tried on the next tick. Without this, one bad
+    /// JSON write — say from a buggy CLI release — would freeze the bus on
+    /// the same offset forever and silently swallow every later event.
     fn tick(&mut self, log: &EventLog, emitter: &dyn BusEmitter) -> Result<()> {
-        let entries = log.read_from(self.next_offset)?;
+        let (entries, skipped) = log.read_from_lossy(self.next_offset)?;
+        for skip in &skipped {
+            eprintln!(
+                "event_bus[{}]: skipping malformed line at offset {} ({})",
+                self.mission_id, skip.offset, skip.error
+            );
+        }
+        // Compute the new `next_offset` from the max of every line seen this
+        // tick — entries AND skips. If we used only entries we'd re-read
+        // skipped bytes whenever a bad line came *after* the last good one;
+        // if we used only skips we'd lose track when bad lines came first.
+        let max_skip_next = skipped.iter().map(|s| s.next_offset).max().unwrap_or(0);
+        let max_entry_next = entries.iter().map(|e| e.next_offset).max().unwrap_or(0);
+        let new_offset = self.next_offset.max(max_skip_next).max(max_entry_next);
         for entry in entries {
-            self.next_offset = entry.next_offset;
             let event = entry.event;
 
             emitter.appended(&AppendedEvent {
@@ -327,6 +344,7 @@ impl BusState {
                 }
             }
         }
+        self.next_offset = new_offset;
         Ok(())
     }
 
@@ -792,6 +810,53 @@ mod tests {
             2,
             "broadcast message should inbox for both lead and coder"
         );
+    }
+
+    #[test]
+    fn malformed_line_is_skipped_with_warning() {
+        // Regression for the v0-mvp-tests.md C7 contract: one bad line
+        // doesn't poison the bus. Without `read_from_lossy`, the consumer
+        // would re-tick the same offset forever and never deliver the good
+        // event after the corruption.
+        use std::io::Write;
+
+        let dir = fresh_mission_dir();
+        let log = EventLog::open(dir.path()).unwrap();
+        log.append(message("lead", None, "first")).unwrap();
+
+        // Hand-write a malformed line directly. A real writer would never
+        // produce this, but a buggy CLI release on PATH could.
+        {
+            let mut f = std::fs::OpenOptions::new()
+                .append(true)
+                .open(dir.path().join("events.ndjson"))
+                .unwrap();
+            f.write_all(b"this is not json\n").unwrap();
+        }
+
+        let cap = Arc::new(Capture::default());
+        let _bus = EventBus::for_mission(
+            "mission".into(),
+            dir.path(),
+            &["lead".to_string()],
+            cap_dyn(&cap),
+        )
+        .unwrap();
+        // Wait for initial replay to flush.
+        wait_until(1000, || cap.appended.lock().unwrap().len() == 1);
+
+        // Append another good event AFTER the bad line. The bus must
+        // surface it — proving the corruption didn't freeze the offset.
+        log.append(message("lead", None, "second")).unwrap();
+
+        let arrived = wait_until(3000, || cap.appended.lock().unwrap().len() == 2);
+        assert!(
+            arrived,
+            "bus must skip past the bad line and deliver later events"
+        );
+        let appended = cap.appended.lock().unwrap();
+        assert_eq!(appended[0].event.payload["text"], "first");
+        assert_eq!(appended[1].event.payload["text"], "second");
     }
 
     #[test]

--- a/src-tauri/src/event_bus/mod.rs
+++ b/src-tauri/src/event_bus/mod.rs
@@ -367,6 +367,18 @@ impl BusState {
             // only authorized writer of these and it always sets up_to.
             return;
         };
+        // Reject up_to values that aren't real ULIDs. Without this guard a
+        // junk value like "zzzz" sorts after every real ULID lexically, so
+        // the comparisons below would silently mark every existing inbox
+        // entry as read and hide every future entry whose ULID came before
+        // "zzzz" — which, given Crockford's alphabet, is all of them.
+        if up_to.parse::<ulid::Ulid>().is_err() {
+            eprintln!(
+                "event_bus[{}]: dropping inbox_read with non-ULID up_to {:?}",
+                self.mission_id, up_to
+            );
+            return;
+        }
         let handle = event.from.clone();
         let inbox = self.inbox.entry(handle.clone()).or_default();
 
@@ -810,6 +822,43 @@ mod tests {
             2,
             "broadcast message should inbox for both lead and coder"
         );
+    }
+
+    #[test]
+    fn inbox_read_with_non_ulid_up_to_is_dropped() {
+        // Regression: a junk `up_to` like "zzzz" sorts past every real
+        // ULID lexically; without ULID validation, the bus would mark
+        // every existing inbox entry as read and hide every future one.
+        // The signal must be silently dropped so the watermark stays put.
+        let dir = fresh_mission_dir();
+        let log = EventLog::open(dir.path()).unwrap();
+        log.append(message("lead", None, "real broadcast")).unwrap();
+        log.append(signal(
+            "lead",
+            "inbox_read",
+            serde_json::json!({ "up_to": "zzzz" }),
+        ))
+        .unwrap();
+
+        let cap = Arc::new(Capture::default());
+        let _bus = EventBus::for_mission(
+            "mission".into(),
+            dir.path(),
+            &["lead".to_string()],
+            cap_dyn(&cap),
+        )
+        .unwrap();
+
+        wait_until(1000, || cap.appended.lock().unwrap().len() == 2);
+        // The bad inbox_read must not produce a watermark advance.
+        let wm = cap.watermark.lock().unwrap();
+        assert!(
+            wm.is_empty(),
+            "junk up_to must not advance the watermark; got {wm:?}"
+        );
+        // The real broadcast still got inboxed; unread_count should be 1.
+        let inbox = cap.inbox.lock().unwrap();
+        assert_eq!(inbox.last().unwrap().unread_count, 1);
     }
 
     #[test]

--- a/src-tauri/src/event_bus/mod.rs
+++ b/src-tauri/src/event_bus/mod.rs
@@ -188,21 +188,23 @@ impl EventBus {
                     eprintln!("event_bus[{mission_id_for_thread}]: initial tick failed: {e}");
                 }
                 loop {
-                    if shutdown_for_thread.load(Ordering::SeqCst) {
-                        return;
-                    }
                     // recv_timeout lets us notice shutdown without a notify
                     // event arriving; also serves as a slow-poll safety net
                     // in case notify drops something.
-                    match rx.recv_timeout(Duration::from_millis(500)) {
-                        Ok(WatchPing::FsEvent) | Err(_) => {
-                            if shutdown_for_thread.load(Ordering::SeqCst) {
-                                return;
-                            }
-                            if let Err(e) = state.tick(&log, emitter_for_thread.as_ref()) {
-                                eprintln!("event_bus[{mission_id_for_thread}]: tick failed: {e}");
-                            }
-                        }
+                    let _ = rx.recv_timeout(Duration::from_millis(500));
+                    let shutting = shutdown_for_thread.load(Ordering::SeqCst);
+                    // Always tick, even when shutting down: `mission_stop`
+                    // appends the terminal `mission_stopped` event *before*
+                    // calling unmount, and clients need to see it via
+                    // `event/appended` before the bus tears down. Without
+                    // this final drain, the consumer can wake on the
+                    // shutdown flag and exit before notify delivered the
+                    // terminal write, dropping the event silently.
+                    if let Err(e) = state.tick(&log, emitter_for_thread.as_ref()) {
+                        eprintln!("event_bus[{mission_id_for_thread}]: tick failed: {e}");
+                    }
+                    if shutting {
+                        return;
                     }
                 }
             })
@@ -296,18 +298,20 @@ impl BusState {
                 event: event.clone(),
             });
 
-            // inbox_read signals advance watermarks; do this *before*
-            // projecting the event into inboxes so a runner's own read
-            // signal doesn't show up as an unread item in their projection
-            // (signals with no `to` would otherwise project everywhere).
+            // inbox_read signals advance watermarks; handle them and move on.
+            // Other signals (mission_start, mission_goal, ask_lead, …) never
+            // project into inboxes — per arch §2.7 the inbox is strictly
+            // `kind = "message" AND (to = null OR to = h)`.
             if Self::is_inbox_read(&event) {
                 self.handle_inbox_read(&event, emitter);
                 continue;
             }
+            if !matches!(event.kind, EventKind::Message) {
+                continue;
+            }
 
-            // Project into matching inboxes. Per arch §5.5 the inbox
-            // includes broadcast events (`to == null`) and direct mail
-            // (`to == handle`).
+            // Project into matching inboxes. Broadcasts (`to == null`) land in
+            // every roster member's inbox; directs land in exactly one.
             for handle in self.handles.clone() {
                 if event_targets(&event, &handle) {
                     let inbox = self.inbox.entry(handle.clone()).or_default();
@@ -731,6 +735,107 @@ mod tests {
             cap.appended.lock().unwrap().len(),
             1,
             "no events should arrive after unmount"
+        );
+    }
+
+    #[test]
+    fn signals_never_enter_inbox_projection() {
+        // Regression for review finding #1: inbox is messages-only per arch
+        // §2.7 (`kind = "message" AND (to = null OR to = h)`). Signals with
+        // no `to` would otherwise show up as unread for every roster member,
+        // so a brand-new mission would start with a bogus unread count from
+        // its own `mission_start` + `mission_goal` opening events.
+        let dir = fresh_mission_dir();
+        let log = EventLog::open(dir.path()).unwrap();
+        log.append(signal("system", "mission_start", serde_json::json!({})))
+            .unwrap();
+        log.append(signal(
+            "human",
+            "mission_goal",
+            serde_json::json!({ "text": "ship it" }),
+        ))
+        .unwrap();
+        log.append(signal(
+            "coder",
+            "ask_lead",
+            serde_json::json!({ "question": "?" }),
+        ))
+        .unwrap();
+
+        let cap = Arc::new(Capture::default());
+        let _bus = EventBus::for_mission(
+            "mission".into(),
+            dir.path(),
+            &["lead".to_string(), "coder".to_string()],
+            cap_dyn(&cap),
+        )
+        .unwrap();
+
+        wait_until(1000, || cap.appended.lock().unwrap().len() == 3);
+        assert_eq!(
+            cap.appended.lock().unwrap().len(),
+            3,
+            "all signals appended"
+        );
+        // Critical: no inbox_updated emissions for these signals.
+        assert!(
+            cap.inbox.lock().unwrap().is_empty(),
+            "signals must not project into inboxes; got {:?}",
+            cap.inbox.lock().unwrap()
+        );
+
+        // Now post a real message — it must inbox normally for both runners.
+        log.append(message("lead", None, "broadcast")).unwrap();
+        wait_until(3000, || cap.inbox.lock().unwrap().len() == 2);
+        assert_eq!(
+            cap.inbox.lock().unwrap().len(),
+            2,
+            "broadcast message should inbox for both lead and coder"
+        );
+    }
+
+    #[test]
+    fn unmount_drains_pending_writes_before_exiting() {
+        // Regression for review finding #2: writes that landed just before
+        // `unmount` must surface via `event/appended` even if the consumer
+        // hadn't ticked them yet. Simulates `mission_stop`'s real ordering:
+        // append the terminal event, then call unmount immediately.
+        let dir = fresh_mission_dir();
+        let _log_init = EventLog::open(dir.path()).unwrap();
+
+        let cap = Arc::new(Capture::default());
+        let registry = BusRegistry::new();
+        registry
+            .mount(
+                "mission".into(),
+                dir.path(),
+                &["lead".to_string()],
+                cap_dyn(&cap),
+            )
+            .unwrap();
+        // Let the initial replay settle.
+        wait_until(200, || true);
+
+        let log = EventLog::open(dir.path()).unwrap();
+        log.append(signal("system", "mission_stopped", serde_json::json!({})))
+            .unwrap();
+        // Mirror mission_stop: unmount immediately after the append. The
+        // consumer must do one final tick on its way out.
+        registry.unmount("mission");
+
+        let appended = cap.appended.lock().unwrap();
+        assert!(
+            appended.iter().any(|a| a
+                .event
+                .signal_type
+                .as_ref()
+                .map(|t| t.as_str() == "mission_stopped")
+                .unwrap_or(false)),
+            "terminal event must surface before bus tears down; got {:?}",
+            appended
+                .iter()
+                .map(|a| a.event.signal_type.as_ref().map(|t| t.as_str().to_string()))
+                .collect::<Vec<_>>()
         );
     }
 }

--- a/src-tauri/src/event_bus/mod.rs
+++ b/src-tauri/src/event_bus/mod.rs
@@ -1,2 +1,736 @@
-// Event bus — NDJSON append-only log + file watcher for inter-runner comm.
-// TODO: implement with notify crate.
+// Event bus — tails a mission's append-only NDJSON log and broadcasts every
+// new event to the rest of the process.
+//
+// Why this layer exists: C4 gave us durable append. C5 emits the opening
+// events. C6 spawns the runners. None of those are enough for the UI or the
+// orchestrator to *react* — they need a stream of envelopes as they land.
+// Once C8 arrives, the orchestrator subscribes to this bus to inject stdin
+// in response to signals; until then, the bus already powers replay + the
+// per-runner inbox/watermark accounting that C10's workspace UI consumes.
+//
+// Design notes:
+//
+//   - One bus per live mission. The watcher tails exactly one file. We mount
+//     in `mission_start` after the opening events are durable, and unmount in
+//     `mission_stop`. Crashes during mount don't strand a watcher because the
+//     bus owns its watcher and is dropped on error.
+//
+//   - notify can fire spurious modify events; we always re-read from the
+//     stored byte offset. `EventLog::read_from` returns an empty Vec when
+//     there's nothing new, so a duplicate notify is a cheap no-op. We never
+//     trust notify's contents — only that "something might have changed".
+//
+//   - The watcher runs notify on its own thread and pipes events to a single
+//     consumer thread that owns mutable bus state. We do NOT process inside
+//     notify's callback, both to keep that thread fast and to serialize all
+//     state updates through one channel. The consumer calls back into the
+//     emitter (Tauri or test fake) so the bus is unit-testable without a
+//     running app.
+//
+//   - Per-runner inbox projection is `events where to == null OR to == handle`.
+//     We track every matching event id per handle so unread_count after a
+//     watermark advance is just `len - read_idx` — no log rescans.
+//
+//   - Watermarks come exclusively from `inbox_read` signals (per arch §5.3 and
+//     v0-mvp.md C7), never inferred from `--since` or wall time. The signal's
+//     `from` identifies which runner is reading; `payload.up_to` is the ULID
+//     they claim to have read through.
+
+use std::collections::{BTreeMap, HashMap};
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::channel;
+use std::sync::{Arc, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+use notify::{
+    Event as NotifyEvent, EventKind as NotifyKind, RecommendedWatcher, RecursiveMode, Watcher,
+};
+use runners_core::event_log::EventLog;
+use runners_core::model::{Event, EventKind};
+use serde::Serialize;
+use tauri::Emitter;
+
+use crate::error::{Error, Result};
+
+/// Decouples the bus from Tauri so the consumer thread can be unit-tested
+/// without a running AppHandle. Production wraps `AppHandle::emit`; tests
+/// use a recording fake. Mirrors the `SessionEvents` trait in `session::manager`.
+pub trait BusEmitter: Send + Sync + 'static {
+    fn appended(&self, ev: &AppendedEvent);
+    fn inbox_updated(&self, ev: &InboxUpdate);
+    fn watermark_advanced(&self, ev: &WatermarkUpdate);
+}
+
+/// Real Tauri emitter — fans out to `event/appended`, `inbox/updated`,
+/// `watermark/advanced` so the React workspace can subscribe.
+pub struct TauriBusEvents(pub tauri::AppHandle);
+
+impl BusEmitter for TauriBusEvents {
+    fn appended(&self, ev: &AppendedEvent) {
+        let _ = self.0.emit("event/appended", ev);
+    }
+    fn inbox_updated(&self, ev: &InboxUpdate) {
+        let _ = self.0.emit("inbox/updated", ev);
+    }
+    fn watermark_advanced(&self, ev: &WatermarkUpdate) {
+        let _ = self.0.emit("watermark/advanced", ev);
+    }
+}
+
+/// Payload for `event/appended`. The full envelope plus the mission id so the
+/// frontend can route across multiple open missions.
+#[derive(Debug, Clone, Serialize)]
+pub struct AppendedEvent {
+    pub mission_id: String,
+    pub event: Event,
+}
+
+/// Payload for `inbox/updated`. Sent every time a runner's matching-event set
+/// or unread count changes — that is, on every newly-projected event for that
+/// handle, plus on every watermark advance that reduces unread_count.
+#[derive(Debug, Clone, Serialize)]
+pub struct InboxUpdate {
+    pub mission_id: String,
+    pub runner_handle: String,
+    /// Highest ULID currently in the runner's projected inbox, or `None` if
+    /// nothing has been routed to them yet.
+    pub last_id: Option<String>,
+    /// `payload.up_to` from the most recent `inbox_read` signal this runner
+    /// emitted, or `None` if they haven't read anything.
+    pub watermark: Option<String>,
+    pub unread_count: usize,
+}
+
+/// Payload for `watermark/advanced`. Emitted only when an `inbox_read` signal
+/// pushes the watermark forward — never for redundant reads. The frontend can
+/// use this to clear unread badges without re-reading inbox state.
+#[derive(Debug, Clone, Serialize)]
+pub struct WatermarkUpdate {
+    pub mission_id: String,
+    pub runner_handle: String,
+    pub watermark: String,
+    pub unread_count: usize,
+}
+
+/// One mission's tail-and-project loop. Holding this value alive keeps the
+/// notify watcher and consumer thread running; dropping it tears both down.
+pub struct EventBus {
+    mission_id: String,
+    shutdown: Arc<AtomicBool>,
+    consumer: Mutex<Option<JoinHandle<()>>>,
+    /// Notify watcher — kept alive for the bus's lifetime. It feeds the
+    /// channel; we never read from it directly.
+    _watcher: RecommendedWatcher,
+}
+
+impl EventBus {
+    /// Mount a bus on `mission_dir`'s `events.ndjson`, replay everything
+    /// that's already on disk through the emitter, then keep tailing.
+    ///
+    /// `roster` is the list of runner handles whose inboxes we'll project.
+    /// Adding handles after mount is not supported in MVP — crews can't grow
+    /// mid-mission.
+    pub fn for_mission(
+        mission_id: String,
+        mission_dir: &Path,
+        roster: &[String],
+        emitter: Arc<dyn BusEmitter>,
+    ) -> Result<Arc<Self>> {
+        let log = EventLog::open(mission_dir)?;
+        let log_path_for_filter = log.path().to_path_buf();
+
+        // The watcher's notify thread sends `()` pings on every fs event;
+        // the consumer drains the channel and re-reads from the stored
+        // offset. A bounded channel isn't needed — pings collapse anyway,
+        // and notify can drop its own queue if we fall too far behind.
+        let (tx_for_watcher, rx) = channel::<WatchPing>();
+
+        // Watch the parent directory rather than the file itself. On macOS
+        // `FSEvents` only delivers reliable updates for the file you watched
+        // by exact inode; if a writer truncates+renames (which our event log
+        // never does, but defense in depth) the original watch is silently
+        // useless. Watching the dir + filtering on path is cheap and robust.
+        let watch_root = mission_dir.to_path_buf();
+        let mut watcher = notify::recommended_watcher(
+            move |res: std::result::Result<NotifyEvent, notify::Error>| {
+                let Ok(ev) = res else { return };
+                if !ev.paths.iter().any(|p| p == &log_path_for_filter) {
+                    return;
+                }
+                if matches!(
+                    ev.kind,
+                    NotifyKind::Modify(_) | NotifyKind::Create(_) | NotifyKind::Any
+                ) {
+                    let _ = tx_for_watcher.send(WatchPing::FsEvent);
+                }
+            },
+        )
+        .map_err(|e| Error::msg(format!("notify watcher: {e}")))?;
+        watcher
+            .watch(&watch_root, RecursiveMode::NonRecursive)
+            .map_err(|e| Error::msg(format!("notify watch {watch_root:?}: {e}")))?;
+
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let mission_id_for_thread = mission_id.clone();
+        let roster_for_thread: Vec<String> = roster.to_vec();
+        let shutdown_for_thread = Arc::clone(&shutdown);
+        let emitter_for_thread = Arc::clone(&emitter);
+        let consumer = thread::Builder::new()
+            .name(format!("event-bus-{mission_id}"))
+            .spawn(move || {
+                let mut state = BusState::new(mission_id_for_thread.clone(), roster_for_thread);
+                // Initial replay: read everything already on disk so the UI
+                // can rehydrate after a reopen and so any backlog the writer
+                // produced before the watcher attached is delivered.
+                if let Err(e) = state.tick(&log, emitter_for_thread.as_ref()) {
+                    eprintln!("event_bus[{mission_id_for_thread}]: initial tick failed: {e}");
+                }
+                loop {
+                    if shutdown_for_thread.load(Ordering::SeqCst) {
+                        return;
+                    }
+                    // recv_timeout lets us notice shutdown without a notify
+                    // event arriving; also serves as a slow-poll safety net
+                    // in case notify drops something.
+                    match rx.recv_timeout(Duration::from_millis(500)) {
+                        Ok(WatchPing::FsEvent) | Err(_) => {
+                            if shutdown_for_thread.load(Ordering::SeqCst) {
+                                return;
+                            }
+                            if let Err(e) = state.tick(&log, emitter_for_thread.as_ref()) {
+                                eprintln!("event_bus[{mission_id_for_thread}]: tick failed: {e}");
+                            }
+                        }
+                    }
+                }
+            })
+            .map_err(|e| Error::msg(format!("spawn event-bus consumer: {e}")))?;
+
+        Ok(Arc::new(Self {
+            mission_id,
+            shutdown,
+            consumer: Mutex::new(Some(consumer)),
+            _watcher: watcher,
+        }))
+    }
+
+    /// Stop the consumer thread and drop the watcher. Idempotent — safe to
+    /// call from `mission_stop` even if the bus is already shutting down.
+    pub fn stop(&self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        if let Some(handle) = self.consumer.lock().unwrap().take() {
+            let _ = handle.join();
+        }
+    }
+
+    pub fn mission_id(&self) -> &str {
+        &self.mission_id
+    }
+}
+
+impl Drop for EventBus {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        // Don't join from Drop — if the consumer is blocked on the emitter,
+        // we'd deadlock the caller. The watcher dropping below closes the
+        // notify side; the consumer wakes up via recv_timeout and exits.
+    }
+}
+
+enum WatchPing {
+    FsEvent,
+}
+
+/// Per-mission projection state. Owns nothing thread-shared — the consumer
+/// thread is the only writer. `Vec<Ulid>` per handle holds matching event ids
+/// in append order; `read_idx` advances on `inbox_read` signals so unread
+/// count is `matched.len() - read_idx` without a log rescan.
+struct BusState {
+    mission_id: String,
+    next_offset: u64,
+    /// Roster of runner handles whose inboxes we project. Stable for the
+    /// mission's lifetime.
+    handles: Vec<String>,
+    inbox: BTreeMap<String, RunnerInbox>,
+}
+
+#[derive(Default)]
+struct RunnerInbox {
+    matched: Vec<String>, // ULIDs in append order
+    /// Index of the first unread entry in `matched`. `matched[read_idx..]`
+    /// is the unread tail; `matched[..read_idx]` has been ack'd via
+    /// inbox_read.
+    read_idx: usize,
+    /// Last `payload.up_to` from inbox_read. `None` means "never read".
+    /// Stored separately from read_idx so we can emit it without scanning.
+    watermark: Option<String>,
+}
+
+impl BusState {
+    fn new(mission_id: String, handles: Vec<String>) -> Self {
+        let mut inbox = BTreeMap::new();
+        for h in &handles {
+            inbox.insert(h.clone(), RunnerInbox::default());
+        }
+        Self {
+            mission_id,
+            next_offset: 0,
+            handles,
+            inbox,
+        }
+    }
+
+    /// Drain whatever new lines are on disk and project them through the
+    /// emitter. Called both on initial mount (from offset 0) and on every
+    /// notify ping.
+    fn tick(&mut self, log: &EventLog, emitter: &dyn BusEmitter) -> Result<()> {
+        let entries = log.read_from(self.next_offset)?;
+        for entry in entries {
+            self.next_offset = entry.next_offset;
+            let event = entry.event;
+
+            emitter.appended(&AppendedEvent {
+                mission_id: self.mission_id.clone(),
+                event: event.clone(),
+            });
+
+            // inbox_read signals advance watermarks; do this *before*
+            // projecting the event into inboxes so a runner's own read
+            // signal doesn't show up as an unread item in their projection
+            // (signals with no `to` would otherwise project everywhere).
+            if Self::is_inbox_read(&event) {
+                self.handle_inbox_read(&event, emitter);
+                continue;
+            }
+
+            // Project into matching inboxes. Per arch §5.5 the inbox
+            // includes broadcast events (`to == null`) and direct mail
+            // (`to == handle`).
+            for handle in self.handles.clone() {
+                if event_targets(&event, &handle) {
+                    let inbox = self.inbox.entry(handle.clone()).or_default();
+                    inbox.matched.push(event.id.clone());
+                    let unread = inbox.matched.len() - inbox.read_idx;
+                    emitter.inbox_updated(&InboxUpdate {
+                        mission_id: self.mission_id.clone(),
+                        runner_handle: handle,
+                        last_id: Some(event.id.clone()),
+                        watermark: inbox.watermark.clone(),
+                        unread_count: unread,
+                    });
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn is_inbox_read(event: &Event) -> bool {
+        matches!(event.kind, EventKind::Signal)
+            && event
+                .signal_type
+                .as_ref()
+                .map(|t| t.as_str() == "inbox_read")
+                .unwrap_or(false)
+    }
+
+    /// Process an `inbox_read` signal: bump `read_idx` for the runner that
+    /// emitted it (taken from `event.from`) past every matched id ≤ up_to,
+    /// store the new watermark, and fire `watermark/advanced` if it actually
+    /// moved. A duplicate or stale `up_to` is silently no-op'd.
+    fn handle_inbox_read(&mut self, event: &Event, emitter: &dyn BusEmitter) {
+        let Some(up_to) = event.payload.get("up_to").and_then(|v| v.as_str()) else {
+            // Malformed inbox_read — log nothing, just drop. The CLI is the
+            // only authorized writer of these and it always sets up_to.
+            return;
+        };
+        let handle = event.from.clone();
+        let inbox = self.inbox.entry(handle.clone()).or_default();
+
+        // Has the watermark moved? Compare lexically: ULIDs sort lex-correct.
+        let already_at_or_past = inbox
+            .watermark
+            .as_deref()
+            .map(|w| w.as_bytes() >= up_to.as_bytes())
+            .unwrap_or(false);
+        if already_at_or_past {
+            return;
+        }
+
+        inbox.watermark = Some(up_to.to_string());
+        // Advance read_idx past every matched id ≤ up_to. matched is already
+        // append-ordered (ULIDs are monotonic), so this is just a forward
+        // walk from the current read_idx.
+        while inbox.read_idx < inbox.matched.len()
+            && inbox.matched[inbox.read_idx].as_bytes() <= up_to.as_bytes()
+        {
+            inbox.read_idx += 1;
+        }
+        let unread = inbox.matched.len() - inbox.read_idx;
+        emitter.watermark_advanced(&WatermarkUpdate {
+            mission_id: self.mission_id.clone(),
+            runner_handle: handle.clone(),
+            watermark: up_to.to_string(),
+            unread_count: unread,
+        });
+        // Also fire inbox/updated so consumers that only listen for that
+        // event still see the new unread count.
+        emitter.inbox_updated(&InboxUpdate {
+            mission_id: self.mission_id.clone(),
+            runner_handle: handle,
+            last_id: inbox.matched.last().cloned(),
+            watermark: inbox.watermark.clone(),
+            unread_count: unread,
+        });
+    }
+}
+
+/// Returns true when `event` should appear in `handle`'s inbox.
+fn event_targets(event: &Event, handle: &str) -> bool {
+    match event.to.as_deref() {
+        None => true,
+        Some(target) => target == handle,
+    }
+}
+
+/// Process-wide registry of live buses, keyed by mission id. Mounted by
+/// `mission_start`, drained by `mission_stop` and at app shutdown.
+pub struct BusRegistry {
+    buses: Mutex<HashMap<String, Arc<EventBus>>>,
+}
+
+impl BusRegistry {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            buses: Mutex::new(HashMap::new()),
+        })
+    }
+
+    /// Mount a bus for `mission_id` if one isn't already registered.
+    /// Returning the existing bus on a duplicate mount keeps the contract
+    /// idempotent — `mission_start`'s rollback path can call `unmount` even
+    /// if mount partially failed.
+    pub fn mount(
+        &self,
+        mission_id: String,
+        mission_dir: &Path,
+        roster: &[String],
+        emitter: Arc<dyn BusEmitter>,
+    ) -> Result<Arc<EventBus>> {
+        let mut buses = self.buses.lock().unwrap();
+        if let Some(existing) = buses.get(&mission_id) {
+            return Ok(Arc::clone(existing));
+        }
+        let bus = EventBus::for_mission(mission_id.clone(), mission_dir, roster, emitter)?;
+        buses.insert(mission_id, Arc::clone(&bus));
+        Ok(bus)
+    }
+
+    pub fn unmount(&self, mission_id: &str) {
+        let bus = self.buses.lock().unwrap().remove(mission_id);
+        if let Some(bus) = bus {
+            bus.stop();
+        }
+    }
+
+    #[allow(dead_code)] // Used by tests + future shutdown path.
+    pub fn get(&self, mission_id: &str) -> Option<Arc<EventBus>> {
+        self.buses.lock().unwrap().get(mission_id).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runners_core::model::{EventDraft, EventKind, SignalType};
+    use std::sync::Mutex as StdMutex;
+    use std::time::Instant;
+
+    /// Recording emitter for unit tests.
+    #[derive(Default)]
+    struct Capture {
+        appended: StdMutex<Vec<AppendedEvent>>,
+        inbox: StdMutex<Vec<InboxUpdate>>,
+        watermark: StdMutex<Vec<WatermarkUpdate>>,
+    }
+
+    impl BusEmitter for Capture {
+        fn appended(&self, ev: &AppendedEvent) {
+            self.appended.lock().unwrap().push(ev.clone());
+        }
+        fn inbox_updated(&self, ev: &InboxUpdate) {
+            self.inbox.lock().unwrap().push(ev.clone());
+        }
+        fn watermark_advanced(&self, ev: &WatermarkUpdate) {
+            self.watermark.lock().unwrap().push(ev.clone());
+        }
+    }
+
+    fn signal(from: &str, ty: &str, payload: serde_json::Value) -> EventDraft {
+        EventDraft {
+            crew_id: "crew".into(),
+            mission_id: "mission".into(),
+            kind: EventKind::Signal,
+            from: from.into(),
+            to: None,
+            signal_type: Some(SignalType::new(ty)),
+            payload,
+        }
+    }
+
+    fn message(from: &str, to: Option<&str>, text: &str) -> EventDraft {
+        EventDraft {
+            crew_id: "crew".into(),
+            mission_id: "mission".into(),
+            kind: EventKind::Message,
+            from: from.into(),
+            to: to.map(String::from),
+            signal_type: None,
+            payload: serde_json::json!({ "text": text }),
+        }
+    }
+
+    /// Wait until `pred` returns true or `deadline_ms` elapses. Returns true
+    /// on success, false on timeout. Used to give notify time to deliver.
+    fn wait_until<F: FnMut() -> bool>(deadline_ms: u64, mut pred: F) -> bool {
+        let deadline = Instant::now() + Duration::from_millis(deadline_ms);
+        while Instant::now() < deadline {
+            if pred() {
+                return true;
+            }
+            thread::sleep(Duration::from_millis(20));
+        }
+        pred()
+    }
+
+    fn fresh_mission_dir() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    fn cap_dyn(cap: &Arc<Capture>) -> Arc<dyn BusEmitter> {
+        Arc::clone(cap) as Arc<dyn BusEmitter>
+    }
+
+    #[test]
+    fn replay_existing_events_on_mount() {
+        // Pre-seed the log, then mount the bus. Every existing event must
+        // surface as an `appended` emission so the UI can rehydrate after
+        // a reopen.
+        let dir = fresh_mission_dir();
+        let log = EventLog::open(dir.path()).unwrap();
+        log.append(signal("system", "mission_start", serde_json::json!({})))
+            .unwrap();
+        log.append(signal(
+            "human",
+            "mission_goal",
+            serde_json::json!({ "text": "ship it" }),
+        ))
+        .unwrap();
+
+        let cap = Arc::new(Capture::default());
+        let _bus = EventBus::for_mission(
+            "mission".into(),
+            dir.path(),
+            &["lead".to_string()],
+            cap_dyn(&cap),
+        )
+        .unwrap();
+
+        wait_until(1000, || cap.appended.lock().unwrap().len() == 2);
+        let appended = cap.appended.lock().unwrap();
+        assert_eq!(appended.len(), 2);
+        assert_eq!(
+            appended[0].event.signal_type.as_ref().unwrap().as_str(),
+            "mission_start"
+        );
+        assert_eq!(
+            appended[1].event.signal_type.as_ref().unwrap().as_str(),
+            "mission_goal"
+        );
+    }
+
+    #[test]
+    fn watcher_observes_appends_after_mount() {
+        // Mount on an empty log, then append. The notify watcher should
+        // wake the consumer and emit `appended`. notify is timing-sensitive
+        // so we poll within a generous window.
+        let dir = fresh_mission_dir();
+        std::fs::create_dir_all(dir.path()).unwrap();
+        // Touch the log so the watcher has something to watch from the start.
+        let log = EventLog::open(dir.path()).unwrap();
+
+        let cap = Arc::new(Capture::default());
+        let _bus = EventBus::for_mission(
+            "mission".into(),
+            dir.path(),
+            &["lead".to_string()],
+            cap_dyn(&cap),
+        )
+        .unwrap();
+        // Wait for the empty initial replay to settle.
+        wait_until(200, || true);
+
+        log.append(message("lead", None, "broadcast hi")).unwrap();
+        log.append(message("lead", Some("impl"), "directed to impl"))
+            .unwrap();
+
+        // Recv-timeout in the consumer is 500ms; allow up to 3s for slow CI.
+        let arrived = wait_until(3000, || cap.appended.lock().unwrap().len() == 2);
+        assert!(arrived, "watcher never observed the appended events");
+    }
+
+    #[test]
+    fn projection_includes_broadcasts_and_directed_only_for_target() {
+        // Two runners on roster. A broadcast event must inbox into both;
+        // a directed event must inbox into only the addressee. The other
+        // runner sees nothing for the directed event.
+        let dir = fresh_mission_dir();
+        let log = EventLog::open(dir.path()).unwrap();
+        log.append(message("lead", None, "broadcast")).unwrap(); // both
+        log.append(message("lead", Some("impl"), "to impl"))
+            .unwrap(); // impl only
+
+        let cap = Arc::new(Capture::default());
+        let _bus = EventBus::for_mission(
+            "mission".into(),
+            dir.path(),
+            &["lead".to_string(), "impl".to_string()],
+            cap_dyn(&cap),
+        )
+        .unwrap();
+
+        wait_until(1000, || cap.inbox.lock().unwrap().len() >= 3);
+        let inbox = cap.inbox.lock().unwrap().clone();
+
+        let lead_updates: Vec<_> = inbox.iter().filter(|u| u.runner_handle == "lead").collect();
+        let impl_updates: Vec<_> = inbox.iter().filter(|u| u.runner_handle == "impl").collect();
+
+        // Lead sees only the broadcast. Impl sees broadcast + directed.
+        assert_eq!(
+            lead_updates.len(),
+            1,
+            "lead should only inbox the broadcast"
+        );
+        assert_eq!(
+            impl_updates.len(),
+            2,
+            "impl should inbox both broadcast and directed"
+        );
+        assert_eq!(impl_updates.last().unwrap().unread_count, 2);
+    }
+
+    #[test]
+    fn inbox_read_advances_watermark_and_clears_unread() {
+        // Append a broadcast event, then an `inbox_read` from "lead" with
+        // up_to = that event's id. The watermark must move forward and
+        // unread_count must drop to zero.
+        let dir = fresh_mission_dir();
+        let log = EventLog::open(dir.path()).unwrap();
+        let bcast = log.append(message("lead", None, "broadcast")).unwrap();
+
+        let cap = Arc::new(Capture::default());
+        let _bus = EventBus::for_mission(
+            "mission".into(),
+            dir.path(),
+            &["lead".to_string()],
+            cap_dyn(&cap),
+        )
+        .unwrap();
+        wait_until(1000, || !cap.inbox.lock().unwrap().is_empty());
+
+        // Now post the inbox_read signal.
+        log.append(signal(
+            "lead",
+            "inbox_read",
+            serde_json::json!({ "up_to": bcast.id }),
+        ))
+        .unwrap();
+
+        wait_until(3000, || !cap.watermark.lock().unwrap().is_empty());
+        let wm = cap.watermark.lock().unwrap().clone();
+        assert_eq!(wm.len(), 1, "exactly one watermark/advanced");
+        assert_eq!(wm[0].runner_handle, "lead");
+        assert_eq!(wm[0].watermark, bcast.id);
+        assert_eq!(wm[0].unread_count, 0);
+
+        // The corresponding inbox/updated should also reflect zero unread.
+        let inbox = cap.inbox.lock().unwrap();
+        let last = inbox.last().unwrap();
+        assert_eq!(last.runner_handle, "lead");
+        assert_eq!(last.unread_count, 0);
+    }
+
+    #[test]
+    fn redundant_inbox_read_emits_no_watermark_event() {
+        // Reading up to the same ULID twice should be a no-op the second
+        // time. Without this guard, every CLI heartbeat would spam the UI.
+        let dir = fresh_mission_dir();
+        let log = EventLog::open(dir.path()).unwrap();
+        let m = log.append(message("lead", None, "x")).unwrap();
+        log.append(signal(
+            "lead",
+            "inbox_read",
+            serde_json::json!({ "up_to": m.id }),
+        ))
+        .unwrap();
+        log.append(signal(
+            "lead",
+            "inbox_read",
+            serde_json::json!({ "up_to": m.id }),
+        ))
+        .unwrap();
+
+        let cap = Arc::new(Capture::default());
+        let _bus = EventBus::for_mission(
+            "mission".into(),
+            dir.path(),
+            &["lead".to_string()],
+            cap_dyn(&cap),
+        )
+        .unwrap();
+
+        wait_until(1000, || cap.appended.lock().unwrap().len() == 3);
+        // Even though we appended three events, only one watermark advance
+        // should have occurred (the second inbox_read is a no-op).
+        let wm = cap.watermark.lock().unwrap();
+        assert_eq!(wm.len(), 1, "duplicate inbox_read must not re-emit");
+    }
+
+    #[test]
+    fn registry_mount_unmount_drops_consumer_thread() {
+        // Mount, append, observe; then unmount. After unmount, further
+        // appends must NOT produce more emissions because the consumer is
+        // gone.
+        let dir = fresh_mission_dir();
+        let _log_init = EventLog::open(dir.path()).unwrap();
+
+        let cap: Arc<Capture> = Arc::new(Capture::default());
+        let registry = BusRegistry::new();
+        registry
+            .mount(
+                "mission".into(),
+                dir.path(),
+                &["lead".to_string()],
+                cap_dyn(&cap),
+            )
+            .unwrap();
+
+        let log = EventLog::open(dir.path()).unwrap();
+        log.append(message("lead", None, "first")).unwrap();
+        wait_until(3000, || cap.appended.lock().unwrap().len() == 1);
+        assert_eq!(cap.appended.lock().unwrap().len(), 1);
+
+        registry.unmount("mission");
+        // The consumer must have stopped; new appends should not surface.
+        log.append(message("lead", None, "second")).unwrap();
+        // Wait long enough that any in-flight notify event would have been
+        // consumed if the bus were still alive.
+        thread::sleep(Duration::from_millis(800));
+        assert_eq!(
+            cap.appended.lock().unwrap().len(),
+            1,
+            "no events should arrive after unmount"
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -20,6 +20,10 @@ pub struct AppState {
     /// Live per-mission PTY sessions. Created at app start, shared across
     /// all Tauri commands and the reader threads they spawn.
     pub sessions: Arc<session::SessionManager>,
+    /// Live per-mission event-bus watchers. Mounted by `mission_start` once
+    /// the opening events are durable; unmounted by `mission_stop` and on
+    /// any rollback path.
+    pub buses: Arc<event_bus::BusRegistry>,
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -39,6 +43,7 @@ pub fn run() {
                 db: pool,
                 app_data_dir,
                 sessions: session::SessionManager::new(),
+                buses: event_bus::BusRegistry::new(),
             });
             Ok(())
         })

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -13,7 +13,20 @@ export function AppShell({ children }: { children: ReactNode }) {
   return (
     <div className="flex h-screen overflow-hidden bg-[#FAFAFA] text-neutral-900">
       <Sidebar />
-      <main className="flex flex-1 flex-col overflow-hidden">{children}</main>
+      <main className="relative flex flex-1 flex-col overflow-hidden">
+        {/* Tauri drag strip across the top of the content pane — same
+            pattern as quill (every page paints its own strip). The
+            sidebar already has its own drag region; this covers the
+            content half so the user can grab the window from anywhere
+            along the title-bar row. h-7 matches the macOS title bar so
+            it overlays the empty space above page headers without
+            clipping any controls. */}
+        <div
+          data-tauri-drag-region
+          className="pointer-events-auto absolute left-0 right-0 top-0 z-10 h-7"
+        />
+        {children}
+      </main>
     </div>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,9 +1,9 @@
 // App sidebar — 240px, matches runners-design.pen "Sidebar" frame.
 //
-// Runners itself is omitted from the nav: per docs/impls/v0-mvp.md §C3
-// scope note ("no top-level Runners page in MVP"), runners are crew-scoped
-// only and managed from Crew Detail. Missions stays visible but disabled
-// until C11 lands, so users see the shape the shell is growing into.
+// Order mirrors the design's Sidebar frame (Runner / Crew / Mission). Runner
+// and Mission are placeholders until their pages land — runners get a
+// top-level home with v0.x, missions ship in C11. Showing them disabled now
+// lets users see the shape the shell is growing into without dead links.
 
 import { NavLink } from "react-router-dom";
 
@@ -15,6 +15,7 @@ type NavItem = {
 };
 
 const NAV: NavItem[] = [
+  { to: "/runners", label: "Runner", enabled: false, hint: "Coming with C8.5" },
   { to: "/crews", label: "Crew", enabled: true },
   { to: "/missions", label: "Mission", enabled: false, hint: "Coming with C11" },
   { to: "/debug", label: "Debug", enabled: true, hint: "C6 PTY scratch page" },

--- a/src/pages/CrewEditor.tsx
+++ b/src/pages/CrewEditor.tsx
@@ -138,8 +138,11 @@ export default function CrewEditor() {
 
   return (
     <AppShell>
-      {/* Top toolbar */}
-      <div className="flex items-center justify-between gap-4 border-b border-[#E5E5E5] bg-white px-8 py-4">
+      {/* Top toolbar — `pt-9` (36px) reserves the macOS title-bar /
+          drag-region row at the top so the AppShell strip doesn't overlay
+          our controls (the strip is z-10 above this toolbar; controls
+          inside `pt-9` start at y≈36, well below the strip's y=28). */}
+      <div className="flex items-center justify-between gap-4 border-b border-[#E5E5E5] bg-white px-8 pb-4 pt-9">
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <Link
             to="/crews"

--- a/src/pages/Debug.tsx
+++ b/src/pages/Debug.tsx
@@ -9,6 +9,7 @@ import { listen } from "@tauri-apps/api/event";
 
 import type { Crew, Mission, SessionStatus } from "../lib/types";
 import { api, SessionRow } from "../lib/api";
+import { AppShell } from "../components/AppShell";
 
 interface OutputEvent {
   session_id: string;
@@ -151,14 +152,12 @@ export default function Debug() {
   const paneList = useMemo(() => Object.values(sessions), [sessions]);
 
   return (
-    <div className="min-h-screen bg-neutral-50 p-6 font-mono text-sm text-neutral-900">
-      <div className="mx-auto max-w-5xl space-y-4">
-        <header className="flex items-baseline justify-between">
-          <h1 className="text-lg font-semibold">C6 Debug — PTY scratch</h1>
-          <a href="#/crews" className="text-xs text-blue-600 underline">
-            back to crews
-          </a>
-        </header>
+    <AppShell>
+      <div className="flex-1 overflow-y-auto bg-neutral-50 p-6 font-mono text-sm text-neutral-900">
+        <div className="mx-auto max-w-5xl space-y-4">
+          <header>
+            <h1 className="text-lg font-semibold">C6 Debug — PTY scratch</h1>
+          </header>
 
         <section className="space-y-2 rounded border border-neutral-300 bg-white p-4">
           <div className="grid grid-cols-2 gap-3">
@@ -280,7 +279,8 @@ export default function Debug() {
             </div>
           ))}
         </section>
+        </div>
       </div>
-    </div>
+    </AppShell>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `event_bus::EventBus` — a `notify`-backed tail of each mission's `events.ndjson` with replay-on-mount, per-runner inbox projection (`to == null || to == handle`), and watermark advance driven exclusively by `inbox_read` signals.
- Emits three Tauri events for the workspace UI to subscribe to: `event/appended`, `inbox/updated`, `watermark/advanced`. Behind a `BusEmitter` trait so the consumer is unit-testable without a running app.
- Wires `BusRegistry` into `AppState`; `mission_start` mounts the bus before session spawn (so `mission_start` + `mission_goal` arrive as the first appended events), `mission_stop` unmounts after the terminal event is durable. Spawn rollback also unmounts.

## Test plan
- [x] 6 new unit tests in `event_bus::tests` (replay-on-mount, watcher-after-mount, projection routing, watermark advance, redundant-read no-op, registry unmount drops the consumer).
- [x] `cargo test --workspace` — 75 tests pass (59 app + 16 core).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all --check` clean.
- [x] `pnpm exec tsc --noEmit` + `pnpm run lint` clean.
- [ ] Manual: nothing renders the bus events yet — that lands in C10 (workspace UI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)