### PR TITLE
feature(c8): signal router v0 + runtime adapter for system_prompt

### DIFF
--- a/docs/arch/v0-arch.md
+++ b/docs/arch/v0-arch.md
@@ -532,11 +532,11 @@ Stdin pushes are deliberately silent: the router writes bytes into the target PT
 ```jsonc
 // When the card is shown:
 {
+  "id": "01HG...",                             // canonical question_id (use this in human_response)
   "kind": "signal",
   "type": "human_question",
   "from": "router",
   "payload": {
-    "question_id": "01HG...",                  // = this event's id; echoed here for convenience
     "triggered_by": <triggering-signal.id>,    // e.g. the changes_requested signal's id
     "prompt": "Reviewer requested changes. Accept or override?",
     "choices": ["accept", "override"],
@@ -550,13 +550,15 @@ Stdin pushes are deliberately silent: the router writes bytes into the target PT
   "type": "human_response",
   "from": "human",
   "payload": {
-    "question_id": <human_question.id>,       // lets rules target a specific card
+    "question_id": <human_question.id>,       // = the card event's `id` field
     "choice": "accept"                         // the clicked value (always one of choices[])
   }
 }
 ```
 
-Causality is carried in-payload rather than on the envelope: `human_question.payload.triggered_by` records which signal opened the card, and `human_response.payload.question_id` records which card the human clicked. The router needs no additional schema fields to match them.
+Causality is carried in-payload rather than on the envelope: `human_question.payload.triggered_by` records which signal opened the card, and `human_response.payload.question_id` records which card the human clicked (set to the `human_question` event's own `id`). The router needs no additional schema fields to match them.
+
+**Implementation note.** `human_question` does *not* echo `question_id` into its own payload. The canonical id is the event's own `id` field, and the parent process can't know that id until after the flock-guarded log append assigns it (pre-allocating would break the cross-process monotonic-ULID invariant in §5.1.1). UI consumers should read `human_question.id` and pass it through as `human_response.payload.question_id`.
 
 If two `ask_human` prompts are ever outstanding at once and we need richer discrimination, v0.x will add event-DAG fields. v0 ships the simple case; concurrent prompts are out of scope.
 

--- a/docs/arch/v0-arch.md
+++ b/docs/arch/v0-arch.md
@@ -21,12 +21,12 @@ Runners is a local desktop app. A user configures a **crew** of CLI coding agent
 │           │                          │                          │           │
 │           │                          │                          ▼           │
 │           │                          │               ┌──────────────────┐   │
-│           │                          │               │ Orchestrator     │   │
-│           │                          │               │  - policy rules  │   │
-│           │                          │               │  - action dispch │   │
+│           │                          │               │ Signal router    │   │
+│           │                          │               │  - fixed handlers│   │
+│           │                          │               │  - status map    │   │
 │           │                          │               └────────┬─────────┘   │
 │           │                          │                        │             │
-│           │      inject_stdin / ask_human / pause / ...       │             │
+│           │      inject_stdin / human_question / status        │             │
 │           └─────────────────────────►│◄───────────────────────┘             │
 │                                      ▼                                      │
 │  ┌──────────────────────────────────────────────────────────────────────┐   │
@@ -44,7 +44,7 @@ Runners is a local desktop app. A user configures a **crew** of CLI coding agent
 │                  ┌─────────────────────────────┐                          │
 │                  │  events.ndjson (per mission)│                          │
 │                  └──────────────┬──────────────┘                          │
-│                                 │ notify → EventBus → Orchestrator + UI   │
+│                                 │ notify → EventBus → Router + UI         │
 └─────────────────────────────────┼─────────────────────────────────────────┘
                                   ▼
                          ┌───────────────────────┐
@@ -56,14 +56,14 @@ Runners is a local desktop app. A user configures a **crew** of CLI coding agent
 
 ### 1.2 The one-paragraph story
 
-The user defines a **crew** (configuration: runners + policy). They click **Start Mission**, which creates a **mission** (runtime container), spawns one PTY-backed **session** per runner, and composes each runner's system prompt with the mission brief, the crew roster, and coordination instructions. Runners run real CLI binaries inside PTYs. They coordinate through two primitives — **signals** (typed events for the orchestrator to route on) and **messages** (flat prose stream for runner-to-runner conversation) — both carried through a bundled `runner` CLI that appends to the mission's NDJSON file. The **orchestrator** tails that file, applies a rule-based policy, and dispatches actions (inject stdin, ask human, pause, etc.). The UI is a read-only tail that renders terminals, messages, signals, and HITL prompts.
+The user defines a **crew** (configuration: runners + signal allowlist). They click **Start Mission**, which creates a **mission** (runtime container), spawns one PTY-backed **session** per runner, and composes each runner's system prompt with the mission brief, the crew roster, and coordination instructions. Runners run real CLI binaries inside PTYs. They coordinate through two primitives — **signals** (typed events for the parent process to route on) and **messages** (flat prose stream for runner-to-runner conversation) — both carried through a bundled `runner` CLI that appends to the mission's NDJSON file. The **signal router** tails that file and applies fixed built-in handlers for bootstrap, wake-ups, HITL cards, and runner availability. The lead runner, not the router, owns coordination judgment.
 
 ## 2. Concepts
 
 Domain objects split cleanly into two layers:
 
-- **Configuration** — persistent, user-edited. Outlives missions. Crew, Runner, Orchestrator Policy.
-- **Runtime** — created at mission start, torn down at mission end. Everything here is scoped to a mission: the Mission itself, its Sessions, its coordination primitives (Signals, Messages), and the orchestrator's in-memory state.
+- **Configuration** — persistent, user-edited. Outlives missions. Crew, Runner, signal allowlist.
+- **Runtime** — created at mission start, torn down at mission end. Everything here is scoped to a mission: the Mission itself, its Sessions, its coordination primitives (Signals, Messages), and the router's in-memory state.
 
 The key insight: **Runner is config; Session is its runtime instance** — the same pattern as Crew (config) → Mission (runtime). A runner never runs on its own. A runner runs *inside a mission* as a session. The session is born when the mission starts, lives while the mission runs, and dies when the mission ends.
 
@@ -77,17 +77,17 @@ The key insight: **Runner is config; Session is its runtime instance** — the s
 │         │       binary, brief)       │    │      mission; lives & dies with the      │
 │         │                            │    │      mission)                            │
 │         │                            │    │                                         │
-│         └── Orchestrator Policy      │    │     ▲                                    │
-│               │                      │    │     │  spawned & owned by                │
-│               └── attached to ───────┼────┼──► Mission ─── events.ndjson             │
+│         └── Signal allowlist         │    │     ▲                                    │
+│                                      │    │     │  spawned & owned by                │
+│                                      ├────┼──► Mission ─── events.ndjson             │
 │                                      │    │     │              │                    │
 │                                      │    │     │              ├─► Signal   [v0]    │
 │                                      │    │     │              ├─► Message  [v0]    │
 │                                      │    │     │              ├─► Thread   [v0.x]  │
 │                                      │    │     │              └─► Fact     [v0.x]  │
 │                                      │    │     │                                   │
-│                                      │    │     ├─► Orchestrator in-memory state    │
-│                                      │    │     │    (pending asks, dispatch ledger)│
+│                                      │    │     ├─► Router in-memory state          │
+│                                      │    │     │    (pending asks, runner status)  │
 │                                      │    │     │                                   │
 │                                      │    │     └─► Shared context:                 │
 │                                      │    │           brief + roster (v0)           │
@@ -95,15 +95,15 @@ The key insight: **Runner is config; Session is its runtime instance** — the s
 └──────────────────────────────────────┘    └─────────────────────────────────────────┘
 ```
 
-A mission is a container. Everything in the runtime column is either the container itself (Mission) or an object whose lifecycle is scoped by it. **Sessions are first-class members of this container** alongside the coordination bus and the orchestrator state — not a side effect of spawning runners.
+A mission is a container. Everything in the runtime column is either the container itself (Mission) or an object whose lifecycle is scoped by it. **Sessions are first-class members of this container** alongside the coordination bus and the router state — not a side effect of spawning runners.
 
 ### 2.2 Crew — *a configured team*
 
-The persistent "who's on the team and how they work together" record. A crew has a name, a default mission goal, a list of runners, an orchestrator policy, and a signal-type allowlist. It does not run. It is blueprint.
+The persistent "who's on the team and how they work together" record. A crew has a name, a default mission goal, a list of runners, and a signal-type allowlist. It does not run. It is blueprint.
 
-**Every crew must have exactly one lead runner.** The lead is the human's counterpart in the crew: the mission goal and human-originated broadcast signals route to the lead by default, and the lead dispatches work to the other runners via directed messages. This is a hard invariant — a crew with zero runners or zero leads is invalid and cannot start a mission. The first runner added to a new crew becomes lead automatically; the user can reassign lead between existing runners, but cannot remove the lead runner without first designating a replacement. The lead is a routing convention, not a privileged capability: any runner can emit signals, post directed messages, and trigger orchestrator actions. Lead only governs *where inbound-from-human signals land by default*.
+**Every crew must have exactly one lead runner.** The lead is the human's counterpart in the crew: the mission goal and human-originated broadcast signals route to the lead by default, and the lead dispatches work to the other runners via directed messages. This is a hard invariant — a crew with zero runners or zero leads is invalid and cannot start a mission. The first runner added to a new crew becomes lead automatically; the user can reassign lead between existing runners, but cannot remove the lead runner without first designating a replacement. The lead is a routing convention, not a privileged capability: any runner can emit signals and post directed messages. Lead only governs *where inbound-from-human signals land by default*.
 
-**Lead is also the default HITL gateway.** When a worker needs human input, it does not ask the human directly — it emits an `ask_lead` signal whose payload carries the question. The orchestrator wakes the lead (signals trigger actions; messages don't — see §5.5.0), who decides whether to answer from their own context or escalate to the human via `ask_human`. If the lead escalates, the human's answer flows back to the lead, who forwards it to the original worker as a directed message that the worker picks up on its next `runner msg read`. This keeps the human's attention focused on one interlocutor and lets the lead absorb, filter, or batch worker questions. See §5.5.0 for the protocol details (the `ask_lead` signal, the `on_behalf_of` payload field on `ask_human`, and the forwarding flow). Workers *may* emit `ask_human` directly as a fallback — it's not forbidden at the protocol layer — but the default runner system prompt instructs them to go through the lead.
+**Lead is also the default HITL gateway.** When a worker needs human input, it does not ask the human directly — it emits an `ask_lead` signal whose payload carries the question. The router wakes the lead (signals trigger fixed handlers; messages don't — see §5.5), who decides whether to answer from their own context or escalate to the human via `ask_human`. If the lead escalates, the human's answer flows back to the lead, who forwards it to the original worker as a directed message that the worker picks up on its next `runner msg read`. This keeps the human's attention focused on one interlocutor and lets the lead absorb, filter, or batch worker questions. See §5.5 for the protocol details (the `ask_lead` signal, the `on_behalf_of` payload field on `ask_human`, and the forwarding flow). Workers *may* emit `ask_human` directly as a fallback — it's not forbidden at the protocol layer — but the default runner system prompt instructs them to go through the lead.
 
 Lifecycle: created by the user, edited freely, deleted when no longer needed. Persisted in SQLite.
 
@@ -113,20 +113,18 @@ An individual CLI agent: what binary to run, with what args, in what working dir
 
 A runner has two identifying fields:
 
-- **`handle`** — a lowercase slug (e.g. `coder`, `reviewer`, `tester`). Required, immutable once set, **globally unique** across the app. Used everywhere addressing is needed: as `from` and `to` in events, as `--to <handle>` on the CLI, and in policy rules. Global uniqueness means `@impl` names the same runner whether it's seen in crew A's event log or crew B's.
+- **`handle`** — a lowercase slug (e.g. `coder`, `reviewer`, `tester`). Required, immutable once set, **globally unique** across the app. Used everywhere addressing is needed: as `from` and `to` in events, as `--to <handle>` on the CLI, and in router state. Global uniqueness means `@impl` names the same runner whether it's seen in crew A's event log or crew B's.
 - **`display_name`** — a free-form label for the UI (e.g. "Coder", "Lead Reviewer"). Editable; not used in event fields or addressing.
 
 Keeping these separate means renaming a runner for the UI doesn't break briefs, rules, or historical events. `handle` is the identity; `display_name` is just presentation.
 
 **Runners are top-level config; crews compose them.** A runner is its own entity, not a child of a crew. The same runner can be a member of multiple crews — `@architect` can sit in `runners-feature` and `runners-ops` simultaneously. Crew membership lives in the `crew_runners` join table, which carries the per-crew `position` and `lead` flag (see §7.1). This is a deliberate post-C3 product change: a user typically curates a small stable of runners and reuses them across crews and ad-hoc direct chats; tying a runner to a single crew would force them to clone configs every time.
 
-Exactly one runner per crew carries the per-crew `lead` flag (see §2.2). The orchestrator treats the lead as the default recipient of human broadcast messages and the mission-goal inject at startup; other crew members receive traffic only when directly addressed. The flag lives on `crew_runners`, enforced by a unique partial index: `UNIQUE(crew_id) WHERE lead = 1`. Lead is per-crew, not per-runner — the same runner can be lead in one crew and a worker in another.
+Exactly one runner per crew carries the per-crew `lead` flag (see §2.2). The router treats the lead as the default recipient of human broadcast messages and the mission-goal inject at startup; other crew members receive traffic only when directly addressed. The flag lives on `crew_runners`, enforced by a unique partial index: `UNIQUE(crew_id) WHERE lead = 1`. Lead is per-crew, not per-runner — the same runner can be lead in one crew and a worker in another.
 
-### 2.4 Orchestrator Policy — *the crew's decision rules*
+### 2.4 Signal allowlist — *the crew's protocol vocabulary*
 
-A JSON list of `{when, do}` rules attached to the crew. This is where all routing and human-in-the-loop behavior is expressed. Shared across every mission the crew runs (in-memory state like pending asks is per-mission, but the rule set is per-crew).
-
-There is no code here — just a lookup table. No scripting, no LLM. v0 is deliberately dumb.
+A JSON array of signal type strings attached to the crew and exported beside the mission log. The CLI validates emitted signals against this allowlist so typos fail visibly. MVP uses the built-in set only; user-defined signal types and policy-driven routing are v0.x.
 
 ### 2.5 Mission — *one activation of the crew, and the runtime container*
 
@@ -134,12 +132,12 @@ A mission is the only runtime container in the system. Everything alive at runti
 
 - A **Session** per runner (the PTY processes — see §2.6).
 - The **coordination bus** — the NDJSON event log carrying signals and messages.
-- The **orchestrator's in-memory state** — pending HITL asks, dispatch ledger (which triggering events have been handled), per-runner read watermarks, (later) fact projection.
+- The **router's in-memory state** — pending HITL asks and latest runner availability. Per-runner read watermarks belong to the event bus projection.
 - The **shared context** injected into each runner's composed prompt — the mission brief and the roster.
 
 Lifecycle:
-- **Start**: user clicks Start Mission on a crew. A mission row is created, one session is spawned per runner in the crew, the orchestrator boots with fresh state, and an NDJSON file is opened.
-- **End**: explicit stop, or all sessions exited. Every session is killed, the orchestrator stops, the mission row is closed out.
+- **Start**: user clicks Start Mission on a crew. A mission row is created, one session is spawned per runner in the crew, the router boots with fresh state, and an NDJSON file is opened.
+- **End**: explicit stop, or all sessions exited. Every session is killed, the router stops, the mission row is closed out.
 
 This framing matters: when we say "the coordination bus is mission-scoped" or "the fact whiteboard is mission-scoped," we're saying the same thing as "sessions are mission-scoped." They all share one lifecycle because they all belong to the same container.
 
@@ -151,13 +149,13 @@ The runtime instance of a Runner. A Session is to a Runner what a Mission is to 
 
 A session has two flavors, distinguished by whether `mission_id` is set:
 
-- **Mission session** — spawned when a mission starts; one session per crew member. It dies with the mission. The runner participates in the crew's coordination bus, sees broadcasts, can receive `inject_stdin` from the orchestrator, etc. This is the path the v0 demo flow exercises.
-- **Direct-chat session** — spawned ad-hoc from the Runners page (see §2.3) without a parent mission. `mission_id` is null and the working directory lives on the session row directly. The runner is **not on any coordination bus** — there's no event log, no orchestrator, no inbox; it's just a one-on-one PTY between the human and the runner's CLI. Useful for "I just want to ask `@architect` something quickly" without spinning up a full crew.
+- **Mission session** — spawned when a mission starts; one session per crew member. It dies with the mission. The runner participates in the crew's coordination bus, sees broadcasts, can receive `inject_stdin` from the router, etc. This is the path the v0 demo flow exercises.
+- **Direct-chat session** — spawned ad-hoc from the Runners page (see §2.3) without a parent mission. `mission_id` is null and the working directory lives on the session row directly. The runner is **not on any coordination bus** — there's no event log, no router, no inbox; it's just a one-on-one PTY between the human and the runner's CLI. Useful for "I just want to ask `@architect` something quickly" without spinning up a full crew.
 
 A session owns:
 - A PTY master handle (the only object in the system with a file descriptor to a running child process).
 - A blocking reader thread that drains the PTY and pushes to the scrollback ring.
-- A writer for stdin injection (used by the human and by the orchestrator's `inject_stdin` action).
+- A writer for stdin injection (used by the human and by the router's fixed handlers).
 - A ring buffer (~10k lines) for scrollback that survives frontend tab-switches and app restarts within the mission.
 - An exit status once the child has terminated.
 
@@ -169,7 +167,7 @@ Runners don't share a programming model; they share an IM-like surface. The same
 
 | Primitive | Role | v0 | v0.x | v1+ |
 |---|---|:---:|:---:|:---:|
-| **Signal** | Typed notification; orchestrator routes on these. Verb grammar. | ✅ | | |
+| **Signal** | Typed notification; the router handles built-ins. Verb grammar. | ✅ | | |
 | **Message** | Prose, broadcast or directed to a specific runner. | ✅ | | |
 | **Inbox** | Per-runner projection: broadcasts + messages addressed to me. | ✅ | | |
 | **Thread** | Scoped sub-conversation within a mission. | | ✅ | |
@@ -177,15 +175,15 @@ Runners don't share a programming model; they share an IM-like surface. The same
 | **Mention** | Targeted `@name` inside a message's prose (lighter-weight than `--to`). | | | ✅ |
 | **Reaction** | Lightweight signal attached to a message (`👍`, `🔍`, `blocking`). | | | ✅ |
 
-#### 2.7.1 Signal — *"something happened, please decide"*
+#### 2.7.1 Signal — *"something happened, please wake the right surface"*
 
-Short, typed, orchestrator-routable. Grammar: past-tense verb.
+Short, typed, router-visible. Grammar: past-tense verb.
 
 Examples: `review_requested`, `changes_requested`, `approved`, `blocked`.
 
-Signals are machine-readable by design. The orchestrator has rules keyed to signal types. Runners emit them when they want the mission to move to its next state.
+Signals are machine-readable by design. The router has fixed handlers keyed to built-in signal types. Runners emit them when they need parent-process plumbing: wake the lead, show a human card, or report availability.
 
-A signal carries an optional `payload` (JSON) but the payload is meant for the orchestrator's decision logic, not for runners to read as prose.
+A signal carries an optional `payload` (JSON) for the router and UI. Human-readable conversation belongs in messages.
 
 #### 2.7.2 Message — *"here's what I think"*
 
@@ -203,10 +201,10 @@ Examples:
 Messages are **flat in v0** — one stream per mission, no thread scoping. Each runner consumes messages through their **inbox** (§2.7.5): broadcasts plus directly-addressed messages.
 
 Messages and signals are separate for good reasons:
-- Signals are typed and small; orchestrator logic keys off them. Messages are prose; orchestrator doesn't parse them.
+- Signals are typed and small; router handlers key off them. Messages are prose; the router doesn't parse them.
 - A signal without prose works ("approved"). Prose without a signal works too ("I noticed X"). Conflating them forces every signal to carry prose and every note to carry a type.
 - Runners (LLM agents) already know how to use both: signals are like exit codes, messages are like comments. The CLI keeps them linguistically separate.
-- Direct messages enable real conversation between runners without forcing every interaction through the orchestrator policy.
+- Direct messages enable real conversation between runners without forcing every interaction through parent-process wake-ups.
 
 #### 2.7.3 Inbox — *"what's in my mailbox"*
 
@@ -225,7 +223,7 @@ This design keeps the storage model simple (one event log per mission, same as b
 The recipient learns to read its inbox through two mechanisms:
 
 1. **Convention** — the composed system prompt (§4.3) instructs every runner to check its inbox at natural task boundaries.
-2. **Signals as the urgent wake-up** — if a sender needs the recipient to drop everything, they emit a signal in addition to (or instead of) the message. The signal goes through the orchestrator's policy, which typically injects stdin. On any stdin injection, the orchestrator automatically appends a summary of the recipient's unread inbox messages (§5.5), so urgent wake-ups carry relevant conversation context with them.
+2. **Signals as the urgent wake-up** — if a sender needs the recipient to drop everything, they emit a signal in addition to (or instead of) the message. The signal goes through the router's fixed handlers, which may inject stdin. In MVP the injection is not enriched with inbox summaries; the recipient calls `runner msg read` when it wants the related conversation context.
 
 The inbox is not a queue in the delete-on-read sense — messages stay in the log forever (well, for the mission). The "read" in `msg read` is lookup, not consumption.
 
@@ -237,7 +235,7 @@ Cut from v0 because the v0 demo is two runners on one loop — the whole mission
 
 #### 2.7.5 Fact *(v0.x)* — *queryable state*
 
-A KV whiteboard. Any runner can `ctx set key value` and `ctx get key`. Mission-scoped; each mission starts with an empty whiteboard. Backed by the event log as a `fact_recorded` event type, projected in-memory by the orchestrator for O(1) reads.
+A KV whiteboard. Any runner can `ctx set key value` and `ctx get key`. Mission-scoped; each mission starts with an empty whiteboard. Backed by the event log as a `fact_recorded` event type, projected in-memory by the backend for O(1) reads.
 
 Facts differ from messages and signals: they're **current state**, not events. Reading a fact answers "what is true right now?" not "what happened?" Cut from v0 because the demo doesn't need a dashboard-style current-state view.
 
@@ -245,7 +243,7 @@ Facts differ from messages and signals: they're **current state**, not events. R
 
 Every coordination primitive is persisted as an **event** — one line in the per-mission NDJSON file. An event has: `{id, ts, crew_id, mission_id, kind, from, to, type, payload}`.
 
-The `kind` field is the primitive discriminator — `signal`, `message`, and (later) `fact`, `thread_opened`. For `kind: "signal"`, the `type` field carries the signal's semantic verb (`review_requested`, `changes_requested`, etc.); for `kind: "message"`, `type` is omitted and the prose lives in `payload.text`. The orchestrator and UI project events into primitive-specific views based on `kind`.
+The `kind` field is the primitive discriminator — `signal`, `message`, and (later) `fact`, `thread_opened`. For `kind: "signal"`, the `type` field carries the signal's semantic verb (`runner_status`, `ask_lead`, etc.); for `kind: "message"`, `type` is omitted and the prose lives in `payload.text`. The router and UI project events into primitive-specific views based on `kind`.
 
 This is a transport detail — runners interact through the CLI verbs (`runner signal`, `runner msg`), not the event schema directly. There is no separate `signal_emitted` or `message_posted` event type; the `kind` field is authoritative.
 
@@ -265,7 +263,7 @@ user clicks Start Mission on a crew
         │                                roster(crew),
         │                                coordination_notes(crew.signal_types))
         │     SessionManager.spawn(mission_id, runner, composed_prompt)
-        ├─ Orchestrator.start(mission_id)  ← fresh in-memory state
+        ├─ Router.start(mission_id)  ← fresh in-memory state
         │     open events.ndjson, read history (empty), tail via notify
         └─ emit Tauri event: mission:{id}:started
 ```
@@ -276,7 +274,7 @@ user clicks Start Mission on a crew
 user clicks End Mission  (or all sessions have exited)
   └─► MissionManager.end(mission_id, status):
         ├─ SessionManager.kill_all_in_mission(mission_id)
-        ├─ Orchestrator.stop(mission_id)
+        ├─ Router.stop(mission_id)
         ├─ update `missions` row: status (completed/aborted), stopped_at
         └─ emit Tauri event: mission:{id}:ended
 ```
@@ -366,21 +364,21 @@ address crewmates. Display names are shown for readability only.
 - xterm.js `onData` → `send_input(session_id, bytes)` → `master.writer.write_all(bytes)`.
 - Frontend window resize → debounced (~100ms) `master.resize(rows, cols)` → SIGWINCH to child. Non-optional; without it, TUIs mis-render.
 
-**Human takeover is a first-class capability.** At any moment, the human can type directly into any runner's stdin — the same writer the orchestrator uses for `inject_stdin`. This is deliberate: the human can step in to answer a prompt the agent is stuck on, correct a bad plan, kill a runaway tool call, or just chat with the agent mid-flight.
+**Human takeover is a first-class capability.** At any moment, the human can type directly into any runner's stdin — the same writer the router uses for stdin pushes. This is deliberate: the human can step in to answer a prompt the agent is stuck on, correct a bad plan, kill a runaway tool call, or just chat with the agent mid-flight.
 
-The UI surface for this is the xterm pane itself — it's a real terminal, not a log viewer. Typing sends keystrokes through untouched, including special keys (arrows, Enter, Ctrl-C). The agent on the other end can't tell whether the bytes came from the orchestrator, the human, or a replay — which is the whole point.
+The UI surface for this is the xterm pane itself — it's a real terminal, not a log viewer. Typing sends keystrokes through untouched, including special keys (arrows, Enter, Ctrl-C). The agent on the other end can't tell whether the bytes came from the router, the human, or its normal terminal input — which is the whole point.
 
 ### 4.5 Sessions outlive the UI
 
-Sessions live in the Rust backend and belong to the mission, not to any webview or tab. Closing the mission control window does *not* kill the sessions — the agents keep running, events keep flowing into the NDJSON file, the orchestrator keeps applying rules. Re-opening the window re-attaches: the frontend fetches each session's scrollback ring to rebuild xterm state, then subscribes to live output from wherever it was.
+Sessions live in the Rust backend and belong to the mission, not to any webview or tab. Closing the mission control window does *not* kill the sessions — the agents keep running, events keep flowing into the NDJSON file, and the router keeps handling live signals. Re-opening the window re-attaches: the frontend fetches each session's scrollback ring to rebuild xterm state, then subscribes to live output from wherever it was.
 
 The only things that end a session in v0 are: user clicks End Mission, the child process exits, or the app itself quits. A closed webview window is none of those.
 
-**Why this matters for human takeover:** if the only way to type into a runner required the UI to be visible, then minimizing or closing the mission view to focus on something else would silently cut the human out of the loop. That's wrong — the human should be able to close the monitor and still inject stdin (or let the orchestrator do it) without anything changing about how agents run.
+**Why this matters for human takeover:** if the only way to type into a runner required the UI to be visible, then minimizing or closing the mission view to focus on something else would silently cut the human out of the loop. That's wrong — the human should be able to close the monitor and still inject stdin (or let the router do it) without anything changing about how agents run.
 
 ### 4.6 Writer serialization
 
-The PTY master writer is shared between the human (via `send_input` command) and the orchestrator (via `inject_stdin` action). Concurrent writers could interleave bytes mid-line, which would confuse the TUI on the other end.
+The PTY master writer is shared between the human (via `send_input` command) and the router (via stdin pushes). Concurrent writers could interleave bytes mid-line, which would confuse the TUI on the other end.
 
 Solution: wrap each session's writer in a `tokio::sync::Mutex`. Every write is one `write_all` call under the lock. Small writes (keystrokes, short prompts) are fast enough that contention is invisible.
 
@@ -412,7 +410,7 @@ Why a file instead of an in-memory bus:
 - **Debuggable** — `tail -f events.ndjson | jq .`.
 - **Crash-durable** — whatever's on disk survived the crash.
 - **Atomic** under explicit guards (see §5.1.1) — concurrent `runner` invocations interleave correctly at line granularity.
-- **Replayable for free** — restart the orchestrator, re-scan, resume.
+- **Replayable for projections** — restart the router, re-scan pending asks and runner status, resume live tail.
 
 #### 5.1.1 Concurrent-write correctness
 
@@ -430,7 +428,7 @@ This gives us:
 
 **Filesystem requirements.** The app data directory must be on a local POSIX filesystem (APFS, ext4, XFS, etc.). Network filesystems (NFS, SMB) and iCloud-synced volumes may not honor `flock()` or may re-order appends across clients; v0 documents this and checks at app startup.
 
-Writers: only the bundled `runner` CLI writes to the log (the Rust backend also writes orchestrator-generated events — it uses the same `flock`-guarded path). No other process should write to this file; the orchestrator refuses to start a mission if another holder has an exclusive lock at boot.
+Writers: the bundled `runner` CLI writes runner-authored events to the log; the Rust backend writes router-generated events such as `human_question` and `mission_warning` through the same `flock`-guarded path. No other process should write to this file.
 
 ### 5.2 Event schema
 
@@ -441,7 +439,7 @@ Writers: only the bundled `runner` CLI writes to the log (the Rust backend also 
   "crew_id": "01HG...",
   "mission_id": "01HG...",
   "kind": "signal",                 // signal | message  (v0.x adds: fact, thread_opened, ...)
-  "from": "coder",                  // runner handle | "human" | "orchestrator"
+  "from": "coder",                  // runner handle | "human" | "router"
   "to": null,                       // null = broadcast; runner handle = directed (messages);
                                     //   for signals, always null in v0 (policy decides routing)
   "type": "review_requested",       // for kind=signal; omitted for kind=message
@@ -460,7 +458,7 @@ For a message event: `kind=message`, `payload.text` is the prose.
 - No runner-authored event has a reliable prior cause to cite; exposing `--correlation-id` / `--causation-id` as CLI flags just invites agents to leave them null or hallucinate values.
 - "Groups events in one conversation" has no referent until threads (v0.x) define what a conversation is. Ship the concept with the thing that needs it.
 
-v0.x will reintroduce explicit event-DAG fields when threads and richer routing require them. Until then, the orchestrator's in-memory dispatch table carries causality for the actions that need it.
+v0.x will reintroduce explicit event-DAG fields when threads and richer routing require them. Until then, HITL causality is carried by `human_question.payload.triggered_by` and `human_response.payload.question_id`.
 
 ### 5.3 How runners emit signals and messages
 
@@ -492,7 +490,7 @@ User-authored briefs include examples at the moments where signaling or messagin
 
 - No in-band protocol in the PTY stream. Not parsing stdout for magic markers.
 - Works for any CLI agent (MCP or not). Only requirement: can run shell commands.
-- Fails visibly. If the agent forgets to signal, the orchestrator sees nothing and the user sees an idle runner.
+- Fails visibly. If the agent forgets to signal, the router sees nothing and the user sees the runner's last reported status.
 - Fully observable. `$ runner signal review_requested` shows up literally in the terminal pane; the resulting event shows up in the timeline and messages panel.
 
 #### Failure mode: hallucinated signal types
@@ -505,24 +503,27 @@ Messages have no allowlist — they're prose.
 
 Two subscribers to the NDJSON file, both via `notify`:
 
-- **Orchestrator** — deserializes each new line. For signals, runs the policy and dispatches actions. For messages, no-op by default (v0.x: threads, routing-by-mention).
+- **Signal router** — deserializes each new line. For built-in signals, runs a fixed handler. For messages, no-op by design (v0.x: threads, routing-by-mention).
 - **UI** — the backend re-emits each line as a `mission:{id}:event` Tauri event. Frontend splits by `kind` into the messages panel and the signal/timeline panel.
 
 #### Startup replay
 
-On orchestrator boot: open the mission's file, fold events into in-memory state (pending asks, dispatch ledger, read watermarks), then switch to tailing. The file *is* the state.
+On router boot: open the mission's file, fold `ask_human` / `human_response` and `runner_status` rows into in-memory state, then switch to tailing from the current end of the log. Replay rebuilds projections; it does not re-run historical stdin pushes.
 
-### 5.5 Orchestrator actions
+### 5.5 Signal router handlers
 
-Every action emits at least one audit signal. Each audit payload carries `triggered_by: <triggering-event.id>` so causality is visible without relying on envelope fields.
+The router is a flat dispatcher, not a policy engine. There is no per-crew `{when, do}` rule list in MVP. The lead runner owns coordination judgment; the router owns parent-process plumbing that a child PTY cannot do itself.
 
-| Action | Effect | Emits signal(s) with `type` |
-|---|---|---|
-| `inject_stdin` | write template + `\r` to target runner's PTY writer | `stdin_injected`, payload `{ triggered_by, target, watermark }` |
-| `ask_human` | add card to HITL panel; wait for click | `human_question` on card open; `human_response` on click (shapes in §5.5.0) |
-| `notify_human` | fire a toast | `human_notified`, payload `{ triggered_by, message }` |
-| `pause_runner` | SIGSTOP to target PTY | `runner_paused`, payload `{ triggered_by, target }` |
-| `resume_runner` | SIGCONT to target PTY | `runner_resumed`, payload `{ triggered_by, target }` |
+Stdin pushes are deliberately silent: the router writes bytes into the target PTY but does not synthesize `stdin_injected` audit events. The event log records the signal that caused the push, plus `human_question` / `human_response` for HITL cards.
+
+| Signal type | Fixed handler |
+|---|---|
+| `mission_goal` | Compose launch prompt and inject it to the lead's stdin. |
+| `human_said` | Inject `payload.text` to `payload.target` if present, otherwise to the lead. |
+| `ask_lead` | Inject the worker's `{ question, context }` to the lead. |
+| `ask_human` | Append a `human_question` event for the UI. |
+| `human_response` | Look up the matching `question_id` and inject the answer to the runner that emitted the original `ask_human`. |
+| `runner_status` | Update the latest-status map from `payload.state`. If a non-lead reports `idle`, inject a short availability update to the lead. |
 
 #### 5.5.0 `ask_human` — payload shapes and matching
 
@@ -533,7 +534,7 @@ Every action emits at least one audit signal. Each audit payload carries `trigge
 {
   "kind": "signal",
   "type": "human_question",
-  "from": "orchestrator",
+  "from": "router",
   "payload": {
     "question_id": "01HG...",                  // = this event's id; echoed here for convenience
     "triggered_by": <triggering-signal.id>,    // e.g. the changes_requested signal's id
@@ -555,11 +556,9 @@ Every action emits at least one audit signal. Each audit payload carries `trigge
 }
 ```
 
-Causality is carried in-payload rather than on the envelope: `human_question.payload.triggered_by` records which signal opened the card, and `human_response.payload.question_id` records which card the human clicked. The orchestrator needs no additional schema fields to match them.
+Causality is carried in-payload rather than on the envelope: `human_question.payload.triggered_by` records which signal opened the card, and `human_response.payload.question_id` records which card the human clicked. The router needs no additional schema fields to match them.
 
-**Matching semantics for follow-up rules.** Downstream rules match `human_response` by choice value — `{ when: { signal: "human_response", payload: { choice: "accept" } }, do: ... }`. Matches any accept, regardless of which question triggered it.
-
-If two `ask_human` prompts are ever outstanding at once and we need to discriminate between them, v0.x will add richer matching (via the v0.x event-DAG fields). v0 ships the simple case; concurrent prompts are out of scope.
+If two `ask_human` prompts are ever outstanding at once and we need richer discrimination, v0.x will add event-DAG fields. v0 ships the simple case; concurrent prompts are out of scope.
 
 **Lead-mediated asks (the canonical pattern).** By convention (§2.2), workers do not escalate to the human directly. The flow is entirely signal-driven — never message-triggered — so it does not violate the pull-based rule below.
 
@@ -569,13 +568,13 @@ If two `ask_human` prompts are ever outstanding at once and we need to discrimin
    runner signal ask_lead --payload '{"question": "Should I add notify-debouncer-full?", "context": "Pros: … Cons: …"}'
    ```
 
-   `ask_lead` is a built-in signal type. Its built-in rule is `ask_lead → inject_stdin @lead` (payload rendered into the injection template). The worker's stdin stays blocked waiting; the lead wakes.
+   `ask_lead` is a built-in signal type. Its fixed handler is `ask_lead → inject_stdin @lead` (payload rendered into the injection template). The worker's stdin stays blocked waiting; the lead wakes.
 
 2. **Lead decides.**
    - **Answer from own context.** Lead posts a directed message back to the worker via `runner msg post --to @impl "…"`. The worker picks it up on its next `runner msg read`. Pull-based; no new wake-up needed because the worker is already polling between turns per its system prompt.
-   - **Escalate to human.** Lead emits `ask_human` with `payload.on_behalf_of: "@impl"` (the original asker's handle) and a `prompt` that restates the question for the human. The orchestrator renders the card; the UI uses `on_behalf_of` to show the attribution chain (*@impl → @architect → you*).
+   - **Escalate to human.** Lead emits `ask_human` with `payload.on_behalf_of: "@impl"` (the original asker's handle) and a `prompt` that restates the question for the human. The router appends `human_question`; the UI uses `on_behalf_of` to show the attribution chain (*@impl → @architect → you*).
 
-3. **Human responds.** On click, `human_response` fires. The orchestrator injects the result into **the lead's stdin** (the lead was the asker of record for that `question_id`). The lead then forwards the answer onward via a directed message:
+3. **Human responds.** On click, `human_response` fires. The router injects the result into **the lead's stdin** (the lead was the asker of record for that `question_id`). The lead then forwards the answer onward via a directed message:
 
    ```
    runner msg post --to @impl "Human approved: use notify-debouncer-full."
@@ -587,68 +586,54 @@ This is not a new protocol — it is `ask_lead` + `ask_human` + directed message
 
 **Why route through the lead.** The lead can absorb, filter, or batch worker questions, and the human's attention stays focused on one interlocutor. The tradeoff is added latency and the possibility of the lead paraphrasing the human's answer imprecisely — both acceptable for v0. The full chain is always visible in the event log for audit.
 
-**Worker-initiated asks.** A worker *may* emit `ask_human` directly (with no `on_behalf_of`); the orchestrator will route `human_response` back to that worker's stdin as in the direct flow. This is a fallback for cases where the lead is paused or unavailable and the system prompt explicitly permits it. It is not the default path.
+**Worker-initiated asks.** A worker *may* emit `ask_human` directly (with no `on_behalf_of`); the router will route `human_response` back to that worker's stdin as in the direct flow. This is a fallback for cases where the lead is paused or unavailable and the system prompt explicitly permits it. It is not the default path.
 
-**Messages do not trigger orchestrator actions in v0.** The inbox is pull-based (§2.7.3). If a sender needs the recipient to drop everything, they emit a signal — signals are the urgent wake-up mechanism; direct messages are async conversation.
+**Messages do not trigger router actions in v0.** The inbox is pull-based (§2.7.3). If a sender needs the recipient to drop everything, they emit a signal — signals are the urgent wake-up mechanism; direct messages are async conversation.
 
-#### 5.5.1 Enriched stdin injection
+#### 5.5.1 `runner_status` — availability reporting
 
-When `inject_stdin` fires, the orchestrator automatically enriches the template with the recipient's unread inbox summary.
+Workers report capacity explicitly instead of making the parent process infer intent from PTY output:
 
-**Watermark tracking.** The orchestrator maintains a per-runner `read_watermark` — the ULID of the newest message that runner has been shown. The watermark advances only on authoritative events, not on heuristics:
-
-- Every `runner msg read` invocation ends by emitting an `inbox_read` audit event with `kind: "signal"`, `type: "inbox_read"`, `from: <runner>`, `payload: { up_to: <max_ulid_returned> }`. The orchestrator advances the runner's watermark to `payload.up_to`.
-- An `inject_stdin` that included an unread summary also emits a `stdin_injected` event with `payload: { watermark: <max_ulid_in_summary> }`, so the next summary is scoped strictly to messages newer than this value — the injection itself counts as showing them.
-
-The watermark is initialized to `"0"` (before any ULID) at mission start and is rebuilt from the log on crash-replay by scanning these events. It is never inferred from `--since` flags (agents can set those to arbitrary values).
-
-**Injection shape.** Before firing, the orchestrator gathers all inbox messages newer than the recipient's watermark. The injected stdin is: `{template}\n\n{unread summary}`, and the watermark advances on the resulting `stdin_injected` event.
-
-Example — rule `{when: signal=changes_requested, do: inject_stdin target=coder template="Reviewer requested changes — check msg read for details."}` fires after Reviewer posted two direct messages. The Coder's PTY receives:
-
-```
-Reviewer requested changes — check msg read for details.
-
-You have 2 new messages:
-  [reviewer 12:38]: Line 47 auth.rs needs a null check.
-  [reviewer 12:39]: session.rs timeout is 30s; our convention is 10s.
-Run `runner msg read` for full content.
+```jsonc
+{
+  "kind": "signal",
+  "type": "runner_status",
+  "from": "impl",
+  "payload": {
+    "state": "idle",                         // "busy" | "idle" in MVP
+    "note": "ready for next task"             // optional
+  }
+}
 ```
 
-The Coder wakes up with both the signal and the conversation context in one interruption. If the Coder does then call `runner msg read`, the CLI returns the same two messages, emits `inbox_read { up_to: <reviewer's second message ULID> }`, and the watermark is already at that point from the injection — so nothing further is shown on the next signal unless genuinely new.
-
-This makes the urgent path (signal → inject_stdin) carry the async path (direct messages) with it automatically. Senders don't decide between "just message" and "signal-plus-message" — they send a message for data, and signal only when they need immediate attention; the enrichment glues the two together on arrival, and the watermark keeps them in sync.
-
-**Crash correctness:** emit the event *before* performing the action. Worst case on crash+replay is a duplicate action, recoverable (stdin seen twice; HITL cards deduped by event id). Silent loss is not.
+The router updates an in-memory status map and the UI projects the latest value in the runners rail. If a non-lead reports `idle`, the router also injects a short availability update to the lead. The lead decides whether to assign work; the router does not run a dispatch policy.
 
 ### 5.6 Who does delivery
 
 Two different delivery models, by primitive kind:
 
-- **Signals are orchestrator-routed.** Runners never address other runners with a signal. A signal is emitted into the bus; the orchestrator policy decides what happens (including whether to inject stdin into some specific runner). This keeps all control-flow routing in one place and lets you swap runners without rewriting emitters.
-- **Messages support both broadcast and direct addressing, but are pull-based.** A runner can `msg post` (everyone's inbox) or `msg post --to <runner>` (that runner's inbox only). The orchestrator is *not* in the delivery path — messages sit in the inbox until the recipient runs `msg read`. If a sender needs immediate attention, they emit a signal; signals are the urgent-wake-up channel.
+- **Signals are router-routed.** Runners never address other runners with a signal. A signal is emitted into the bus; the router's fixed handler decides the parent-process side effect, if any. This keeps urgent wake-up plumbing in one place while leaving work assignment decisions to the lead.
+- **Messages support both broadcast and direct addressing, but are pull-based.** A runner can `msg post` (everyone's inbox) or `msg post --to <runner>` (that runner's inbox only). The router is *not* in the message delivery path — messages sit in the inbox until the recipient runs `msg read`. If a sender needs immediate attention, they emit a signal; signals are the urgent-wake-up channel.
 
 The split:
 
-| | Sender addresses recipient? | Delivery timing | Orchestrator in path? |
+| | Sender addresses recipient? | Delivery timing | Router in path? |
 |---|:---:|---|:---:|
-| Signal | No — policy decides | Immediate (via `inject_stdin` etc.) | Always |
+| Signal | No — fixed handler decides | Immediate for wake-up handlers | Always |
 | Broadcast message | No | On recipient's `msg read` | No |
 | Direct message | Yes (`--to`) | On recipient's `msg read` | No |
 
-When the orchestrator does inject stdin on a signal, it automatically enriches the injection with the recipient's unread inbox summary (§5.5.1) — so an urgent signal pulls the associated async conversation along with it. That's how messages effectively "get delivered" to a running agent without a dedicated nudge mechanism.
-
-- **Decoupled control flow** — the Coder doesn't need to know the Reviewer's name to *signal* a review. Swap the Reviewer without rewriting the Coder's signal emissions.
+- **Decoupled wake-up plumbing** — a worker can ask the lead or report idle without knowing anything about the parent process's PTY writers.
 - **Coupled content flow where it's natural** — if Coder wants to ask Reviewer a specific question, it can just `msg post --to reviewer ...`. The roster injection (§4.3) already tells each runner the current names of its crewmates, so direct addressing works without extra config.
-- **Single policy location** for control — every "when signal X, do Y" lives on the crew row.
+- **Single parent-process routing location** — every urgent wake-up mechanism lives in one fixed router, not scattered across runners.
 - **No auto-interrupt for messages** — agents check their inboxes on convention and on signal-triggered wake-ups. This preserves the signal/message split (urgent vs async) and keeps in-flight tool calls uncorrupted.
 
 ### 5.7 Known failure modes
 
 | Failure | Mitigation |
 |---|---|
-| Orchestrator crashes mid-action | Emit event before action; replay on boot; accept duplicates |
-| Two runners ask human at once | HITL queues both; user answers in order |
+| Router crashes mid-stdin push | Replay rebuilds pending asks and runner status, but does not replay historical stdin pushes; the lead or human may need to retry the lost wake-up. |
+| Two runners ask human at once | Concurrent prompts are out of scope for MVP; UI should render both if present, but the default prompt tells workers to go through the lead. |
 | Event storm | Surface events/sec warning; no rate limit in v0 |
 | Malformed NDJSON line | Skip and warn; file stays valid |
 | NDJSON grows large | End the mission; new mission = new file |
@@ -780,7 +765,7 @@ macOS: `$APPDATA` = `~/Library/Application Support/com.wycstudios.runner`. Dev b
 Tauri main thread
   ├── Tauri async runtime (tokio)
   │     ├── MissionManager (async)
-  │     ├── Orchestrator task per live mission (notify + dispatch)
+  │     ├── Router task per live mission (notify + fixed handlers)
   │     └── Tauri command handlers (CRUD)
   ├── Thread per active session (blocking PTY reader)
   └── Webview process (React + xterm.js)
@@ -800,7 +785,7 @@ For v0 scale (one live mission, ≤ ~10 sessions): fine.
 - MCP-based signal emission
 - Auto-restart on crash
 - Event log rotation (solved implicitly by per-mission files)
-- LLM-based orchestrator rules
+- LLM-based signal routing
 - Multi-user / multi-machine coordination bus
 
 ## 10. Next milestones (vision)
@@ -811,12 +796,12 @@ For v0 scale (one live mission, ≤ ~10 sessions): fine.
 - `runners thread open <name>` → returns thread_id
 - `runner msg post --thread <id> <text>`
 - `runner msg read --thread <id>`
-- Orchestrator rules gain "open thread on signal X" action
+- Router can gain "open thread on signal X" handling
 - UI splits message stream by thread
 
 **Facts** — the shared whiteboard. Add:
 - `runners ctx set/get/unset/list`
-- `fact_recorded` event type; last-writer-wins projection in orchestrator
+- `fact_recorded` event type; last-writer-wins projection in the backend
 - UI gains a facts panel
 - Solves "current state of the mission" at a glance
 
@@ -824,7 +809,7 @@ Both live on the same event log as new `kind` values. No transport changes.
 
 ### v1 — Mentions, reactions, richer routing
 
-- `@runner` mentions inside messages → orchestrator can route on them
+- `@runner` mentions inside messages → router can route on them
 - Reactions (`👍`, `blocking`) on messages — lightweight signals
 - Cross-mission memory / "crew memory"
 - Concurrent missions per crew
@@ -835,8 +820,8 @@ Both live on the same event log as new `kind` values. No transport changes.
 2. **PTY, not pipes.** TUI fidelity is non-negotiable.
 3. **NDJSON file per mission, not broker.** Debuggable and crash-durable.
 4. **CLI wrapper, not MCP.** Works with every agent today.
-5. **Signals and messages as distinct primitives.** Keeps orchestrator simple and prose natural.
-6. **Orchestrator is the only router.** Runners stay decoupled.
+5. **Signals and messages as distinct primitives.** Keeps the router simple and prose natural.
+6. **The signal router is the only urgent wake-up path.** Runners stay decoupled.
 7. **Prompt composition at spawn time.** Replaces runtime handshakes.
 8. **Incremental vocabulary.** v0 = signals + messages; v0.x adds threads + facts; v1 adds mentions + reactions.
 9. **xterm.js for rendering.** Don't reinvent the terminal emulator.
@@ -849,7 +834,7 @@ Both live on the same event log as new `kind` values. No transport changes.
 3. Signal type allowlist: per-crew only (current), or global defaults + per-crew overrides?
 4. `from` field: locked to env (v0), or `--from` override?
 5. Does `runner msg read` return everything or paginate? v0: everything, sorted by ULID.
-6. Does the orchestrator ever inject messages (not signals) into runners' stdin? v0: yes — when it routes a signal to a runner, it can include a summary of recent messages as context.
+6. Does the router include recent messages when injecting stdin on a signal? v0: no — the recipient calls `runner msg read` when it wants inbox context.
 
 ## 13. What would break this architecture
 

--- a/docs/arch/v0-prd.md
+++ b/docs/arch/v0-prd.md
@@ -2,10 +2,7 @@
 
 > Status: draft, open for feedback. Anything in **[OPEN]** is a decision we haven't taken yet.
 >
-> **Canonicity.** `docs/arch/v0-arch.md` is the source of truth for all protocol, schema, and event-model decisions. Where this PRD conflicts with the arch doc, the arch doc wins. Sections marked **⚠️ SUPERSEDED** below have been overtaken by arch updates and are kept only for historical context until the PRD is rewritten:
-> - §5 (Golden path) — the `changes_requested → ask_human → inject Coder` flow has been replaced by lead-mediated HITL (arch §2.2, §5.5.0).
-> - §6.8 (`runner` CLI) — the `--correlation-id` / `--causation-id` flags are dropped (arch §5.2).
-> - §6.11.1 — "clicking a message highlights correlated signals" relies on the dropped correlation fields.
+> **Canonicity.** `docs/arch/v0-arch.md` is the source of truth for all protocol, schema, and event-model decisions. Where this PRD conflicts with the arch doc, the arch doc wins.
 
 ## 1. Problem
 
@@ -20,8 +17,8 @@ A local desktop app where one person can:
 1. Assemble a **crew** of CLI coding agents on their own machine.
 2. Give each **runner** a role and a brief (system prompt / instructions).
 3. **Launch a mission** — one activation of the whole crew — and watch every runner's live output in one window.
-4. Let runners **coordinate** through two channels: **signals** (typed, orchestrator-routable) and **messages** (prose, runner-to-runner).
-5. Get pulled in by an **orchestrator** only when a decision needs a human.
+4. Let runners **coordinate** through two channels: **signals** (typed, router-visible) and **messages** (prose, runner-to-runner).
+5. Get pulled in through the **lead runner** when a decision needs a human.
 
 v0 proves the loop works end-to-end with two runners on a single mission. v1+ scales it.
 
@@ -31,10 +28,10 @@ v0 proves the loop works end-to-end with two runners on a single mission. v1+ sc
 - **Runner** — an individual CLI agent (one PTY, one role, one system prompt).
 - **Mission** — one activation of the crew. Everyone spawns together, shares a coordination bus, ends together.
 - **Session** — the live PTY process for a single runner within a single mission.
-- **Signal** — a typed notification runners emit for the orchestrator to route on. Verb grammar (`review_requested`, `approved`, `blocked`).
+- **Signal** — a typed notification runners emit for the router to handle. Verb grammar (`ask_lead`, `ask_human`, `runner_status`).
 - **Message** — prose posted to the mission. Can be broadcast (to the mission) or directed (to a specific runner via `--to`).
 - **Inbox** — each runner's projection of the mission: broadcast messages plus messages addressed directly to it. Read via `runner msg read`. Pull-based: runners check their inbox on convention; there is no automatic interrupt for arriving messages.
-- **Orchestrator** — the rule-based router that reads signals and decides what happens next. Signals are the urgent wake-up channel; when the orchestrator injects stdin on a signal, it also appends a summary of the recipient's unread inbox so relevant messages ride along.
+- **Signal router** — the parent-process dispatcher that handles built-in signals. It owns wake-up plumbing and HITL card creation; the lead runner owns coordination judgment.
 
 ## 4. v0 scope
 
@@ -51,7 +48,7 @@ All four are described in `v0-arch.md` §2.7 with milestone tags, so the vision 
 - Multiple concurrent missions per crew
 - Cross-mission memory
 - Session replay, session history browsing
-- LLM-based orchestrator (v0 is rule-based only)
+- LLM-based signal routing
 - Remote / cloud / multi-host runners
 - Cost tracking, observability dashboards
 - Runner templates, presets, marketplace
@@ -70,22 +67,12 @@ The concrete loop v0 must support end-to-end:
 4. Coder writes code, runs tests, then:
    - `runner msg post "Branch feat/x is ready. I refactored auth and added session tests."`
    - `runner signal review_requested`
-5. Orchestrator routes `review_requested`: injects into Reviewer's stdin "A review is pending — check `runner msg read`."
-6. Reviewer:
-   - `runner msg read` (sees Coder's message)
-   - reads the diff
-   - `runner msg post --to coder "Line 47 auth.rs needs a null check."`
-   - `runner msg post --to coder "session.rs timeout is 30s; our convention is 10s."`
-   - `runner signal changes_requested`
-       *(orchestrator rule fires: injects into Coder's stdin — "Reviewer requested changes — check msg read." — and automatically appends a summary of Coder's 2 unread direct messages.)*
-7. Orchestrator policy for `changes_requested` says `ask_human`. The HITL panel pops a card: *"Reviewer requested changes. Accept and forward to Coder, or override?"*
-8. User clicks **Accept**. Orchestrator injects into Coder's stdin: "Reviewer requested changes — check `runner msg read`."
-9. Coder:
-   - `runner msg read`
-   - fixes the null check; defends the 30s timeout
-   - `runner msg post "Added null check. Kept 30s timeout — provider is slow on cold start."`
-   - `runner signal review_requested`
-10. Reviewer reads, agrees, `runner signal approved`.
+5. Worker finishes the current task and emits `runner status idle --note "ready for next task"`.
+6. Router records the worker as idle and injects a short availability update into the lead's stdin.
+7. Lead decides whether to assign follow-up work, answer from its own context, or ask the human.
+8. If human input is needed, lead emits `runner signal ask_human --payload '{"prompt":"Approve the change?","choices":["yes","no"],"on_behalf_of":"coder"}'`.
+9. The HITL panel pops a card. User clicks **yes**. UI emits `human_response`; router injects the answer into the lead's stdin.
+10. Lead forwards the answer to the worker with `runner msg post --to coder "Human approved."`; worker reads it on the next `runner msg read`.
 11. User clicks **End Mission**. Sessions terminate, mission status flips to `completed`, the mission appears in the crew's history list.
 
 If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
@@ -94,13 +81,13 @@ If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
 
 ### 6.1 Crew CRUD
 - Create, rename, delete crews.
-- A crew has: `name`, `goal` (default mission brief), list of runners, orchestrator policy, signal-type allowlist.
+- A crew has: `name`, `goal` (default mission brief), list of runners, signal-type allowlist, and a reserved `orchestrator_policy` column for v0.x.
 - Persisted in SQLite.
 
 ### 6.2 Runner CRUD (top-level, shared across crews)
 - Create, edit, delete runners as standalone config; add or remove a runner's membership in a given crew via `crew_runners`. The same runner can sit in multiple crews simultaneously (post-C5.5a).
 - A runner has:
-  - `handle` — lowercase slug (e.g. `coder`). Immutable once set; **globally unique** across the app. Used everywhere addressing is needed (`from`/`to` in events, `--to <handle>` on the CLI, policy rules) so `@coder` names the same runner everywhere it appears.
+  - `handle` — lowercase slug (e.g. `coder`). Immutable once set; **globally unique** across the app. Used everywhere addressing is needed (`from`/`to` in events, `--to <handle>` on the CLI, router state) so `@coder` names the same runner everywhere it appears.
   - `display_name` — free-form UI label (e.g. "Coder", "Lead Reviewer"). Editable; presentation-only.
   - `role` — short label, e.g. "implementation".
   - `runtime` — enum: `claude-code | codex | shell`. Adds the right default `command` + `args`.
@@ -122,14 +109,14 @@ If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
 - Frontend renders with **xterm.js** to preserve ANSI colors, cursor control, and TUI layouts.
 - Scrollback retained per session (cap at ~10k lines; overflow dumped to a per-session log file).
 - Status chip per runner: `idle | running | waiting_for_input | blocked_on_human | crashed`.
-- **Human takeover, first-class.** The xterm pane is a real terminal, not a log viewer. At any moment the human can type directly into a runner's stdin — to answer a prompt, correct a bad plan, kill a runaway tool, or just chat with the agent mid-flight. Keystrokes including arrows, Enter, and Ctrl-C pass through untouched. Same writer path as the orchestrator's `inject_stdin`, so human and orchestrator are symmetric.
-- **Sessions outlive the UI.** Closing the mission control window does not kill sessions — agents keep running, events keep flowing, the orchestrator keeps routing. Re-opening re-attaches by fetching each session's scrollback ring. A session ends only on End Mission, child exit, or app quit. This means the human can close the monitor and still rely on the orchestrator + rules without cutting anyone out of the loop.
+- **Human takeover, first-class.** The xterm pane is a real terminal, not a log viewer. At any moment the human can type directly into a runner's stdin — to answer a prompt, correct a bad plan, kill a runaway tool, or just chat with the agent mid-flight. Keystrokes including arrows, Enter, and Ctrl-C pass through untouched. Same writer path as the router's stdin pushes, so human and router are symmetric.
+- **Sessions outlive the UI.** Closing the mission control window does not kill sessions — agents keep running, events keep flowing, the router keeps handling live signals. Re-opening re-attaches by fetching each session's scrollback ring. A session ends only on End Mission, child exit, or app quit. This means the human can close the monitor and still rely on the router without cutting anyone out of the loop.
 
-### 6.5 Signals — typed orchestrator-routable notifications
+### 6.5 Signals — typed router-visible notifications
 - Runners emit via `runner signal <type> [--payload <json>]`.
 - Types are per-crew allowlisted (stored in `crews.signal_types`).
-- Payload is optional JSON for the orchestrator's decision logic.
-- Emitted signals appear as events in the coordination bus (see §6.7) and drive the orchestrator.
+- Payload is optional JSON for the router and UI.
+- Emitted signals appear as events in the coordination bus (see §6.7) and drive fixed router handlers.
 
 ### 6.6 Messages — prose with broadcast or direct addressing
 - Broadcast: `runner msg post "<text>"` — visible to everyone in the mission.
@@ -145,55 +132,44 @@ If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
 Runners learn to check their inboxes through two mechanisms:
 
 1. **Convention.** Each runner's composed prompt instructs it to check `runner msg read` at natural task boundaries (before a new task, before emitting a signal, while waiting).
-2. **Signals as the wake-up channel.** If a sender needs immediate attention, they emit a signal in addition to (or instead of) the message. Signal routing through `inject_stdin` automatically enriches the injection with the recipient's unread inbox summary — so urgent wake-ups carry the related conversation with them. See `v0-arch.md` §5.5.1.
+2. **Signals as the wake-up channel.** If a sender needs immediate attention, they emit a signal in addition to (or instead of) the message. The signal router handles the built-in wake-up types with fixed parent-process actions. Stdin pushes are not enriched with inbox summaries in MVP; runners call `runner msg read` when they want inbox context.
 
 ### 6.7 Coordination bus
 - Single append-only NDJSON file per mission at `$APPDATA/runner/crews/{crew_id}/missions/{mission_id}/events.ndjson`.
 - Both signals and messages are persisted as events with `kind: "signal"` or `kind: "message"`.
-- File is watched with the `notify` crate. Orchestrator and UI both subscribe.
+- File is watched with the `notify` crate. Router and UI both subscribe.
 - Tailable with `tail -f` for debugging. Per-mission file solves log rotation implicitly.
 
 ### 6.8 `runner` CLI
 
 ```
-runner signal <type> [--payload <json>] [--correlation-id <id>] [--causation-id <id>]
-runner msg    post <text> [--to <runner>] [--correlation-id <id>] [--causation-id <id>]
+runner signal <type> [--payload <json>]
+runner msg    post <text> [--to <runner>]
 runner msg    read [--since <ts>] [--from <runner>]
+runner status <busy|idle> [--note <text>]
 runner help
 ```
 
-One binary, two verbs. Reads context (crew, mission, runner, log path) from env vars injected at PTY spawn. Bundled with the app; dropped at `$APPDATA/runner/bin/runner` on first run; PATH is prepended for each session so agents can invoke it unqualified.
+One binary, three verbs. Reads context (crew, mission, runner, log path) from env vars injected at PTY spawn. Bundled with the app; dropped at `$APPDATA/runner/bin/runner` on first run; PATH is prepended for each session so agents can invoke it unqualified.
 
 See `v0-arch.md` §5.3 for the full three-layer emission mechanism (system prompt → CLI on PATH → role brief examples).
 
-### 6.9 Orchestrator (rule-based)
-- Policy is per-crew, stored as JSON on the crew row. Shared across all missions.
-- In-memory state (pending asks, correlation tracking) is per-mission; cleared on mission end.
-- Policy is an ordered list of `{ when, do }` rules. First match wins. Schema:
-  ```json
-  [
-    { "when": { "signal": "review_requested" },
-      "do": { "action": "inject_stdin", "target": "reviewer",
-              "template": "A review is pending — run `runner msg read` for context." } },
-    { "when": { "signal": "changes_requested" },
-      "do": { "action": "ask_human",
-              "prompt": "Reviewer requested changes. Accept or override?",
-              "choices": ["accept", "override"] } },
-    { "when": { "signal": "approved" },
-      "do": { "action": "notify_human", "message": "Review approved." } }
-  ]
-  ```
-- Supported actions in v0:
-  - `inject_stdin` — write a message into the target runner's stdin. Automatically enriched with the recipient's unread inbox summary; watermark advances on the resulting `stdin_injected` event (see `v0-arch.md` §5.5.1).
-  - `ask_human` — show a card in the HITL panel; emits a `human_question` signal. On click, emits a `human_response` signal with payload `{ question_id, choice }` and `correlation_id` = the original triggering signal's id. Downstream rules match on `payload.choice`.
-  - `notify_human` — fire a toast.
-  - `pause_runner` / `resume_runner` — SIGSTOP/SIGCONT the target PTY.
-- Rules fire on signals only. Messages do not trigger orchestrator actions in v0 — the inbox is pull-based. Senders escalate via signals when immediate attention is needed. (v0.x: mentions inside messages will trigger routing.)
+### 6.9 Signal router (fixed handlers)
+- No user-authored policy rules in MVP. The crew row keeps `orchestrator_policy` only as forward-compatible schema; it is unread in v0.
+- In-memory state (pending asks, latest runner status) is per-mission and cleared on mission end. Reopen reconstructs that state from the log.
+- Supported built-in handlers in v0:
+  - `mission_goal` — compose and inject the launch prompt to the lead.
+  - `human_said` — inject human text to `payload.target`, or to the lead by default.
+  - `ask_lead` — inject the worker's question/context to the lead.
+  - `ask_human` — append a `human_question` signal for the HITL panel. On click, append `human_response` with payload `{ question_id, choice }`.
+  - `human_response` — inject the answer to the runner that emitted the matching `ask_human`.
+  - `runner_status` — update the latest status map; when a non-lead reports `idle`, inject a short availability update to the lead.
+- Messages do not trigger router actions in v0 — the inbox is pull-based. Senders escalate via signals when immediate attention is needed. (v0.x: mentions inside messages may trigger routing.)
 
 ### 6.10 Human-in-the-loop panel
 - Right-rail panel showing all pending `ask_human` cards for the current mission.
-- Each card shows: triggering signal, orchestrator prompt, choices.
-- User clicks a choice → orchestrator emits a `human_response` signal with `correlation_id = triggering signal's id` which downstream rules can match.
+- Each card shows: triggering signal, prompt, choices, and optional `on_behalf_of` attribution.
+- User clicks a choice → the UI emits a `human_response` signal with `payload.question_id` pointing at the `human_question`.
 - Cleared when the mission ends.
 
 ### 6.11 Mission control UI
@@ -203,7 +179,7 @@ One screen per live mission. Surfaces and their responsibilities:
 - **Runner list** — every runner in the crew with a status indicator (`idle | running | waiting_for_input | blocked_on_human | crashed`). Selecting one focuses the main terminal area on it. Includes a control to spawn additional runners.
 - **Focused terminal** — the xterm.js view for the selected runner. Live PTY output with full TUI fidelity, stdin input for human takeover, and scrollback. Terminals stay alive across focus switches (§6.4).
 - **Signals pane** — chronological list of all signals emitted in this mission: timestamp, emitter, type. Scoped to the mission.
-- **HITL panel** — pending `ask_human` cards. Each card shows the triggering signal, the orchestrator's prompt, and choice buttons. Always visible so the operator never misses a pending decision.
+- **HITL panel** — pending `ask_human` cards. Each card shows the triggering signal, the prompt, and choice buttons. Always visible so the operator never misses a pending decision.
 - **Messages pane** — every message in the mission (see §6.11.1 for visibility semantics and view modes).
 - **Mission header** — crew name, mission start time, global controls (Start/Pause/Stop, End Mission).
 
@@ -283,7 +259,7 @@ Signals and messages live in the mission's NDJSON file, not in SQLite. SQLite is
 - **Backend:** Rust, Tauri 2. PTY via `portable-pty`. File watching via `notify`. Persistence via `rusqlite` (WAL).
 - **Frontend:** React 19, TypeScript, Tailwind 4, xterm.js, React Router.
 - **Coordination bus:** NDJSON file per mission.
-- **Orchestrator:** Rust module in the Tauri backend, subscribes to the mission's event file via `notify`.
+- **Signal router:** Rust module in the Tauri backend, subscribes to the mission's event file via `notify`.
 - **`runner` CLI:** small Rust binary, bundled with the app, dropped at `$APPDATA/runner/bin/runner`, PATH-prepended per session.
 
 ## 9. Open questions
@@ -293,7 +269,7 @@ Signals and messages live in the mission's NDJSON file, not in SQLite. SQLite is
 3. **Restart semantics** — if a runner crashes, auto-restart? v0: no.
 4. **Event ordering guarantees** — single-writer per line via `O_APPEND`. Document filesystem requirements (local POSIX).
 5. **Does `msg read` paginate?** v0: return everything, client can filter by `--since`.
-6. **Should the orchestrator include recent messages as context** when injecting stdin on a signal? Leaning yes — helpful for runners that don't immediately think to call `msg read`.
+6. **Should the router include recent messages as context** when injecting stdin on a signal? v0: no — runners call `runner msg read` when they want inbox context.
 
 ## 10. Risks
 
@@ -307,7 +283,7 @@ v0 ships when:
 - [ ] A user can create a crew, spawn two runners, click Start Mission, and see two live terminals.
 - [ ] Runners can emit signals via `runner signal` and the UI shows them in the signal log.
 - [ ] Runners can post and read messages via `runner msg`, and the UI shows the live messages pane.
-- [ ] A rule-based policy can route a signal into another runner's stdin.
-- [ ] A rule-based policy can pause the mission and ask the human a question, then resume based on the answer.
+- [ ] The fixed router can route `ask_lead`, `human_said`, and `human_response` into the right runner's stdin.
+- [ ] The fixed router can turn `ask_human` into a HITL card and return the human response to the asker.
 - [ ] End Mission terminates all sessions, marks the mission completed, and the crew page shows it in history.
 - [ ] The Coder + Reviewer demo loop from §5 works end-to-end without the user touching a terminal outside the app.

--- a/docs/impls/v0-mvp.md
+++ b/docs/impls/v0-mvp.md
@@ -9,7 +9,7 @@
 > **2026-04-26 plan revision.** C8 was reframed from "orchestrator v0" to "signal router v0" — a flat parent-process dispatcher, not a rule engine. The dispatch ledger, replay idempotence, inbox-summary enrichment, and policy loader were all explicitly descoped because the lead runner already owns coordination judgment; C8 only owns the plumbing (bootstrap, cross-process stdin push, UI bridge) the lead can't do from inside a child PTY. See **C8 — Signal router v0** below for the rationale and the descoped list. The cross-cutting prompt/runtime adapter is now part of C8 instead of a separate prerequisite.
 
 
-The persistence, configuration, PTY runtime, event log, event bus, and top-level runner/direct-chat surfaces are in place. The remaining MVP work is the coordination loop: prompt composition, the signal router that wires events to stdin pushes and UI cards, the `runner` CLI, mission workspace UI, and the final Start Mission entrypoint.
+The persistence, configuration, PTY runtime, event log, event bus, and top-level runner/direct-chat surfaces are in place. The remaining MVP work is the coordination loop: prompt composition, the signal router that wires events to stdin pushes, UI cards, and runner availability updates, the `runner` CLI, mission workspace UI, and the final Start Mission entrypoint.
 
 ### Implemented
 
@@ -40,7 +40,7 @@ The persistence, configuration, PTY runtime, event log, event bus, and top-level
 - **Runner `system_prompt` is stored and displayed but not passed to the runtime.** `runner.system_prompt` is accepted by create/update forms and shown on Runner Detail, but `SessionManager::spawn` and `spawn_direct` currently launch only `runner.command + runner.args`. No runtime adapter adds `--append-system-prompt` for Claude Code or the Codex equivalent yet. This must be fixed before claiming the default system prompt is "used whenever this runner spawns."
 - **Mission prompt composition does not exist yet.** The architecture says the launch prompt is `runner.system_prompt + mission goal + roster + coordination instructions + signal allowlist`, but the current C6/C8 boundary only starts PTYs and appends `mission_goal`. Nothing injects the composed prompt into the child.
 - **No runner-to-runner CLI yet.** The app prepends `$APPDATA/runner/bin` to `PATH`, but there is no `runner` binary installed there, so agents cannot emit `runner signal` or `runner msg` events.
-- **No signal router yet.** The event bus emits events, but no code consumes them to wake the lead, route `ask_lead`, render `ask_human`, or inject `human_response`. Tracked as C8.
+- **No signal router yet.** The event bus emits events, but no code consumes them to wake the lead, route `ask_lead`, render `ask_human`, inject `human_response`, or surface runner availability updates. Tracked as C8.
 - **No mission workspace UI or Start Mission UI yet.** The backend commands exist; the polished `/missions` entrypoint and workspace are still missing.
 
 ### Integrated C5.5 amendment context
@@ -72,13 +72,14 @@ The launch/prompt adapter that was previously listed as a separate cross-cutting
 
 ### C8 — Signal router v0
 
-**Reframing.** The earlier plan called this an "orchestrator" and described it as a deterministic policy state machine with a dispatch ledger and inbox-summary enrichment. That framing oversold what's actually needed. The lead runner is the agent that *thinks* about coordination — it plans, dispatches workers via directed messages, decides when to escalate. C8 is the parent-process plumbing under that lead, doing three things the lead can't do from inside a child PTY:
+**Reframing.** The earlier plan called this an "orchestrator" and described it as a deterministic policy state machine with a dispatch ledger and inbox-summary enrichment. That framing oversold what's actually needed. The lead runner is the agent that *thinks* about coordination — it plans, dispatches workers via directed messages, decides when to escalate. C8 is the parent-process plumbing under that lead, doing four things the lead can't do from inside a child PTY:
 
 1. **Bootstrap.** Write the composed launch prompt (`runner.system_prompt + mission goal + roster + coordination instructions + signal allowlist`) to the lead's stdin on `mission_start`. The lead can't bootstrap itself — there's no LLM yet when the mission opens.
 2. **Cross-process stdin push.** A worker's stdin is owned by the parent. So `ask_lead` (worker → lead's stdin) and `human_said` (UI → lead's or worker's stdin) require a parent-side router.
 3. **UI bridge.** `ask_human` becomes a card on the workspace. The lead emits the signal; only the parent can render the card and capture the click. `human_response` then routes the answer back to the original asker.
+4. **Availability bridge.** Workers self-report `runner_status` (`busy` / `idle`) as signals. The router keeps the latest status map and tells the lead when a worker becomes idle so the lead can assign the next task. The router does not infer status from terminal bytes and does not decide what the worker should do next.
 
-That's it. There are no policy rules to evolve — these are five hardcoded mechanisms. v0.x can revisit policy/LLM-in-the-loop framing if user-defined signal types ever ship; MVP has no place for it.
+That's it. There are no policy rules to evolve — these are a few hardcoded mechanisms. v0.x can revisit policy/LLM-in-the-loop framing if user-defined signal types ever ship; MVP has no place for it.
 
 **Where:** `src-tauri/src/orchestrator/mod.rs` is a stub; rename to `src-tauri/src/router/` with this chunk so the next reader doesn't expect a framework.
 
@@ -91,13 +92,15 @@ That's it. There are no policy rules to evolve — these are five hardcoded mech
   - `ask_lead` → inject the worker's question/context to the lead.
   - `ask_human` → append a `human_question` event preserving `on_behalf_of`; the workspace UI (C10) renders the card from that event.
   - `human_response` → look up the matching `question_id` in an in-memory pending-ask map and inject the answer to the original asker (the lead in the lead-mediated flow, the worker in the direct flow).
+  - `runner_status` → update the latest-status map from `payload.state` (`busy` / `idle`) and inject a short availability update to the lead when a non-lead runner reports `idle`.
 - Pending-ask map: in-memory `HashMap<question_id, asker_handle>` populated when an `ask_human` event is observed (live or during replay). No persistence; on reopen the map is reconstructed by re-reading the log through the same handler.
+- Runner-status map: in-memory `HashMap<runner_handle, RunnerStatus>` populated from `runner_status` events and session lifecycle (`crashed` / `stopped` still come from the session row). Reopen reconstructs it from the log before live tail begins.
 - Dead-session errors produce a visible mission-warning event in the log, not a silent drop. The mission workspace surfaces these.
 
 **Explicitly descoped (was in the original C8 doc, deferred to v0.x):**
 - **Dispatch ledger / replay idempotence.** The router is not re-run against historical events on reopen; live tail starts from the current end of the log. `mission_goal` only fires once per mission anyway, `human_question` is rendered from log replay by the UI (not re-emitted), and re-injecting old prompts into a sleeping LLM is bizarre UX. The pending-ask map is the only state that needs reopen reconstruction — we get it for free by re-reading `ask_human`/`human_response` rows in order, no ledger required.
 - **Inbox-summary enrichment in injected stdin templates.** Originally the router was going to prepend the recipient's unread message summary onto every injection and advance the watermark via a synthesized `stdin_injected` event. MVP drops this — the lead can call `runner msg read` itself when it wants its inbox, and that's the documented contract. Keeping enrichment out of the injection path means the router does not have to write log events, only consume them.
-- **Rule abstraction / policy loader.** No `Rule` trait, no policy JSON loaded from `crews.orchestrator_policy`. The five handlers are a `match signal_type { … }` and that's the whole router.
+- **Rule abstraction / policy loader.** No `Rule` trait, no policy JSON loaded from `crews.orchestrator_policy`. The handlers are a `match signal_type { … }` and that's the whole router.
 
 **Cross-cutting prerequisite — launch/prompt adapter.**
 - `mission_goal`'s injected prompt is `runner.system_prompt + mission goal + roster + coordination instructions + signal allowlist`. There's no composer today.
@@ -120,6 +123,7 @@ Required behavior:
   - `runner signal <type> [--payload <json>]`;
   - `runner msg post <text> [--to <handle>]`;
   - `runner msg read [--since <ulid>] [--from <handle>]`;
+  - `runner status <busy|idle> [--note <text>]` as a convenience wrapper that emits `signal runner_status`;
   - `runner help`.
 - `msg read` must project the caller's inbox and emit `inbox_read` with `payload.up_to = max ULID` for messages shown.
 - Reuse `runner_core::event_log` for append/read; do not duplicate log writer semantics.
@@ -128,7 +132,7 @@ Required behavior:
 Risks to settle:
 - Direct-chat sessions intentionally do not set mission/event-log env vars. CLI commands in that context must print a clear no-bus message or no-op cleanly, not crash the agent process.
 - Packaging needs executable bits on macOS/Linux and a predictable update path when the app ships a newer CLI.
-- The CLI's signal-type validation must match the seven built-ins seeded in C1 before user-defined signal types are opened up.
+- The CLI's signal-type validation must match the eight built-ins seeded in C1 before user-defined signal types are opened up.
 
 ### C10 — Mission workspace UI
 
@@ -229,7 +233,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 **Deliverables.**
 - `src-tauri/src/db.rs` — connection pool with WAL mode, `rusqlite` migrations runner, bootstrapped at app start.
 - Migration `0001_init.sql` — implements **arch §7.1 verbatim**, including the four tables (`crews`, `runners`, `missions`, `sessions`) and the `one_lead_per_crew` partial unique index. No additions, no renames. The plan used to list the columns inline; that list has been deleted to remove the two-source-of-truth risk the earlier review called out. Implementers copy §7.1 directly into `0001_init.sql`.
-- **Default signal-type allowlist.** Every new crew row is seeded with `signal_types = ["mission_goal", "human_said", "ask_lead", "ask_human", "human_question", "human_response", "inbox_read"]` — the full set of built-in types the MVP needs. Users can extend this list in v0.x; in MVP it is write-only from the DB layer. Without this seeding the CLI will reject the built-in signals at spawn time per arch §5.3 Layer 2.
+- **Default signal-type allowlist.** Every new crew row is seeded with `signal_types = ["mission_goal", "human_said", "ask_lead", "ask_human", "human_question", "human_response", "runner_status", "inbox_read"]` — the full set of built-in types the MVP needs. Users can extend this list in v0.x; in MVP it is write-only from the DB layer. Without this seeding the CLI will reject the built-in signals at spawn time per arch §5.3 Layer 2.
 - Rust types in `src-tauri/src/model.rs`: `Crew`, `Runner`, `Mission`, `Session`, `Event`, `EventKind`, `SignalType`, serde-derived. Serde field attributes map Rust-idiomatic snake_case (`args`, `env`) to the DB column names (`args_json`, `env_json`) where they differ.
 - TS types in `src/lib/types.ts` hand-synced with Rust (we're not pulling in `ts-rs` yet — too much ceremony for the MVP).
 
@@ -354,13 +358,14 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 
 ## C8 — Signal router v0
 
-**Goal.** A flat parent-process dispatcher that wires five signal types into stdin pushes and a UI-card event. Not a framework — a hardcoded `match` of about 200 LOC plus the prompt composer it needs for `mission_goal`. See "C8 — Signal router v0" in the **Remaining v0 work** section above for the full reframing rationale and explicit descoping.
+**Goal.** A flat parent-process dispatcher that wires built-in signal types into stdin pushes, runner availability projection, and a UI-card event. Not a framework — a hardcoded `match` plus the prompt composer it needs for `mission_goal`. See "C8 — Signal router v0" in the **Remaining v0 work** section above for the full reframing rationale and explicit descoping.
 
 **Deliverables.**
 - `src-tauri/src/router/mod.rs` (renamed from the existing `orchestrator/` stub):
   - `Router::for_mission(mission, crew_roster, sessions, log)` — mounted by `mission_start`, unmounted by `mission_stop` and the spawn-rollback path.
-  - `Router::handle_event(&Event)` — single entry point invoked by the bus on each appended event. `EventKind::Message` is a no-op (per arch §5.5.0); `EventKind::Signal` matches on `signal_type` against the five built-ins.
+  - `Router::handle_event(&Event)` — single entry point invoked by the bus on each appended event. `EventKind::Message` is a no-op (per arch §5.5.0); `EventKind::Signal` matches on `signal_type` against the built-ins.
   - In-memory pending-ask map keyed by `question_id`. Reconstructed on reopen by replaying `ask_human` / `human_response` rows through the same handler before live tail begins.
+  - In-memory runner-status map keyed by handle. Reconstructed on reopen by replaying `runner_status` rows and session lifecycle state before live tail begins.
   - Dead-session writes append a `mission_warning` event to the log instead of silently dropping. The workspace UI surfaces these.
 - `src-tauri/src/router/handlers.rs` (or inline in `mod.rs` if it fits):
   - `mission_goal` → compose launch prompt, inject to the lead's stdin via `SessionManager::inject_stdin`.
@@ -368,6 +373,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
   - `ask_lead` → render worker's `{question, context}` into a short stdin template, inject to the lead.
   - `ask_human` → append a `human_question` event carrying `on_behalf_of` (if present) and the original `ask_human` id as `triggered_by`. UI renders the card from the appended event in C10.
   - `human_response` → look up `question_id` in the pending-ask map; inject `payload.text` to the original asker. Unmatched `human_response` logs a warning event, no panic.
+  - `runner_status` → accept `payload.state = "busy" | "idle"` and optional `payload.note`; update the status map; when a non-lead reports `idle`, inject a short availability update to the lead.
 - `src-tauri/src/router/prompt.rs` — composes `runner.system_prompt + mission goal + roster + coordination instructions + signal allowlist` into the `mission_goal` injection. Pure function over inputs; no I/O; easy to unit-test.
 - Cross-cutting **launch/prompt adapter** (must land in this chunk):
   - `src-tauri/src/runtime.rs` — adapter trait + per-runtime impls. `claude-code` injects `runner.system_prompt` via `--append-system-prompt`. `codex` ships with a TODO until its CLI flag is verified. Fallback runtimes get a documented no-op + a warning log.
@@ -376,6 +382,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 **Tests.**
 - Each handler fires exactly once per triggering event under live tail.
 - Reopen reconstructs the pending-ask map: append `ask_human` then `mission_stop`, reopen, append `human_response`, assert the right asker's stdin received the answer.
+- Reopen reconstructs the runner-status map from `runner_status` rows; a worker `idle` signal updates the map and reaches the lead.
 - `human_response` without a matching `human_question` emits a `mission_warning`, not a panic.
 - `messages_do_not_trigger_router_actions` — appending an `EventKind::Message` produces no `inject_stdin` call.
 - Runtime adapter resolves `--append-system-prompt` for claude-code on both `spawn` and `spawn_direct`. Missing `system_prompt` is fine (no flag added).

--- a/docs/impls/v0-mvp.md
+++ b/docs/impls/v0-mvp.md
@@ -6,7 +6,10 @@
 
 ## Current status — 2026-04-26
 
-The persistence, configuration, PTY runtime, event log, event bus, and top-level runner/direct-chat surfaces are in place. The remaining MVP work is the coordination loop: prompt composition, orchestrator routing, the `runner` CLI, mission workspace UI, and the final Start Mission entrypoint.
+> **2026-04-26 plan revision.** C8 was reframed from "orchestrator v0" to "signal router v0" — a flat parent-process dispatcher, not a rule engine. The dispatch ledger, replay idempotence, inbox-summary enrichment, and policy loader were all explicitly descoped because the lead runner already owns coordination judgment; C8 only owns the plumbing (bootstrap, cross-process stdin push, UI bridge) the lead can't do from inside a child PTY. See **C8 — Signal router v0** below for the rationale and the descoped list. The cross-cutting prompt/runtime adapter is now part of C8 instead of a separate prerequisite.
+
+
+The persistence, configuration, PTY runtime, event log, event bus, and top-level runner/direct-chat surfaces are in place. The remaining MVP work is the coordination loop: prompt composition, the signal router that wires events to stdin pushes and UI cards, the `runner` CLI, mission workspace UI, and the final Start Mission entrypoint.
 
 ### Implemented
 
@@ -37,7 +40,7 @@ The persistence, configuration, PTY runtime, event log, event bus, and top-level
 - **Runner `system_prompt` is stored and displayed but not passed to the runtime.** `runner.system_prompt` is accepted by create/update forms and shown on Runner Detail, but `SessionManager::spawn` and `spawn_direct` currently launch only `runner.command + runner.args`. No runtime adapter adds `--append-system-prompt` for Claude Code or the Codex equivalent yet. This must be fixed before claiming the default system prompt is "used whenever this runner spawns."
 - **Mission prompt composition does not exist yet.** The architecture says the launch prompt is `runner.system_prompt + mission goal + roster + coordination instructions + signal allowlist`, but the current C6/C8 boundary only starts PTYs and appends `mission_goal`. Nothing injects the composed prompt into the child.
 - **No runner-to-runner CLI yet.** The app prepends `$APPDATA/runner/bin` to `PATH`, but there is no `runner` binary installed there, so agents cannot emit `runner signal` or `runner msg` events.
-- **No orchestrator yet.** The event bus emits events, but no code consumes them to wake the lead, route `ask_lead`, render `ask_human`, or inject `human_response`.
+- **No signal router yet.** The event bus emits events, but no code consumes them to wake the lead, route `ask_lead`, render `ask_human`, or inject `human_response`. Tracked as C8.
 - **No mission workspace UI or Start Mission UI yet.** The backend commands exist; the polished `/missions` entrypoint and workspace are still missing.
 
 ### Integrated C5.5 amendment context
@@ -65,44 +68,46 @@ Product consequences:
 
 ## Remaining v0 work
 
-### Cross-cutting launch/prompt adapter
+The launch/prompt adapter that was previously listed as a separate cross-cutting prerequisite is now folded into C8 — see the "Cross-cutting prerequisite" block under C8.
 
-This should land before or with C8, because every runtime path depends on it.
+### C8 — Signal router v0
 
-- Build a prompt composer that renders:
-  - the runner's default `system_prompt`;
-  - the mission goal (`goal_override` or crew default);
-  - the crew roster with handles, roles, lead flag, and brief summaries;
-  - coordination instructions for `runner signal`, `runner msg post`, `runner msg read`, and when to use each;
-  - the crew's signal-type allowlist.
-- Add a runtime launch adapter instead of sprinkling flags directly in `SessionManager`:
-  - `claude-code`: append the composed prompt through Claude Code's native system-prompt flag (`--append-system-prompt` per the architecture doc);
-  - `codex`: verify and implement the current Codex CLI equivalent before shipping the Codex runtime as first-class;
-  - fallback/no-native-support runtime: document whether v0 rejects the runtime, writes an initial stdin message after spawn, or leaves the prompt unused.
-- Apply the same default prompt policy to direct-chat sessions. Direct chats have no mission goal or roster, but they still should receive the runner's default role brief if the UI says the prompt is used on spawn.
-- Add tests that assert the resolved command/env for a runner with `system_prompt` actually contains the runtime-specific prompt injection, and tests that direct-chat spawn does not silently drop the prompt.
+**Reframing.** The earlier plan called this an "orchestrator" and described it as a deterministic policy state machine with a dispatch ledger and inbox-summary enrichment. That framing oversold what's actually needed. The lead runner is the agent that *thinks* about coordination — it plans, dispatches workers via directed messages, decides when to escalate. C8 is the parent-process plumbing under that lead, doing three things the lead can't do from inside a child PTY:
 
-### C8 — Orchestrator v0
+1. **Bootstrap.** Write the composed launch prompt (`runner.system_prompt + mission goal + roster + coordination instructions + signal allowlist`) to the lead's stdin on `mission_start`. The lead can't bootstrap itself — there's no LLM yet when the mission opens.
+2. **Cross-process stdin push.** A worker's stdin is owned by the parent. So `ask_lead` (worker → lead's stdin) and `human_said` (UI → lead's or worker's stdin) require a parent-side router.
+3. **UI bridge.** `ask_human` becomes a card on the workspace. The lead emits the signal; only the parent can render the card and capture the click. `human_response` then routes the answer back to the original asker.
 
-**Where:** `src-tauri/src/orchestrator/mod.rs` is still a stub. The event bus already provides ordered replay/tail input; C8 owns the deterministic policy state machine on top.
+That's it. There are no policy rules to evolve — these are five hardcoded mechanisms. v0.x can revisit policy/LLM-in-the-loop framing if user-defined signal types ever ship; MVP has no place for it.
 
-Required behavior:
+**Where:** `src-tauri/src/orchestrator/mod.rs` is a stub; rename to `src-tauri/src/router/` with this chunk so the next reader doesn't expect a framework.
+
+**Required behavior:**
 - Mount per live mission when `mission_start` succeeds; unmount when `mission_stop` completes or spawn rollback aborts.
-- Reconstruct state on reopen by replaying the log through the same handler used for live events.
-- Maintain a dispatch ledger keyed by `triggering_event_id` so replay is idempotent.
-- Maintain a pending-ask map keyed by `question_id` for `ask_human` / `human_response`.
-- Built-in signal rules, signal-driven only:
-  - `mission_goal` wakes the crew lead with the mission brief and coordination instructions.
-  - `human_said` injects to `payload.target` when present, otherwise to the lead.
-  - `ask_lead` injects the worker's question/context to the lead.
-  - `ask_human` appends/renders a `human_question` event, preserving `on_behalf_of` for the UI.
-  - `human_response` injects the chosen response to the original asker for the matching `question_id`.
-- Enrich every injected stdin template with the recipient's unread inbox summary, then advance the watermark through a `stdin_injected`/equivalent event so replay and future summaries stay consistent.
+- Subscribe to the existing `EventBus` (which already replays-then-tails). Handle each event in arrival order through one flat dispatcher.
+- Hardcoded signal handlers (signal-driven only — per arch §5.5.0, messages never trigger router actions; per arch §5.2, signals always carry `to: null` and any target lives in `payload.target`):
+  - `mission_goal` → inject the composed launch prompt to the crew lead's stdin.
+  - `human_said` → inject `payload.text` to `payload.target` if present, otherwise to the lead.
+  - `ask_lead` → inject the worker's question/context to the lead.
+  - `ask_human` → append a `human_question` event preserving `on_behalf_of`; the workspace UI (C10) renders the card from that event.
+  - `human_response` → look up the matching `question_id` in an in-memory pending-ask map and inject the answer to the original asker (the lead in the lead-mediated flow, the worker in the direct flow).
+- Pending-ask map: in-memory `HashMap<question_id, asker_handle>` populated when an `ask_human` event is observed (live or during replay). No persistence; on reopen the map is reconstructed by re-reading the log through the same handler.
+- Dead-session errors produce a visible mission-warning event in the log, not a silent drop. The mission workspace surfaces these.
 
-Risks to settle:
-- Replay must never duplicate human-visible cards or repeated stdin injection in normal reopen flows.
-- Stdin writes are currently a mutex-protected write path, not a queued command stream. MVP can keep one rule output per trigger; anything more needs per-session sequencing.
-- Errors from a dead session should produce a visible mission warning, not silently drop the orchestration action.
+**Explicitly descoped (was in the original C8 doc, deferred to v0.x):**
+- **Dispatch ledger / replay idempotence.** The router is not re-run against historical events on reopen; live tail starts from the current end of the log. `mission_goal` only fires once per mission anyway, `human_question` is rendered from log replay by the UI (not re-emitted), and re-injecting old prompts into a sleeping LLM is bizarre UX. The pending-ask map is the only state that needs reopen reconstruction — we get it for free by re-reading `ask_human`/`human_response` rows in order, no ledger required.
+- **Inbox-summary enrichment in injected stdin templates.** Originally the router was going to prepend the recipient's unread message summary onto every injection and advance the watermark via a synthesized `stdin_injected` event. MVP drops this — the lead can call `runner msg read` itself when it wants its inbox, and that's the documented contract. Keeping enrichment out of the injection path means the router does not have to write log events, only consume them.
+- **Rule abstraction / policy loader.** No `Rule` trait, no policy JSON loaded from `crews.orchestrator_policy`. The five handlers are a `match signal_type { … }` and that's the whole router.
+
+**Cross-cutting prerequisite — launch/prompt adapter.**
+- `mission_goal`'s injected prompt is `runner.system_prompt + mission goal + roster + coordination instructions + signal allowlist`. There's no composer today.
+- `runner.system_prompt` is also dropped on the floor by `SessionManager::spawn` and `spawn_direct`. C8 must add a runtime adapter (`claude-code` → `--append-system-prompt`, `codex` → its equivalent, fallback → documented behavior) and apply it on both the mission and direct-chat spawn paths.
+- Direct chats receive the runner's default `system_prompt` only; no roster, no goal.
+- Tests assert resolved command/env contains the prompt for claude-code on both paths.
+
+**Risks to settle:**
+- Stdin writes are a mutex-protected write path, not a queued command stream. MVP keeps one handler output per triggering event; anything more would need per-session sequencing.
+- The pending-ask map is in-memory only. If the app crashes between a worker's `ask_human` and the user's response, the map is lost. v0 accepts this — the next reopen rebuilds the map from log replay before any new events tail in.
 
 ### C9 — `runner` CLI binary
 
@@ -153,11 +158,11 @@ Required behavior:
 - Add `src/pages/Missions.tsx` with Active/Past tabs, mission rows, status, started/stopped timestamps, crew name, and open/stop actions.
 - Add `StartMissionModal` with crew picker, title, goal textarea, cwd picker, and an Advanced section stub.
 - Start flow: call `mission_start`, then route to `/missions/:id`.
-- Reopen flow: selecting an active mission routes to C10's workspace and reconstructs feed/orchestrator state.
-- Pending ask indicator: derive from orchestrator state once C8 exposes it.
+- Reopen flow: selecting an active mission routes to C10's workspace and reconstructs feed + router state.
+- Pending ask indicator: derive from the router's pending-ask map once C8 exposes it (or, if the router isn't mounted yet for that mission, scan the log for unmatched `ask_human` rows — see the risks block).
 
 Risks to settle:
-- The pending-ask flag either needs persisted orchestrator projection state or an on-demand log scan. Persisted projection is better for list performance; log scan is acceptable for MVP-sized data.
+- The pending-ask flag either reads from the live router's pending-ask map or runs an on-demand log scan for unmatched `ask_human` rows. Live-map read is better for list performance; log scan is acceptable for MVP-sized data and is the only option for missions whose router isn't mounted (e.g., before the user opens the workspace).
 - `/debug` should be removed or hidden behind a dev flag once this lands, because it currently bypasses the intended user flow.
 
 ## Definition of done (demo path)
@@ -169,7 +174,7 @@ From a clean launch of the app, a user can:
 3. Watch the lead runner receive the goal via stdin, draft a plan, and post a directed message to the worker; see the worker pick it up on its next `runner msg read`.
 4. See a worker emit an `ask_lead` signal; watch the lead decide to escalate via `ask_human`; click **Approve** on the resulting card; see the lead receive the response and forward it to the worker.
 5. Post a broadcast human signal from the workspace input and have it land on the lead by default.
-6. Close and reopen the mission; the feed replays and the orchestrator's in-memory state reconstructs.
+6. Close and reopen the mission; the feed replays and the router's in-memory pending-ask map reconstructs from the log.
 
 Anything beyond this is explicitly v0.x or later.
 
@@ -177,7 +182,7 @@ Anything beyond this is explicitly v0.x or later.
 
 - Windows support (macOS + Linux only for v0).
 - Threads / reactions / reply-to semantics beyond `--to <handle>`.
-- LLM-in-the-loop orchestrator rules (v0 is rule-based only; see arch §2.3).
+- LLM-in-the-loop signal routing (v0's router is a hardcoded dispatcher; see arch §2.3).
 - Envelope-level `correlation_id` / `causation_id` fields (see arch §5.2).
 - Mission branching / forking / rewind.
 - Multi-device sync, auth, cloud persistence.
@@ -205,7 +210,7 @@ Anything beyond this is explicitly v0.x or later.
     │           ├─► C6  PTY session runtime ─► C9    `runner` CLI
     │           │                          └─► C8.5  Runners page + Runner Detail + direct chat
     │           │
-    │           └─► C7  event bus + notify watcher ─► C8  orchestrator v0
+    │           └─► C7  event bus + notify watcher ─► C8  signal router v0
     │
     └─► C4  event log primitives  (feeds C5, C7, C9)
 
@@ -213,7 +218,7 @@ Anything beyond this is explicitly v0.x or later.
   C11  missions list + Start Mission modal   (depends on C3, C5, C10)
 ```
 
-C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel after C5. C8 (orchestrator) and C8.5 (Runners page) are peers — both depend on C6, neither depends on the other, so they can ship in either order.
+C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel after C5. C8 (signal router) and C8.5 (Runners page) are peers — both depend on C6, neither depends on the other, so they can ship in either order.
 
 ---
 
@@ -261,7 +266,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 
 **Goal.** Wire the config CRUD to the wireframes in `design/runners-design.pen`. This is the first chunk a non-engineer can interact with.
 
-**Scope note — Runners are top-level in MVP, but the dedicated Runners pages land in C8.5.** C5.5a already moved runners out from under crews and made the same runner shareable across crews; the data model has no notion of "crew-scoped runner" anymore. C3 still does runner CRUD inside Crew Detail (Add Slot + edit drawer) because that's the path the demo flow needs. The standalone Runners list and Runner Detail frames in `design/runners-design.pen` (`2Oecf`, `ocAFJ`) are built in C8.5 (sibling chunk of C8 orchestrator).
+**Scope note — Runners are top-level in MVP, but the dedicated Runners pages land in C8.5.** C5.5a already moved runners out from under crews and made the same runner shareable across crews; the data model has no notion of "crew-scoped runner" anymore. C3 still does runner CRUD inside Crew Detail (Add Slot + edit drawer) because that's the path the demo flow needs. The standalone Runners list and Runner Detail frames in `design/runners-design.pen` (`2Oecf`, `ocAFJ`) are built in C8.5 (sibling chunk of C8 signal router).
 
 **Deliverables.**
 - `src/pages/Crews.tsx` — crew cards (create, list, delete).
@@ -343,30 +348,42 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 
 **Tests.** Append events, watcher sees them, projections include/exclude the right rows.
 
-**Out of scope.** Orchestrator reactions to events — that's C8.
+**Out of scope.** Router reactions to events — that's C8.
 
 ---
 
-## C8 — Orchestrator v0
+## C8 — Signal router v0
 
-**Goal.** The deterministic rule-based router that turns events into actions.
+**Goal.** A flat parent-process dispatcher that wires five signal types into stdin pushes and a UI-card event. Not a framework — a hardcoded `match` of about 200 LOC plus the prompt composer it needs for `mission_goal`. See "C8 — Signal router v0" in the **Remaining v0 work** section above for the full reframing rationale and explicit descoping.
 
 **Deliverables.**
-- `src-tauri/src/orchestrator/mod.rs`:
-  - Policy loader (reads the crew's policy JSON).
-  - Built-in rules — **all signal-driven** (per arch §5.5.0, messages never trigger orchestrator actions). Per arch §5.2, signals always carry `to: null` in v0; any target lives in `payload.target`.
-    - `signal mission_goal → inject_stdin @lead` with a composed prompt including the goal, the crew roster, and coordination instructions (see arch §4 for the template).
-    - `signal human_said (from: "human", payload: { text, target? }) → inject_stdin @payload.target if set, else @lead`. One signal type covers both broadcast and directed human input; routing is payload-driven, not envelope-driven. The workspace input emits this signal on Post.
-    - `signal ask_lead (from: <worker>, payload: { question, context }) → inject_stdin @lead` with the payload rendered into the injection template. The worker-asks-lead half of the lead-mediated HITL flow.
-    - `signal ask_human (from: <runner>, payload: { prompt, choices, on_behalf_of? }) → emit human_question event + open card in UI`. If `payload.on_behalf_of` is present (the lead-mediated case), carry it into the `human_question` payload so the UI can render the attribution chain.
-    - `signal human_response → inject_stdin to the runner that emitted the matching ask_human` — the lead in the lead-mediated flow, the worker in the fallback direct flow. Orchestrator looks up the original asker by `question_id`.
-  - Lead-forwards-answer back to worker and any runner-to-runner exchange are **directed messages**, not orchestrator actions — recipients see them on their next `runner msg read`. No `directed message → inject` rule in MVP.
-  - Dispatch ledger (in-memory map of `triggering_event_id → handled`) so replay is idempotent.
-  - Pending-ask map keyed by `question_id`.
+- `src-tauri/src/router/mod.rs` (renamed from the existing `orchestrator/` stub):
+  - `Router::for_mission(mission, crew_roster, sessions, log)` — mounted by `mission_start`, unmounted by `mission_stop` and the spawn-rollback path.
+  - `Router::handle_event(&Event)` — single entry point invoked by the bus on each appended event. `EventKind::Message` is a no-op (per arch §5.5.0); `EventKind::Signal` matches on `signal_type` against the five built-ins.
+  - In-memory pending-ask map keyed by `question_id`. Reconstructed on reopen by replaying `ask_human` / `human_response` rows through the same handler before live tail begins.
+  - Dead-session writes append a `mission_warning` event to the log instead of silently dropping. The workspace UI surfaces these.
+- `src-tauri/src/router/handlers.rs` (or inline in `mod.rs` if it fits):
+  - `mission_goal` → compose launch prompt, inject to the lead's stdin via `SessionManager::inject_stdin`.
+  - `human_said` → resolve recipient (`payload.target` or lead), inject `payload.text`.
+  - `ask_lead` → render worker's `{question, context}` into a short stdin template, inject to the lead.
+  - `ask_human` → append a `human_question` event carrying `on_behalf_of` (if present) and the original `ask_human` id as `triggered_by`. UI renders the card from the appended event in C10.
+  - `human_response` → look up `question_id` in the pending-ask map; inject `payload.text` to the original asker. Unmatched `human_response` logs a warning event, no panic.
+- `src-tauri/src/router/prompt.rs` — composes `runner.system_prompt + mission goal + roster + coordination instructions + signal allowlist` into the `mission_goal` injection. Pure function over inputs; no I/O; easy to unit-test.
+- Cross-cutting **launch/prompt adapter** (must land in this chunk):
+  - `src-tauri/src/runtime.rs` — adapter trait + per-runtime impls. `claude-code` injects `runner.system_prompt` via `--append-system-prompt`. `codex` ships with a TODO until its CLI flag is verified. Fallback runtimes get a documented no-op + a warning log.
+  - Apply on both `SessionManager::spawn` (mission) and `spawn_direct` (direct chat). Direct chat gets the runner's `system_prompt` only — no roster, no goal.
 
-**Tests.** Each built-in rule fires exactly once. Replay after reopen reconstructs state from the log. `human_response` without a matching `human_question` is dropped with a log warning, not panic.
+**Tests.**
+- Each handler fires exactly once per triggering event under live tail.
+- Reopen reconstructs the pending-ask map: append `ask_human` then `mission_stop`, reopen, append `human_response`, assert the right asker's stdin received the answer.
+- `human_response` without a matching `human_question` emits a `mission_warning`, not a panic.
+- `messages_do_not_trigger_router_actions` — appending an `EventKind::Message` produces no `inject_stdin` call.
+- Runtime adapter resolves `--append-system-prompt` for claude-code on both `spawn` and `spawn_direct`. Missing `system_prompt` is fine (no flag added).
 
-**Out of scope.** LLM policy, user-authored rules. MVP ships only the built-ins plus a no-op policy slot.
+**Out of scope.**
+- Dispatch ledger / replay idempotence — descoped, see reframing section.
+- Inbox-summary enrichment in injection templates — descoped, the lead calls `runner msg read` itself.
+- LLM policy, user-authored rules, `crews.orchestrator_policy` schema usage — deferred to v0.x. The column stays in the schema for forward compatibility but is unread in MVP.
 
 ---
 
@@ -374,7 +391,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 
 **Goal.** Promote runners to a top-level UI surface, mirroring the design's `2Oecf` (Runners list) and `ocAFJ` (Runner Detail) frames, plus a "Chat now" path that exercises the direct-chat session shape C5.5a already baked into the schema. Without this chunk, runners that aren't in any crew are invisible and the user can never spawn a runner without going through a full mission.
 
-**Why it sits at C8.5.** Sibling/parallel to C8 (orchestrator) — both depend on C6 and neither depends on the other, following the C5.5a precedent for inserted chunks. The orchestrator and the Runners page can ship in either order; this just records that the work is part of v0-mvp, not deferred.
+**Why it sits at C8.5.** Sibling/parallel to C8 (signal router) — both depend on C6 and neither depends on the other, following the C5.5a precedent for inserted chunks. The router and the Runners page can ship in either order; this just records that the work is part of v0-mvp, not deferred.
 
 **Scope-shift context.** Originally cut from MVP under the C3 "no top-level Runners page" scope note, now restored: the C5.5a schema work is wasted UI-side until this lands.
 
@@ -382,7 +399,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 - **Backend.**
   - `commands/runner.rs::runner_list_with_activity()` — extends the existing `runner_list` to include `running_session_count` (from `sessions WHERE status = 'running'`) and `open_mission_count` (from `crew_runners ⨝ missions WHERE status = 'running'`). The Runners list cards need both counters.
   - `commands/runner.rs::runner_get_by_handle(handle)` — used by `/runners/:handle` so the URL is stable across runner-id rotations.
-  - `commands/session.rs::session_start_direct(runner_id, cwd)` — inserts a `sessions` row with `mission_id = NULL` and the chosen `cwd`, then spawns through the existing `SessionManager::spawn` path. Differences from the mission flavor: no `RUNNER_MISSION_ID`, `RUNNER_EVENT_LOG`, or `RUNNER_CREW_ID` env vars are set, and the runner does not join any event bus or orchestrator. The `runner` CLI must no-op gracefully when those vars are absent (small change in C9-land — the CLI errors today on `RUNNER_EVENT_LOG`-not-set, which would crash a direct-chat agent the moment it tries to emit an event).
+  - `commands/session.rs::session_start_direct(runner_id, cwd)` — inserts a `sessions` row with `mission_id = NULL` and the chosen `cwd`, then spawns through the existing `SessionManager::spawn` path. Differences from the mission flavor: no `RUNNER_MISSION_ID`, `RUNNER_EVENT_LOG`, or `RUNNER_CREW_ID` env vars are set, and the runner does not join any event bus or signal router. The `runner` CLI must no-op gracefully when those vars are absent (small change in C9-land — the CLI errors today on `RUNNER_EVENT_LOG`-not-set, which would crash a direct-chat agent the moment it tries to emit an event).
   - Live activity events: `SessionManager` emits `runner/activity { runner_id, running_sessions, open_missions }` on every spawn, reap, and kill so the Runners list and Runner Detail can update without polling.
 - **Frontend.**
   - `src/components/Sidebar.tsx` — flip the placeholder Runner item to an enabled `NavLink to="/runners"`. Order in the design is Runner / Crew / Mission, top to bottom.
@@ -422,7 +439,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 
 **Tests.** Integration test: spawn a shell with the env a real session would have, run CLI commands, assert events land in the ndjson.
 
-**Out of scope.** Any form of direct-to-orchestrator RPC — everything goes through the log.
+**Out of scope.** Any form of direct-to-router RPC — everything goes through the log.
 
 ---
 
@@ -434,7 +451,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 - `src/pages/MissionWorkspace.tsx` — subscribes to `event/appended`, renders the feed.
 - `src/components/EventFeed.tsx` — message / signal / `ask_human` card variants.
 - `src/components/AskHumanCard.tsx` — buttons emit a `human_response` signal. If the underlying `human_question` carries `on_behalf_of`, render the attribution chain (e.g. *@impl → @architect → you*).
-- `src/components/MissionInput.tsx` — the Slack-channel input. Default recipient in the UI is `@<lead>`. Submitting always emits a `signal human_said` (not a message event) so the orchestrator can wake the recipient, per arch §5.5.0. Signal envelope keeps `to: null` per arch §5.2; the picked recipient lives in `payload.target` (omitted for broadcast, set to the handle for directed). The UI label can still say "message" for user-facing clarity; the underlying event kind is `signal`.
+- `src/components/MissionInput.tsx` — the Slack-channel input. Default recipient in the UI is `@<lead>`. Submitting always emits a `signal human_said` (not a message event) so the router can wake the recipient, per arch §5.5.0. Signal envelope keeps `to: null` per arch §5.2; the picked recipient lives in `payload.target` (omitted for broadcast, set to the handle for directed). The UI label can still say "message" for user-facing clarity; the underlying event kind is `signal`.
 - `src/components/RunnersRail.tsx` — list of sessions with status dot, `LEAD` badge, "open pty" action.
 - `src/components/RunnerTerminal.tsx` — xterm.js bound to the session output stream (popped out of the rail).
 
@@ -449,7 +466,7 @@ C3 and C4 can run in parallel after C2 lands. C6 and C7 can run in parallel afte
 **Goal.** The entrypoint to everything C10 renders. The final chunk that closes the loop.
 
 **Deliverables.**
-- `src/pages/Missions.tsx` — Active / Past tabs, mission rows, status dot, "pending ask" flag derived from orchestrator state.
+- `src/pages/Missions.tsx` — Active / Past tabs, mission rows, status dot, "pending ask" flag derived from the router's pending-ask map (or a log scan for unmounted missions).
 - `src/components/StartMissionModal.tsx` — crew picker, title, goal textarea, cwd with `Browse…`, Advanced collapse (stubbed).
 - Navigation: Start → call `mission_start` → route to `/missions/:id`.
 
@@ -471,16 +488,16 @@ Part of the v0 MVP umbrella. See docs/impls/v0-mvp.md.
 Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
 ```
 
-Areas: `db`, `commands`, `ui`, `event-log`, `session`, `event-bus`, `orchestrator`, `cli`, `mission`.
+Areas: `db`, `commands`, `ui`, `event-log`, `session`, `event-bus`, `router`, `cli`, `mission`.
 
 ## Branching
 
-- Each chunk lives on its own branch off `main` (e.g. `feat/c8-orchestrator-v0`).
+- Each chunk lives on its own branch off `main` (e.g. `feat/c8-router-v0`).
 - Chunk PRs target `main` directly, merged with `--squash --delete-branch`.
 - The original plan stacked chunks on a `feature/v0-mvp` umbrella branch
   that batched-merged into `main` once C11 landed. That added a layer of
   ceremony without buying anything: chunks already ship in
-  feature-flagged-by-absence increments (an unfinished orchestrator just
+  feature-flagged-by-absence increments (an unfinished router just
   means the relevant signals don't get routed yet) and the umbrella was
   one extra rebase target. Dropped after C8.5; stale references to
   `feature/v0-mvp` elsewhere in the docs predate this change.

--- a/docs/tests/v0-mvp-tests.md
+++ b/docs/tests/v0-mvp-tests.md
@@ -67,7 +67,7 @@ Rust-level `#[cfg(test)] mod tests` co-located with the module under test. One-l
 Already landed (10 tests):
 
 - `migrations_bootstrap_all_tables` — creates `crews`, `runners`, `missions`, `sessions`.
-- `new_crew_is_seeded_with_default_signal_types` — the seven built-in types land via SQL `DEFAULT`.
+- `new_crew_is_seeded_with_default_signal_types` — the eight built-in types land via SQL `DEFAULT`.
 - `one_lead_per_crew_index_rejects_second_lead` — partial unique index.
 - `one_lead_per_crew_allows_leads_across_crews` — the index is crew-scoped.
 - `unique_handle_within_crew` — `UNIQUE (crew_id, handle)`.
@@ -125,9 +125,11 @@ The router is a flat dispatcher, not a rule engine. C8 was reframed in `docs/imp
   - `ask_lead → inject_stdin @lead` with the worker's `{question, context}` rendered into a stdin template.
   - `ask_human → emit human_question` event preserving `on_behalf_of` and `triggered_by` (the original `ask_human` id). The card is rendered by the workspace UI (C10) from the appended event, not by the router.
   - `human_response → inject_stdin to the asker that emitted the matching ask_human` — looked up by `question_id` in the in-memory pending-ask map.
+  - `runner_status idle|busy → update latest runner status`; non-lead `idle` also injects a short availability update to the lead.
 - `human_response_without_matching_question_emits_mission_warning` — appends a `mission_warning` event to the log; must not panic.
 - `messages_do_not_trigger_router_actions` — arch §5.5.0 invariant; only signals invoke handlers.
 - `pending_ask_map_reconstructs_from_log_on_reopen` — append `ask_human`, unmount the router, remount, append `human_response`, assert the right asker's stdin received the answer.
+- `runner_status_map_reconstructs_from_log_on_reopen` — append `runner_status busy`, then `runner_status idle`, remount, assert the latest state is `idle` and the UI projection reflects it.
 
 **Cross-cutting — runtime / prompt adapter (lands in C8):**
 
@@ -192,7 +194,7 @@ File: `cli/tests/roundtrip.rs` (in the `cli/` crate).
   Spawn `runner signal mission_goal --payload '{"text":"go"}'` with the env a real session has. Assert the NDJSON file grew by exactly one line, parsable as a v0.2 envelope (arch §5.2), with `from` = `$RUNNER_HANDLE`.
 
 - **I2.2 — `runner signal` rejects unknown types.**
-  With the sidecar at `$APPDATA/runner/crews/{id}/signal_types.json` containing the default seven, run `runner signal not_a_real_type`. Exit code non-zero, stderr mentions the allowlist, no line appended.
+  With the sidecar at `$APPDATA/runner/crews/{id}/signal_types.json` containing the default eight, run `runner signal not_a_real_type`. Exit code non-zero, stderr mentions the allowlist, no line appended.
 
 - **I2.3 — `runner msg post --to impl` routes.**
   Assert the envelope has `kind: "message"`, `to: "impl"`, `payload.text` set.
@@ -203,10 +205,13 @@ File: `cli/tests/roundtrip.rs` (in the `cli/` crate).
 - **I2.5 — `runner msg read` emits `inbox_read`.**
   Pre-populate the log with two directed messages to `impl`. Run `runner msg read`. Assert: stdout contains both messages in ULID order, and a final `signal inbox_read` line was appended with `payload.up_to` = max ULID of the two.
 
-- **I2.6 — Concurrent writers interleave atomically.**
+- **I2.6 — `runner status idle` emits `runner_status`.**
+  Run `runner status idle --note "ready for next task"`. Assert the appended signal has `type = "runner_status"`, `from = "$RUNNER_HANDLE"`, and `payload.state = "idle"`.
+
+- **I2.7 — Concurrent writers interleave atomically.**
   10 shells × 100 invocations each write signals to the same log. Resulting NDJSON: exactly 1000 lines, no partial lines, no interleaved bytes. Every line parses.
 
-- **I2.7 — Missing env vars fail fast.**
+- **I2.8 — Missing env vars fail fast.**
   Unset `RUNNER_EVENT_LOG`; CLI exits non-zero with a pointer at which env var is missing.
 
 ### Fixture sketch
@@ -258,13 +263,16 @@ Driver pseudocode:
     → appends: message(from=lead, to=impl)
 10. driver feeds `impl`: `runner msg read`
     → appends: inbox_read(up_to=<approved msg ulid>)
-11. mission_stop
+11. driver feeds `impl`: `runner status idle --note "ready for next task"`
+    → appends: runner_status(from=impl, payload.state=idle)
+    → router updates the status map and injects a short availability update to lead — no synthetic event
+12. mission_stop
     → appends: mission_stopped
 ```
 
 Assertions:
 - The ordered sequence of `(kind, type or None, from, to)` tuples matches exactly.
-- The router writes no events for handler invocations — only the `human_question` event for the `ask_human → UI bridge` step. (Stdin pushes for `mission_goal`, `human_said`, `ask_lead`, and `human_response` are silent.)
+- The router writes no events for handler invocations — only the `human_question` event for the `ask_human → UI bridge` step. (Stdin pushes for `mission_goal`, `human_said`, `ask_lead`, `human_response`, and `runner_status idle` are silent.)
 - After `mission_stop`, every session row is `stopped` and no child processes remain.
 
 ### Crash-replay assertion (same file)
@@ -376,7 +384,7 @@ Expected on first mount:
 
 Expected within ~1s of `mission_start`:
 - `lead` terminal shows the composed prompt (template from arch §4: goal + roster + coordination).
-- Feed contains `stdin_injected` audit with `payload.target = "lead"`, `payload.triggered_by = <mission_goal.id>`.
+- No extra feed row appears for the stdin push; the feed still shows the original `mission_goal` signal.
 
 **S10.3 — Directed message is pull-based**
 
@@ -395,7 +403,7 @@ Expected: the message is returned in stdout; an `inbox_read` signal event append
 
 1. `impl`: `runner signal ask_lead --payload '{"question":"A or B?","context":"A fast, B small."}'`
 
-Expected: `ask_lead` event; `lead` PTY receives rendered injection containing the question; injection includes the unread-inbox summary per arch §5.5.1 (possibly empty).
+Expected: `ask_lead` event; `lead` PTY receives rendered injection containing the question. No unread-inbox summary is injected in MVP; the lead can call `runner msg read` when it wants inbox context.
 
 2. `lead`: `runner signal ask_human --payload '{"prompt":"Use A?","choices":["yes","no"],"on_behalf_of":"impl"}'`
 
@@ -434,10 +442,21 @@ Expected:
 - Sessions reconnect or show a clear "stopped" state consistent with C6's close behavior.
 - Read-watermarks rebuilt from the log; no action double-fires.
 - Any pending `ask_human` cards re-render (none in this scenario).
+- Runner status labels reconstruct from `runner_status` events and current session state.
 
 **S10.8 — Messages/signals split**
 
-Expected: feed visibly segregates `kind: message` rows from `kind: signal`. The signal panel shows runner-emitted signals (`mission_goal`, `human_said`, `ask_lead`, `ask_human`, `human_response`, `inbox_read`) plus the router's bridged `human_question`. Stdin pushes (the router's reaction to `mission_goal` / `ask_lead` / `human_response`) are not events and don't appear in the feed.
+Expected: feed visibly segregates `kind: message` rows from `kind: signal`. The signal panel shows runner-emitted signals (`mission_goal`, `human_said`, `ask_lead`, `ask_human`, `human_response`, `runner_status`, `inbox_read`) plus the router's bridged `human_question`. Stdin pushes (the router's reaction to `mission_goal` / `ask_lead` / `human_response` / `runner_status idle`) are not events and don't appear in the feed.
+
+**S10.9 — Worker idle signal informs lead**
+
+1. In `impl` pane: `runner status busy --note "reading the spec"`.
+2. Then: `runner status idle --note "ready for next task"`.
+
+Expected:
+- Feed shows two `runner_status` signals from `impl`.
+- Runners rail updates `impl` from busy to idle.
+- `lead` PTY receives a short availability update when `impl` reports idle. The router does not assign work; the lead decides whether to send the next directed message.
 
 ### Known gaps — do NOT verify in C10
 
@@ -515,7 +534,7 @@ From a clean launch of the app:
 
 1. On Crews, create **Demo Crew**. Add two runners: one `claude-code` `lead` (real LLM agent), one `shell` worker (e.g. `sh`). The lead invariant holds at every step.
 2. Click **Start Mission**, fill goal `Write a README stub for this repo.`, cwd = a scratch dir. Workspace opens with two live PTYs.
-3. Lead receives the goal via stdin, drafts a plan, and posts a directed message to the worker. Worker picks it up on its next `runner msg read`.
+3. Lead receives the goal via stdin, drafts a plan, and posts a directed message to the worker. Worker picks it up on its next `runner msg read`, then emits `runner_status busy` while working and `runner_status idle` when ready for more work. The lead receives the idle update.
 4. Worker emits an `ask_lead` signal; lead decides to escalate via `ask_human`; click **Approve** on the resulting card; lead receives the response and forwards it to the worker via a directed message.
 5. Post a broadcast human signal from the workspace input; it lands on the lead by default (payload omits `target`).
 6. Close the mission tab and reopen from the Missions list; the feed replays and the router's in-memory pending-ask map reconstructs from the log. Watermarks rebuild from `inbox_read` rows (per C7).

--- a/docs/tests/v0-mvp-tests.md
+++ b/docs/tests/v0-mvp-tests.md
@@ -12,7 +12,7 @@ Single source of truth for MVP test coverage. Pairs with `docs/impls/v0-mvp.md` 
 | **Demo path** | full Definition-of-Done run from `docs/impls/v0-mvp.md` | Human | C11 (gates the `main` merge) |
 
 - **Unit** — pure Rust, SQL constraints, serde roundtrips. No PTY, no Tauri, no filesystem beyond tempdirs.
-- **Integration** — seams: event log + CLI, orchestrator + bus, PTY + sessions. Headless, uses `tempfile` for `$APPDATA` isolation.
+- **Integration** — seams: event log + CLI, router + bus, PTY + sessions. Headless, uses `tempfile` for `$APPDATA` isolation.
 - **Smoke (UI)** — a human clicking through the Tauri app after each UI-bearing chunk. Each UI chunk PR must reproduce the matching checklist in its PR description (per `docs/impls/v0-mvp.md` chunking principles); this file is the authoritative version.
 - **Demo path** — the single end-to-end run from `docs/impls/v0-mvp.md` §"Definition of done". Running it successfully gates closure of v0 MVP (declared on the C11 PR description).
 
@@ -26,7 +26,7 @@ C4  + unit (event log primitives)
 C5  + unit (mission bookkeeping)
 C6  + integration (PTY)
 C7  + unit (notify watcher + projections)
-C8  + unit (orchestrator rules + replay)
+C8  + unit (router handlers + pending-ask reconstruction)
 C9  + integration (CLI ↔ event log)
 C10 + smoke (workspace) + integration (headless E2E)
 C11 + smoke (entrypoint) + demo path
@@ -35,7 +35,7 @@ C11 + smoke (entrypoint) + demo path
 ### Out of scope for v0 testing
 
 - **Windows.** macOS + Linux only for MVP. Skip Windows-specific assertions.
-- **LLM-driven orchestrator.** Rules are deterministic; never assert on "the lead decides to…" beyond what the fixture runner's script does.
+- **LLM-driven routing.** The router is a hardcoded dispatcher; never assert on "the lead decides to…" beyond what the fixture runner's script does.
 - **UI E2E frameworks** (Playwright / webdriver). Surface is too fluid pre-C11.
 - **Network filesystems** (NFS/SMB/iCloud). Arch §5.1.1 documents this as a hard requirement on local POSIX.
 
@@ -114,22 +114,31 @@ Already landed (10 tests):
 - `watermark_rebuilds_on_boot_from_log_scan` — cold start with a pre-existing log; watermarks match what the live session would have produced.
 - `malformed_line_is_skipped_with_warning` — the NDJSON file stays parseable; one bad line doesn't poison the bus.
 
-## C8 — `src-tauri/src/orchestrator/`
+## C8 — `src-tauri/src/router/`
 
-- Rule-by-rule (each fires exactly once per triggering event):
-  - `mission_goal → inject_stdin @lead`
-  - `human_said with payload.target → inject_stdin @target`
-  - `human_said without target → inject_stdin @lead` (default broadcast recipient)
-  - `ask_lead → inject_stdin @lead`
-  - `ask_human → emit human_question + open card`
-  - `ask_human with on_behalf_of → carry it into human_question.payload`
-  - `human_response → inject_stdin to the matching question's asker` (looked up by `question_id`)
-- `dispatch_ledger_prevents_duplicate_actions_on_replay` — replay the same log twice, observe one action per triggering event.
-- `human_response_without_matching_question_is_dropped_with_warning` — must not panic.
-- `messages_do_not_trigger_any_orchestrator_action` — arch §5.5.0 invariant; only signals wake runners.
-- `inject_stdin_enriches_with_unread_inbox_summary` — arch §5.5.1.
-- `inject_stdin_advances_watermark_via_stdin_injected_signal` — so the next summary is scoped strictly newer.
-- `replay_after_reopen_reconstructs_pending_ask_map` — cards re-appear on reboot if unresolved.
+The router is a flat dispatcher, not a rule engine. C8 was reframed in `docs/impls/v0-mvp.md` to drop the dispatch-ledger / replay-idempotence and inbox-summary-enrichment requirements; this section is updated to match. The lead runner owns coordination judgment; the router is the parent-process plumbing that does bootstrap, cross-process stdin push, and the UI bridge.
+
+- Handler-by-handler (each fires once per triggering event under live tail):
+  - `mission_goal → inject_stdin @lead` with the composed launch prompt (`runner.system_prompt + mission goal + roster + coordination instructions + signal allowlist`).
+  - `human_said with payload.target → inject_stdin @target`.
+  - `human_said without target → inject_stdin @lead` (default broadcast recipient).
+  - `ask_lead → inject_stdin @lead` with the worker's `{question, context}` rendered into a stdin template.
+  - `ask_human → emit human_question` event preserving `on_behalf_of` and `triggered_by` (the original `ask_human` id). The card is rendered by the workspace UI (C10) from the appended event, not by the router.
+  - `human_response → inject_stdin to the asker that emitted the matching ask_human` — looked up by `question_id` in the in-memory pending-ask map.
+- `human_response_without_matching_question_emits_mission_warning` — appends a `mission_warning` event to the log; must not panic.
+- `messages_do_not_trigger_router_actions` — arch §5.5.0 invariant; only signals invoke handlers.
+- `pending_ask_map_reconstructs_from_log_on_reopen` — append `ask_human`, unmount the router, remount, append `human_response`, assert the right asker's stdin received the answer.
+
+**Cross-cutting — runtime / prompt adapter (lands in C8):**
+
+- `claude_code_runtime_adds_append_system_prompt` — when `runner.runtime == "claude-code"` and `runner.system_prompt` is set, the resolved command contains `--append-system-prompt <prompt>` on both `SessionManager::spawn` and `spawn_direct`.
+- `direct_chat_does_not_drop_system_prompt` — the runner's default `system_prompt` reaches the child via the runtime adapter even with no mission/roster context.
+- `missing_system_prompt_omits_flag` — runners with no `system_prompt` spawn cleanly with no extra flag.
+
+**Explicitly NOT tested (descoped from the original C8 plan):**
+
+- Dispatch-ledger replay idempotence — the router never re-runs against historical events. Reopen reconstructs only the pending-ask map by replaying `ask_human`/`human_response` rows.
+- Inbox-summary enrichment in injected stdin templates — the lead calls `runner msg read` itself when it wants its inbox; the router does not synthesize summaries or `stdin_injected` watermark events.
 
 ---
 
@@ -233,18 +242,18 @@ Driver pseudocode:
 1.  bootstrap pool + create crew {lead, impl}
 2.  mission_start(crew, "E2E", goal = "solve it", cwd = tmp)
     → events.ndjson now has: mission_start, mission_goal
-3.  orchestrator starts; observes mission_goal → inject_stdin @lead
-    → appends: stdin_injected(target=lead, triggered_by=mission_goal.id)
+3.  router observes mission_goal → inject_stdin @lead with composed launch prompt
+    (no event written — stdin push is not logged)
 4.  driver feeds the `lead` PTY a scripted response: `runner msg post --to impl "go"`
     → appends: message(from=lead, to=impl, text="go")
 5.  driver feeds the `impl` PTY: `runner msg read` then `runner signal ask_lead …`
     → appends: inbox_read(up_to=<msg ulid>), ask_lead(from=impl)
-6.  orchestrator observes ask_lead → inject_stdin @lead (with inbox summary)
-    → appends: stdin_injected(target=lead, watermark=<inbox max>)
+6.  router observes ask_lead → inject_stdin @lead (template renders {question, context}; no inbox summary in MVP)
 7.  driver feeds `lead`: `runner signal ask_human --payload '{"prompt":"…","choices":["yes","no"],"on_behalf_of":"impl"}'`
-    → appends: ask_human(from=lead, payload.on_behalf_of=impl), human_question(from=orchestrator, payload.triggered_by=<ask_human.id>)
-8.  driver simulates human click: orchestrator.handle_human_click(question_id, "yes")
-    → appends: human_response(from=human, payload.question_id=<q.id>, choice=yes), stdin_injected(target=lead, triggered_by=<human_response.id>)
+    → appends: ask_human(from=lead, payload.on_behalf_of=impl), human_question(from=router, payload.triggered_by=<ask_human.id>, payload.on_behalf_of=impl)
+8.  driver simulates human click: router.handle_human_click(question_id, "yes")
+    → appends: human_response(from=human, payload.question_id=<q.id>, choice=yes)
+    → router injects to the asker (lead) — no synthetic event
 9.  driver feeds `lead`: `runner msg post --to impl "Human approved."`
     → appends: message(from=lead, to=impl)
 10. driver feeds `impl`: `runner msg read`
@@ -255,16 +264,15 @@ Driver pseudocode:
 
 Assertions:
 - The ordered sequence of `(kind, type or None, from, to)` tuples matches exactly.
-- No duplicate orchestrator actions even if the test replays the log through a second orchestrator instance (C8's dispatch-ledger idempotence).
-- Every audit signal carries `payload.triggered_by` pointing at a real event id.
+- The router writes no events for handler invocations — only the `human_question` event for the `ask_human → UI bridge` step. (Stdin pushes for `mission_goal`, `human_said`, `ask_lead`, and `human_response` are silent.)
 - After `mission_stop`, every session row is `stopped` and no child processes remain.
 
 ### Crash-replay assertion (same file)
 
-After step 8, **hard-kill** the driver's orchestrator and restart it from scratch against the same log:
+After step 8, **hard-kill** the driver's router and restart it from scratch against the same log:
 - The rebuilt in-memory `pending_ask` map is empty (the question was resolved before the crash).
-- No rule re-fires: steps 3, 6, 8's audit signals exist exactly once each.
-- Watermarks match the live run.
+- The router does not re-inject historical events (live tail starts from current end of log; replay is only used to reconstruct the `pending_ask` map).
+- A fresh `ask_human` appended after restart routes correctly to the new asker.
 
 ---
 
@@ -429,7 +437,7 @@ Expected:
 
 **S10.8 — Messages/signals split**
 
-Expected: feed visibly segregates `kind: message` rows from `kind: signal`. Orchestrator-emitted audit signals (`inject_stdin`, `human_question`, `human_response`, `inbox_read`) all go to the signal panel.
+Expected: feed visibly segregates `kind: message` rows from `kind: signal`. The signal panel shows runner-emitted signals (`mission_goal`, `human_said`, `ask_lead`, `ask_human`, `human_response`, `inbox_read`) plus the router's bridged `human_question`. Stdin pushes (the router's reaction to `mission_goal` / `ask_lead` / `human_response`) are not events and don't appear in the feed.
 
 ### Known gaps — do NOT verify in C10
 
@@ -480,7 +488,7 @@ Expected: modal surfaces a clean error ("crew has no runners" or "no lead"); mis
 1. Start a mission from `Demo Crew`. From the `lead` PTY, open an `ask_human` card (as in S10.4). Close the tab without clicking the card.
 2. Return to Missions list.
 
-Expected: the mission row in Active shows a "pending ask" flag (derived from orchestrator state). Clicking it reopens the workspace with the card still pending.
+Expected: the mission row in Active shows a "pending ask" flag (derived from the router's pending-ask map for mounted missions, or a log scan otherwise). Clicking it reopens the workspace with the card still pending.
 
 **S11.5 — Past tab shows stopped missions**
 
@@ -510,7 +518,7 @@ From a clean launch of the app:
 3. Lead receives the goal via stdin, drafts a plan, and posts a directed message to the worker. Worker picks it up on its next `runner msg read`.
 4. Worker emits an `ask_lead` signal; lead decides to escalate via `ask_human`; click **Approve** on the resulting card; lead receives the response and forwards it to the worker via a directed message.
 5. Post a broadcast human signal from the workspace input; it lands on the lead by default (payload omits `target`).
-6. Close the mission tab and reopen from the Missions list; the feed replays and the orchestrator's in-memory state reconstructs (pending asks, watermarks, dispatch ledger).
+6. Close the mission tab and reopen from the Missions list; the feed replays and the router's in-memory pending-ask map reconstructs from the log. Watermarks rebuild from `inbox_read` rows (per C7).
 
 All six steps must succeed in one session without restarting the app. Capture a screen recording and attach it to the squash-merge PR.
 

--- a/src-tauri/migrations/0001_init.sql
+++ b/src-tauri/migrations/0001_init.sql
@@ -1,7 +1,7 @@
 -- Migration 0001: initial schema (shared-runner edition).
 --
 -- Superseded the per-crew runner model from the original v0 draft. See
--- docs/impls/v0-mvp-c5-5-shared-runners.md. In MVP (no prod data yet) we
+-- docs/impls/v0-mvp.md. In MVP (no prod data yet) we
 -- rewrite DDL in place rather than layering a 0002 migration. Dev users
 -- delete their local DB file ($APPDATA/runner/runner.db) once to pick
 -- up the new shape.
@@ -25,7 +25,7 @@ CREATE TABLE crews (
     purpose TEXT,
     goal TEXT,
     orchestrator_policy TEXT,
-    signal_types TEXT NOT NULL DEFAULT '["mission_goal","human_said","ask_lead","ask_human","human_question","human_response","inbox_read"]',
+    signal_types TEXT NOT NULL DEFAULT '["mission_goal","human_said","ask_lead","ask_human","human_question","human_response","runner_status","inbox_read"]',
     created_at TEXT NOT NULL,
     updated_at TEXT NOT NULL
 );

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -324,6 +324,9 @@ pub async fn mission_start(
     input: StartMissionInput,
 ) -> Result<StartMissionOutput> {
     use crate::event_bus::{BusEmitter, TauriBusEvents};
+    use crate::router::{
+        open_log_for_mission, CompositeBusEmitter, Router, RouterSubscriber, StdinInjector,
+    };
     use crate::session::manager::{SessionEvents, TauriSessionEvents};
     use std::sync::Arc;
 
@@ -341,6 +344,11 @@ pub async fn mission_start(
     //
     // Post-C5.5a the roster lives in `crew_runners`, so we join through it
     // instead of listing global runners.
+    let (crew_name, allowed_signals) = {
+        let conn = state.db.get()?;
+        let crew = crew::get(&conn, &out.mission.crew_id)?;
+        (crew.name, crew.signal_types)
+    };
     let roster = {
         let conn = state.db.get()?;
         crew_runner::list(&conn, &out.mission.crew_id)?
@@ -348,21 +356,71 @@ pub async fn mission_start(
     let events_log_path =
         event_log::events_path(&state.app_data_dir, &out.mission.crew_id, &out.mission.id);
 
+    // Build the router up front so it can subscribe to the bus's initial
+    // replay — that's how the `mission_goal` opening event reaches the
+    // dispatcher and the launch prompt gets composed. Sessions are
+    // registered after the spawn loop succeeds; until then the router has
+    // no PTYs to push into. The injection for `mission_goal` will arrive
+    // *after* `register_sessions` because the bus's consumer thread doesn't
+    // start its initial replay synchronously inside `mount`.
+    let mission_dir =
+        event_log::mission_dir(&state.app_data_dir, &out.mission.crew_id, &out.mission.id);
+    let log_arc = match open_log_for_mission(&mission_dir) {
+        Ok(l) => l,
+        Err(e) => {
+            // Couldn't open the log — roll the mission row back. Bus isn't
+            // mounted yet, no sessions were spawned, nothing to clean up.
+            if let Ok(conn) = state.db.get() {
+                let _ = conn.execute(
+                    "UPDATE missions
+                        SET status = 'aborted', stopped_at = ?1
+                      WHERE id = ?2",
+                    rusqlite::params![Utc::now().to_rfc3339(), out.mission.id],
+                );
+            }
+            return Err(e);
+        }
+    };
+    let injector: Arc<dyn StdinInjector> = Arc::clone(&state.sessions) as Arc<dyn StdinInjector>;
+    let router = match Router::new(
+        out.mission.id.clone(),
+        out.mission.crew_id.clone(),
+        crew_name,
+        &roster,
+        allowed_signals,
+        Arc::clone(&log_arc),
+        injector,
+    ) {
+        Ok(r) => r,
+        Err(e) => {
+            if let Ok(conn) = state.db.get() {
+                let _ = conn.execute(
+                    "UPDATE missions
+                        SET status = 'aborted', stopped_at = ?1
+                      WHERE id = ?2",
+                    rusqlite::params![Utc::now().to_rfc3339(), out.mission.id],
+                );
+            }
+            return Err(e);
+        }
+    };
+
     // Mount the event-bus watcher *before* spawning sessions. The opening
     // events are already on disk (start() emitted them under the same DB
     // tx), so the bus's initial replay will pick up `mission_start` and
-    // `mission_goal` and surface them to the UI. Mounting before spawn
-    // also means anything a runner writes to the log on startup is
-    // observed without a race against the watcher attaching.
-    let mission_dir =
-        event_log::mission_dir(&state.app_data_dir, &out.mission.crew_id, &out.mission.id);
+    // `mission_goal` and surface them to the UI and the router. Mounting
+    // before spawn also means anything a runner writes to the log on
+    // startup is observed without a race against the watcher attaching.
     let roster_handles: Vec<String> = roster.iter().map(|m| m.runner.handle.clone()).collect();
-    let bus_emitter: Arc<dyn BusEmitter> = Arc::new(TauriBusEvents(app.clone()));
+    let tauri_emitter: Arc<dyn BusEmitter> = Arc::new(TauriBusEvents(app.clone()));
+    let router_emitter: Arc<dyn BusEmitter> = Arc::new(RouterSubscriber(Arc::clone(&router)));
+    let composite: Arc<dyn BusEmitter> =
+        Arc::new(CompositeBusEmitter::new(vec![tauri_emitter, router_emitter]));
     if let Err(e) = state.buses.mount(
         out.mission.id.clone(),
         &mission_dir,
         &roster_handles,
-        bus_emitter,
+        composite,
     ) {
         // Roll back the mission row so the crew isn't stuck behind a
         // phantom `running` if the watcher couldn't attach.
@@ -378,7 +436,8 @@ pub async fn mission_start(
     }
 
     let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app.clone()));
-    for member in roster {
+    let mut spawned_pairs: Vec<(String, String)> = Vec::with_capacity(roster.len());
+    for member in &roster {
         let spawn_res = state.sessions.spawn(
             &out.mission,
             &member.runner,
@@ -387,23 +446,35 @@ pub async fn mission_start(
             state.db.clone(),
             Arc::clone(&emitter),
         );
-        if let Err(e) = spawn_res {
-            // Rollback: kill the sessions that did start, drop the bus,
-            // mark the mission aborted so the crew isn't stuck behind a
-            // phantom `running`, then surface the original spawn error.
-            let _ = state.sessions.kill_all_for_mission(&out.mission.id);
-            state.buses.unmount(&out.mission.id);
-            if let Ok(conn) = state.db.get() {
-                let _ = conn.execute(
-                    "UPDATE missions
-                        SET status = 'aborted', stopped_at = ?1
-                      WHERE id = ?2",
-                    rusqlite::params![Utc::now().to_rfc3339(), out.mission.id],
-                );
+        match spawn_res {
+            Ok(spawned) => {
+                spawned_pairs.push((member.runner.handle.clone(), spawned.id));
             }
-            return Err(e);
+            Err(e) => {
+                // Rollback: kill the sessions that did start, drop the bus,
+                // mark the mission aborted so the crew isn't stuck behind a
+                // phantom `running`, then surface the original spawn error.
+                let _ = state.sessions.kill_all_for_mission(&out.mission.id);
+                state.buses.unmount(&out.mission.id);
+                if let Ok(conn) = state.db.get() {
+                    let _ = conn.execute(
+                        "UPDATE missions
+                            SET status = 'aborted', stopped_at = ?1
+                          WHERE id = ?2",
+                        rusqlite::params![Utc::now().to_rfc3339(), out.mission.id],
+                    );
+                }
+                return Err(e);
+            }
         }
     }
+    // All sessions started — register them with the router so handlers can
+    // resolve handle → session_id. Done after the spawn loop because we
+    // only want a complete map (partial maps would let a stray
+    // `human_response` route to a still-mounted asker whose worker hadn't
+    // booted yet, hiding the actual rollback failure).
+    router.register_sessions(&spawned_pairs);
+    state.routers.register(out.mission.id.clone(), router);
     Ok(out)
 }
 
@@ -420,6 +491,10 @@ pub async fn mission_stop(state: State<'_, AppState>, id: String) -> Result<Miss
     // disk, so the watcher gets one last tick and clients see it before
     // the bus tears down. unmount() is idempotent and never fails.
     state.buses.unmount(&id);
+    // Drop the router after the bus so any final events delivered during
+    // the bus's drain pass still reach a live router. Unregister is a
+    // simple HashMap remove; safe to call even if nothing was registered.
+    state.routers.unregister(&id);
     Ok(mission)
 }
 

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -462,8 +462,10 @@ pub async fn mission_start(
     let roster_handles: Vec<String> = roster.iter().map(|m| m.runner.handle.clone()).collect();
     let tauri_emitter: Arc<dyn BusEmitter> = Arc::new(TauriBusEvents(app.clone()));
     let router_emitter: Arc<dyn BusEmitter> = Arc::new(RouterSubscriber(Arc::clone(&router)));
-    let composite: Arc<dyn BusEmitter> =
-        Arc::new(CompositeBusEmitter::new(vec![tauri_emitter, router_emitter]));
+    let composite: Arc<dyn BusEmitter> = Arc::new(CompositeBusEmitter::new(vec![
+        tauri_emitter,
+        router_emitter,
+    ]));
     if let Err(e) = state.buses.mount(
         out.mission.id.clone(),
         &mission_dir,

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -356,13 +356,9 @@ pub async fn mission_start(
     let events_log_path =
         event_log::events_path(&state.app_data_dir, &out.mission.crew_id, &out.mission.id);
 
-    // Build the router up front so it can subscribe to the bus's initial
-    // replay — that's how the `mission_goal` opening event reaches the
-    // dispatcher and the launch prompt gets composed. Sessions are
-    // registered after the spawn loop succeeds; until then the router has
-    // no PTYs to push into. The injection for `mission_goal` will arrive
-    // *after* `register_sessions` because the bus's consumer thread doesn't
-    // start its initial replay synchronously inside `mount`.
+    // Build the router up front (opens the log, validates the lead, holds
+    // empty state). It does NOT subscribe to the bus yet — see ordering
+    // below.
     let mission_dir =
         event_log::mission_dir(&state.app_data_dir, &out.mission.crew_id, &out.mission.id);
     let log_arc = match open_log_for_mission(&mission_dir) {
@@ -405,36 +401,20 @@ pub async fn mission_start(
         }
     };
 
-    // Mount the event-bus watcher *before* spawning sessions. The opening
-    // events are already on disk (start() emitted them under the same DB
-    // tx), so the bus's initial replay will pick up `mission_start` and
-    // `mission_goal` and surface them to the UI and the router. Mounting
-    // before spawn also means anything a runner writes to the log on
-    // startup is observed without a race against the watcher attaching.
-    let roster_handles: Vec<String> = roster.iter().map(|m| m.runner.handle.clone()).collect();
-    let tauri_emitter: Arc<dyn BusEmitter> = Arc::new(TauriBusEvents(app.clone()));
-    let router_emitter: Arc<dyn BusEmitter> = Arc::new(RouterSubscriber(Arc::clone(&router)));
-    let composite: Arc<dyn BusEmitter> =
-        Arc::new(CompositeBusEmitter::new(vec![tauri_emitter, router_emitter]));
-    if let Err(e) = state.buses.mount(
-        out.mission.id.clone(),
-        &mission_dir,
-        &roster_handles,
-        composite,
-    ) {
-        // Roll back the mission row so the crew isn't stuck behind a
-        // phantom `running` if the watcher couldn't attach.
-        if let Ok(conn) = state.db.get() {
-            let _ = conn.execute(
-                "UPDATE missions
-                    SET status = 'aborted', stopped_at = ?1
-                  WHERE id = ?2",
-                rusqlite::params![Utc::now().to_rfc3339(), out.mission.id],
-            );
-        }
-        return Err(e);
-    }
-
+    // Spawn sessions BEFORE the bus mounts so `register_sessions` can
+    // populate the handle→session_id map up front. The bus's consumer
+    // thread starts its initial replay asynchronously inside `mount`; if
+    // we mounted first, the `mission_goal` injection could race the
+    // session registration and silently no-op (the lead would never get
+    // its launch prompt — review finding P1).
+    //
+    // The bus's initial replay reads from offset 0, so the opening
+    // `mission_start` / `mission_goal` events still surface even though
+    // the watcher attaches after the writes. Spawning runners before
+    // mount is safe: their PTYs come up here, but `runner` CLI invocations
+    // can't run before they receive their first stdin (which only comes
+    // after the bus delivers `mission_goal` post-mount), so no log writes
+    // can race the watcher attachment.
     let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app.clone()));
     let mut spawned_pairs: Vec<(String, String)> = Vec::with_capacity(roster.len());
     for member in &roster {
@@ -451,11 +431,10 @@ pub async fn mission_start(
                 spawned_pairs.push((member.runner.handle.clone(), spawned.id));
             }
             Err(e) => {
-                // Rollback: kill the sessions that did start, drop the bus,
-                // mark the mission aborted so the crew isn't stuck behind a
-                // phantom `running`, then surface the original spawn error.
+                // Rollback: kill the sessions that did start, mark the
+                // mission aborted, surface the original error. Bus and
+                // router aren't mounted yet so no event-side cleanup.
                 let _ = state.sessions.kill_all_for_mission(&out.mission.id);
-                state.buses.unmount(&out.mission.id);
                 if let Ok(conn) = state.db.get() {
                     let _ = conn.execute(
                         "UPDATE missions
@@ -468,12 +447,42 @@ pub async fn mission_start(
             }
         }
     }
-    // All sessions started — register them with the router so handlers can
-    // resolve handle → session_id. Done after the spawn loop because we
-    // only want a complete map (partial maps would let a stray
-    // `human_response` route to a still-mounted asker whose worker hadn't
-    // booted yet, hiding the actual rollback failure).
+    // Register the full session map BEFORE the bus mount. From this point
+    // any event the bus's initial replay delivers to the router will land
+    // on a fully-wired handle map.
     router.register_sessions(&spawned_pairs);
+
+    // Now mount the bus. Initial replay from offset 0 picks up the opening
+    // events (durable since `start()` committed them under the DB tx),
+    // fans them to the Tauri emitter (UI) and the RouterSubscriber (which
+    // dispatches `mission_goal` → launch prompt to the lead). Fresh
+    // mission: NO `reconstruct_from_log()` call — setting a watermark
+    // over the just-written `mission_goal` would suppress the bootstrap
+    // (reviewer's caveat).
+    let roster_handles: Vec<String> = roster.iter().map(|m| m.runner.handle.clone()).collect();
+    let tauri_emitter: Arc<dyn BusEmitter> = Arc::new(TauriBusEvents(app.clone()));
+    let router_emitter: Arc<dyn BusEmitter> = Arc::new(RouterSubscriber(Arc::clone(&router)));
+    let composite: Arc<dyn BusEmitter> =
+        Arc::new(CompositeBusEmitter::new(vec![tauri_emitter, router_emitter]));
+    if let Err(e) = state.buses.mount(
+        out.mission.id.clone(),
+        &mission_dir,
+        &roster_handles,
+        composite,
+    ) {
+        // Bus didn't attach — kill the sessions we spawned, abort the row.
+        let _ = state.sessions.kill_all_for_mission(&out.mission.id);
+        if let Ok(conn) = state.db.get() {
+            let _ = conn.execute(
+                "UPDATE missions
+                    SET status = 'aborted', stopped_at = ?1
+                  WHERE id = ?2",
+                rusqlite::params![Utc::now().to_rfc3339(), out.mission.id],
+            );
+        }
+        return Err(e);
+    }
+
     state.routers.register(out.mission.id.clone(), router);
     Ok(out)
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -25,6 +25,7 @@ pub const DEFAULT_SIGNAL_TYPES: &[&str] = &[
     "ask_human",
     "human_question",
     "human_response",
+    "runner_status",
     "inbox_read",
 ];
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,7 +3,7 @@ mod db;
 mod error;
 mod event_bus;
 mod model;
-mod orchestrator;
+mod router;
 mod session;
 
 use std::path::PathBuf;
@@ -24,6 +24,10 @@ pub struct AppState {
     /// the opening events are durable; unmounted by `mission_stop` and on
     /// any rollback path.
     pub buses: Arc<event_bus::BusRegistry>,
+    /// Live per-mission signal routers. Mounted alongside the bus so the
+    /// router observes the bootstrap `mission_goal` event during initial
+    /// replay and pushes the launch prompt into the lead's stdin.
+    pub routers: Arc<router::RouterRegistry>,
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -61,6 +65,7 @@ pub fn run() {
                 app_data_dir,
                 sessions: session::SessionManager::new(),
                 buses: event_bus::BusRegistry::new(),
+                routers: router::RouterRegistry::new(),
             });
             Ok(())
         })

--- a/src-tauri/src/orchestrator/mod.rs
+++ b/src-tauri/src/orchestrator/mod.rs
@@ -1,2 +1,0 @@
-// Orchestrator — rule-based policy router that decides when human
-// interaction is required. TODO: implement policy evaluation.

--- a/src-tauri/src/router/handlers.rs
+++ b/src-tauri/src/router/handlers.rs
@@ -1,0 +1,199 @@
+// Hardcoded signal handlers. One function per built-in signal type.
+// Per arch §5.2, signals always carry `to: null`; per-target routing lives
+// in `payload.target` (only `human_said` uses this in v0). Per arch §5.5.0
+// invariant, messages never reach this module — `Router::handle_event`
+// short-circuits non-signal events.
+//
+// Stdin pushes are silent: handlers do NOT write `inject_stdin_*` audit
+// events. The originating signal already records the cause in the log.
+// Only `ask_human` results in a derived event (`human_question`), because
+// that one is consumed by the workspace UI as a card.
+
+use runner_core::model::Event;
+
+use super::prompt::{compose_launch_prompt, LaunchPromptInput, RosterEntry};
+use super::{Router, RunnerStatus};
+
+pub(super) fn mission_goal(router: &Router, event: &Event) {
+    let goal = event
+        .payload
+        .get("text")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let launch = router.launch();
+    let roster_entries: Vec<RosterEntry> = launch
+        .roster()
+        .iter()
+        .map(|r| RosterEntry {
+            handle: r.handle(),
+            display_name: r.display_name(),
+            role: r.role(),
+            lead: r.is_lead(),
+        })
+        .collect();
+    let prompt = compose_launch_prompt(&LaunchPromptInput {
+        lead: launch.lead(),
+        crew_name: launch.crew_name(),
+        mission_goal: goal,
+        roster: &roster_entries,
+        allowed_signals: launch.allowed_signals(),
+    });
+    if let Err(e) = router.inject_to_handle(launch.lead().handle.as_str(), prompt.as_bytes()) {
+        router.warn(format!("mission_goal injection to lead failed: {e}"));
+    }
+}
+
+pub(super) fn human_said(router: &Router, event: &Event) {
+    let text = event
+        .payload
+        .get("text")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let target = event
+        .payload
+        .get("target")
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(|| router.lead_handle().to_string());
+
+    // Always end with a newline so the TUI submits the line.
+    let mut bytes = text.to_string();
+    if !bytes.ends_with('\n') {
+        bytes.push('\n');
+    }
+    if let Err(e) = router.inject_to_handle(&target, bytes.as_bytes()) {
+        router.warn(format!(
+            "human_said injection to @{target} failed: {e} (text: {text:?})"
+        ));
+    }
+}
+
+pub(super) fn ask_lead(router: &Router, event: &Event) {
+    let question = event
+        .payload
+        .get("question")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let context = event.payload.get("context").and_then(|v| v.as_str());
+
+    // Render a stdin template the lead can read in-stream. The asker handle
+    // (`event.from`) is preserved in the prefix so the lead knows whom to
+    // reply to with `runner msg post --to <asker>`.
+    let mut text = format!(
+        "[ask_lead from @{asker}] {question}\n",
+        asker = event.from,
+        question = question,
+    );
+    if let Some(ctx) = context {
+        let ctx = ctx.trim();
+        if !ctx.is_empty() {
+            text.push_str("Context:\n");
+            text.push_str(ctx);
+            text.push('\n');
+        }
+    }
+
+    let lead_handle = router.lead_handle().to_string();
+    if let Err(e) = router.inject_to_handle(&lead_handle, text.as_bytes()) {
+        router.warn(format!("ask_lead injection to lead failed: {e}"));
+    }
+}
+
+pub(super) fn ask_human(router: &Router, event: &Event) {
+    let prompt = event
+        .payload
+        .get("prompt")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let choices = event
+        .payload
+        .get("choices")
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!([]));
+    let on_behalf_of = event
+        .payload
+        .get("on_behalf_of")
+        .and_then(|v| v.as_str());
+
+    // The asker is always the runner that emitted the `ask_human` signal —
+    // typically the lead in the lead-mediated flow, or a worker in the
+    // direct-fallback flow. Stored under the ask_human event's id so the
+    // matching `human_response` (which carries `payload.question_id =
+    // ask_human.id`) can route back to the right asker.
+    router.record_pending_ask(event.id.clone(), event.from.clone());
+    router.append_human_question(&event.id, prompt, &choices, on_behalf_of);
+}
+
+pub(super) fn human_response(router: &Router, event: &Event) {
+    let Some(question_id) = event
+        .payload
+        .get("question_id")
+        .and_then(|v| v.as_str())
+    else {
+        router.warn("human_response missing payload.question_id");
+        return;
+    };
+    let Some(asker) = router.take_pending_ask(question_id) else {
+        router.warn(format!(
+            "human_response references unknown question_id {question_id}"
+        ));
+        return;
+    };
+
+    // Render the human's choice as a single line. Free-text answers (a
+    // future v0.x extension) would land in `payload.text`; for now we
+    // expect `choice` only.
+    let choice = event
+        .payload
+        .get("choice")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let text = format!("[human_response] {choice}\n");
+    if let Err(e) = router.inject_to_handle(&asker, text.as_bytes()) {
+        router.warn(format!(
+            "human_response injection to @{asker} failed: {e}"
+        ));
+    }
+}
+
+pub(super) fn runner_status(router: &Router, event: &Event) {
+    let state = match event
+        .payload
+        .get("state")
+        .and_then(|v| v.as_str())
+    {
+        Some("busy") => RunnerStatus::Busy,
+        Some("idle") => RunnerStatus::Idle,
+        other => {
+            router.warn(format!(
+                "runner_status from @{} has unknown state {:?}",
+                event.from, other
+            ));
+            return;
+        }
+    };
+    router.set_status(event.from.clone(), state);
+
+    // Wake the lead only when a non-lead reports idle. A worker reporting
+    // busy is already implicit in the fact that they're working; spamming
+    // the lead on every busy→still-busy transition would be noise. arch
+    // §5.5.1.
+    let lead_handle = router.lead_handle().to_string();
+    if state == RunnerStatus::Idle && event.from != lead_handle {
+        let note = event
+            .payload
+            .get("note")
+            .and_then(|v| v.as_str())
+            .map(|n| format!(" — {n}"))
+            .unwrap_or_default();
+        let text = format!(
+            "[runner_status] @{worker} is idle{note}\n",
+            worker = event.from
+        );
+        if let Err(e) = router.inject_to_handle(&lead_handle, text.as_bytes()) {
+            router.warn(format!(
+                "runner_status idle notice to lead failed: {e}"
+            ));
+        }
+    }
+}

--- a/src-tauri/src/router/handlers.rs
+++ b/src-tauri/src/router/handlers.rs
@@ -110,10 +110,7 @@ pub(super) fn ask_human(router: &Router, event: &Event) {
         .get("choices")
         .cloned()
         .unwrap_or_else(|| serde_json::json!([]));
-    let on_behalf_of = event
-        .payload
-        .get("on_behalf_of")
-        .and_then(|v| v.as_str());
+    let on_behalf_of = event.payload.get("on_behalf_of").and_then(|v| v.as_str());
 
     // Append the `human_question` card first; its id is the canonical
     // `question_id` per arch §5.5.0. The asker is the runner that emitted
@@ -130,11 +127,7 @@ pub(super) fn ask_human(router: &Router, event: &Event) {
 }
 
 pub(super) fn human_response(router: &Router, event: &Event) {
-    let Some(question_id) = event
-        .payload
-        .get("question_id")
-        .and_then(|v| v.as_str())
-    else {
+    let Some(question_id) = event.payload.get("question_id").and_then(|v| v.as_str()) else {
         router.warn("human_response missing payload.question_id");
         return;
     };
@@ -155,18 +148,12 @@ pub(super) fn human_response(router: &Router, event: &Event) {
         .unwrap_or("");
     let text = format!("[human_response] {choice}\n");
     if let Err(e) = router.inject_to_handle(&asker, text.as_bytes()) {
-        router.warn(format!(
-            "human_response injection to @{asker} failed: {e}"
-        ));
+        router.warn(format!("human_response injection to @{asker} failed: {e}"));
     }
 }
 
 pub(super) fn runner_status(router: &Router, event: &Event) {
-    let state = match event
-        .payload
-        .get("state")
-        .and_then(|v| v.as_str())
-    {
+    let state = match event.payload.get("state").and_then(|v| v.as_str()) {
         Some("busy") => RunnerStatus::Busy,
         Some("idle") => RunnerStatus::Idle,
         other => {
@@ -196,9 +183,7 @@ pub(super) fn runner_status(router: &Router, event: &Event) {
             worker = event.from
         );
         if let Err(e) = router.inject_to_handle(&lead_handle, text.as_bytes()) {
-            router.warn(format!(
-                "runner_status idle notice to lead failed: {e}"
-            ));
+            router.warn(format!("runner_status idle notice to lead failed: {e}"));
         }
     }
 }

--- a/src-tauri/src/router/handlers.rs
+++ b/src-tauri/src/router/handlers.rs
@@ -115,13 +115,18 @@ pub(super) fn ask_human(router: &Router, event: &Event) {
         .get("on_behalf_of")
         .and_then(|v| v.as_str());
 
-    // The asker is always the runner that emitted the `ask_human` signal —
-    // typically the lead in the lead-mediated flow, or a worker in the
-    // direct-fallback flow. Stored under the ask_human event's id so the
-    // matching `human_response` (which carries `payload.question_id =
-    // ask_human.id`) can route back to the right asker.
-    router.record_pending_ask(event.id.clone(), event.from.clone());
-    router.append_human_question(&event.id, prompt, &choices, on_behalf_of);
+    // Append the `human_question` card first; its id is the canonical
+    // `question_id` per arch §5.5.0. The asker is the runner that emitted
+    // the `ask_human` signal (typically the lead, or a worker in the
+    // direct-fallback flow). Pending-ask map is keyed on the *card* id so
+    // a matching `human_response` (which carries
+    // `payload.question_id = human_question.id`) routes back to the
+    // original asker. If the append fails, no mapping is recorded — the
+    // human_response would have nothing to reference anyway, and the
+    // failure is already logged inside `append_human_question`.
+    if let Some(card_id) = router.append_human_question(&event.id, prompt, &choices, on_behalf_of) {
+        router.record_pending_ask(card_id, event.from.clone());
+    }
 }
 
 pub(super) fn human_response(router: &Router, event: &Event) {

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -1,0 +1,398 @@
+// Signal router v0 — flat parent-process dispatcher.
+//
+// What this is. The lead runner is the agent that *thinks* about
+// coordination — it plans, dispatches workers via directed messages,
+// decides when to escalate. The router is the parent-process plumbing
+// underneath: bootstrap (write the launch prompt to the lead's stdin on
+// `mission_goal`), cross-process stdin push (`ask_lead`, `human_said`,
+// `human_response`), the UI bridge (`ask_human` → `human_question` event),
+// and the runner-availability map (`runner_status`). See arch §5.5 and
+// docs/impls/v0-mvp.md `C8 — Signal router v0`.
+//
+// What this is not. There is no policy engine, no rule abstraction, no
+// per-crew config in MVP. Handlers are a flat `match signal_type { … }`.
+// `crews.orchestrator_policy` is reserved for v0.x and is not read here.
+//
+// Per arch §5.5.0 invariant: messages never trigger router actions. Only
+// `EventKind::Signal` reaches the dispatcher; messages flow through the
+// inbox projection in `event_bus`.
+
+mod handlers;
+pub mod prompt;
+pub mod runtime;
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use runner_core::event_log::EventLog;
+use runner_core::model::{Event, EventKind, SignalType};
+
+use crate::error::Result;
+use crate::event_bus::{AppendedEvent, BusEmitter, InboxUpdate, WatermarkUpdate};
+use crate::model::{CrewRunner, Runner};
+use crate::session::manager::SessionManager;
+
+/// What the router uses to push bytes into a child's PTY. The full
+/// `SessionManager` impls it; tests use a recording fake. Lives behind a
+/// trait so the router doesn't pull a PTY runtime into unit tests.
+pub trait StdinInjector: Send + Sync + 'static {
+    fn inject(&self, session_id: &str, bytes: &[u8]) -> Result<()>;
+}
+
+impl StdinInjector for SessionManager {
+    fn inject(&self, session_id: &str, bytes: &[u8]) -> Result<()> {
+        SessionManager::inject_stdin(self, session_id, bytes)
+    }
+}
+
+/// Latest-known availability for a runner. Populated from `runner_status`
+/// signals; never inferred from PTY bytes (arch §5.5.1).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunnerStatus {
+    Busy,
+    Idle,
+}
+
+/// Inputs to the launch-prompt composer, captured at mount so the
+/// `mission_goal` handler doesn't have to round-trip the DB. The lead row
+/// also doubles as the lead-resolved handle the dispatcher routes to.
+pub(crate) struct LaunchInputs {
+    crew_name: String,
+    lead: Runner,
+    roster: Vec<RosterRow>,
+    allowed_signals: Vec<SignalType>,
+}
+
+pub(crate) struct RosterRow {
+    handle: String,
+    display_name: String,
+    role: String,
+    lead: bool,
+}
+
+/// Mutable per-mission state. Rebuilt on reopen by replaying the log
+/// through `handle_event` — no separate persistence layer.
+#[derive(Default)]
+struct RouterState {
+    /// Resolved at mount from the spawned `SpawnedSession` rows. The map is
+    /// authoritative for the mission's lifetime; if a child crashes the
+    /// entry stays so subsequent injections fail visibly with a
+    /// `mission_warning` (the desired behavior — better than silently
+    /// dropping a `human_response`).
+    session_by_handle: HashMap<String, String>,
+    /// `ask_human.id` → asker handle. Populated when an `ask_human` event
+    /// is observed; consumed when a matching `human_response` arrives.
+    pending_asks: HashMap<String, String>,
+    /// Latest `runner_status` per handle.
+    status: HashMap<String, RunnerStatus>,
+}
+
+/// One mission's router. Mounted by `mission_start` after sessions spawn,
+/// dropped by `mission_stop`. Wired into the event bus as a `BusEmitter`
+/// subscriber so `handle_event` runs on every appended envelope.
+pub struct Router {
+    mission_id: String,
+    crew_id: String,
+    log: Arc<EventLog>,
+    injector: Arc<dyn StdinInjector>,
+    launch: LaunchInputs,
+    state: Mutex<RouterState>,
+}
+
+impl Router {
+    /// Build a router from the crew's roster and lead. `roster` is the same
+    /// slice `mission_start` already loaded for the spawn loop.
+    pub fn new(
+        mission_id: String,
+        crew_id: String,
+        crew_name: String,
+        roster: &[CrewRunner],
+        allowed_signals: Vec<SignalType>,
+        log: Arc<EventLog>,
+        injector: Arc<dyn StdinInjector>,
+    ) -> Result<Arc<Self>> {
+        let lead = roster
+            .iter()
+            .find(|m| m.lead)
+            .map(|m| m.runner.clone())
+            .ok_or_else(|| {
+                crate::error::Error::msg(format!(
+                    "router mount: crew {crew_id} has no lead runner"
+                ))
+            })?;
+        let roster_rows = roster
+            .iter()
+            .map(|m| RosterRow {
+                handle: m.runner.handle.clone(),
+                display_name: m.runner.display_name.clone(),
+                role: m.runner.role.clone(),
+                lead: m.lead,
+            })
+            .collect();
+
+        Ok(Arc::new(Self {
+            mission_id,
+            crew_id,
+            log,
+            injector,
+            launch: LaunchInputs {
+                crew_name,
+                lead,
+                roster: roster_rows,
+                allowed_signals,
+            },
+            state: Mutex::new(RouterState::default()),
+        }))
+    }
+
+    /// Register the spawned session ids so handlers can find which PTY
+    /// owns each handle. Called once after `mission_start`'s spawn loop
+    /// succeeds — the router is mounted earlier (so it can observe replay)
+    /// but stdin pushes need session ids to land somewhere.
+    pub fn register_sessions(&self, sessions: &[(String, String)]) {
+        let mut state = self.state.lock().unwrap();
+        for (handle, session_id) in sessions {
+            state
+                .session_by_handle
+                .insert(handle.clone(), session_id.clone());
+        }
+    }
+
+    pub fn lead_handle(&self) -> &str {
+        &self.launch.lead.handle
+    }
+
+    /// Single dispatcher entry point. Bus calls this for every appended
+    /// event in arrival order. Messages return early per arch §5.5.0.
+    pub fn handle_event(&self, event: &Event) {
+        if !matches!(event.kind, EventKind::Signal) {
+            return;
+        }
+        let Some(signal) = event.signal_type.as_ref() else {
+            return;
+        };
+        match signal.as_str() {
+            "mission_goal" => handlers::mission_goal(self, event),
+            "human_said" => handlers::human_said(self, event),
+            "ask_lead" => handlers::ask_lead(self, event),
+            "ask_human" => handlers::ask_human(self, event),
+            "human_response" => handlers::human_response(self, event),
+            "runner_status" => handlers::runner_status(self, event),
+            // mission_start, mission_stopped, inbox_read, human_question,
+            // mission_warning — observed but not routed here. inbox_read is
+            // owned by the bus's projection layer; mission_warning /
+            // human_question are events the router itself emits.
+            _ => {}
+        }
+    }
+
+    // ---- helpers used by handlers --------------------------------------
+
+    pub(crate) fn inject_to_handle(&self, handle: &str, bytes: &[u8]) -> Result<()> {
+        let session_id = {
+            let state = self.state.lock().unwrap();
+            state.session_by_handle.get(handle).cloned()
+        };
+        let Some(session_id) = session_id else {
+            return Err(crate::error::Error::msg(format!(
+                "router: no live session for handle @{handle}"
+            )));
+        };
+        self.injector.inject(&session_id, bytes)
+    }
+
+    pub(crate) fn launch(&self) -> &LaunchInputs {
+        &self.launch
+    }
+
+    pub(crate) fn record_pending_ask(&self, question_id: String, asker: String) {
+        self.state
+            .lock()
+            .unwrap()
+            .pending_asks
+            .insert(question_id, asker);
+    }
+
+    pub(crate) fn take_pending_ask(&self, question_id: &str) -> Option<String> {
+        self.state.lock().unwrap().pending_asks.remove(question_id)
+    }
+
+    pub(crate) fn set_status(&self, handle: String, status: RunnerStatus) {
+        self.state.lock().unwrap().status.insert(handle, status);
+    }
+
+    /// Append a `mission_warning` event when a handler hits an unexpected
+    /// state (dead session, unmatched `human_response`, malformed payload).
+    /// Best-effort: a log-write failure here is logged but never panics
+    /// the router thread.
+    pub(crate) fn warn(&self, message: impl Into<String>) {
+        let message = message.into();
+        let draft = runner_core::model::EventDraft::signal(
+            self.crew_id.clone(),
+            self.mission_id.clone(),
+            "router",
+            SignalType::new("mission_warning"),
+            serde_json::json!({ "message": message }),
+        );
+        if let Err(e) = self.log.append(draft) {
+            eprintln!(
+                "router[{}]: failed to append mission_warning ({}): {e}",
+                self.mission_id, message,
+            );
+        }
+    }
+
+    pub(crate) fn append_human_question(
+        &self,
+        ask_human_id: &str,
+        prompt: &str,
+        choices: &serde_json::Value,
+        on_behalf_of: Option<&str>,
+    ) {
+        let mut payload = serde_json::Map::new();
+        payload.insert(
+            "question_id".into(),
+            serde_json::Value::String(ask_human_id.to_string()),
+        );
+        payload.insert(
+            "triggered_by".into(),
+            serde_json::Value::String(ask_human_id.to_string()),
+        );
+        payload.insert(
+            "prompt".into(),
+            serde_json::Value::String(prompt.to_string()),
+        );
+        payload.insert("choices".into(), choices.clone());
+        if let Some(on_behalf_of) = on_behalf_of {
+            payload.insert(
+                "on_behalf_of".into(),
+                serde_json::Value::String(on_behalf_of.to_string()),
+            );
+        }
+        let draft = runner_core::model::EventDraft::signal(
+            self.crew_id.clone(),
+            self.mission_id.clone(),
+            "router",
+            SignalType::new("human_question"),
+            serde_json::Value::Object(payload),
+        );
+        if let Err(e) = self.log.append(draft) {
+            eprintln!(
+                "router[{}]: failed to append human_question: {e}",
+                self.mission_id
+            );
+        }
+    }
+}
+
+impl LaunchInputs {
+    pub(crate) fn crew_name(&self) -> &str {
+        &self.crew_name
+    }
+    pub(crate) fn lead(&self) -> &Runner {
+        &self.lead
+    }
+    pub(crate) fn roster(&self) -> &[RosterRow] {
+        &self.roster
+    }
+    pub(crate) fn allowed_signals(&self) -> &[SignalType] {
+        &self.allowed_signals
+    }
+}
+
+impl RosterRow {
+    pub(crate) fn handle(&self) -> &str {
+        &self.handle
+    }
+    pub(crate) fn display_name(&self) -> &str {
+        &self.display_name
+    }
+    pub(crate) fn role(&self) -> &str {
+        &self.role
+    }
+    pub(crate) fn is_lead(&self) -> bool {
+        self.lead
+    }
+}
+
+/// `BusEmitter` adapter so the existing `BusRegistry::mount` machinery can
+/// drive the router. Only `appended` carries the work; the inbox/watermark
+/// methods are no-ops because those are projections owned by the bus.
+pub struct RouterSubscriber(pub Arc<Router>);
+
+impl BusEmitter for RouterSubscriber {
+    fn appended(&self, ev: &AppendedEvent) {
+        self.0.handle_event(&ev.event);
+    }
+    fn inbox_updated(&self, _ev: &InboxUpdate) {}
+    fn watermark_advanced(&self, _ev: &WatermarkUpdate) {}
+}
+
+/// Fan a single bus emission to multiple subscribers. The bus accepts only
+/// one emitter, so `mission_start` wraps the Tauri emitter and the router
+/// in this composite. Each sub-emitter is called in registration order.
+pub struct CompositeBusEmitter {
+    subs: Vec<Arc<dyn BusEmitter>>,
+}
+
+impl CompositeBusEmitter {
+    pub fn new(subs: Vec<Arc<dyn BusEmitter>>) -> Self {
+        Self { subs }
+    }
+}
+
+impl BusEmitter for CompositeBusEmitter {
+    fn appended(&self, ev: &AppendedEvent) {
+        for s in &self.subs {
+            s.appended(ev);
+        }
+    }
+    fn inbox_updated(&self, ev: &InboxUpdate) {
+        for s in &self.subs {
+            s.inbox_updated(ev);
+        }
+    }
+    fn watermark_advanced(&self, ev: &WatermarkUpdate) {
+        for s in &self.subs {
+            s.watermark_advanced(ev);
+        }
+    }
+}
+
+/// Process-wide registry of live routers, keyed by mission id. Mirrors
+/// `event_bus::BusRegistry`.
+pub struct RouterRegistry {
+    routers: Mutex<HashMap<String, Arc<Router>>>,
+}
+
+impl RouterRegistry {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            routers: Mutex::new(HashMap::new()),
+        })
+    }
+
+    pub fn register(&self, mission_id: String, router: Arc<Router>) {
+        self.routers.lock().unwrap().insert(mission_id, router);
+    }
+
+    pub fn unregister(&self, mission_id: &str) {
+        self.routers.lock().unwrap().remove(mission_id);
+    }
+
+    #[allow(dead_code)] // Exposed for the future workspace UI bridge.
+    pub fn get(&self, mission_id: &str) -> Option<Arc<Router>> {
+        self.routers.lock().unwrap().get(mission_id).cloned()
+    }
+}
+
+/// Convenience for `mission_start`: open the events log Arc once. Both the
+/// router (for log appends) and `mission_start`'s opening writes use the
+/// same flock-guarded path, so multiple `EventLog` instances are safe.
+pub fn open_log_for_mission(mission_dir: &Path) -> Result<Arc<EventLog>> {
+    Ok(Arc::new(EventLog::open(mission_dir)?))
+}
+
+#[cfg(test)]
+mod tests;

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -125,9 +125,7 @@ impl Router {
             .find(|m| m.lead)
             .map(|m| m.runner.clone())
             .ok_or_else(|| {
-                crate::error::Error::msg(format!(
-                    "router mount: crew {crew_id} has no lead runner"
-                ))
+                crate::error::Error::msg(format!("router mount: crew {crew_id} has no lead runner"))
             })?;
         let roster_rows = roster
             .iter()
@@ -192,7 +190,18 @@ impl Router {
     /// initial replay to no-op the bootstrap injection, leaving the lead
     /// without its launch prompt.
     pub fn reconstruct_from_log(&self) -> Result<()> {
-        let entries = self.log.read_from(0)?;
+        // Lossy read so a single malformed NDJSON line — a buggy CLI
+        // release, a partial write the writer recovered from — doesn't
+        // make the whole reopen fail. The bus uses the same forgiveness
+        // (`read_from_lossy` in `event_bus::BusState::tick`); reopen must
+        // tolerate at least the same set of histories the bus does.
+        let (entries, skipped) = self.log.read_from_lossy(0)?;
+        for skip in &skipped {
+            eprintln!(
+                "router[{}]: reconstruct skipping malformed line at offset {} ({})",
+                self.mission_id, skip.offset, skip.error,
+            );
+        }
 
         // Walk once, building a transient ask_human.id → asker map so we
         // can pair the next human_question with the right asker. Once the
@@ -217,10 +226,7 @@ impl Router {
                     ask_human_asker.insert(event.id.clone(), event.from.clone());
                 }
                 "human_question" => {
-                    let triggered_by = event
-                        .payload
-                        .get("triggered_by")
-                        .and_then(|v| v.as_str());
+                    let triggered_by = event.payload.get("triggered_by").and_then(|v| v.as_str());
                     if let Some(ask_id) = triggered_by {
                         if let Some(asker) = ask_human_asker.remove(ask_id) {
                             pending.insert(event.id.clone(), asker);
@@ -228,11 +234,7 @@ impl Router {
                     }
                 }
                 "human_response" => {
-                    if let Some(qid) = event
-                        .payload
-                        .get("question_id")
-                        .and_then(|v| v.as_str())
-                    {
+                    if let Some(qid) = event.payload.get("question_id").and_then(|v| v.as_str()) {
                         pending.remove(qid);
                     }
                 }

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -71,8 +71,8 @@ pub(crate) struct RosterRow {
     lead: bool,
 }
 
-/// Mutable per-mission state. Rebuilt on reopen by replaying the log
-/// through `handle_event` — no separate persistence layer.
+/// Mutable per-mission state. Rebuilt on reopen by replaying the log into
+/// `reconstruct_from_log` — no separate persistence layer.
 #[derive(Default)]
 struct RouterState {
     /// Resolved at mount from the spawned `SpawnedSession` rows. The map is
@@ -81,11 +81,19 @@ struct RouterState {
     /// `mission_warning` (the desired behavior — better than silently
     /// dropping a `human_response`).
     session_by_handle: HashMap<String, String>,
-    /// `ask_human.id` → asker handle. Populated when an `ask_human` event
-    /// is observed; consumed when a matching `human_response` arrives.
+    /// `human_question.id` → asker handle. Populated when an `ask_human`
+    /// is dispatched (the appended card's id is the canonical question_id
+    /// per arch §5.5.0) and consumed by the matching `human_response`.
     pending_asks: HashMap<String, String>,
     /// Latest `runner_status` per handle.
     status: HashMap<String, RunnerStatus>,
+    /// Replay high-water ULID. Set by `reconstruct_from_log` on reopen;
+    /// `handle_event` short-circuits any event whose `id` is `≤` this so
+    /// the bus's initial replay doesn't re-inject historical stdin or
+    /// re-emit `human_question` cards. `None` for fresh missions: the
+    /// opening `mission_goal` event must reach the live dispatcher to
+    /// bootstrap the lead.
+    replay_high_water: Option<String>,
 }
 
 /// One mission's router. Mounted by `mission_start` after sessions spawn,
@@ -148,8 +156,11 @@ impl Router {
 
     /// Register the spawned session ids so handlers can find which PTY
     /// owns each handle. Called once after `mission_start`'s spawn loop
-    /// succeeds — the router is mounted earlier (so it can observe replay)
-    /// but stdin pushes need session ids to land somewhere.
+    /// succeeds. Live `mission_start` calls `register_sessions` *before*
+    /// the bus mounts so the initial replay's `mission_goal` lands on a
+    /// fully-wired router; reopen paths register against existing live
+    /// PTYs (when reattach lands) or skip injection (the workspace
+    /// surfaces `mission_warning` from `inject_to_handle` either way).
     pub fn register_sessions(&self, sessions: &[(String, String)]) {
         let mut state = self.state.lock().unwrap();
         for (handle, session_id) in sessions {
@@ -159,12 +170,103 @@ impl Router {
         }
     }
 
+    /// Reopen path only — fold historical projection state from the log
+    /// without firing handler side effects, and set the replay high-water
+    /// mark so the subsequent bus mount's initial replay no-ops past it.
+    ///
+    /// What is rebuilt:
+    /// - `pending_asks` from `ask_human` → `human_question` pairs (the
+    ///   card id is the canonical `question_id`; we walk in append order
+    ///   to match each ask with its following card via
+    ///   `human_question.payload.triggered_by`). Asks already answered
+    ///   by a `human_response` are removed.
+    /// - `runner_status` from the latest `runner_status` row per handle.
+    ///
+    /// What is *not* rebuilt: stdin pushes. The launch prompt, ask_lead
+    /// relays, human_said echoes, and idle nudges are all live-only side
+    /// effects. Per the C8 plan, replay does not re-inject prompts into
+    /// a sleeping LLM.
+    ///
+    /// **MUST NOT be called for fresh missions.** Setting the watermark
+    /// over the just-written opening `mission_goal` would cause the bus
+    /// initial replay to no-op the bootstrap injection, leaving the lead
+    /// without its launch prompt.
+    pub fn reconstruct_from_log(&self) -> Result<()> {
+        let entries = self.log.read_from(0)?;
+
+        // Walk once, building a transient ask_human.id → asker map so we
+        // can pair the next human_question with the right asker. Once the
+        // pairing lands in pending_asks, the ask_human.id is no longer
+        // needed.
+        let mut ask_human_asker: HashMap<String, String> = HashMap::new();
+        let mut pending: HashMap<String, String> = HashMap::new();
+        let mut status: HashMap<String, RunnerStatus> = HashMap::new();
+        let mut last_id: Option<String> = None;
+
+        for entry in &entries {
+            let event = &entry.event;
+            last_id = Some(event.id.clone());
+            if !matches!(event.kind, EventKind::Signal) {
+                continue;
+            }
+            let Some(t) = event.signal_type.as_ref() else {
+                continue;
+            };
+            match t.as_str() {
+                "ask_human" => {
+                    ask_human_asker.insert(event.id.clone(), event.from.clone());
+                }
+                "human_question" => {
+                    let triggered_by = event
+                        .payload
+                        .get("triggered_by")
+                        .and_then(|v| v.as_str());
+                    if let Some(ask_id) = triggered_by {
+                        if let Some(asker) = ask_human_asker.remove(ask_id) {
+                            pending.insert(event.id.clone(), asker);
+                        }
+                    }
+                }
+                "human_response" => {
+                    if let Some(qid) = event
+                        .payload
+                        .get("question_id")
+                        .and_then(|v| v.as_str())
+                    {
+                        pending.remove(qid);
+                    }
+                }
+                "runner_status" => {
+                    let s = match event.payload.get("state").and_then(|v| v.as_str()) {
+                        Some("busy") => Some(RunnerStatus::Busy),
+                        Some("idle") => Some(RunnerStatus::Idle),
+                        _ => None,
+                    };
+                    if let Some(s) = s {
+                        status.insert(event.from.clone(), s);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let mut state = self.state.lock().unwrap();
+        state.pending_asks = pending;
+        state.status = status;
+        state.replay_high_water = last_id;
+        Ok(())
+    }
+
     pub fn lead_handle(&self) -> &str {
         &self.launch.lead.handle
     }
 
     /// Single dispatcher entry point. Bus calls this for every appended
     /// event in arrival order. Messages return early per arch §5.5.0.
+    /// On reopen, events at-or-below the replay high-water mark are
+    /// short-circuited so the bus's initial replay doesn't re-inject
+    /// historical stdin or re-emit cards (arch §5.5: "stdin pushes are
+    /// deliberately silent" + plan's projection-only replay).
     pub fn handle_event(&self, event: &Event) {
         if !matches!(event.kind, EventKind::Signal) {
             return;
@@ -172,6 +274,15 @@ impl Router {
         let Some(signal) = event.signal_type.as_ref() else {
             return;
         };
+        // Watermark check before signal-type match: covers every handler
+        // (mission_goal, human_said, ask_lead, ask_human, human_response,
+        // runner_status) in one place. Lex-compare on bytes; ULIDs sort
+        // lex-correct.
+        if let Some(w) = self.state.lock().unwrap().replay_high_water.as_deref() {
+            if event.id.as_bytes() <= w.as_bytes() {
+                return;
+            }
+        }
         match signal.as_str() {
             "mission_goal" => handlers::mission_goal(self, event),
             "human_said" => handlers::human_said(self, event),
@@ -243,18 +354,22 @@ impl Router {
         }
     }
 
+    /// Append a `human_question` event for the workspace UI and return its
+    /// id. Per arch §5.5.0 the canonical `question_id` is the appended
+    /// event's own `id`; `human_response.payload.question_id` references
+    /// that. We deliberately do *not* echo `question_id` into the payload —
+    /// the spec calls that "echoed here for convenience" and constructing
+    /// it would require knowing the id before append. Consumers should
+    /// read `event.id`. `triggered_by` ties the card back to the
+    /// originating `ask_human` for replay reconstruction and audit.
     pub(crate) fn append_human_question(
         &self,
         ask_human_id: &str,
         prompt: &str,
         choices: &serde_json::Value,
         on_behalf_of: Option<&str>,
-    ) {
+    ) -> Option<String> {
         let mut payload = serde_json::Map::new();
-        payload.insert(
-            "question_id".into(),
-            serde_json::Value::String(ask_human_id.to_string()),
-        );
         payload.insert(
             "triggered_by".into(),
             serde_json::Value::String(ask_human_id.to_string()),
@@ -277,11 +392,15 @@ impl Router {
             SignalType::new("human_question"),
             serde_json::Value::Object(payload),
         );
-        if let Err(e) = self.log.append(draft) {
-            eprintln!(
-                "router[{}]: failed to append human_question: {e}",
-                self.mission_id
-            );
+        match self.log.append(draft) {
+            Ok(ev) => Some(ev.id),
+            Err(e) => {
+                eprintln!(
+                    "router[{}]: failed to append human_question: {e}",
+                    self.mission_id
+                );
+                None
+            }
         }
     }
 }

--- a/src-tauri/src/router/prompt.rs
+++ b/src-tauri/src/router/prompt.rs
@@ -80,9 +80,7 @@ pub fn compose_launch_prompt(input: &LaunchPromptInput<'_>) -> String {
     }
 
     out.push_str("== Coordination ==\n");
-    out.push_str(
-        "- You are the human's counterpart. Workers escalate to you via `ask_lead`.\n",
-    );
+    out.push_str("- You are the human's counterpart. Workers escalate to you via `ask_lead`.\n");
     out.push_str(
         "- Reply to a worker with `runner msg post --to <handle> \"…\"`; broadcasts omit `--to`.\n",
     );
@@ -92,7 +90,11 @@ pub fn compose_launch_prompt(input: &LaunchPromptInput<'_>) -> String {
     );
     out.push_str("- Report idle with `runner status idle` so the lead view stays accurate.\n");
     if !input.allowed_signals.is_empty() {
-        let names: Vec<&str> = input.allowed_signals.iter().map(SignalType::as_str).collect();
+        let names: Vec<&str> = input
+            .allowed_signals
+            .iter()
+            .map(SignalType::as_str)
+            .collect();
         out.push_str(&format!("- Allowed signal types: {}.\n", names.join(", ")));
     }
 

--- a/src-tauri/src/router/prompt.rs
+++ b/src-tauri/src/router/prompt.rs
@@ -1,0 +1,194 @@
+// Composed launch prompt for the lead, written to stdin on `mission_goal`.
+//
+// Pure function over the inputs: no I/O, no DB access, no globals — easy to
+// unit-test against fixture rosters and goal strings.
+//
+// The four sections (brief, mission, crewmates, coordination) mirror the
+// example in arch §4.3. We diverge from the per-runner spawn-time prompt in
+// one place: this is what the *lead* sees on `mission_goal`, not every
+// runner's startup prompt. Worker runtime adapters get the runner's own
+// `system_prompt` via `--append-system-prompt`-equivalent flags at spawn
+// time (see runtime.rs); this composer is the lead's coordination kit.
+//
+// Output ends with a trailing `\n` so it lands as a single submitted line
+// when injected into a TUI's input box.
+
+use runner_core::model::SignalType;
+
+use crate::model::Runner;
+
+/// One crewmate in the lead's roster section.
+pub struct RosterEntry<'a> {
+    pub handle: &'a str,
+    pub display_name: &'a str,
+    pub role: &'a str,
+    pub lead: bool,
+}
+
+/// All inputs for the launch prompt. Borrowed so the caller can compose
+/// without copying the runner row.
+pub struct LaunchPromptInput<'a> {
+    pub lead: &'a Runner,
+    pub crew_name: &'a str,
+    pub mission_goal: &'a str,
+    pub roster: &'a [RosterEntry<'a>],
+    pub allowed_signals: &'a [SignalType],
+}
+
+pub fn compose_launch_prompt(input: &LaunchPromptInput<'_>) -> String {
+    let mut out = String::new();
+
+    out.push_str(&format!(
+        "You are `{}` ({}), lead runner in crew \"{}\".\n",
+        input.lead.handle, input.lead.display_name, input.crew_name,
+    ));
+    out.push_str(&format!("Your role: {}.\n\n", input.lead.role));
+
+    if let Some(brief) = input.lead.system_prompt.as_deref() {
+        let brief = brief.trim();
+        if !brief.is_empty() {
+            out.push_str("== Your brief ==\n");
+            out.push_str(brief);
+            out.push_str("\n\n");
+        }
+    }
+
+    out.push_str("== Mission ==\n");
+    if input.mission_goal.trim().is_empty() {
+        out.push_str("Goal: (no goal set; await human_said).\n\n");
+    } else {
+        out.push_str(&format!("Goal: {}\n\n", input.mission_goal.trim()));
+    }
+
+    let crewmates: Vec<&RosterEntry> = input
+        .roster
+        .iter()
+        .filter(|r| r.handle != input.lead.handle)
+        .collect();
+    if !crewmates.is_empty() {
+        out.push_str("== Your crewmates ==\n");
+        for r in crewmates {
+            out.push_str(&format!(
+                "- `{}` ({}, {}){}\n",
+                r.handle,
+                r.display_name,
+                r.role,
+                if r.lead { " — lead" } else { "" },
+            ));
+        }
+        out.push('\n');
+    }
+
+    out.push_str("== Coordination ==\n");
+    out.push_str(
+        "- You are the human's counterpart. Workers escalate to you via `ask_lead`.\n",
+    );
+    out.push_str(
+        "- Reply to a worker with `runner msg post --to <handle> \"…\"`; broadcasts omit `--to`.\n",
+    );
+    out.push_str("- Read your inbox with `runner msg read` — it's pull-based.\n");
+    out.push_str(
+        "- Escalate to the human with `runner signal ask_human --payload '{\"prompt\":\"…\",\"choices\":[\"yes\",\"no\"],\"on_behalf_of\":\"<asker>\"}'`.\n",
+    );
+    out.push_str("- Report idle with `runner status idle` so the lead view stays accurate.\n");
+    if !input.allowed_signals.is_empty() {
+        let names: Vec<&str> = input.allowed_signals.iter().map(SignalType::as_str).collect();
+        out.push_str(&format!("- Allowed signal types: {}.\n", names.join(", ")));
+    }
+
+    out.push('\n');
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::collections::HashMap;
+
+    fn runner(handle: &str, system_prompt: Option<&str>) -> Runner {
+        Runner {
+            id: "r".into(),
+            handle: handle.into(),
+            display_name: "Lead".into(),
+            role: "coordinator".into(),
+            runtime: "claude-code".into(),
+            command: "/bin/sh".into(),
+            args: vec![],
+            working_dir: None,
+            system_prompt: system_prompt.map(String::from),
+            env: HashMap::new(),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn includes_brief_when_present_and_omits_when_blank() {
+        let lead = runner("lead", Some("Drive coordination."));
+        let allowed = [SignalType::new("mission_goal")];
+        let prompt = compose_launch_prompt(&LaunchPromptInput {
+            lead: &lead,
+            crew_name: "Alpha",
+            mission_goal: "ship v0",
+            roster: &[],
+            allowed_signals: &allowed,
+        });
+        assert!(prompt.contains("== Your brief =="));
+        assert!(prompt.contains("Drive coordination."));
+        assert!(prompt.contains("Goal: ship v0"));
+        assert!(prompt.contains("Allowed signal types: mission_goal"));
+
+        let lead2 = runner("lead", None);
+        let prompt2 = compose_launch_prompt(&LaunchPromptInput {
+            lead: &lead2,
+            crew_name: "Alpha",
+            mission_goal: "ship v0",
+            roster: &[],
+            allowed_signals: &allowed,
+        });
+        assert!(!prompt2.contains("== Your brief =="));
+    }
+
+    #[test]
+    fn empty_goal_renders_placeholder() {
+        let lead = runner("lead", None);
+        let prompt = compose_launch_prompt(&LaunchPromptInput {
+            lead: &lead,
+            crew_name: "A",
+            mission_goal: "",
+            roster: &[],
+            allowed_signals: &[],
+        });
+        assert!(prompt.contains("(no goal set"));
+    }
+
+    #[test]
+    fn roster_section_excludes_self_and_lists_crewmates() {
+        let lead = runner("lead", None);
+        let prompt = compose_launch_prompt(&LaunchPromptInput {
+            lead: &lead,
+            crew_name: "A",
+            mission_goal: "g",
+            roster: &[
+                RosterEntry {
+                    handle: "lead",
+                    display_name: "Lead",
+                    role: "coord",
+                    lead: true,
+                },
+                RosterEntry {
+                    handle: "impl",
+                    display_name: "Impl",
+                    role: "coding",
+                    lead: false,
+                },
+            ],
+            allowed_signals: &[],
+        });
+        assert!(prompt.contains("`impl`"));
+        // Self-row must not appear under crewmates.
+        let crewmates_section = prompt.split("== Your crewmates ==").nth(1).unwrap();
+        assert!(!crewmates_section.contains("`lead`"));
+    }
+}

--- a/src-tauri/src/router/runtime.rs
+++ b/src-tauri/src/router/runtime.rs
@@ -1,0 +1,71 @@
+// Runtime adapter: maps `runner.runtime` + `runner.system_prompt` to the
+// extra CLI args the child process needs to receive the prompt.
+//
+// arch §4.2 / §4.3: the system prompt is passed through the runtime's native
+// flag — `--append-system-prompt` for `claude-code`, the equivalent for each
+// other runtime. The `runtime` enum in the `runners` table owns that mapping.
+//
+// Keeping this in one place means both `SessionManager::spawn` (mission) and
+// `spawn_direct` (chat) get the same behavior with no chance of drift.
+//
+// Lives under router/ because the router's `mission_goal` handler already
+// owns prompt composition; the runtime adapter is the related "how do we
+// hand a prompt to a real CLI" piece.
+
+/// Compute the extra args (in declaration order) to append after the
+/// runner's configured `args` so the child receives `system_prompt` via the
+/// runtime's native flag. Returns an empty Vec when no prompt is set or the
+/// runtime is unrecognized — unrecognized runtimes degrade silently rather
+/// than failing the spawn (the user might be prototyping a custom CLI).
+pub fn system_prompt_args(runtime: &str, system_prompt: Option<&str>) -> Vec<String> {
+    let prompt = match system_prompt {
+        Some(p) if !p.trim().is_empty() => p,
+        _ => return Vec::new(),
+    };
+    match runtime {
+        // claude-code accepts --append-system-prompt <text>; the flag layers
+        // onto its built-in default rather than replacing it, which is what
+        // we want — we're appending the runner's brief, not overwriting.
+        "claude-code" => vec!["--append-system-prompt".into(), prompt.to_string()],
+        // codex's analogue. Per its CLI docs, the flag is --instructions.
+        "codex" => vec!["--instructions".into(), prompt.to_string()],
+        // shell / unknown — no flag. The prompt is still discoverable on
+        // the runner row; the user will configure their wrapper script
+        // themselves if they want it injected.
+        _ => Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_code_appends_system_prompt() {
+        let args = system_prompt_args("claude-code", Some("be helpful"));
+        assert_eq!(args, vec!["--append-system-prompt", "be helpful"]);
+    }
+
+    #[test]
+    fn codex_uses_instructions_flag() {
+        let args = system_prompt_args("codex", Some("be helpful"));
+        assert_eq!(args, vec!["--instructions", "be helpful"]);
+    }
+
+    #[test]
+    fn shell_runtime_omits_flag() {
+        assert!(system_prompt_args("shell", Some("ignored")).is_empty());
+    }
+
+    #[test]
+    fn missing_or_blank_prompt_omits_flag() {
+        assert!(system_prompt_args("claude-code", None).is_empty());
+        assert!(system_prompt_args("claude-code", Some("")).is_empty());
+        assert!(system_prompt_args("claude-code", Some("   ")).is_empty());
+    }
+
+    #[test]
+    fn unknown_runtime_degrades_to_no_flag() {
+        assert!(system_prompt_args("aider-future", Some("hi")).is_empty());
+    }
+}

--- a/src-tauri/src/router/runtime.rs
+++ b/src-tauri/src/router/runtime.rs
@@ -27,11 +27,13 @@ pub fn system_prompt_args(runtime: &str, system_prompt: Option<&str>) -> Vec<Str
         // onto its built-in default rather than replacing it, which is what
         // we want — we're appending the runner's brief, not overwriting.
         "claude-code" => vec!["--append-system-prompt".into(), prompt.to_string()],
-        // codex's analogue. Per its CLI docs, the flag is --instructions.
-        "codex" => vec!["--instructions".into(), prompt.to_string()],
-        // shell / unknown — no flag. The prompt is still discoverable on
-        // the runner row; the user will configure their wrapper script
-        // themselves if they want it injected.
+        // codex / shell / unknown — no flag. We tried `codex --instructions`
+        // first but the installed Codex CLI rejects it ("unexpected argument
+        // --instructions found"). Until a verified prompt mechanism lands
+        // (e.g. a documented flag on a pinned Codex version, or a wrapper
+        // script convention), Codex runners spawn without the brief; the
+        // prompt is still on the runner row and the user can configure
+        // their own wrapper. Tracked for follow-up.
         _ => Vec::new(),
     }
 }
@@ -47,9 +49,11 @@ mod tests {
     }
 
     #[test]
-    fn codex_uses_instructions_flag() {
-        let args = system_prompt_args("codex", Some("be helpful"));
-        assert_eq!(args, vec!["--instructions", "be helpful"]);
+    fn codex_runtime_omits_flag_until_verified_mechanism() {
+        // The installed `codex` CLI rejects `--instructions`. Until a
+        // documented prompt flag is verified, the codex runtime degrades
+        // to no-flag rather than crashing the spawn.
+        assert!(system_prompt_args("codex", Some("be helpful")).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/router/tests.rs
+++ b/src-tauri/src/router/tests.rs
@@ -135,8 +135,10 @@ fn message(from: &str, to: Option<&str>, text: &str) -> EventDraft {
 }
 
 fn read_signals(log: &EventLog) -> Vec<Event> {
-    log.read_from(0)
-        .unwrap()
+    // Lossy so the malformed-line test (which hand-injects a bad NDJSON
+    // line to verify reconstruct's tolerance) can still inspect signals.
+    let (entries, _skipped) = log.read_from_lossy(0).unwrap();
+    entries
         .into_iter()
         .map(|e| e.event)
         .filter(|e| matches!(e.kind, EventKind::Signal))
@@ -334,7 +336,9 @@ fn human_response_routes_back_to_asker() {
 
     let lead_pushes = injector.pushes_for("S-LEAD");
     assert!(
-        lead_pushes.iter().any(|p| p.contains("[human_response] yes")),
+        lead_pushes
+            .iter()
+            .any(|p| p.contains("[human_response] yes")),
         "lead must receive the routed answer; got {lead_pushes:?}",
     );
     // The pending-ask map is consumed; a duplicate response surfaces a
@@ -357,19 +361,18 @@ fn human_response_routes_back_to_asker() {
         })
         .collect();
     assert!(
-        warnings
-            .iter()
-            .any(|w| w.payload["message"].as_str().unwrap().contains("unknown question_id")),
+        warnings.iter().any(|w| w.payload["message"]
+            .as_str()
+            .unwrap()
+            .contains("unknown question_id")),
         "duplicate response must produce mission_warning; got {warnings:?}",
     );
 }
 
 #[test]
 fn human_response_without_matching_question_emits_mission_warning() {
-    let (router, injector, log, _dir) = fixture(
-        vec![crew_runner("lead", true)],
-        &[("lead", "S-LEAD")],
-    );
+    let (router, injector, log, _dir) =
+        fixture(vec![crew_runner("lead", true)], &[("lead", "S-LEAD")]);
     let resp = log
         .append(signal(
             "human",
@@ -521,14 +524,24 @@ fn pending_ask_map_reconstructs_from_log_on_reopen() {
     // log) and the lead is NOT re-injected with anything.
     let card_count_before = read_signals(&log)
         .iter()
-        .filter(|s| s.signal_type.as_ref().map(|t| t.as_str() == "human_question").unwrap_or(false))
+        .filter(|s| {
+            s.signal_type
+                .as_ref()
+                .map(|t| t.as_str() == "human_question")
+                .unwrap_or(false)
+        })
         .count();
     for entry in log.read_from(0).unwrap() {
         router2.handle_event(&entry.event);
     }
     let card_count_after = read_signals(&log)
         .iter()
-        .filter(|s| s.signal_type.as_ref().map(|t| t.as_str() == "human_question").unwrap_or(false))
+        .filter(|s| {
+            s.signal_type
+                .as_ref()
+                .map(|t| t.as_str() == "human_question")
+                .unwrap_or(false)
+        })
         .count();
     assert_eq!(
         card_count_before, card_count_after,
@@ -553,7 +566,9 @@ fn pending_ask_map_reconstructs_from_log_on_reopen() {
 
     let lead_pushes = injector.pushes_for("S-LEAD");
     assert!(
-        lead_pushes.iter().any(|p| p.contains("[human_response] yes")),
+        lead_pushes
+            .iter()
+            .any(|p| p.contains("[human_response] yes")),
         "after reopen + reconstruct, response must route to original asker; got {lead_pushes:?}",
     );
 }
@@ -689,10 +704,8 @@ fn dead_session_for_handler_target_emits_mission_warning() {
     // The pending-ask map persists past a session crash by design — better
     // to surface the missed wake-up than to silently drop it. The router
     // attempts the inject, fails, and writes a mission_warning.
-    let (router, injector, log, _dir) = fixture(
-        vec![crew_runner("lead", true)],
-        &[("lead", "S-LEAD")],
-    );
+    let (router, injector, log, _dir) =
+        fixture(vec![crew_runner("lead", true)], &[("lead", "S-LEAD")]);
     injector.mark_dead("S-LEAD");
     let ev = log
         .append(signal(
@@ -720,11 +733,106 @@ fn dead_session_for_handler_target_emits_mission_warning() {
 }
 
 #[test]
-fn registry_register_get_unregister() {
-    let (router, _i, _l, _d) = fixture(
-        vec![crew_runner("lead", true)],
-        &[("lead", "S-LEAD")],
+fn reconstruct_tolerates_malformed_lines_like_the_bus() {
+    // Regression: the bus uses `read_from_lossy` so a single bad NDJSON
+    // line doesn't poison projection. `reconstruct_from_log` must do the
+    // same — otherwise reopen would fail on a log the bus is otherwise
+    // happily tailing.
+    use std::io::Write;
+
+    let dir = tempfile::tempdir().unwrap();
+    let log = Arc::new(EventLog::open(dir.path()).unwrap());
+
+    // Pre-seed an ask_human, then a hand-written malformed line, then a
+    // matching human_question via the live router. Reconstruct must
+    // recover the pending-ask mapping despite the bad line in between.
+    let ask = log
+        .append(signal(
+            "lead",
+            "ask_human",
+            serde_json::json!({
+                "prompt": "ok?",
+                "choices": ["yes", "no"],
+            }),
+        ))
+        .unwrap();
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .append(true)
+            .open(dir.path().join("events.ndjson"))
+            .unwrap();
+        f.write_all(b"this is not json\n").unwrap();
+    }
+
+    let roster = vec![crew_runner("lead", true)];
+    // First mount handles the ask live — appends human_question.
+    {
+        let injector = Arc::new(RecordingInjector::default());
+        let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
+        let router = Router::new(
+            "mission-1".into(),
+            "crew-1".into(),
+            "Crew One".into(),
+            &roster,
+            vec![],
+            log.clone(),
+            injector_dyn,
+        )
+        .unwrap();
+        router.register_sessions(&[("lead".into(), "S-LEAD".into())]);
+        router.handle_event(&ask);
+    }
+    let card_id = read_signals(&log)
+        .into_iter()
+        .find(|s| {
+            s.signal_type
+                .as_ref()
+                .map(|t| t.as_str() == "human_question")
+                .unwrap_or(false)
+        })
+        .expect("router must append human_question")
+        .id;
+
+    // Reopen + reconstruct: must not fail despite the malformed middle line.
+    let injector = Arc::new(RecordingInjector::default());
+    let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
+    let router2 = Router::new(
+        "mission-1".into(),
+        "crew-1".into(),
+        "Crew One".into(),
+        &roster,
+        vec![],
+        log.clone(),
+        injector_dyn,
+    )
+    .unwrap();
+    router2.register_sessions(&[("lead".into(), "S-LEAD".into())]);
+    router2
+        .reconstruct_from_log()
+        .expect("reconstruct must tolerate malformed lines");
+
+    // The pending-ask map should still resolve; route a human_response and
+    // assert the answer reaches the lead.
+    let resp = log
+        .append(signal(
+            "human",
+            "human_response",
+            serde_json::json!({ "question_id": card_id, "choice": "yes" }),
+        ))
+        .unwrap();
+    router2.handle_event(&resp);
+    let lead_pushes = injector.pushes_for("S-LEAD");
+    assert!(
+        lead_pushes
+            .iter()
+            .any(|p| p.contains("[human_response] yes")),
+        "reconstruct must have recovered the pending ask; got {lead_pushes:?}",
     );
+}
+
+#[test]
+fn registry_register_get_unregister() {
+    let (router, _i, _l, _d) = fixture(vec![crew_runner("lead", true)], &[("lead", "S-LEAD")]);
     let reg = RouterRegistry::new();
     reg.register("mission-1".into(), router.clone());
     assert!(reg.get("mission-1").is_some());

--- a/src-tauri/src/router/tests.rs
+++ b/src-tauri/src/router/tests.rs
@@ -1,0 +1,553 @@
+// Router unit tests. The list mirrors docs/tests/v0-mvp-tests.md C8.
+//
+// We bypass the event bus entirely here — the router exposes
+// `handle_event(&Event)` synchronously so we can drive it with hand-crafted
+// envelopes and assert what landed in the recording injector + the log.
+// Bus integration is covered separately (mission lifecycle + mission_e2e).
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use chrono::Utc;
+use runner_core::event_log::EventLog;
+use runner_core::model::{Event, EventDraft, EventKind, SignalType};
+
+use super::{Router, RouterRegistry, StdinInjector};
+use crate::error::Result;
+use crate::model::{CrewRunner, Runner};
+
+/// Records every `inject` call so handler outputs can be asserted.
+#[derive(Default)]
+struct RecordingInjector {
+    pushes: Mutex<Vec<(String, Vec<u8>)>>,
+    /// Optional `dead_session` set — `inject` errors when called with one
+    /// of these ids, simulating a crashed PTY for `mission_warning` tests.
+    dead: Mutex<Vec<String>>,
+}
+
+impl RecordingInjector {
+    fn pushes_for(&self, session_id: &str) -> Vec<String> {
+        self.pushes
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(s, _)| s == session_id)
+            .map(|(_, bytes)| String::from_utf8_lossy(bytes).into_owned())
+            .collect()
+    }
+
+    fn all_pushes(&self) -> Vec<(String, String)> {
+        self.pushes
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|(s, b)| (s.clone(), String::from_utf8_lossy(b).into_owned()))
+            .collect()
+    }
+
+    fn mark_dead(&self, session_id: &str) {
+        self.dead.lock().unwrap().push(session_id.to_string());
+    }
+}
+
+impl StdinInjector for RecordingInjector {
+    fn inject(&self, session_id: &str, bytes: &[u8]) -> Result<()> {
+        if self.dead.lock().unwrap().iter().any(|d| d == session_id) {
+            return Err(crate::error::Error::msg(format!(
+                "test: session {session_id} is dead"
+            )));
+        }
+        self.pushes
+            .lock()
+            .unwrap()
+            .push((session_id.to_string(), bytes.to_vec()));
+        Ok(())
+    }
+}
+
+fn runner(handle: &str, runtime: &str) -> Runner {
+    Runner {
+        id: format!("rid-{handle}"),
+        handle: handle.into(),
+        display_name: handle.to_uppercase(),
+        role: "test".into(),
+        runtime: runtime.into(),
+        command: "/bin/sh".into(),
+        args: vec![],
+        working_dir: None,
+        system_prompt: Some(format!("brief for {handle}")),
+        env: HashMap::new(),
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+fn crew_runner(handle: &str, lead: bool) -> CrewRunner {
+    CrewRunner {
+        runner: runner(handle, "claude-code"),
+        position: 0,
+        lead,
+        added_at: Utc::now(),
+    }
+}
+
+/// Build a router around a fresh tempdir log + recording injector. Returns
+/// `(router, injector, log, dir)` so tests can inspect everything without
+/// re-opening the file. The dir is returned so tempdir cleanup is delayed
+/// to test-end (otherwise the log path would be invalidated immediately).
+fn fixture(
+    roster: Vec<CrewRunner>,
+    sessions: &[(&str, &str)],
+) -> (
+    Arc<Router>,
+    Arc<RecordingInjector>,
+    Arc<EventLog>,
+    tempfile::TempDir,
+) {
+    let dir = tempfile::tempdir().unwrap();
+    let log = Arc::new(EventLog::open(dir.path()).unwrap());
+    let injector = Arc::new(RecordingInjector::default());
+    let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
+    let router = Router::new(
+        "mission-1".into(),
+        "crew-1".into(),
+        "Crew One".into(),
+        &roster,
+        vec![SignalType::new("mission_goal"), SignalType::new("ask_lead")],
+        log.clone(),
+        injector_dyn,
+    )
+    .unwrap();
+    let session_pairs: Vec<(String, String)> = sessions
+        .iter()
+        .map(|(h, s)| (h.to_string(), s.to_string()))
+        .collect();
+    router.register_sessions(&session_pairs);
+    (router, injector, log, dir)
+}
+
+fn signal(from: &str, ty: &str, payload: serde_json::Value) -> EventDraft {
+    EventDraft::signal("crew-1", "mission-1", from, SignalType::new(ty), payload)
+}
+
+fn message(from: &str, to: Option<&str>, text: &str) -> EventDraft {
+    EventDraft::message("crew-1", "mission-1", from, to.map(String::from), text)
+}
+
+fn read_signals(log: &EventLog) -> Vec<Event> {
+    log.read_from(0)
+        .unwrap()
+        .into_iter()
+        .map(|e| e.event)
+        .filter(|e| matches!(e.kind, EventKind::Signal))
+        .collect()
+}
+
+#[test]
+fn messages_do_not_trigger_router_actions() {
+    // Arch §5.5.0: messages flow through the inbox projection only; the
+    // router's dispatcher must early-return on EventKind::Message. A
+    // `mission_warning` from a missing handler would also surface here, so
+    // an empty pushes Vec proves both that the dispatcher matched on kind
+    // and that no handler ran.
+    let (router, injector, log, _dir) = fixture(
+        vec![crew_runner("lead", true), crew_runner("impl", false)],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    let bcast = log.append(message("lead", None, "broadcast")).unwrap();
+    let direct = log.append(message("lead", Some("impl"), "go")).unwrap();
+    router.handle_event(&bcast);
+    router.handle_event(&direct);
+    assert!(injector.all_pushes().is_empty());
+}
+
+#[test]
+fn mission_goal_injects_composed_prompt_to_lead() {
+    let (router, injector, log, _dir) = fixture(
+        vec![crew_runner("lead", true), crew_runner("impl", false)],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    let ev = log
+        .append(signal(
+            "human",
+            "mission_goal",
+            serde_json::json!({ "text": "ship v0" }),
+        ))
+        .unwrap();
+    router.handle_event(&ev);
+
+    let lead_pushes = injector.pushes_for("S-LEAD");
+    assert_eq!(lead_pushes.len(), 1, "lead receives one prompt push");
+    let prompt = &lead_pushes[0];
+    assert!(prompt.contains("Goal: ship v0"));
+    assert!(prompt.contains("`impl`"));
+    assert!(prompt.contains("Allowed signal types"));
+    // Workers do not receive the launch prompt.
+    assert!(injector.pushes_for("S-IMPL").is_empty());
+}
+
+#[test]
+fn human_said_routes_to_target_or_lead() {
+    let (router, injector, log, _dir) = fixture(
+        vec![crew_runner("lead", true), crew_runner("impl", false)],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+
+    // Targeted: lands on the worker.
+    let direct = log
+        .append(signal(
+            "human",
+            "human_said",
+            serde_json::json!({ "text": "look at line 42", "target": "impl" }),
+        ))
+        .unwrap();
+    router.handle_event(&direct);
+    let impl_pushes = injector.pushes_for("S-IMPL");
+    assert_eq!(impl_pushes.len(), 1);
+    assert!(impl_pushes[0].contains("look at line 42"));
+    assert!(injector.pushes_for("S-LEAD").is_empty());
+
+    // Untargeted: defaults to the lead.
+    let bcast = log
+        .append(signal(
+            "human",
+            "human_said",
+            serde_json::json!({ "text": "status?" }),
+        ))
+        .unwrap();
+    router.handle_event(&bcast);
+    let lead_pushes = injector.pushes_for("S-LEAD");
+    assert_eq!(lead_pushes.len(), 1);
+    assert!(lead_pushes[0].contains("status?"));
+}
+
+#[test]
+fn ask_lead_injects_question_and_context_to_lead() {
+    let (router, injector, log, _dir) = fixture(
+        vec![crew_runner("lead", true), crew_runner("impl", false)],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    let ev = log
+        .append(signal(
+            "impl",
+            "ask_lead",
+            serde_json::json!({ "question": "use notify-debouncer-full?", "context": "Pros: …\nCons: …" }),
+        ))
+        .unwrap();
+    router.handle_event(&ev);
+
+    let pushes = injector.pushes_for("S-LEAD");
+    assert_eq!(pushes.len(), 1);
+    let text = &pushes[0];
+    assert!(text.contains("[ask_lead from @impl]"));
+    assert!(text.contains("use notify-debouncer-full?"));
+    assert!(text.contains("Pros:"));
+    // Worker stdin must not see the relayed question.
+    assert!(injector.pushes_for("S-IMPL").is_empty());
+}
+
+#[test]
+fn ask_human_appends_human_question_card_and_records_pending_ask() {
+    let (router, _injector, log, _dir) = fixture(
+        vec![crew_runner("lead", true), crew_runner("impl", false)],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    let ev = log
+        .append(signal(
+            "lead",
+            "ask_human",
+            serde_json::json!({
+                "prompt": "Approve?",
+                "choices": ["yes", "no"],
+                "on_behalf_of": "impl",
+            }),
+        ))
+        .unwrap();
+    router.handle_event(&ev);
+
+    // Append a `human_question` event referencing the original ask.
+    let signals = read_signals(&log);
+    let card = signals
+        .iter()
+        .find(|s| {
+            s.signal_type
+                .as_ref()
+                .map(|t| t.as_str() == "human_question")
+                .unwrap_or(false)
+        })
+        .expect("router must append human_question");
+    assert_eq!(card.from, "router");
+    assert_eq!(card.payload["prompt"], "Approve?");
+    assert_eq!(card.payload["choices"], serde_json::json!(["yes", "no"]));
+    assert_eq!(card.payload["on_behalf_of"], "impl");
+    assert_eq!(card.payload["question_id"], ev.id);
+    assert_eq!(card.payload["triggered_by"], ev.id);
+}
+
+#[test]
+fn human_response_routes_back_to_asker() {
+    let (router, injector, log, _dir) = fixture(
+        vec![crew_runner("lead", true), crew_runner("impl", false)],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    let ask = log
+        .append(signal(
+            "lead",
+            "ask_human",
+            serde_json::json!({
+                "prompt": "Approve?",
+                "choices": ["yes", "no"],
+                "on_behalf_of": "impl",
+            }),
+        ))
+        .unwrap();
+    router.handle_event(&ask);
+
+    let resp = log
+        .append(signal(
+            "human",
+            "human_response",
+            serde_json::json!({ "question_id": ask.id, "choice": "yes" }),
+        ))
+        .unwrap();
+    router.handle_event(&resp);
+
+    let lead_pushes = injector.pushes_for("S-LEAD");
+    assert!(
+        lead_pushes.iter().any(|p| p.contains("[human_response] yes")),
+        "lead must receive the routed answer; got {lead_pushes:?}",
+    );
+    // The pending-ask map is consumed; a duplicate response surfaces a
+    // warning rather than re-injecting.
+    let dup = log
+        .append(signal(
+            "human",
+            "human_response",
+            serde_json::json!({ "question_id": ask.id, "choice": "no" }),
+        ))
+        .unwrap();
+    router.handle_event(&dup);
+    let warnings: Vec<_> = read_signals(&log)
+        .into_iter()
+        .filter(|s| {
+            s.signal_type
+                .as_ref()
+                .map(|t| t.as_str() == "mission_warning")
+                .unwrap_or(false)
+        })
+        .collect();
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.payload["message"].as_str().unwrap().contains("unknown question_id")),
+        "duplicate response must produce mission_warning; got {warnings:?}",
+    );
+}
+
+#[test]
+fn human_response_without_matching_question_emits_mission_warning() {
+    let (router, injector, log, _dir) = fixture(
+        vec![crew_runner("lead", true)],
+        &[("lead", "S-LEAD")],
+    );
+    let resp = log
+        .append(signal(
+            "human",
+            "human_response",
+            serde_json::json!({ "question_id": "01HUNKNOWN", "choice": "yes" }),
+        ))
+        .unwrap();
+    router.handle_event(&resp);
+
+    assert!(injector.all_pushes().is_empty());
+    let warnings: Vec<_> = read_signals(&log)
+        .into_iter()
+        .filter(|s| {
+            s.signal_type
+                .as_ref()
+                .map(|t| t.as_str() == "mission_warning")
+                .unwrap_or(false)
+        })
+        .collect();
+    assert_eq!(warnings.len(), 1);
+}
+
+#[test]
+fn runner_status_idle_for_worker_notifies_lead_and_busy_does_not() {
+    let (router, injector, log, _dir) = fixture(
+        vec![crew_runner("lead", true), crew_runner("impl", false)],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+
+    // busy from a worker — silent (no push to lead).
+    let busy = log
+        .append(signal(
+            "impl",
+            "runner_status",
+            serde_json::json!({ "state": "busy" }),
+        ))
+        .unwrap();
+    router.handle_event(&busy);
+    assert!(injector.pushes_for("S-LEAD").is_empty());
+
+    // idle from a worker — push to the lead, mentioning the worker.
+    let idle = log
+        .append(signal(
+            "impl",
+            "runner_status",
+            serde_json::json!({ "state": "idle", "note": "ready for next task" }),
+        ))
+        .unwrap();
+    router.handle_event(&idle);
+    let pushes = injector.pushes_for("S-LEAD");
+    assert_eq!(pushes.len(), 1);
+    assert!(pushes[0].contains("@impl is idle"));
+    assert!(pushes[0].contains("ready for next task"));
+
+    // idle from the lead itself — does not self-notify.
+    let lead_idle = log
+        .append(signal(
+            "lead",
+            "runner_status",
+            serde_json::json!({ "state": "idle" }),
+        ))
+        .unwrap();
+    router.handle_event(&lead_idle);
+    assert_eq!(
+        injector.pushes_for("S-LEAD").len(),
+        1,
+        "lead going idle must not push to lead",
+    );
+}
+
+#[test]
+fn pending_ask_map_reconstructs_from_log_on_reopen() {
+    // Append `ask_human`, drop the router, build a fresh one, replay the log
+    // through it, then append `human_response`. The answer must still route
+    // to the asker — no separate persistence required.
+    let dir = tempfile::tempdir().unwrap();
+    let log = Arc::new(EventLog::open(dir.path()).unwrap());
+    let roster = vec![crew_runner("lead", true), crew_runner("impl", false)];
+
+    let ask = log
+        .append(signal(
+            "lead",
+            "ask_human",
+            serde_json::json!({
+                "prompt": "Approve?",
+                "choices": ["yes", "no"],
+                "on_behalf_of": "impl",
+            }),
+        ))
+        .unwrap();
+
+    // First mount processes only the ask, then is dropped.
+    {
+        let injector = Arc::new(RecordingInjector::default());
+        let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
+        let router = Router::new(
+            "mission-1".into(),
+            "crew-1".into(),
+            "Crew One".into(),
+            &roster,
+            vec![],
+            log.clone(),
+            injector_dyn,
+        )
+        .unwrap();
+        router.register_sessions(&[
+            ("lead".into(), "S-LEAD".into()),
+            ("impl".into(), "S-IMPL".into()),
+        ]);
+        router.handle_event(&ask);
+    }
+
+    // Second mount: replay the log up to and including the ask, then route
+    // the response.
+    let injector = Arc::new(RecordingInjector::default());
+    let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
+    let router2 = Router::new(
+        "mission-1".into(),
+        "crew-1".into(),
+        "Crew One".into(),
+        &roster,
+        vec![],
+        log.clone(),
+        injector_dyn,
+    )
+    .unwrap();
+    router2.register_sessions(&[
+        ("lead".into(), "S-LEAD".into()),
+        ("impl".into(), "S-IMPL".into()),
+    ]);
+    // Mirror what `BusEmitter` would do during initial replay: feed every
+    // historical envelope through `handle_event`. The router has no
+    // dispatch ledger — it just rebuilds the pending-ask map from the
+    // ask_human row it sees.
+    for entry in log.read_from(0).unwrap() {
+        router2.handle_event(&entry.event);
+    }
+
+    let resp = log
+        .append(signal(
+            "human",
+            "human_response",
+            serde_json::json!({ "question_id": ask.id, "choice": "yes" }),
+        ))
+        .unwrap();
+    router2.handle_event(&resp);
+
+    let lead_pushes = injector.pushes_for("S-LEAD");
+    assert!(
+        lead_pushes.iter().any(|p| p.contains("[human_response] yes")),
+        "after reopen + replay, response must route to original asker; got {lead_pushes:?}",
+    );
+}
+
+#[test]
+fn dead_session_for_handler_target_emits_mission_warning() {
+    // The pending-ask map persists past a session crash by design — better
+    // to surface the missed wake-up than to silently drop it. The router
+    // attempts the inject, fails, and writes a mission_warning.
+    let (router, injector, log, _dir) = fixture(
+        vec![crew_runner("lead", true)],
+        &[("lead", "S-LEAD")],
+    );
+    injector.mark_dead("S-LEAD");
+    let ev = log
+        .append(signal(
+            "human",
+            "human_said",
+            serde_json::json!({ "text": "hi" }),
+        ))
+        .unwrap();
+    router.handle_event(&ev);
+
+    let warnings: Vec<_> = read_signals(&log)
+        .into_iter()
+        .filter(|s| {
+            s.signal_type
+                .as_ref()
+                .map(|t| t.as_str() == "mission_warning")
+                .unwrap_or(false)
+        })
+        .collect();
+    assert_eq!(warnings.len(), 1);
+    assert!(warnings[0].payload["message"]
+        .as_str()
+        .unwrap()
+        .contains("human_said injection"));
+}
+
+#[test]
+fn registry_register_get_unregister() {
+    let (router, _i, _l, _d) = fixture(
+        vec![crew_runner("lead", true)],
+        &[("lead", "S-LEAD")],
+    );
+    let reg = RouterRegistry::new();
+    reg.register("mission-1".into(), router.clone());
+    assert!(reg.get("mission-1").is_some());
+    reg.unregister("mission-1");
+    assert!(reg.get("mission-1").is_none());
+}

--- a/src-tauri/src/router/tests.rs
+++ b/src-tauri/src/router/tests.rs
@@ -265,7 +265,11 @@ fn ask_human_appends_human_question_card_and_records_pending_ask() {
         .unwrap();
     router.handle_event(&ev);
 
-    // Append a `human_question` event referencing the original ask.
+    // Append a `human_question` event referencing the original ask. Per
+    // arch §5.5.0, the canonical `question_id` is the card event's own
+    // `id`; `triggered_by` ties it back to the originating `ask_human`.
+    // The convenience-echo `payload.question_id` is intentionally absent
+    // because the id isn't known until after append.
     let signals = read_signals(&log);
     let card = signals
         .iter()
@@ -280,8 +284,11 @@ fn ask_human_appends_human_question_card_and_records_pending_ask() {
     assert_eq!(card.payload["prompt"], "Approve?");
     assert_eq!(card.payload["choices"], serde_json::json!(["yes", "no"]));
     assert_eq!(card.payload["on_behalf_of"], "impl");
-    assert_eq!(card.payload["question_id"], ev.id);
     assert_eq!(card.payload["triggered_by"], ev.id);
+    assert!(
+        card.payload.get("question_id").is_none(),
+        "question_id is the event's own id; not echoed in payload"
+    );
 }
 
 #[test]
@@ -303,11 +310,24 @@ fn human_response_routes_back_to_asker() {
         .unwrap();
     router.handle_event(&ask);
 
+    // human_response.payload.question_id is the human_question.id (arch
+    // §5.5.0), not the ask_human.id. Find the card the router appended.
+    let card_id = read_signals(&log)
+        .into_iter()
+        .find(|s| {
+            s.signal_type
+                .as_ref()
+                .map(|t| t.as_str() == "human_question")
+                .unwrap_or(false)
+        })
+        .expect("router must append human_question")
+        .id;
+
     let resp = log
         .append(signal(
             "human",
             "human_response",
-            serde_json::json!({ "question_id": ask.id, "choice": "yes" }),
+            serde_json::json!({ "question_id": card_id, "choice": "yes" }),
         ))
         .unwrap();
     router.handle_event(&resp);
@@ -323,7 +343,7 @@ fn human_response_routes_back_to_asker() {
         .append(signal(
             "human",
             "human_response",
-            serde_json::json!({ "question_id": ask.id, "choice": "no" }),
+            serde_json::json!({ "question_id": card_id, "choice": "no" }),
         ))
         .unwrap();
     router.handle_event(&dup);
@@ -422,9 +442,10 @@ fn runner_status_idle_for_worker_notifies_lead_and_busy_does_not() {
 
 #[test]
 fn pending_ask_map_reconstructs_from_log_on_reopen() {
-    // Append `ask_human`, drop the router, build a fresh one, replay the log
-    // through it, then append `human_response`. The answer must still route
-    // to the asker — no separate persistence required.
+    // Mount router #1, dispatch ask_human (which appends human_question),
+    // drop. Mount router #2, call reconstruct_from_log (the reopen entry
+    // point), then route human_response. The answer must still reach the
+    // original asker — no separate persistence layer.
     let dir = tempfile::tempdir().unwrap();
     let log = Arc::new(EventLog::open(dir.path()).unwrap());
     let roster = vec![crew_runner("lead", true), crew_runner("impl", false)];
@@ -441,7 +462,7 @@ fn pending_ask_map_reconstructs_from_log_on_reopen() {
         ))
         .unwrap();
 
-    // First mount processes only the ask, then is dropped.
+    // First mount handles the ask live (appends human_question).
     {
         let injector = Arc::new(RecordingInjector::default());
         let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
@@ -461,9 +482,21 @@ fn pending_ask_map_reconstructs_from_log_on_reopen() {
         ]);
         router.handle_event(&ask);
     }
+    // Capture the card id router #1 produced; we'll use it as
+    // human_response.payload.question_id below.
+    let card_id = read_signals(&log)
+        .into_iter()
+        .find(|s| {
+            s.signal_type
+                .as_ref()
+                .map(|t| t.as_str() == "human_question")
+                .unwrap_or(false)
+        })
+        .expect("router #1 must have appended human_question")
+        .id;
 
-    // Second mount: replay the log up to and including the ask, then route
-    // the response.
+    // Reopen: build router #2, fold projection state from history. This
+    // is the path mission_resume / mount-on-app-restart will follow.
     let injector = Arc::new(RecordingInjector::default());
     let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
     let router2 = Router::new(
@@ -480,19 +513,40 @@ fn pending_ask_map_reconstructs_from_log_on_reopen() {
         ("lead".into(), "S-LEAD".into()),
         ("impl".into(), "S-IMPL".into()),
     ]);
-    // Mirror what `BusEmitter` would do during initial replay: feed every
-    // historical envelope through `handle_event`. The router has no
-    // dispatch ledger — it just rebuilds the pending-ask map from the
-    // ask_human row it sees.
+    router2.reconstruct_from_log().unwrap();
+
+    // Replay the historical events through handle_event the way the bus's
+    // initial replay would. The watermark must short-circuit them so the
+    // ask_human is NOT re-handled (no second human_question card in the
+    // log) and the lead is NOT re-injected with anything.
+    let card_count_before = read_signals(&log)
+        .iter()
+        .filter(|s| s.signal_type.as_ref().map(|t| t.as_str() == "human_question").unwrap_or(false))
+        .count();
     for entry in log.read_from(0).unwrap() {
         router2.handle_event(&entry.event);
     }
+    let card_count_after = read_signals(&log)
+        .iter()
+        .filter(|s| s.signal_type.as_ref().map(|t| t.as_str() == "human_question").unwrap_or(false))
+        .count();
+    assert_eq!(
+        card_count_before, card_count_after,
+        "replay must NOT re-emit human_question cards",
+    );
+    assert!(
+        injector.all_pushes().is_empty(),
+        "replay must NOT re-inject historical stdin; got {:?}",
+        injector.all_pushes(),
+    );
 
+    // Now post a *new* response (id strictly greater than the watermark)
+    // and assert it routes to the asker the reconstruct path recovered.
     let resp = log
         .append(signal(
             "human",
             "human_response",
-            serde_json::json!({ "question_id": ask.id, "choice": "yes" }),
+            serde_json::json!({ "question_id": card_id, "choice": "yes" }),
         ))
         .unwrap();
     router2.handle_event(&resp);
@@ -500,8 +554,134 @@ fn pending_ask_map_reconstructs_from_log_on_reopen() {
     let lead_pushes = injector.pushes_for("S-LEAD");
     assert!(
         lead_pushes.iter().any(|p| p.contains("[human_response] yes")),
-        "after reopen + replay, response must route to original asker; got {lead_pushes:?}",
+        "after reopen + reconstruct, response must route to original asker; got {lead_pushes:?}",
     );
+}
+
+#[test]
+fn reconstruct_recovers_latest_runner_status_only() {
+    // Reopen-path test for arch §5.5.1: latest reported state per handle.
+    // busy → idle → busy must leave status[impl] = Busy after reconstruct,
+    // and no historical idle-notice should re-inject into the lead.
+    let dir = tempfile::tempdir().unwrap();
+    let log = Arc::new(EventLog::open(dir.path()).unwrap());
+    let roster = vec![crew_runner("lead", true), crew_runner("impl", false)];
+
+    log.append(signal(
+        "impl",
+        "runner_status",
+        serde_json::json!({ "state": "busy" }),
+    ))
+    .unwrap();
+    log.append(signal(
+        "impl",
+        "runner_status",
+        serde_json::json!({ "state": "idle", "note": "first idle" }),
+    ))
+    .unwrap();
+    log.append(signal(
+        "impl",
+        "runner_status",
+        serde_json::json!({ "state": "busy" }),
+    ))
+    .unwrap();
+
+    let injector = Arc::new(RecordingInjector::default());
+    let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
+    let router = Router::new(
+        "mission-1".into(),
+        "crew-1".into(),
+        "Crew One".into(),
+        &roster,
+        vec![],
+        log.clone(),
+        injector_dyn,
+    )
+    .unwrap();
+    router.register_sessions(&[
+        ("lead".into(), "S-LEAD".into()),
+        ("impl".into(), "S-IMPL".into()),
+    ]);
+    router.reconstruct_from_log().unwrap();
+
+    // Bus replay of the historical events must short-circuit; no idle
+    // notice is pushed to the lead, even though one of them is `idle`.
+    for entry in log.read_from(0).unwrap() {
+        router.handle_event(&entry.event);
+    }
+    assert!(
+        injector.all_pushes().is_empty(),
+        "historical idle must not push to lead on replay; got {:?}",
+        injector.all_pushes(),
+    );
+
+    // A *new* idle event after the watermark must push normally — proves
+    // the watermark only suppresses history, not live tail.
+    let live_idle = log
+        .append(signal(
+            "impl",
+            "runner_status",
+            serde_json::json!({ "state": "idle", "note": "live" }),
+        ))
+        .unwrap();
+    router.handle_event(&live_idle);
+    let lead_pushes = injector.pushes_for("S-LEAD");
+    assert_eq!(lead_pushes.len(), 1);
+    assert!(lead_pushes[0].contains("@impl is idle"));
+    assert!(lead_pushes[0].contains("live"));
+}
+
+#[test]
+fn fresh_mission_start_does_not_call_reconstruct_so_mission_goal_fires() {
+    // Regression on the reviewer's caveat: if a fresh-start mount called
+    // reconstruct_from_log() over the just-written opening events, the
+    // watermark would cover mission_goal and the lead would never receive
+    // its launch prompt. mission_start must skip reconstruct entirely.
+    // This test mirrors that path: pre-write opening events, build a
+    // router WITHOUT calling reconstruct, then replay through handle_event
+    // (what the bus does). The mission_goal handler must fire.
+    let dir = tempfile::tempdir().unwrap();
+    let log = Arc::new(EventLog::open(dir.path()).unwrap());
+    let roster = vec![crew_runner("lead", true)];
+
+    log.append(signal(
+        "system",
+        "mission_start",
+        serde_json::json!({ "title": "fresh" }),
+    ))
+    .unwrap();
+    log.append(signal(
+        "human",
+        "mission_goal",
+        serde_json::json!({ "text": "go" }),
+    ))
+    .unwrap();
+
+    let injector = Arc::new(RecordingInjector::default());
+    let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
+    let router = Router::new(
+        "mission-1".into(),
+        "crew-1".into(),
+        "Crew One".into(),
+        &roster,
+        vec![],
+        log.clone(),
+        injector_dyn,
+    )
+    .unwrap();
+    router.register_sessions(&[("lead".into(), "S-LEAD".into())]);
+    // NB: no reconstruct call. The bus's initial replay drives the
+    // bootstrap.
+    for entry in log.read_from(0).unwrap() {
+        router.handle_event(&entry.event);
+    }
+    let lead_pushes = injector.pushes_for("S-LEAD");
+    assert_eq!(
+        lead_pushes.len(),
+        1,
+        "mission_goal must fire on fresh start; got {lead_pushes:?}",
+    );
+    assert!(lead_pushes[0].contains("Goal: go"));
 }
 
 #[test]

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -180,6 +180,14 @@ impl SessionManager {
 
         let mut cmd = CommandBuilder::new(&runner.command);
         cmd.args(&runner.args);
+        // Append the runtime-specific flag that hands `system_prompt` to the
+        // child. Without this the user-authored brief on the runner row is
+        // dropped on the floor (arch §4.2 / §4.3).
+        for extra in
+            crate::router::runtime::system_prompt_args(&runner.runtime, runner.system_prompt.as_deref())
+        {
+            cmd.arg(extra);
+        }
 
         // Working directory: runner override if set, else mission cwd, else
         // inherit parent's. `CommandBuilder::cwd` requires a concrete path.
@@ -369,6 +377,15 @@ impl SessionManager {
 
         let mut cmd = CommandBuilder::new(&runner.command);
         cmd.args(&runner.args);
+        // Apply the same runtime adapter as the mission spawn so direct chat
+        // sessions also receive the runner's `system_prompt`. Direct chats
+        // get only the brief — no roster, no goal, no coordination notes —
+        // so this is strictly the per-runner default.
+        for extra in
+            crate::router::runtime::system_prompt_args(&runner.runtime, runner.system_prompt.as_deref())
+        {
+            cmd.arg(extra);
+        }
 
         // Working directory precedence: explicit `cwd` arg (the user picked
         // a folder in the Chat now dialog) ► runner's own `working_dir`

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -183,9 +183,10 @@ impl SessionManager {
         // Append the runtime-specific flag that hands `system_prompt` to the
         // child. Without this the user-authored brief on the runner row is
         // dropped on the floor (arch §4.2 / §4.3).
-        for extra in
-            crate::router::runtime::system_prompt_args(&runner.runtime, runner.system_prompt.as_deref())
-        {
+        for extra in crate::router::runtime::system_prompt_args(
+            &runner.runtime,
+            runner.system_prompt.as_deref(),
+        ) {
             cmd.arg(extra);
         }
 
@@ -381,9 +382,10 @@ impl SessionManager {
         // sessions also receive the runner's `system_prompt`. Direct chats
         // get only the brief — no roster, no goal, no coordination notes —
         // so this is strictly the per-runner default.
-        for extra in
-            crate::router::runtime::system_prompt_args(&runner.runtime, runner.system_prompt.as_deref())
-        {
+        for extra in crate::router::runtime::system_prompt_args(
+            &runner.runtime,
+            runner.system_prompt.as_deref(),
+        ) {
             cmd.arg(extra);
         }
 


### PR DESCRIPTION
## Summary
- Reframe C8 in the v0-mvp plan from "orchestrator v0" to "signal router v0" — a flat parent-process dispatcher, not a rule engine. The lead runner owns coordination judgment; C8 owns the plumbing the lead can't do from inside a child PTY (bootstrap, cross-process stdin push, UI bridge).
- Explicitly descope dispatch ledger / replay idempotence, inbox-summary enrichment, and the rule/policy abstraction. Each comes with a paragraph explaining why the lead handles the responsibility instead.
- Fold the previously-separate "Cross-cutting launch/prompt adapter" block into C8 — the prompt composer feeds the `mission_goal` handler directly.
- Sync `docs/tests/v0-mvp-tests.md`: drop the dispatch-ledger replay test and the `inject_stdin_*` audit-event tests, add `pending_ask_map_reconstructs_from_log_on_reopen`, add the runtime-adapter tests, and rewrite the `mission_e2e` driver pseudocode so stdin pushes are silent (no synthetic events for handler invocations).

## Why this changed

Previous plan's framing made C8 sound like a framework with a rule engine and audit-event ledger. In practice the only mechanisms MVP needs are five hardcoded `match` arms:

| Signal | Mechanism |
|---|---|
| `mission_goal` | Inject composed launch prompt to lead's stdin |
| `human_said` | Inject `payload.text` to `payload.target` (or lead) |
| `ask_lead` | Inject worker's `{question, context}` to lead's stdin |
| `ask_human` | Append `human_question` event for the workspace UI |
| `human_response` | Look up `question_id`, inject answer to original asker |

There's no policy to evolve and no rule to override, so the framework framing was buying complexity we'd never use. v0.x can revisit if user-defined signal types ship.

## Code path

No code changes in this PR — plan/test docs only. The implementation PR will rename `src-tauri/src/orchestrator/` → `src-tauri/src/router/` and ship the five handlers + the prompt composer + the runtime adapter (claude-code `--append-system-prompt` on both `spawn` and `spawn_direct`).

## Test plan
- [x] Plan and test docs are internally consistent (no orchestrator-as-engine references left except: historical reframing context, the actual SQL column name `crews.orchestrator_policy`, and the existing module-stub path being renamed)
- [ ] Reviewer agrees with the descope rationale before the implementation PR builds against this plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)