### PR TITLE
feature(c9): runner CLI binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,6 +530,52 @@ dependencies = [
  "wasm-bindgen",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1943,6 +2039,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2567,6 +2669,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "open"
@@ -3408,6 +3516,19 @@ dependencies = [
  "tauri-plugin-shell",
  "tempfile",
  "thiserror 1.0.69",
+ "ulid",
+]
+
+[[package]]
+name = "runner-cli"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "runner-core",
+ "serde",
+ "serde_json",
+ "tempfile",
  "ulid",
 ]
 
@@ -4979,6 +5100,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = [
     "src-tauri",
     "crates/runner-core",
+    "cli",
 ]
 
 [workspace.package]
@@ -11,6 +12,7 @@ authors = ["Jason Wang <yuesihan@gmail.com>"]
 
 [workspace.dependencies]
 chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive"] }
 fs2 = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "runner-cli"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+description = "Bundled `runner` CLI agents use to append signals/messages to a mission's NDJSON event log."
+
+# Bin name = "runner" so the on-disk file matches the PATH expectation in
+# `SessionManager::spawn` / `spawn_direct` ($APPDATA/runner/bin/runner).
+[[bin]]
+name = "runner"
+path = "src/main.rs"
+
+[dependencies]
+runner-core = { path = "../crates/runner-core" }
+clap = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+ulid = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -5,10 +5,13 @@ edition.workspace = true
 authors.workspace = true
 description = "Bundled `runner` CLI agents use to append signals/messages to a mission's NDJSON event log."
 
-# Bin name = "runner" so the on-disk file matches the PATH expectation in
-# `SessionManager::spawn` / `spawn_direct` ($APPDATA/runner/bin/runner).
+# Source-side bin name is `runner-cli` so it doesn't collide with the
+# Tauri app crate, which also produces a `runner` binary in the same
+# workspace `target/` dir. `cli_install` renames it to `runner` when
+# copying into `$APPDATA/runner/bin/` so the on-disk file at the PATH
+# expectation matches what `SessionManager::spawn` looks for.
 [[bin]]
-name = "runner"
+name = "runner-cli"
 path = "src/main.rs"
 
 [dependencies]

--- a/cli/src/allowlist.rs
+++ b/cli/src/allowlist.rs
@@ -1,0 +1,88 @@
+// Read the per-crew signal-types allowlist that `mission_start` writes
+// to `$APPDATA/runner/crews/{crew_id}/signal_types.json`. The CLI uses
+// this to reject `runner signal <type>` invocations whose type isn't on
+// the list (arch §5.3 Layer 2).
+//
+// Where it lives: two directories above the mission's events log. The
+// CLI receives the events-log path via `RUNNER_EVENT_LOG`, which is
+// `$APPDATA/runner/crews/{crew_id}/missions/{mission_id}/events.ndjson`.
+// `signal_types.json` lives at the crew level (one per crew, shared
+// across that crew's missions), so we walk up:
+//   events.ndjson → mission_dir → crew_dir → signal_types.json
+
+use std::path::{Path, PathBuf};
+
+/// Locate the allowlist sidecar from the events-log path.
+pub fn sidecar_path(event_log: &Path) -> Option<PathBuf> {
+    // events.ndjson → missions/{id}/ → crews/{crew_id}/
+    let crew_dir = event_log.parent()?.parent()?.parent()?;
+    Some(crew_dir.join("signal_types.json"))
+}
+
+/// Load the allowlist, or `None` if the sidecar is missing/unreadable.
+/// Missing-sidecar is treated permissively (the CLI prints a warning
+/// and accepts any signal type) only because losing the sidecar should
+/// not silently strand a running mission. The mission_start path always
+/// writes it; a missing file means something else is broken.
+pub fn load(event_log: &Path) -> Option<Vec<String>> {
+    let path = sidecar_path(event_log)?;
+    let bytes = std::fs::read(&path).ok()?;
+    serde_json::from_slice::<Vec<String>>(&bytes).ok()
+}
+
+/// Returns true if `ty` is allowed. If the allowlist can't be read, we
+/// permit (best-effort) but log to stderr so the operator notices.
+pub fn is_allowed(event_log: &Path, ty: &str) -> bool {
+    match load(event_log) {
+        Some(list) => list.iter().any(|t| t == ty),
+        None => {
+            eprintln!(
+                "runner: signal_types sidecar missing/unreadable; allowing {ty:?} permissively. \
+                 Re-run mission_start to restore the sidecar."
+            );
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sidecar_path_walks_up_three_levels() {
+        let log = Path::new("/data/runner/crews/CREW01/missions/MISS01/events.ndjson");
+        assert_eq!(
+            sidecar_path(log).unwrap(),
+            PathBuf::from("/data/runner/crews/CREW01/signal_types.json"),
+        );
+    }
+
+    #[test]
+    fn load_returns_some_for_valid_json_array() {
+        let dir = tempfile::tempdir().unwrap();
+        let crew = dir.path().join("crews/C");
+        let mission = crew.join("missions/M");
+        std::fs::create_dir_all(&mission).unwrap();
+        std::fs::write(
+            crew.join("signal_types.json"),
+            br#"["mission_goal","ask_lead"]"#,
+        )
+        .unwrap();
+        let log = mission.join("events.ndjson");
+        let list = load(&log).unwrap();
+        assert_eq!(
+            list,
+            vec!["mission_goal".to_string(), "ask_lead".to_string()]
+        );
+    }
+
+    #[test]
+    fn is_allowed_permits_when_sidecar_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("events.ndjson");
+        // No sidecar at all — permissive fallback. Stderr noise is fine
+        // for a buggy parent setup.
+        assert!(is_allowed(&log, "anything"));
+    }
+}

--- a/cli/src/env.rs
+++ b/cli/src/env.rs
@@ -1,0 +1,144 @@
+// Resolve the four `RUNNER_*` env vars that locate the caller in the
+// coordination bus. Mission sessions set all four (see
+// `SessionManager::spawn`); direct-chat sessions set none
+// (`spawn_direct`). Anything in between is a bug.
+//
+// We don't read any other env. PATH manipulation, signal handling, etc.
+// are out of scope — the parent process owns those.
+
+use std::path::PathBuf;
+
+const VAR_CREW: &str = "RUNNER_CREW_ID";
+const VAR_MISSION: &str = "RUNNER_MISSION_ID";
+const VAR_HANDLE: &str = "RUNNER_HANDLE";
+const VAR_LOG: &str = "RUNNER_EVENT_LOG";
+
+/// Per-process env after presence resolution.
+pub enum BusContext {
+    /// All four vars present — proceed normally.
+    Mission(MissionEnv),
+    /// None of the four set — direct-chat / off-bus session. The verb
+    /// caller should print a soft notice on stderr and exit 0 so the
+    /// agent process doesn't bail out.
+    OffBus,
+    /// Some-but-not-all set — the parent process is buggy. Bail with a
+    /// pointer at the missing names.
+    Partial { missing: Vec<&'static str> },
+}
+
+#[derive(Clone, Debug)]
+pub struct MissionEnv {
+    pub crew_id: String,
+    pub mission_id: String,
+    pub handle: String,
+    pub event_log: PathBuf,
+}
+
+pub fn resolve() -> BusContext {
+    resolve_from(|name| std::env::var(name).ok())
+}
+
+/// Test-friendly variant. Production goes through `resolve()`; tests
+/// inject their own lookup so they don't have to mutate the live env.
+pub fn resolve_from<F: Fn(&str) -> Option<String>>(get: F) -> BusContext {
+    let crew = get(VAR_CREW);
+    let mission = get(VAR_MISSION);
+    let handle = get(VAR_HANDLE);
+    let log = get(VAR_LOG);
+
+    let present = [
+        (VAR_CREW, crew.is_some()),
+        (VAR_MISSION, mission.is_some()),
+        (VAR_HANDLE, handle.is_some()),
+        (VAR_LOG, log.is_some()),
+    ];
+    let count = present.iter().filter(|(_, p)| *p).count();
+    if count == 0 {
+        return BusContext::OffBus;
+    }
+    if count < 4 {
+        let missing: Vec<&'static str> = present
+            .iter()
+            .filter(|(_, p)| !*p)
+            .map(|(n, _)| *n)
+            .collect();
+        return BusContext::Partial { missing };
+    }
+
+    BusContext::Mission(MissionEnv {
+        crew_id: crew.unwrap(),
+        mission_id: mission.unwrap(),
+        handle: handle.unwrap(),
+        event_log: PathBuf::from(log.unwrap()),
+    })
+}
+
+/// Top-level helper used by every verb except `help`. Encapsulates the
+/// "off-bus → notice + exit 0" / "partial → exit 2" boilerplate so the
+/// verb implementations stay focused on their actual work.
+///
+/// Returns `Some(MissionEnv)` to proceed, or `None` if the caller has
+/// already exited via the side-channels above.
+pub fn require_mission_or_handle_offbus(verb: &str) -> Option<MissionEnv> {
+    match resolve() {
+        BusContext::Mission(m) => Some(m),
+        BusContext::OffBus => {
+            // Soft no-op. arch §2.6 + the C8.5 risk: direct-chat sessions
+            // are off-bus by design; an agent that didn't read the system
+            // prompt and tried `runner status idle` here shouldn't crash.
+            eprintln!("runner {verb}: no mission context (RUNNER_* env vars unset); ignoring.");
+            std::process::exit(0);
+        }
+        BusContext::Partial { missing } => {
+            eprintln!(
+                "runner {verb}: missing required env var(s): {}",
+                missing.join(", ")
+            );
+            std::process::exit(2);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn lookup(map: HashMap<&'static str, &'static str>) -> impl Fn(&str) -> Option<String> {
+        move |name| map.get(name).map(|s| s.to_string())
+    }
+
+    #[test]
+    fn all_four_present_resolves_mission() {
+        let map = HashMap::from([
+            (VAR_CREW, "c"),
+            (VAR_MISSION, "m"),
+            (VAR_HANDLE, "impl"),
+            (VAR_LOG, "/tmp/events.ndjson"),
+        ]);
+        let BusContext::Mission(env) = resolve_from(lookup(map)) else {
+            panic!("expected Mission");
+        };
+        assert_eq!(env.crew_id, "c");
+        assert_eq!(env.mission_id, "m");
+        assert_eq!(env.handle, "impl");
+        assert_eq!(env.event_log, PathBuf::from("/tmp/events.ndjson"));
+    }
+
+    #[test]
+    fn none_set_is_off_bus() {
+        let map = HashMap::new();
+        assert!(matches!(resolve_from(lookup(map)), BusContext::OffBus));
+    }
+
+    #[test]
+    fn partial_set_lists_missing_vars() {
+        let map = HashMap::from([(VAR_CREW, "c"), (VAR_MISSION, "m")]);
+        let BusContext::Partial { missing } = resolve_from(lookup(map)) else {
+            panic!("expected Partial");
+        };
+        assert!(missing.contains(&VAR_HANDLE));
+        assert!(missing.contains(&VAR_LOG));
+        assert_eq!(missing.len(), 2);
+    }
+}

--- a/cli/src/help.rs
+++ b/cli/src/help.rs
@@ -1,0 +1,46 @@
+// `runner help` — long-form help, in the same shape as docs/arch
+// §6.3. clap's `--help` covers the short auto-generated form; this is
+// the verbose one with examples.
+
+pub fn print() {
+    println!(
+        r#"runner — coordinate with the rest of the crew via the mission event log.
+
+USAGE:
+  runner signal <type> [--payload <json>]
+  runner msg post <text> [--to <handle>]
+  runner msg read [--since <ulid>] [--from <handle>]
+  runner status busy|idle [--note <text>]
+  runner help
+
+ENVIRONMENT:
+  RUNNER_CREW_ID, RUNNER_MISSION_ID, RUNNER_HANDLE, RUNNER_EVENT_LOG
+  Set automatically by the parent app when this binary is spawned inside
+  a mission session. Direct-chat sessions intentionally don't set them;
+  every verb except `help` is a no-op in that context.
+
+EXAMPLES:
+  runner signal mission_goal --payload '{{"text":"ship v0"}}'
+      Emit a typed signal that the parent-process router handles.
+
+  runner msg post --to reviewer "ready for review on PR #42"
+      Direct message; lands in @reviewer's inbox only.
+
+  runner msg post "starting work on feature X"
+      Broadcast; lands in every crewmate's inbox.
+
+  runner msg read --since 01HG... --from coder
+      Print messages addressed to you (broadcasts + directs) since the
+      given ULID, optionally filtered by sender. Emits inbox_read on
+      success so the parent's watermark advances.
+
+  runner status idle --note "ready for next task"
+      Sugar for `runner signal runner_status --payload {{state, note}}`.
+      The router uses this to wake the lead when a worker becomes idle.
+
+DOCS:
+  Architecture: docs/arch/v0-arch.md (§5 coordination bus, §6.3 CLI)
+  Implementation: docs/impls/v0-mvp.md (C9 — runner CLI binary)
+"#
+    );
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,102 @@
+// `runner` — the bundled CLI that agents inside spawned PTYs invoke to
+// append to the mission's NDJSON event log. See `docs/arch/v0-arch.md`
+// §6.3 for the user-facing surface and `docs/impls/v0-mvp.md#C9` for the
+// chunk's scope.
+//
+// Design notes:
+// - Thin shell over `runner_core::event_log`. The CLI never reimplements
+//   log semantics (flock, monotonic ULIDs, lossy reads); it owns only env
+//   resolution, sidecar reads, and verb dispatch.
+// - Direct-chat sessions deliberately set no `RUNNER_*` env vars
+//   (`SessionManager::spawn_direct`). Every verb except `help` checks the
+//   env up front: all-set → run; none-set → exit 0 with a stderr nudge
+//   (so a curious agent calling `runner status idle` in a chat doesn't
+//   crash); partially set → exit 2 with a precise pointer at which var
+//   is missing.
+
+mod allowlist;
+mod env;
+mod help;
+mod msg;
+mod roster;
+mod signal;
+
+use clap::{Parser, Subcommand};
+
+#[derive(Parser, Debug)]
+#[command(
+    name = "runner",
+    about = "Coordinate with the rest of the crew via the mission event log.",
+    version,
+    // Our `Help` subcommand prints the long-form usage from arch §6.3.
+    // clap also auto-generates a `help` subcommand by default; disable
+    // it so the two don't collide.
+    disable_help_subcommand = true
+)]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand, Debug)]
+enum Cmd {
+    /// Emit a typed signal that the parent-process router handles.
+    Signal {
+        /// Signal type (must be in the crew's signal_types allowlist).
+        r#type: String,
+        /// Optional JSON payload object. Defaults to `{}`.
+        #[arg(long)]
+        payload: Option<String>,
+    },
+    /// Post or read prose messages.
+    Msg {
+        #[command(subcommand)]
+        cmd: MsgCmd,
+    },
+    /// Sugar over `signal runner_status` — report `busy` or `idle`.
+    Status {
+        state: String,
+        #[arg(long)]
+        note: Option<String>,
+    },
+    /// Print usage help.
+    Help,
+}
+
+#[derive(Subcommand, Debug)]
+enum MsgCmd {
+    /// Post a message — broadcast unless `--to <handle>` is given.
+    Post {
+        text: String,
+        #[arg(long)]
+        to: Option<String>,
+    },
+    /// Print the caller's inbox; emits `signal inbox_read` on success.
+    Read {
+        /// Lower-bound by ULID; messages with id ≤ this are skipped.
+        #[arg(long)]
+        since: Option<String>,
+        /// Filter by sender handle.
+        #[arg(long)]
+        from: Option<String>,
+    },
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let code = match cli.cmd {
+        Cmd::Help => {
+            help::print();
+            0
+        }
+        Cmd::Signal { r#type, payload } => signal::run(&r#type, payload.as_deref()),
+        Cmd::Status { state, note } => signal::run_status(&state, note.as_deref()),
+        Cmd::Msg {
+            cmd: MsgCmd::Post { text, to },
+        } => msg::post(&text, to.as_deref()),
+        Cmd::Msg {
+            cmd: MsgCmd::Read { since, from },
+        } => msg::read(since.as_deref(), from.as_deref()),
+    };
+    std::process::exit(code);
+}

--- a/cli/src/msg.rs
+++ b/cli/src/msg.rs
@@ -127,24 +127,38 @@ pub fn read(since: Option<&str>, from: Option<&str>) -> i32 {
         print_message(ev);
     }
 
-    // Emit `inbox_read` only when something was actually shown — an empty
-    // inbox shouldn't generate noise (or a redundant watermark) in the
-    // log. The bus de-dupes redundant up_to values anyway, but skipping
-    // here keeps the log readable.
-    if let Some(last) = printed.last() {
-        let draft = EventDraft {
-            crew_id: env.crew_id.clone(),
-            mission_id: env.mission_id.clone(),
-            kind: EventKind::Signal,
-            from: env.handle.clone(),
-            to: None,
-            signal_type: Some(SignalType::new("inbox_read")),
-            payload: serde_json::json!({ "up_to": last.id }),
-        };
-        if let Err(e) = log.append(draft) {
-            eprintln!("runner msg read: failed to emit inbox_read: {e}");
-            // Still exit 0 — the user got their messages; failing to
-            // mark them read is a UI-only annoyance.
+    // Emit `inbox_read` only when:
+    //   1. Something was actually shown — an empty inbox shouldn't add
+    //      noise (or a redundant watermark) to the log.
+    //   2. The read was NOT filtered by `--from`. The bus's per-runner
+    //      watermark is global across the inbox projection (any inbox
+    //      message with `id <= up_to` is marked read). If we advance
+    //      it from a filtered read, unread messages from other senders
+    //      whose ids fall below the printed `up_to` get silently
+    //      cleared without ever being shown — exactly the corruption
+    //      the reviewer caught. See the bus's `handle_inbox_read` in
+    //      `src-tauri/src/event_bus/mod.rs`.
+    //
+    // `--since` is safe: it's a forward filter on the already-watermark-
+    // ordered projection, so a printed last id is still a sound
+    // upper-bound on "everything ≤ here has been seen".
+    let safe_to_advance_watermark = from.is_none();
+    if safe_to_advance_watermark {
+        if let Some(last) = printed.last() {
+            let draft = EventDraft {
+                crew_id: env.crew_id.clone(),
+                mission_id: env.mission_id.clone(),
+                kind: EventKind::Signal,
+                from: env.handle.clone(),
+                to: None,
+                signal_type: Some(SignalType::new("inbox_read")),
+                payload: serde_json::json!({ "up_to": last.id }),
+            };
+            if let Err(e) = log.append(draft) {
+                eprintln!("runner msg read: failed to emit inbox_read: {e}");
+                // Still exit 0 — the user got their messages; failing
+                // to mark them read is a UI-only annoyance.
+            }
         }
     }
     0

--- a/cli/src/msg.rs
+++ b/cli/src/msg.rs
@@ -1,0 +1,210 @@
+// `runner msg post` and `runner msg read`.
+//
+// Post: append one `EventDraft::message` (broadcast if `--to` is None;
+// directed otherwise). The recipient must be in the per-mission roster
+// sidecar so typos can't silently land in nobody's inbox.
+//
+// Read: project the caller's inbox — `kind = "message" AND (to == null
+// OR to == handle)` — apply the optional `--since` / `--from` filters,
+// print in append order, and (only on success with at least one message
+// printed) emit a single `signal inbox_read` with `payload.up_to = max
+// printed ULID`. The watermark advance is what C7's `EventBus` consumes
+// to clear unread badges.
+
+use runner_core::event_log::EventLog;
+use runner_core::model::{Event, EventDraft, EventKind, SignalType};
+
+use crate::{env, roster};
+
+pub fn post(text: &str, to: Option<&str>) -> i32 {
+    let Some(env) = env::require_mission_or_handle_offbus("msg post") else {
+        return 0;
+    };
+
+    if let Some(handle) = to {
+        if !roster::is_known(&env.event_log, handle) {
+            eprintln!(
+                "runner msg post: --to @{handle} is not in this mission's roster. \
+                 Use one of the handles printed by `runner msg read --from <handle>` \
+                 or check the mission workspace's runner rail."
+            );
+            return 1;
+        }
+    }
+
+    let Some(mission_dir) = env.event_log.parent() else {
+        eprintln!(
+            "runner: RUNNER_EVENT_LOG has no parent directory: {}",
+            env.event_log.display()
+        );
+        return 2;
+    };
+    let log = match EventLog::open(mission_dir) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("runner: failed to open event log: {e}");
+            return 1;
+        }
+    };
+
+    let draft = EventDraft {
+        crew_id: env.crew_id.clone(),
+        mission_id: env.mission_id.clone(),
+        kind: EventKind::Message,
+        from: env.handle.clone(),
+        to: to.map(String::from),
+        signal_type: None,
+        payload: serde_json::json!({ "text": text }),
+    };
+    match log.append(draft) {
+        Ok(_ev) => 0,
+        Err(e) => {
+            eprintln!("runner: append failed: {e}");
+            1
+        }
+    }
+}
+
+pub fn read(since: Option<&str>, from: Option<&str>) -> i32 {
+    let Some(env) = env::require_mission_or_handle_offbus("msg read") else {
+        return 0;
+    };
+
+    let Some(mission_dir) = env.event_log.parent() else {
+        eprintln!(
+            "runner: RUNNER_EVENT_LOG has no parent directory: {}",
+            env.event_log.display()
+        );
+        return 2;
+    };
+    let log = match EventLog::open(mission_dir) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("runner: failed to open event log: {e}");
+            return 1;
+        }
+    };
+
+    // Lossy read so a single bad NDJSON line doesn't make `runner msg
+    // read` return non-zero in the middle of an otherwise healthy
+    // session. Mirrors `event_bus` and `Router::reconstruct_from_log`.
+    let entries = match log.read_from_lossy(0) {
+        Ok((entries, skipped)) => {
+            for skip in &skipped {
+                eprintln!(
+                    "runner msg read: skipping malformed line at offset {} ({})",
+                    skip.offset, skip.error
+                );
+            }
+            entries
+        }
+        Err(e) => {
+            eprintln!("runner msg read: failed to read event log: {e}");
+            return 1;
+        }
+    };
+
+    let mut printed: Vec<&Event> = Vec::new();
+    for entry in &entries {
+        let ev = &entry.event;
+        if !is_inbox(ev, &env.handle) {
+            continue;
+        }
+        if let Some(s) = since {
+            if ev.id.as_bytes() <= s.as_bytes() {
+                continue;
+            }
+        }
+        if let Some(sender) = from {
+            if ev.from != sender {
+                continue;
+            }
+        }
+        printed.push(ev);
+    }
+
+    for ev in &printed {
+        print_message(ev);
+    }
+
+    // Emit `inbox_read` only when something was actually shown — an empty
+    // inbox shouldn't generate noise (or a redundant watermark) in the
+    // log. The bus de-dupes redundant up_to values anyway, but skipping
+    // here keeps the log readable.
+    if let Some(last) = printed.last() {
+        let draft = EventDraft {
+            crew_id: env.crew_id.clone(),
+            mission_id: env.mission_id.clone(),
+            kind: EventKind::Signal,
+            from: env.handle.clone(),
+            to: None,
+            signal_type: Some(SignalType::new("inbox_read")),
+            payload: serde_json::json!({ "up_to": last.id }),
+        };
+        if let Err(e) = log.append(draft) {
+            eprintln!("runner msg read: failed to emit inbox_read: {e}");
+            // Still exit 0 — the user got their messages; failing to
+            // mark them read is a UI-only annoyance.
+        }
+    }
+    0
+}
+
+fn is_inbox(ev: &Event, handle: &str) -> bool {
+    if !matches!(ev.kind, EventKind::Message) {
+        return false;
+    }
+    match ev.to.as_deref() {
+        None => true,
+        Some(target) => target == handle,
+    }
+}
+
+fn print_message(ev: &Event) {
+    let to = ev.to.as_deref().unwrap_or("*");
+    let text = ev
+        .payload
+        .get("text")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    println!(
+        "[{ts}] @{from} -> @{to}: {text}",
+        ts = ev.ts.to_rfc3339(),
+        from = ev.from,
+    );
+    println!("  id: {}", ev.id);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use runner_core::model::Event;
+
+    fn msg(id: &str, from: &str, to: Option<&str>) -> Event {
+        Event {
+            id: id.to_string(),
+            ts: chrono::Utc::now(),
+            crew_id: "c".into(),
+            mission_id: "m".into(),
+            kind: EventKind::Message,
+            from: from.into(),
+            to: to.map(String::from),
+            signal_type: None,
+            payload: serde_json::json!({ "text": "hi" }),
+        }
+    }
+
+    #[test]
+    fn inbox_includes_broadcast_and_directed_to_self_only() {
+        assert!(is_inbox(&msg("1", "lead", None), "impl"));
+        assert!(is_inbox(&msg("1", "lead", Some("impl")), "impl"));
+        assert!(!is_inbox(&msg("1", "lead", Some("reviewer")), "impl"));
+    }
+
+    #[test]
+    fn signals_never_appear_in_inbox() {
+        let mut ev = msg("1", "lead", None);
+        ev.kind = EventKind::Signal;
+        assert!(!is_inbox(&ev, "impl"));
+    }
+}

--- a/cli/src/roster.rs
+++ b/cli/src/roster.rs
@@ -1,0 +1,85 @@
+// Read the per-mission roster sidecar that `mission_start` writes to
+// `$APPDATA/runner/crews/{crew_id}/missions/{mission_id}/roster.json`.
+// The CLI uses it to validate `runner msg post --to <handle>` (I2.4).
+//
+// Per-mission, not per-crew, so historical missions validate `--to`
+// against the roster frozen at mission_start — even if crew membership
+// later changes.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RosterEntry {
+    pub handle: String,
+    pub lead: bool,
+}
+
+/// Locate the sidecar from the events-log path. The roster.json sits in
+/// the same mission directory as events.ndjson.
+pub fn sidecar_path(event_log: &Path) -> Option<PathBuf> {
+    let mission_dir = event_log.parent()?;
+    Some(mission_dir.join("roster.json"))
+}
+
+pub fn load(event_log: &Path) -> Option<Vec<RosterEntry>> {
+    let path = sidecar_path(event_log)?;
+    let bytes = std::fs::read(&path).ok()?;
+    serde_json::from_slice::<Vec<RosterEntry>>(&bytes).ok()
+}
+
+/// Returns true if `handle` is in the roster. Missing-sidecar is
+/// permissive for the same reason as the allowlist (a missing roster
+/// sidecar means something is broken upstream — don't strand the
+/// mission). Stderr warning surfaces the gap.
+pub fn is_known(event_log: &Path, handle: &str) -> bool {
+    match load(event_log) {
+        Some(list) => list.iter().any(|r| r.handle == handle),
+        None => {
+            eprintln!(
+                "runner: roster sidecar missing/unreadable; allowing --to @{handle} permissively. \
+                 Re-run mission_start to restore the sidecar."
+            );
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sidecar_path_is_in_same_dir_as_events() {
+        let log = Path::new("/data/runner/crews/C/missions/M/events.ndjson");
+        assert_eq!(
+            sidecar_path(log).unwrap(),
+            PathBuf::from("/data/runner/crews/C/missions/M/roster.json"),
+        );
+    }
+
+    #[test]
+    fn load_parses_lead_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        let mission = dir.path().join("crews/C/missions/M");
+        std::fs::create_dir_all(&mission).unwrap();
+        std::fs::write(
+            mission.join("roster.json"),
+            br#"[{"handle":"lead","lead":true},{"handle":"impl","lead":false}]"#,
+        )
+        .unwrap();
+        let log = mission.join("events.ndjson");
+        let r = load(&log).unwrap();
+        assert_eq!(r.len(), 2);
+        assert!(r.iter().any(|e| e.handle == "lead" && e.lead));
+        assert!(r.iter().any(|e| e.handle == "impl" && !e.lead));
+    }
+
+    #[test]
+    fn is_known_permits_when_sidecar_missing() {
+        let dir = tempfile::tempdir().unwrap();
+        let log = dir.path().join("events.ndjson");
+        assert!(is_known(&log, "anyone"));
+    }
+}

--- a/cli/src/signal.rs
+++ b/cli/src/signal.rs
@@ -1,0 +1,110 @@
+// `runner signal <type> [--payload <json>]` and the `runner status` sugar
+// wrapper. Both append a single `EventDraft::signal` line to the
+// mission's NDJSON event log via `runner_core::event_log::EventLog`.
+//
+// Per arch §5.2, signals always carry `to: null`; per-target routing
+// lives in `payload.target` (only `human_said` uses this in v0). The CLI
+// preserves this — `--to` is intentionally not exposed for `signal`.
+
+use runner_core::event_log::EventLog;
+use runner_core::model::{EventDraft, EventKind, SignalType};
+
+use crate::{allowlist, env};
+
+pub fn run(ty: &str, payload: Option<&str>) -> i32 {
+    let Some(env) = env::require_mission_or_handle_offbus("signal") else {
+        return 0; // unreachable in practice; the helper exits or returns Some.
+    };
+
+    if !allowlist::is_allowed(&env.event_log, ty) {
+        eprintln!(
+            "runner signal: {ty:?} is not in the crew's signal_types allowlist. \
+             Edit the crew's signal types in the app, then re-run mission_start \
+             to refresh the sidecar."
+        );
+        return 1;
+    }
+
+    let payload_value = match payload {
+        Some(s) => match serde_json::from_str::<serde_json::Value>(s) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("runner signal: --payload is not valid JSON: {e}");
+                return 1;
+            }
+        },
+        None => serde_json::json!({}),
+    };
+
+    append(&env, ty, payload_value)
+}
+
+/// `runner status busy|idle [--note <text>]` — emits a `runner_status`
+/// signal with the validated state. Validation lives here so the CLI can
+/// reject typos like `runner status sleeping` before they hit the log.
+pub fn run_status(state: &str, note: Option<&str>) -> i32 {
+    let normalized = match state {
+        "busy" | "idle" => state,
+        other => {
+            eprintln!("runner status: state must be \"busy\" or \"idle\"; got {other:?}");
+            return 1;
+        }
+    };
+    let mut payload = serde_json::Map::new();
+    payload.insert(
+        "state".into(),
+        serde_json::Value::String(normalized.to_string()),
+    );
+    if let Some(n) = note {
+        payload.insert("note".into(), serde_json::Value::String(n.to_string()));
+    }
+    let value = serde_json::Value::Object(payload);
+
+    let Some(env) = env::require_mission_or_handle_offbus("status") else {
+        return 0;
+    };
+    // `runner_status` is in the default allowlist (see C1 seed) but we
+    // still go through the same check so a user who removed it sees the
+    // same rejection path as any other signal.
+    if !allowlist::is_allowed(&env.event_log, "runner_status") {
+        eprintln!("runner status: runner_status is not in the crew's signal_types allowlist.");
+        return 1;
+    }
+    append(&env, "runner_status", value)
+}
+
+fn append(env: &env::MissionEnv, ty: &str, payload: serde_json::Value) -> i32 {
+    // `EventLog::open` recreates the dir if needed; here it just resolves
+    // the existing mission_dir. The flock + ULID floor logic lives there.
+    let Some(mission_dir) = env.event_log.parent() else {
+        eprintln!(
+            "runner: RUNNER_EVENT_LOG has no parent directory: {}",
+            env.event_log.display()
+        );
+        return 2;
+    };
+    let log = match EventLog::open(mission_dir) {
+        Ok(l) => l,
+        Err(e) => {
+            eprintln!("runner: failed to open event log: {e}");
+            return 1;
+        }
+    };
+
+    let draft = EventDraft {
+        crew_id: env.crew_id.clone(),
+        mission_id: env.mission_id.clone(),
+        kind: EventKind::Signal,
+        from: env.handle.clone(),
+        to: None,
+        signal_type: Some(SignalType::new(ty)),
+        payload,
+    };
+    match log.append(draft) {
+        Ok(_ev) => 0,
+        Err(e) => {
+            eprintln!("runner: append failed: {e}");
+            1
+        }
+    }
+}

--- a/cli/tests/roundtrip.rs
+++ b/cli/tests/roundtrip.rs
@@ -1,0 +1,418 @@
+// I2 — `runner` CLI ↔ event log roundtrip.
+// Mirrors docs/tests/v0-mvp-tests.md `## I2`.
+//
+// Each test sets up a tempdir mission directory, seeds the signal-types
+// and roster sidecars (the parts `mission_start` would write), spawns
+// the just-built `runner` binary with the four `RUNNER_*` env vars
+// pointing at it, and asserts on the resulting NDJSON.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use runner_core::event_log::EventLog;
+use runner_core::model::EventKind;
+
+/// Locate the `runner` binary built by `cargo build -p runner-cli`.
+/// `CARGO_BIN_EXE_runner` is set by Cargo for integration tests of the
+/// crate that defines the binary.
+fn runner_bin() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_runner"))
+}
+
+struct Fixture {
+    _root: tempfile::TempDir,
+    crew_dir: PathBuf,
+    mission_dir: PathBuf,
+    events_log: PathBuf,
+}
+
+impl Fixture {
+    fn new(crew_id: &str, mission_id: &str) -> Self {
+        let root = tempfile::tempdir().unwrap();
+        let crew_dir = root.path().join("crews").join(crew_id);
+        let mission_dir = crew_dir.join("missions").join(mission_id);
+        std::fs::create_dir_all(&mission_dir).unwrap();
+        let events_log = mission_dir.join("events.ndjson");
+        Self {
+            _root: root,
+            crew_dir,
+            mission_dir,
+            events_log,
+        }
+    }
+
+    fn write_signal_types(&self, types: &[&str]) {
+        let json = serde_json::to_vec(types).unwrap();
+        std::fs::write(self.crew_dir.join("signal_types.json"), json).unwrap();
+    }
+
+    fn write_roster(&self, members: &[(&str, bool)]) {
+        let entries: Vec<serde_json::Value> = members
+            .iter()
+            .map(|(h, lead)| serde_json::json!({ "handle": h, "lead": lead }))
+            .collect();
+        std::fs::write(
+            self.mission_dir.join("roster.json"),
+            serde_json::to_vec(&entries).unwrap(),
+        )
+        .unwrap();
+    }
+
+    fn cmd(&self, handle: &str, args: &[&str]) -> Command {
+        let mut cmd = Command::new(runner_bin());
+        cmd.args(args);
+        cmd.env("RUNNER_CREW_ID", "C");
+        cmd.env("RUNNER_MISSION_ID", "M");
+        cmd.env("RUNNER_HANDLE", handle);
+        cmd.env("RUNNER_EVENT_LOG", &self.events_log);
+        cmd
+    }
+
+    fn read_log(&self) -> Vec<runner_core::model::Event> {
+        if !self.events_log.exists() {
+            return vec![];
+        }
+        let log = EventLog::open(self.events_log.parent().unwrap()).unwrap();
+        log.read_from(0)
+            .unwrap()
+            .into_iter()
+            .map(|e| e.event)
+            .collect()
+    }
+
+    fn line_count(&self) -> usize {
+        std::fs::read_to_string(&self.events_log)
+            .map(|s| s.lines().filter(|l| !l.is_empty()).count())
+            .unwrap_or(0)
+    }
+}
+
+fn standard_signals() -> Vec<&'static str> {
+    vec![
+        "mission_goal",
+        "human_said",
+        "ask_lead",
+        "ask_human",
+        "human_question",
+        "human_response",
+        "runner_status",
+        "inbox_read",
+    ]
+}
+
+#[test]
+fn i2_1_signal_appends_one_line_with_correct_envelope() {
+    let f = Fixture::new("C", "M");
+    f.write_signal_types(&standard_signals());
+
+    let out = f
+        .cmd(
+            "impl",
+            &["signal", "mission_goal", "--payload", r#"{"text":"go"}"#],
+        )
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let events = f.read_log();
+    assert_eq!(events.len(), 1);
+    let ev = &events[0];
+    assert!(matches!(ev.kind, EventKind::Signal));
+    assert_eq!(ev.from, "impl");
+    assert_eq!(ev.to, None);
+    assert_eq!(ev.signal_type.as_ref().unwrap().as_str(), "mission_goal");
+    assert_eq!(ev.payload["text"], "go");
+}
+
+#[test]
+fn i2_2_signal_rejects_unknown_type_and_does_not_append() {
+    let f = Fixture::new("C", "M");
+    f.write_signal_types(&standard_signals());
+
+    let out = f
+        .cmd("impl", &["signal", "not_a_real_type"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("allowlist") || stderr.contains("signal_types"),
+        "stderr should point at the allowlist; got: {stderr}",
+    );
+    assert_eq!(f.line_count(), 0);
+}
+
+#[test]
+fn i2_3_msg_post_to_handle_routes_directed() {
+    let f = Fixture::new("C", "M");
+    f.write_signal_types(&standard_signals());
+    f.write_roster(&[("lead", true), ("impl", false)]);
+
+    let out = f
+        .cmd("lead", &["msg", "post", "ready for review", "--to", "impl"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let events = f.read_log();
+    assert_eq!(events.len(), 1);
+    let ev = &events[0];
+    assert!(matches!(ev.kind, EventKind::Message));
+    assert_eq!(ev.from, "lead");
+    assert_eq!(ev.to.as_deref(), Some("impl"));
+    assert_eq!(ev.payload["text"], "ready for review");
+}
+
+#[test]
+fn i2_4_msg_post_to_unknown_handle_is_rejected() {
+    let f = Fixture::new("C", "M");
+    f.write_signal_types(&standard_signals());
+    f.write_roster(&[("lead", true), ("impl", false)]);
+
+    let out = f
+        .cmd("lead", &["msg", "post", "hi", "--to", "ghost"])
+        .output()
+        .unwrap();
+    assert!(!out.status.success());
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("@ghost") || stderr.contains("roster"),
+        "stderr should mention the unknown handle; got: {stderr}",
+    );
+    assert_eq!(f.line_count(), 0);
+}
+
+#[test]
+fn i2_5_msg_read_prints_inbox_in_order_and_emits_inbox_read() {
+    let f = Fixture::new("C", "M");
+    f.write_signal_types(&standard_signals());
+    f.write_roster(&[("lead", true), ("impl", false)]);
+
+    // Pre-populate two directed messages to @impl from @lead.
+    let log = EventLog::open(&f.mission_dir).unwrap();
+    use runner_core::model::EventDraft;
+    let m1 = log
+        .append(EventDraft::message(
+            "C",
+            "M",
+            "lead",
+            Some("impl".into()),
+            "first",
+        ))
+        .unwrap();
+    let m2 = log
+        .append(EventDraft::message(
+            "C",
+            "M",
+            "lead",
+            Some("impl".into()),
+            "second",
+        ))
+        .unwrap();
+
+    let out = f.cmd("impl", &["msg", "read"]).output().unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let first_pos = stdout.find("first").expect("first message in stdout");
+    let second_pos = stdout.find("second").expect("second message in stdout");
+    assert!(
+        first_pos < second_pos,
+        "messages must print in append order"
+    );
+
+    // The CLI appended one inbox_read with up_to = m2.id.
+    let events = f.read_log();
+    let last = events.last().unwrap();
+    assert_eq!(last.signal_type.as_ref().unwrap().as_str(), "inbox_read");
+    assert_eq!(last.from, "impl");
+    assert_eq!(last.payload["up_to"], m2.id);
+    assert_ne!(last.payload["up_to"], m1.id);
+}
+
+#[test]
+fn i2_5b_msg_read_with_empty_inbox_does_not_emit_inbox_read() {
+    let f = Fixture::new("C", "M");
+    f.write_signal_types(&standard_signals());
+    f.write_roster(&[("lead", true), ("impl", false)]);
+
+    let out = f.cmd("impl", &["msg", "read"]).output().unwrap();
+    assert!(out.status.success());
+    assert_eq!(f.line_count(), 0, "empty inbox must not emit inbox_read");
+}
+
+#[test]
+fn i2_6_status_idle_emits_runner_status_signal() {
+    let f = Fixture::new("C", "M");
+    f.write_signal_types(&standard_signals());
+
+    let out = f
+        .cmd("impl", &["status", "idle", "--note", "ready for next task"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let events = f.read_log();
+    assert_eq!(events.len(), 1);
+    let ev = &events[0];
+    assert!(matches!(ev.kind, EventKind::Signal));
+    assert_eq!(ev.signal_type.as_ref().unwrap().as_str(), "runner_status");
+    assert_eq!(ev.from, "impl");
+    assert_eq!(ev.payload["state"], "idle");
+    assert_eq!(ev.payload["note"], "ready for next task");
+}
+
+#[test]
+fn i2_6b_status_rejects_unknown_state() {
+    let f = Fixture::new("C", "M");
+    f.write_signal_types(&standard_signals());
+
+    let out = f.cmd("impl", &["status", "sleeping"]).output().unwrap();
+    assert!(!out.status.success());
+    assert_eq!(f.line_count(), 0);
+}
+
+#[test]
+fn i2_7_concurrent_writers_interleave_atomically() {
+    let f = Fixture::new("C", "M");
+    f.write_signal_types(&standard_signals());
+
+    // 5 workers × 20 invocations = 100 lines. Cut down from the spec's
+    // 10×100 because we're spawning real processes; 100 is enough to
+    // exercise the flock contract without burning CI minutes on
+    // process spawn overhead.
+    let workers = 5usize;
+    let per_worker = 20usize;
+    let bin = runner_bin();
+    let log = f.events_log.clone();
+    let handles: Vec<_> = (0..workers)
+        .map(|w| {
+            let bin = bin.clone();
+            let log = log.clone();
+            std::thread::spawn(move || {
+                for _ in 0..per_worker {
+                    let status = Command::new(&bin)
+                        .args(["signal", "human_said", "--payload", r#"{"text":"x"}"#])
+                        .env("RUNNER_CREW_ID", "C")
+                        .env("RUNNER_MISSION_ID", "M")
+                        .env("RUNNER_HANDLE", format!("worker{w}"))
+                        .env("RUNNER_EVENT_LOG", &log)
+                        .status()
+                        .unwrap();
+                    assert!(status.success(), "worker {w} signal failed");
+                }
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    let total = workers * per_worker;
+    assert_eq!(
+        f.line_count(),
+        total,
+        "every invocation must produce one line"
+    );
+    let events = f.read_log();
+    assert_eq!(
+        events.len(),
+        total,
+        "every line must parse as a complete event"
+    );
+
+    // ULIDs strictly monotonic — the EventLog flock contract.
+    for w in events.windows(2) {
+        assert!(
+            w[0].id.as_bytes() < w[1].id.as_bytes(),
+            "ULIDs must be strictly monotonic: {} ≥ {}",
+            w[0].id,
+            w[1].id,
+        );
+    }
+}
+
+#[test]
+fn i2_8_partial_env_fails_fast_with_pointer() {
+    // RUNNER_EVENT_LOG missing while the other three are set should
+    // produce a non-zero exit and a stderr message naming the missing
+    // var. Off-bus (none-set) is a separate test below.
+    let f = Fixture::new("C", "M");
+    f.write_signal_types(&standard_signals());
+
+    let mut cmd = Command::new(runner_bin());
+    cmd.args(["signal", "mission_goal"]);
+    cmd.env("RUNNER_CREW_ID", "C");
+    cmd.env("RUNNER_MISSION_ID", "M");
+    cmd.env("RUNNER_HANDLE", "impl");
+    // Deliberately do not set RUNNER_EVENT_LOG; also unset any inherited
+    // one to avoid cross-test bleed-through.
+    cmd.env_remove("RUNNER_EVENT_LOG");
+
+    let out = cmd.output().unwrap();
+    assert!(!out.status.success(), "expected non-zero exit");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("RUNNER_EVENT_LOG"),
+        "stderr should name the missing env var; got: {stderr}",
+    );
+    assert_eq!(f.line_count(), 0);
+}
+
+#[test]
+fn off_bus_with_no_env_vars_exits_zero_with_notice() {
+    // Direct-chat sessions deliberately set none of the four. The CLI
+    // must no-op cleanly so an agent that calls `runner status idle` in
+    // a direct chat doesn't crash.
+    let mut cmd = Command::new(runner_bin());
+    cmd.args(["status", "idle"]);
+    cmd.env_remove("RUNNER_CREW_ID");
+    cmd.env_remove("RUNNER_MISSION_ID");
+    cmd.env_remove("RUNNER_HANDLE");
+    cmd.env_remove("RUNNER_EVENT_LOG");
+
+    let out = cmd.output().unwrap();
+    assert!(out.status.success(), "off-bus must exit 0");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("no mission context") || stderr.contains("ignoring"),
+        "stderr should explain the no-op; got: {stderr}",
+    );
+}
+
+#[test]
+fn help_works_without_env_vars() {
+    let mut cmd = Command::new(runner_bin());
+    cmd.args(["help"]);
+    cmd.env_remove("RUNNER_CREW_ID");
+    cmd.env_remove("RUNNER_MISSION_ID");
+    cmd.env_remove("RUNNER_HANDLE");
+    cmd.env_remove("RUNNER_EVENT_LOG");
+
+    let out = cmd.output().unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("USAGE"));
+    assert!(stdout.contains("runner signal"));
+    assert!(stdout.contains("runner msg"));
+}
+
+// Avoid unused-warning on Path import when the file body changes.
+#[allow(dead_code)]
+fn _path_marker(_p: &Path) {}

--- a/cli/tests/roundtrip.rs
+++ b/cli/tests/roundtrip.rs
@@ -12,11 +12,13 @@ use std::process::Command;
 use runner_core::event_log::EventLog;
 use runner_core::model::EventKind;
 
-/// Locate the `runner` binary built by `cargo build -p runner-cli`.
-/// `CARGO_BIN_EXE_runner` is set by Cargo for integration tests of the
-/// crate that defines the binary.
+/// Locate the CLI binary. The source-side name is `runner-cli` (so it
+/// doesn't collide with the Tauri app's `runner` binary in the shared
+/// workspace target dir). At runtime, `cli_install` renames it to
+/// `runner` when copying into `$APPDATA/runner/bin/`. Integration tests
+/// invoke the source artifact directly via `CARGO_BIN_EXE_runner-cli`.
 fn runner_bin() -> PathBuf {
-    PathBuf::from(env!("CARGO_BIN_EXE_runner"))
+    PathBuf::from(env!("CARGO_BIN_EXE_runner-cli"))
 }
 
 struct Fixture {
@@ -240,6 +242,71 @@ fn i2_5_msg_read_prints_inbox_in_order_and_emits_inbox_read() {
     assert_eq!(last.from, "impl");
     assert_eq!(last.payload["up_to"], m2.id);
     assert_ne!(last.payload["up_to"], m1.id);
+}
+
+#[test]
+fn i2_5c_msg_read_with_from_filter_does_not_emit_inbox_read() {
+    // Regression: `--from` only filters which messages are *printed*,
+    // but `inbox_read` advances a global per-runner watermark in the
+    // bus. If the CLI emitted inbox_read on filtered reads, every
+    // message with id ≤ the printed last would be marked read —
+    // including unread messages from other senders that the user
+    // never saw. The CLI must suppress watermark emission on filtered
+    // reads.
+    let f = Fixture::new("C", "M");
+    f.write_signal_types(&standard_signals());
+    f.write_roster(&[("lead", true), ("impl", false), ("reviewer", false)]);
+
+    let log = EventLog::open(&f.mission_dir).unwrap();
+    use runner_core::model::EventDraft;
+    log.append(EventDraft::message(
+        "C",
+        "M",
+        "lead",
+        Some("impl".into()),
+        "from lead first",
+    ))
+    .unwrap();
+    log.append(EventDraft::message(
+        "C",
+        "M",
+        "reviewer",
+        Some("impl".into()),
+        "from reviewer (must stay unread)",
+    ))
+    .unwrap();
+    log.append(EventDraft::message(
+        "C",
+        "M",
+        "lead",
+        Some("impl".into()),
+        "from lead second",
+    ))
+    .unwrap();
+
+    let out = f
+        .cmd("impl", &["msg", "read", "--from", "lead"])
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Critical: no inbox_read appended. The log must still contain
+    // exactly the three pre-seeded messages.
+    let signals: Vec<_> = f
+        .read_log()
+        .into_iter()
+        .filter(|e| matches!(e.kind, EventKind::Signal))
+        .collect();
+    assert!(
+        !signals
+            .iter()
+            .any(|s| s.signal_type.as_ref().map(|t| t.as_str()) == Some("inbox_read")),
+        "filtered read must NOT emit inbox_read; signals: {signals:?}",
+    );
 }
 
 #[test]

--- a/docs/impls/v0-mvp.md
+++ b/docs/impls/v0-mvp.md
@@ -4,12 +4,14 @@
 >
 > Companion to `docs/arch/v0-arch.md` (architecture) and `docs/arch/v0-prd.md` (scope). This file is the single source for both the MVP implementation plan and current build status.
 
-## Current status — 2026-04-26
+## Current status — 2026-04-27
 
+> **2026-04-27 update.** C8 (signal router v0) and C9 (`runner` CLI binary) are both merged. The router observes the bus, dispatches built-in signals to handlers (bootstrap, ask_lead/human_said relays, ask_human → human_question card, human_response routing, runner_status idle nudges), and reconstructs pending-ask + status state from the log on reopen via a high-water mark. The CLI exposes `signal`, `msg post`, `msg read`, `status`, and `help`; emits `inbox_read` correctly (skipped on `--from` filtered reads to avoid global-watermark corruption); validates against per-crew signal_types and per-mission roster sidecars. The bundled CLI is built by Tauri's `beforeDev`/`beforeBuild` hooks and installed into `$APPDATA/runner/bin/runner` at app startup. Remaining MVP work is the mission workspace UI (C10) and the Missions list + Start Mission modal (C11).
+>
 > **2026-04-26 plan revision.** C8 was reframed from "orchestrator v0" to "signal router v0" — a flat parent-process dispatcher, not a rule engine. The dispatch ledger, replay idempotence, inbox-summary enrichment, and policy loader were all explicitly descoped because the lead runner already owns coordination judgment; C8 only owns the plumbing (bootstrap, cross-process stdin push, UI bridge) the lead can't do from inside a child PTY. See **C8 — Signal router v0** below for the rationale and the descoped list. The cross-cutting prompt/runtime adapter is now part of C8 instead of a separate prerequisite.
 
 
-The persistence, configuration, PTY runtime, event log, event bus, and top-level runner/direct-chat surfaces are in place. The remaining MVP work is the coordination loop: prompt composition, the signal router that wires events to stdin pushes, UI cards, and runner availability updates, the `runner` CLI, mission workspace UI, and the final Start Mission entrypoint.
+The persistence, configuration, PTY runtime, event log, event bus, signal router, and `runner` CLI are all in place. The remaining MVP work is the mission workspace UI and the Start Mission entrypoint.
 
 ### Implemented
 
@@ -26,6 +28,8 @@ The persistence, configuration, PTY runtime, event log, event bus, and top-level
 | C8.5 Runner surfaces | #15 | `/runners`, `/runners/:handle`, direct-chat session backend, `runner_list_with_activity`, `runner/activity` live counters. |
 | Rename / namespace cleanup | #16 + follow-up | Project/crate/app namespace is singular `runner`; env vars are `RUNNER_*`; app data is under `$APPDATA/runner`; planned CLI binary is `runner`. SQL table names stay plural where they represent row collections. |
 | Direct-chat frontend hardening | #17 in review | xterm.js direct-chat pane, persistent sidebar SESSION list, PTY resize handshake, base64 raw PTY output for TUI fidelity. Two review follow-ups are open: reload reattach on the chat route itself, and waiting for output/exit listener registration before spawning. |
+| C8 Signal router v0 + runtime adapter | #18 | Flat parent-process dispatcher (`src-tauri/src/router/`): handlers for `mission_goal`, `human_said`, `ask_lead`, `ask_human`, `human_response`, `runner_status`. Pending-ask + status maps reconstruct on reopen via a replay high-water ULID; live tail short-circuits at-or-below the watermark. Runtime adapter wires `runner.system_prompt` into both mission and direct-chat spawn paths (claude-code → `--append-system-prompt`; codex deferred until a verified flag exists). |
+| C9 `runner` CLI binary | #19 | New `cli/` workspace member produces `runner-cli`, installed at app startup as `$APPDATA/runner/bin/runner` (rename on copy). Verbs: `signal`, `msg post`, `msg read`, `status`, `help`. Validates against per-crew `signal_types.json` and per-mission `roster.json` sidecars (frozen at mission_start). `inbox_read` is suppressed on `--from` filtered reads to avoid corrupting the global per-runner watermark. Tauri's `beforeDev`/`beforeBuild` build the CLI alongside the app so the dev install path needs no manual cargo step. |
 
 ### What runs today
 
@@ -33,15 +37,15 @@ The persistence, configuration, PTY runtime, event log, event bus, and top-level
 - **Direct chat:** Users can open a top-level runner, start a direct PTY session, type through xterm.js, resize the terminal, and stop the session. Direct chats do not join any mission event bus.
 - **Mission start/stop backend:** `mission_start` creates a mission row, writes opening events, mounts the event bus, and spawns one PTY child per crew member. `mission_stop` appends the terminal event, kills/reaps sessions, and unmounts the bus.
 - **Event transport:** Mission logs are durable NDJSON files at `$APPDATA/runner/crews/{crew_id}/missions/{mission_id}/events.ndjson`; the in-process bus replays and tails them into Tauri events.
-- **Tests:** Current checks on PR #17: `pnpm exec tsc --noEmit`, `pnpm run lint`, and `cargo test --workspace` all pass. Backend coverage is 84 tests across the Tauri app and `runner-core`.
+- **Coordination loop:** Spawned mission runners get the composed launch prompt injected into the lead's stdin on `mission_goal`; workers escalate via `ask_lead`; the lead can `ask_human` for HITL cards; `human_response` routes back to the asker; non-lead `runner_status idle` reports nudge the lead.
+- **CLI:** The bundled `runner` binary is dropped into `$APPDATA/runner/bin/` at app startup. Spawned agents can `runner signal`, `runner msg post`, `runner msg read`, `runner status`. Direct-chat sessions (no env vars) no-op cleanly.
+- **Tests:** `pnpm exec tsc --noEmit`, `pnpm run lint`, `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` all pass. Backend coverage is 87 Tauri-app tests + 24 CLI tests (11 unit + 13 integration) + 20 runner-core tests.
 
 ### Known gaps in implemented surfaces
 
-- **Runner `system_prompt` is stored and displayed but not passed to the runtime.** `runner.system_prompt` is accepted by create/update forms and shown on Runner Detail, but `SessionManager::spawn` and `spawn_direct` currently launch only `runner.command + runner.args`. No runtime adapter adds `--append-system-prompt` for Claude Code or the Codex equivalent yet. This must be fixed before claiming the default system prompt is "used whenever this runner spawns."
-- **Mission prompt composition does not exist yet.** The architecture says the launch prompt is `runner.system_prompt + mission goal + roster + coordination instructions + signal allowlist`, but the current C6/C8 boundary only starts PTYs and appends `mission_goal`. Nothing injects the composed prompt into the child.
-- **No runner-to-runner CLI yet.** The app prepends `$APPDATA/runner/bin` to `PATH`, but there is no `runner` binary installed there, so agents cannot emit `runner signal` or `runner msg` events.
-- **No signal router yet.** The event bus emits events, but no code consumes them to wake the lead, route `ask_lead`, render `ask_human`, inject `human_response`, or surface runner availability updates. Tracked as C8.
-- **No mission workspace UI or Start Mission UI yet.** The backend commands exist; the polished `/missions` entrypoint and workspace are still missing.
+- **No mission workspace UI or Start Mission UI yet.** The backend commands and the router are wired end-to-end; what's missing is the polished `/missions` entrypoint and the workspace pane that renders the event feed, ask-human cards, runner rail, and embedded xterms. Tracked as C10 + C11.
+- **Production sidecar packaging.** The dev path now installs the bundled CLI into `$APPDATA/runner/bin/` via Tauri's `beforeDev` hook. Production installer builds (`tauri build`) do not yet ship the CLI as a `bundle.externalBin` sidecar — needs a build-step that stages `runner-cli-<target-triple>` for the bundler. v0 ships in dev; this is a release-engineering follow-up that doesn't affect the demo path.
+- **Codex `system_prompt` flag.** The runtime adapter currently emits `--append-system-prompt` only for the `claude-code` runtime; `codex --instructions` was tried first but the installed Codex CLI rejected it. Codex runners spawn without their `system_prompt` until a verified flag is identified.
 
 ### Integrated C5.5 amendment context
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "preview": "vite preview",
     "tauri": "tauri",
     "package": "tauri build",
-    "lint": "eslint src/"
+    "lint": "eslint src/",
+    "tauri:before:dev": "cargo build -p runner-cli && npm run dev",
+    "tauri:before:build": "cargo build -p runner-cli --release && npm run build"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",

--- a/src-tauri/src/cli_install.rs
+++ b/src-tauri/src/cli_install.rs
@@ -1,0 +1,85 @@
+// Install the bundled `runner` CLI into `$APPDATA/runner/bin/runner` at
+// app startup so child PTYs find it on PATH (arch §5.3 Layer 2).
+//
+// Source resolution: in dev (`cargo run`), the binary built by the
+// workspace lives next to the Tauri exe under `target/{debug,release}/`.
+// In production, Tauri bundles `runner` as an "external binary" the
+// installer drops next to the app's main executable. Either way, the
+// source is `<sibling-of-current-exe>/runner` (or `runner.exe` on
+// Windows). If neither exists, we log and skip — the app stays usable;
+// only `runner` invocations from inside spawned sessions will fail.
+//
+// Skip-if-current optimization: hash-comparing the file would be slower
+// than just rewriting on every startup. Compare (size, mtime) instead —
+// if the source file's mtime is older or equal to the destination's
+// AND sizes match, skip the copy.
+
+use std::path::{Path, PathBuf};
+
+use crate::error::{Error, Result};
+
+const BIN_NAME: &str = if cfg!(windows) {
+    "runner.exe"
+} else {
+    "runner"
+};
+
+pub fn install_runner_cli(app_data_dir: &Path) -> Result<()> {
+    let Some(source) = locate_source()? else {
+        eprintln!(
+            "runner: bundled CLI not found next to current_exe; skipping install. \
+             Sessions that invoke `runner` will error until the binary is on PATH."
+        );
+        return Ok(());
+    };
+    let dest_dir = app_data_dir.join("bin");
+    std::fs::create_dir_all(&dest_dir)?;
+    let dest = dest_dir.join(BIN_NAME);
+
+    if up_to_date(&source, &dest)? {
+        return Ok(());
+    }
+
+    // Copy via tempfile + rename to keep the swap atomic — a half-written
+    // file would crash the next agent that runs `runner help`.
+    let tmp = tempfile::NamedTempFile::new_in(&dest_dir)?;
+    std::fs::copy(&source, tmp.path())?;
+    tmp.persist(&dest).map_err(|e| Error::Io(e.error))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&dest)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&dest, perms)?;
+    }
+    Ok(())
+}
+
+fn locate_source() -> Result<Option<PathBuf>> {
+    let exe = std::env::current_exe()?;
+    let dir = exe
+        .parent()
+        .ok_or_else(|| Error::msg("current_exe has no parent"))?;
+    let candidate = dir.join(BIN_NAME);
+    if candidate.exists() && candidate != exe {
+        return Ok(Some(candidate));
+    }
+    Ok(None)
+}
+
+fn up_to_date(source: &Path, dest: &Path) -> Result<bool> {
+    let Ok(dst_meta) = std::fs::metadata(dest) else {
+        return Ok(false);
+    };
+    let src_meta = std::fs::metadata(source)?;
+    if src_meta.len() != dst_meta.len() {
+        return Ok(false);
+    }
+    let src_mtime = src_meta.modified().ok();
+    let dst_mtime = dst_meta.modified().ok();
+    match (src_mtime, dst_mtime) {
+        (Some(s), Some(d)) => Ok(s <= d),
+        _ => Ok(false),
+    }
+}

--- a/src-tauri/src/cli_install.rs
+++ b/src-tauri/src/cli_install.rs
@@ -1,24 +1,45 @@
-// Install the bundled `runner` CLI into `$APPDATA/runner/bin/runner` at
-// app startup so child PTYs find it on PATH (arch §5.3 Layer 2).
+// Install the bundled CLI as `$APPDATA/runner/bin/runner` at app
+// startup so child PTYs find it on PATH (arch §5.3 Layer 2).
 //
-// Source resolution: in dev (`cargo run`), the binary built by the
-// workspace lives next to the Tauri exe under `target/{debug,release}/`.
-// In production, Tauri bundles `runner` as an "external binary" the
-// installer drops next to the app's main executable. Either way, the
-// source is `<sibling-of-current-exe>/runner` (or `runner.exe` on
-// Windows). If neither exists, we log and skip — the app stays usable;
-// only `runner` invocations from inside spawned sessions will fail.
+// Naming. The Tauri app crate also produces a binary called `runner`,
+// which would collide if the CLI used the same name in the same
+// `target/` dir. The CLI source-side binary is therefore `runner-cli`
+// (`cli/Cargo.toml`'s `[[bin]] name`). This installer copies the
+// `runner-cli` artifact and renames it to `runner` at the destination
+// — so the file on PATH (which is what spawned PTYs invoke) keeps the
+// intended user-facing name without colliding at build time.
 //
-// Skip-if-current optimization: hash-comparing the file would be slower
-// than just rewriting on every startup. Compare (size, mtime) instead —
-// if the source file's mtime is older or equal to the destination's
-// AND sizes match, skip the copy.
+// Source resolution. In dev (`cargo run`), the CLI lives next to the
+// Tauri exe under `target/{debug,release}/runner-cli`. In production,
+// the Tauri bundler is expected to ship the same artifact alongside
+// the app's main executable. Production-bundle wiring (tauri.conf.json
+// `bundle.externalBin` declaration + a beforeBuildCommand step that
+// stages the binary at the target-triple-suffixed path the bundler
+// expects) is tracked as a follow-up; the dev path is what the v0
+// demo runs.
+//
+// Skip-if-current optimization. Compare (size, mtime) — if the source
+// file's mtime is `<=` the destination's AND sizes match, skip the
+// copy. Hash-compare would be slower without buying anything for the
+// "rebuilt-CLI mtime moves forward" case.
 
 use std::path::{Path, PathBuf};
 
 use crate::error::{Error, Result};
 
-const BIN_NAME: &str = if cfg!(windows) {
+/// On-disk name of the CLI source artifact (set in `cli/Cargo.toml`).
+/// Different from the Tauri app crate's binary so they coexist in the
+/// same `target/` dir without overwriting each other.
+const SOURCE_BIN_NAME: &str = if cfg!(windows) {
+    "runner-cli.exe"
+} else {
+    "runner-cli"
+};
+
+/// Name of the file we drop into `$APPDATA/runner/bin/`. Must match what
+/// `SessionManager::spawn` puts on PATH — arch §5.3 Layer 2 has the
+/// CLI being invoked as bare `runner` from inside spawned PTYs.
+const DEST_BIN_NAME: &str = if cfg!(windows) {
     "runner.exe"
 } else {
     "runner"
@@ -27,14 +48,16 @@ const BIN_NAME: &str = if cfg!(windows) {
 pub fn install_runner_cli(app_data_dir: &Path) -> Result<()> {
     let Some(source) = locate_source()? else {
         eprintln!(
-            "runner: bundled CLI not found next to current_exe; skipping install. \
-             Sessions that invoke `runner` will error until the binary is on PATH."
+            "runner: bundled CLI ({SOURCE_BIN_NAME}) not found next to current_exe; \
+             skipping install. Sessions that invoke `runner` will error until the \
+             binary is on PATH. Build the CLI with `cargo build -p runner-cli` and \
+             relaunch."
         );
         return Ok(());
     };
     let dest_dir = app_data_dir.join("bin");
     std::fs::create_dir_all(&dest_dir)?;
-    let dest = dest_dir.join(BIN_NAME);
+    let dest = dest_dir.join(DEST_BIN_NAME);
 
     if up_to_date(&source, &dest)? {
         return Ok(());
@@ -61,7 +84,10 @@ fn locate_source() -> Result<Option<PathBuf>> {
     let dir = exe
         .parent()
         .ok_or_else(|| Error::msg("current_exe has no parent"))?;
-    let candidate = dir.join(BIN_NAME);
+    let candidate = dir.join(SOURCE_BIN_NAME);
+    // The Tauri exe itself is `runner` (different basename from
+    // `runner-cli`), so the equality guard is belt-and-suspenders for
+    // future renames; it still gates on existence.
     if candidate.exists() && candidate != exe {
         return Ok(Some(candidate));
     }
@@ -81,5 +107,55 @@ fn up_to_date(source: &Path, dest: &Path) -> Result<bool> {
     match (src_mtime, dst_mtime) {
         (Some(s), Some(d)) => Ok(s <= d),
         _ => Ok(false),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+
+    #[test]
+    fn install_copies_source_to_dest_and_renames() {
+        // Stage a fake source binary next to a fake current_exe and
+        // assert install_runner_cli puts it at $APPDATA/bin/runner with
+        // executable permissions on Unix.
+        let workspace = tempfile::tempdir().unwrap();
+        let exe_dir = workspace.path().join("target/debug");
+        fs::create_dir_all(&exe_dir).unwrap();
+
+        // Fake the CLI artifact next to the (would-be) current_exe.
+        let source = exe_dir.join(SOURCE_BIN_NAME);
+        {
+            let mut f = fs::File::create(&source).unwrap();
+            writeln!(f, "#!/bin/sh\necho fake").unwrap();
+        }
+        // Note: this test exercises the copy logic indirectly. We call
+        // through the public install fn against an `app_data_dir` that
+        // is just a tempdir; locate_source uses `current_exe()`, which
+        // for `cargo test` returns the test binary itself, not our
+        // fake — so we'd skip with "not found". To make the test
+        // meaningful, we exercise the up_to_date and copy helpers
+        // directly instead. install_runner_cli's prod path is covered
+        // manually until end-to-end packaging tests land.
+        let app_data = tempfile::tempdir().unwrap();
+        let bin_dir = app_data.path().join("bin");
+        fs::create_dir_all(&bin_dir).unwrap();
+        let dest = bin_dir.join(DEST_BIN_NAME);
+
+        // First copy: dest doesn't exist, must be replaced.
+        assert!(!up_to_date(&source, &dest).unwrap());
+        let tmp = tempfile::NamedTempFile::new_in(&bin_dir).unwrap();
+        std::fs::copy(&source, tmp.path()).unwrap();
+        tmp.persist(&dest).unwrap();
+        assert!(dest.exists());
+        assert_eq!(
+            fs::metadata(&source).unwrap().len(),
+            fs::metadata(&dest).unwrap().len()
+        );
+
+        // Second copy: dest now matches by size+mtime, should skip.
+        assert!(up_to_date(&source, &dest).unwrap());
     }
 }

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -194,6 +194,14 @@ pub fn start(
     std::fs::create_dir_all(&mission_dir)?;
     write_signal_types_sidecar(app_data_dir, &crew.id, &crew.signal_types)?;
 
+    // Snapshot the roster into a per-mission sidecar so the CLI can
+    // validate `runner msg post --to <handle>` without DB access. The
+    // roster is frozen here at mission_start: later changes to crew
+    // membership do not retroactively invalidate `--to` lookups in this
+    // mission's log (per PR #19 reviewer guidance).
+    let roster_for_sidecar = crew_runner::list(&tx, &crew.id)?;
+    write_roster_sidecar(&mission_dir, &roster_for_sidecar)?;
+
     // Effective goal = override || crew default || "".
     let goal_text = input
         .goal_override
@@ -311,6 +319,41 @@ fn write_signal_types_sidecar(
     // `MoveFileExW(..., MOVEFILE_REPLACE_EXISTING)` under the hood on Windows.
     let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
     let json = serde_json::to_vec(allowlist)?;
+    tmp.write_all(&json)?;
+    tmp.flush()?;
+    tmp.persist(&target).map_err(|e| Error::Io(e.error))?;
+    Ok(())
+}
+
+/// Write the per-mission roster snapshot to `roster.json` next to
+/// `events.ndjson`. The CLI (`runner msg post --to`) reads this to
+/// validate handles without DB access. Frozen at mission_start: if the
+/// crew's membership changes mid-mission, the running mission still
+/// validates against this snapshot.
+///
+/// Atomic write via `tempfile::NamedTempFile::persist` — same dance as
+/// `write_signal_types_sidecar` — so a crash mid-write can't leave a
+/// half-formed file the CLI would parse-fail on.
+fn write_roster_sidecar(mission_dir: &Path, roster: &[crate::model::CrewRunner]) -> Result<()> {
+    use std::io::Write;
+
+    #[derive(serde::Serialize)]
+    struct RosterEntry<'a> {
+        handle: &'a str,
+        lead: bool,
+    }
+    let entries: Vec<RosterEntry> = roster
+        .iter()
+        .map(|m| RosterEntry {
+            handle: &m.runner.handle,
+            lead: m.lead,
+        })
+        .collect();
+
+    std::fs::create_dir_all(mission_dir)?;
+    let target = mission_dir.join("roster.json");
+    let mut tmp = tempfile::NamedTempFile::new_in(mission_dir)?;
+    let json = serde_json::to_vec(&entries)?;
     tmp.write_all(&json)?;
     tmp.flush()?;
     tmp.persist(&target).map_err(|e| Error::Io(e.error))?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod cli_install;
 mod commands;
 mod db;
 mod error;
@@ -60,6 +61,16 @@ pub fn run() {
                     rusqlite::params![chrono::Utc::now().to_rfc3339()],
                 )?;
             }
+            // Drop the bundled `runner` CLI into $APPDATA/runner/bin/ so
+            // child PTYs find it on PATH (arch §5.3 Layer 2). Best-effort:
+            // a copy failure is logged and the app keeps running. Sessions
+            // spawned with no CLI on PATH will simply error out when they
+            // try to invoke `runner` — surfaced as a runtime stderr from
+            // the agent rather than a startup hang.
+            if let Err(e) = cli_install::install_runner_cli(&app_data_dir) {
+                eprintln!("runner: failed to install bundled CLI: {e}");
+            }
+
             app.manage(AppState {
                 db: pool,
                 app_data_dir,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,9 +4,9 @@
   "version": "0.1.0",
   "identifier": "com.wycstudios.runner",
   "build": {
-    "beforeDevCommand": "npm run dev",
+    "beforeDevCommand": "npm run tauri:before:dev",
     "devUrl": "http://localhost:1420",
-    "beforeBuildCommand": "npm run build",
+    "beforeBuildCommand": "npm run tauri:before:build",
     "frontendDist": "../dist"
   },
   "app": {


### PR DESCRIPTION
Implements C9 from \`docs/impls/v0-mvp.md\`: the standalone \`runner\` binary that spawned agents use to append to the mission's NDJSON event log. Fresh chunk; the implementation plan lives in the first PR comment.