### PR TITLE
feature(c10): mission workspace UI

### DIFF
--- a/design/runners-design.pen
+++ b/design/runners-design.pen
@@ -3617,28 +3617,22 @@
                             },
                             {
                               "type": "frame",
-                              "id": "KzWib",
-                              "name": "slot1_r",
-                              "gap": 12,
+                              "id": "CEGkx",
+                              "name": "slot1_kebab",
+                              "width": 28,
+                              "height": 28,
+                              "cornerRadius": 6,
+                              "justifyContent": "center",
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "text",
-                                  "id": "3OtAa",
-                                  "fill": "#00FF9C",
-                                  "content": "Prompt",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 12,
-                                  "fontWeight": "normal"
-                                },
-                                {
-                                  "type": "text",
-                                  "id": "QjvN7",
-                                  "fill": "#FF4D6D",
-                                  "content": "Remove",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 12,
-                                  "fontWeight": "normal"
+                                  "type": "icon_font",
+                                  "id": "y1dheV",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "ellipsis",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#9A9BA5"
                                 }
                               ]
                             }
@@ -3786,38 +3780,23 @@
                             },
                             {
                               "type": "frame",
-                              "id": "kc00i",
-                              "name": "slot2_r",
-                              "gap": 12,
+                              "id": "r7CLLj",
+                              "name": "slot2_kebab",
+                              "width": 28,
+                              "height": 28,
+                              "fill": "#1F2127",
+                              "cornerRadius": 6,
+                              "justifyContent": "center",
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "text",
-                                  "id": "P93jM",
-                                  "name": "set_lead_2",
-                                  "fill": "#9A9BA5",
-                                  "content": "Set as lead",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 12,
-                                  "fontWeight": "normal"
-                                },
-                                {
-                                  "type": "text",
-                                  "id": "cKnvt",
-                                  "fill": "#00FF9C",
-                                  "content": "Prompt",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 12,
-                                  "fontWeight": "normal"
-                                },
-                                {
-                                  "type": "text",
-                                  "id": "rEgQ0",
-                                  "fill": "#FF4D6D",
-                                  "content": "Remove",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 12,
-                                  "fontWeight": "normal"
+                                  "type": "icon_font",
+                                  "id": "C4ExN",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "ellipsis",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#EDEDF0"
                                 }
                               ]
                             }
@@ -3965,38 +3944,22 @@
                             },
                             {
                               "type": "frame",
-                              "id": "nFVw0",
-                              "name": "slot3_r",
-                              "gap": 12,
+                              "id": "C0lDY",
+                              "name": "slot3_kebab",
+                              "width": 28,
+                              "height": 28,
+                              "cornerRadius": 6,
+                              "justifyContent": "center",
                               "alignItems": "center",
                               "children": [
                                 {
-                                  "type": "text",
-                                  "id": "S849k",
-                                  "name": "set_lead_3",
-                                  "fill": "#9A9BA5",
-                                  "content": "Set as lead",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 12,
-                                  "fontWeight": "normal"
-                                },
-                                {
-                                  "type": "text",
-                                  "id": "1E9tW",
-                                  "fill": "#00FF9C",
-                                  "content": "Prompt",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 12,
-                                  "fontWeight": "normal"
-                                },
-                                {
-                                  "type": "text",
-                                  "id": "oa37n",
-                                  "fill": "#FF4D6D",
-                                  "content": "Remove",
-                                  "fontFamily": "Inter",
-                                  "fontSize": 12,
-                                  "fontWeight": "normal"
+                                  "type": "icon_font",
+                                  "id": "tCodD",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "ellipsis",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#9A9BA5"
                                 }
                               ]
                             }
@@ -4310,6 +4273,156 @@
                           "fontWeight": "normal"
                         }
                       ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "yxWfE",
+              "layoutPosition": "absolute",
+              "x": 648,
+              "y": 410,
+              "name": "slot2_menu",
+              "width": 208,
+              "fill": "#16171B",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#1F2127"
+              },
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#000000AA",
+                "offset": {
+                  "x": 0,
+                  "y": 8
+                },
+                "blur": 30
+              },
+              "layout": "vertical",
+              "gap": 1,
+              "padding": 6,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "QjngL",
+                  "name": "m_setlead",
+                  "width": "fill_container",
+                  "cornerRadius": 6,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "k15zRC",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "star",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FFB020"
+                    },
+                    {
+                      "type": "text",
+                      "id": "jOxEs",
+                      "fill": "#EDEDF0",
+                      "content": "Set as lead",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "sY78T",
+                  "name": "m_editprompt",
+                  "width": "fill_container",
+                  "fill": "#1F2127",
+                  "cornerRadius": 6,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "e2hWB",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "square-pen",
+                      "iconFontFamily": "lucide",
+                      "fill": "#EDEDF0"
+                    },
+                    {
+                      "type": "text",
+                      "id": "U70pX",
+                      "fill": "#EDEDF0",
+                      "content": "Edit prompt",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "f2khq",
+                  "name": "m_div",
+                  "width": "fill_container",
+                  "padding": [
+                    4,
+                    2
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ofV7p",
+                      "width": "fill_container",
+                      "height": 1,
+                      "fill": "#1F2127"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "AMu5f",
+                  "name": "m_remove",
+                  "width": "fill_container",
+                  "cornerRadius": 6,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "FBfI9",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "trash-2",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FF4D6D"
+                    },
+                    {
+                      "type": "text",
+                      "id": "yIPfQ",
+                      "fill": "#FF4D6D",
+                      "content": "Remove from crew",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
                     }
                   ]
                 }

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -374,7 +374,11 @@ pub struct PostHumanSignalInput {
 /// envelopes into its feed before subscribing to `event/appended` for live
 /// tailing. Returns lossy-decoded events so a single corrupt line can't
 /// freeze the UI; the bus already tolerates the same.
-pub fn read_events(app_data_dir: &Path, conn: &Connection, mission_id: &str) -> Result<Vec<runner_core::model::Event>> {
+pub fn read_events(
+    app_data_dir: &Path,
+    conn: &Connection,
+    mission_id: &str,
+) -> Result<Vec<runner_core::model::Event>> {
     let mission = get(conn, mission_id)?;
     let mission_dir = event_log::mission_dir(app_data_dir, &mission.crew_id, mission_id);
     let log = EventLog::open(&mission_dir)?;

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -360,6 +360,79 @@ fn write_roster_sidecar(mission_dir: &Path, roster: &[crate::model::CrewRunner])
     Ok(())
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct PostHumanSignalInput {
+    pub mission_id: String,
+    /// Signal type — restricted to the human-originated ones the workspace
+    /// UI is allowed to emit. Anything else is rejected.
+    pub signal_type: String,
+    pub payload: serde_json::Value,
+}
+
+/// Replay the full event log for a mission. Used by the workspace UI when
+/// it first mounts (or remounts after navigation): it folds the historical
+/// envelopes into its feed before subscribing to `event/appended` for live
+/// tailing. Returns lossy-decoded events so a single corrupt line can't
+/// freeze the UI; the bus already tolerates the same.
+pub fn read_events(app_data_dir: &Path, conn: &Connection, mission_id: &str) -> Result<Vec<runner_core::model::Event>> {
+    let mission = get(conn, mission_id)?;
+    let mission_dir = event_log::mission_dir(app_data_dir, &mission.crew_id, mission_id);
+    let log = EventLog::open(&mission_dir)?;
+    let (entries, _skipped) = log.read_from_lossy(0)?;
+    Ok(entries.into_iter().map(|e| e.event).collect())
+}
+
+#[tauri::command]
+pub async fn mission_events_replay(
+    state: State<'_, AppState>,
+    mission_id: String,
+) -> Result<Vec<runner_core::model::Event>> {
+    let conn = state.db.get()?;
+    read_events(&state.app_data_dir, &conn, &mission_id)
+}
+
+#[tauri::command]
+pub async fn mission_post_human_signal(
+    state: State<'_, AppState>,
+    input: PostHumanSignalInput,
+) -> Result<runner_core::model::Event> {
+    // Whitelist: only the two signal types the workspace UI is supposed
+    // to emit. The router treats `from = "human"` as authoritative for
+    // these, so a buggy frontend that posted `mission_goal` or `ask_lead`
+    // could trigger handler side-effects from the wrong identity.
+    let allowed = matches!(input.signal_type.as_str(), "human_said" | "human_response");
+    if !allowed {
+        return Err(Error::msg(format!(
+            "signal_type {:?} is not allowed from the workspace UI",
+            input.signal_type
+        )));
+    }
+
+    let mission = {
+        let conn = state.db.get()?;
+        get(&conn, &input.mission_id)?
+    };
+    if !matches!(mission.status, MissionStatus::Running) {
+        return Err(Error::msg(format!(
+            "mission {} is not running (status = {:?}); cannot post signals",
+            mission.id, mission.status
+        )));
+    }
+
+    let mission_dir = event_log::mission_dir(&state.app_data_dir, &mission.crew_id, &mission.id);
+    let log = EventLog::open(&mission_dir)?;
+    let event = log.append(EventDraft {
+        crew_id: mission.crew_id.clone(),
+        mission_id: mission.id.clone(),
+        kind: EventKind::Signal,
+        from: "human".into(),
+        to: None,
+        signal_type: Some(SignalType::new(input.signal_type)),
+        payload: input.payload,
+    })?;
+    Ok(event)
+}
+
 #[tauri::command]
 pub async fn mission_start(
     state: State<'_, AppState>,
@@ -1026,6 +1099,52 @@ mod tests {
             })
             .count();
         assert_eq!(stopped_events, 1, "exactly one terminal event must land");
+    }
+
+    #[test]
+    fn read_events_returns_appended_in_order() {
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "A", Some("Ship v0"));
+        add_runner(&mut conn, &crew_id, "lead");
+        let tmp = tempfile::tempdir().unwrap();
+
+        let out = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                crew_id: crew_id.clone(),
+                title: "m".into(),
+                goal_override: None,
+                cwd: None,
+            },
+        )
+        .unwrap();
+
+        // mission_start + mission_goal — that's all the opening events
+        // plant. Mirrors what the workspace UI sees on first mount.
+        let events = read_events(tmp.path(), &conn, &out.mission.id).unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0].signal_type.as_ref().unwrap().as_str(),
+            "mission_start"
+        );
+        assert_eq!(
+            events[1].signal_type.as_ref().unwrap().as_str(),
+            "mission_goal"
+        );
+    }
+
+    #[test]
+    fn read_events_unknown_mission_errors() {
+        let pool = pool();
+        let conn = pool.get().unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+        let err = read_events(tmp.path(), &conn, "01HMISSING").unwrap_err();
+        assert!(
+            format!("{err}").contains("mission not found"),
+            "expected not-found, got {err}"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -31,6 +31,8 @@ pub struct SessionRow {
     /// Handle of the runner this session instantiates — denormalized so the
     /// frontend can render `@coder`-style labels without a second lookup.
     pub handle: String,
+    /// Whether this runner is the lead for the mission's crew.
+    pub lead: bool,
 }
 
 fn row_to_session(row: &Row<'_>) -> rusqlite::Result<SessionRow> {
@@ -67,6 +69,7 @@ fn row_to_session(row: &Row<'_>) -> rusqlite::Result<SessionRow> {
             stopped_at: stopped_at.map(parse_ts).transpose()?,
         },
         handle: row.get("handle")?,
+        lead: row.get("lead")?,
     })
 }
 
@@ -82,7 +85,8 @@ pub async fn session_list(
     let conn = state.db.get()?;
     let mut stmt = conn.prepare(
         "SELECT s.id, s.mission_id, s.runner_id, s.cwd, s.status, s.pid,
-                s.started_at, s.stopped_at, r.handle
+                s.started_at, s.stopped_at, r.handle,
+                COALESCE(cr.lead, 0) AS lead
            FROM sessions s
            JOIN runners r ON r.id = s.runner_id
            JOIN missions m ON m.id = s.mission_id

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -20,7 +20,7 @@ use crate::{
     commands::runner,
     error::{Error, Result},
     model::{Session, SessionStatus, Timestamp},
-    session::manager::{SessionEvents, SpawnedSession, TauriSessionEvents},
+    session::manager::{OutputEvent, SessionEvents, SpawnedSession, TauriSessionEvents},
     AppState,
 };
 
@@ -118,6 +118,14 @@ pub async fn session_resize(
     rows: u16,
 ) -> Result<()> {
     state.sessions.resize(&session_id, cols, rows)
+}
+
+#[tauri::command]
+pub async fn session_output_snapshot(
+    state: State<'_, AppState>,
+    session_id: String,
+) -> Result<Vec<OutputEvent>> {
+    Ok(state.sessions.output_snapshot(&session_id))
 }
 
 /// Spawn a "direct chat" session for a runner — a PTY with no parent

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -104,6 +104,8 @@ pub fn run() {
             commands::mission::mission_stop,
             commands::mission::mission_list,
             commands::mission::mission_get,
+            commands::mission::mission_events_replay,
+            commands::mission::mission_post_human_signal,
             commands::session::session_list,
             commands::session::session_inject_stdin,
             commands::session::session_kill,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -110,6 +110,7 @@ pub fn run() {
             commands::session::session_inject_stdin,
             commands::session::session_kill,
             commands::session::session_resize,
+            commands::session::session_output_snapshot,
             commands::session::session_start_direct,
         ])
         .run(tauri::generate_context!())

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -705,6 +705,8 @@ impl SessionManager {
 
     fn forget(&self, session_id: &str) -> Result<()> {
         self.sessions.lock().unwrap().remove(session_id);
+        self.output_buffers.lock().unwrap().remove(session_id);
+        self.output_seq.lock().unwrap().remove(session_id);
         Ok(())
     }
 
@@ -1242,15 +1244,9 @@ mod tests {
             std::thread::sleep(Duration::from_millis(20));
         }
 
-        let snapshot = mgr.output_snapshot(&spawned.id);
         assert!(
-            !snapshot.is_empty(),
-            "session output snapshot must replay output"
-        );
-        assert_eq!(snapshot[0].seq, 1);
-        assert!(
-            snapshot.iter().all(|ev| ev.session_id == spawned.id),
-            "snapshot must only include chunks for the requested session"
+            mgr.output_snapshot(&spawned.id).is_empty(),
+            "terminal output buffer should be cleared after session exit"
         );
 
         // Activity emissions: at least one on spawn (count=1), and one on
@@ -1264,6 +1260,68 @@ mod tests {
         assert_eq!(
             last.active_sessions, 0,
             "after reap, active_sessions for this runner must be 0"
+        );
+    }
+
+    #[test]
+    fn output_snapshot_replays_live_session_and_clears_after_forget() {
+        let pool = pool_with_schema();
+        let now = Utc::now().to_rfc3339();
+        let runner_id = ulid::Ulid::new().to_string();
+        {
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "INSERT INTO runners
+                    (id, handle, display_name, role, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'buffered', 'Buffered', 'test', 'shell', '/bin/cat',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+                params![runner_id, now],
+            )
+            .unwrap();
+        }
+
+        let mut runner = runner("/bin/cat", &[]);
+        runner.id = runner_id;
+        runner.handle = "buffered".into();
+
+        let mgr = SessionManager::new();
+        let spawned = mgr
+            .spawn_direct(
+                &runner,
+                Some("/tmp"),
+                None,
+                None,
+                std::path::Path::new("/tmp"),
+                Arc::clone(&pool),
+                capture(),
+            )
+            .unwrap();
+
+        mgr.inject_stdin(&spawned.id, b"hello snapshot\n").unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let snapshot = loop {
+            let snapshot = mgr.output_snapshot(&spawned.id);
+            if !snapshot.is_empty() {
+                break snapshot;
+            }
+            if Instant::now() > deadline {
+                panic!("session output snapshot never captured live output");
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        };
+
+        assert_eq!(snapshot[0].seq, 1);
+        assert!(
+            snapshot.iter().all(|ev| ev.session_id == spawned.id),
+            "snapshot must only include chunks for the requested session"
+        );
+
+        mgr.kill(&spawned.id).unwrap();
+        assert!(
+            mgr.output_snapshot(&spawned.id).is_empty(),
+            "forget must drop terminal output buffers"
         );
     }
 }

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -17,7 +17,7 @@
 // `SessionManager::kill_all` at app shutdown (future work; for MVP the
 // child inherits our process group and dies when we exit).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
@@ -32,6 +32,8 @@ use serde::Serialize;
 use crate::db::DbPool;
 use crate::error::{Error, Result};
 use crate::model::{Mission, Runner};
+
+const MAX_OUTPUT_BUFFER_CHUNKS: usize = 4096;
 
 /// Decouples the PTY layer from Tauri so the reader thread can be unit-tested
 /// with a fake. Prod wraps an `AppHandle::emit`; tests use a no-op or a
@@ -91,6 +93,9 @@ impl SessionEvents for TauriSessionEvents {
 pub struct OutputEvent {
     pub session_id: String,
     pub mission_id: Option<String>,
+    /// Monotonic per-session sequence number. Frontend attach uses this to
+    /// merge a replay snapshot with live events without duplicating chunks.
+    pub seq: u64,
     /// Base64-encoded raw bytes read from the PTY.
     pub data: String,
 }
@@ -142,12 +147,16 @@ struct SessionHandle {
 
 pub struct SessionManager {
     sessions: Mutex<HashMap<String, SessionHandle>>,
+    output_buffers: Mutex<HashMap<String, VecDeque<OutputEvent>>>,
+    output_seq: Mutex<HashMap<String, u64>>,
 }
 
 impl SessionManager {
     pub fn new() -> Arc<Self> {
         Arc::new(Self {
             sessions: Mutex::new(HashMap::new()),
+            output_buffers: Mutex::new(HashMap::new()),
+            output_seq: Mutex::new(HashMap::new()),
         })
     }
 
@@ -529,6 +538,7 @@ impl SessionManager {
             let exit = drain_pty_and_reap(
                 reader,
                 &mut *child,
+                manager_t.as_ref(),
                 &session_id,
                 mission_id.as_deref(),
                 events.as_ref(),
@@ -585,6 +595,22 @@ impl SessionManager {
                 .map_err(|e| Error::msg(format!("pty resize failed: {e}")))?;
         }
         Ok(())
+    }
+
+    /// Return the bounded in-memory PTY output snapshot for a session.
+    ///
+    /// Tauri events are live-only; without this, a terminal pane mounted after
+    /// a session already produced output starts blank until the child redraws.
+    /// The snapshot is intentionally process-local and bounded: it covers
+    /// webview reloads / chat switching for live sessions without turning the
+    /// sessions table into a PTY transcript store.
+    pub fn output_snapshot(&self, session_id: &str) -> Vec<OutputEvent> {
+        self.output_buffers
+            .lock()
+            .unwrap()
+            .get(session_id)
+            .map(|chunks| chunks.iter().cloned().collect())
+            .unwrap_or_default()
     }
 
     /// Kill the child and wait for the reader thread to reap it.
@@ -681,6 +707,35 @@ impl SessionManager {
         self.sessions.lock().unwrap().remove(session_id);
         Ok(())
     }
+
+    fn record_output(
+        &self,
+        session_id: &str,
+        mission_id: Option<&str>,
+        data: String,
+    ) -> OutputEvent {
+        let seq = {
+            let mut seqs = self.output_seq.lock().unwrap();
+            let next = seqs.entry(session_id.to_string()).or_insert(0);
+            *next += 1;
+            *next
+        };
+
+        let ev = OutputEvent {
+            session_id: session_id.into(),
+            mission_id: mission_id.map(str::to_string),
+            seq,
+            data,
+        };
+
+        let mut buffers = self.output_buffers.lock().unwrap();
+        let chunks = buffers.entry(session_id.to_string()).or_default();
+        chunks.push_back(ev.clone());
+        while chunks.len() > MAX_OUTPUT_BUFFER_CHUNKS {
+            chunks.pop_front();
+        }
+        ev
+    }
 }
 
 /// Compute current activity counters for `runner` and emit a
@@ -737,6 +792,7 @@ fn emit_runner_activity(pool: &DbPool, runner: &Runner, events: &dyn SessionEven
 fn drain_pty_and_reap(
     mut reader: Box<dyn Read + Send>,
     child: &mut (dyn portable_pty::Child + Send),
+    manager: &SessionManager,
     session_id: &str,
     mission_id: Option<&str>,
     events: &dyn SessionEvents,
@@ -746,11 +802,8 @@ fn drain_pty_and_reap(
         match reader.read(&mut buf) {
             Ok(0) => break,
             Ok(n) => {
-                events.output(&OutputEvent {
-                    session_id: session_id.into(),
-                    mission_id: mission_id.map(str::to_string),
-                    data: BASE64.encode(&buf[..n]),
-                });
+                let ev = manager.record_output(session_id, mission_id, BASE64.encode(&buf[..n]));
+                events.output(&ev);
             }
             Err(_) => break,
         }
@@ -1172,7 +1225,7 @@ mod tests {
             let row: (String, Option<String>) = conn
                 .query_row(
                     "SELECT status, mission_id FROM sessions WHERE id = ?1",
-                    params![spawned.id],
+                    params![&spawned.id],
                     |r| Ok((r.get(0)?, r.get(1)?)),
                 )
                 .unwrap();
@@ -1188,6 +1241,17 @@ mod tests {
             }
             std::thread::sleep(Duration::from_millis(20));
         }
+
+        let snapshot = mgr.output_snapshot(&spawned.id);
+        assert!(
+            !snapshot.is_empty(),
+            "session output snapshot must replay output"
+        );
+        assert_eq!(snapshot[0].seq, 1);
+        assert!(
+            snapshot.iter().all(|ev| ev.session_id == spawned.id),
+            "snapshot must only include chunks for the requested session"
+        );
 
         // Activity emissions: at least one on spawn (count=1), and one on
         // reap (count=0). We don't pin exact counts — the spawn-time emit

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,9 @@
         "height": 900,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "visible": true
+        "visible": true,
+        "acceptFirstMouse": true,
+        "focus": true
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { AppShell } from "./components/AppShell";
 import Crews from "./pages/Crews";
 import CrewEditor from "./pages/CrewEditor";
+import MissionWorkspace from "./pages/MissionWorkspace";
 import Runners from "./pages/Runners";
 import RunnerDetail from "./pages/RunnerDetail";
 import RunnerChat from "./pages/RunnerChat";
@@ -17,6 +18,7 @@ export default function App() {
           <Route path="/runners" element={<Runners />} />
           <Route path="/runners/:handle" element={<RunnerDetail />} />
           <Route path="/runners/:handle/chat" element={<RunnerChat />} />
+          <Route path="/missions/:id" element={<MissionWorkspace />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/components/AskHumanCard.tsx
+++ b/src/components/AskHumanCard.tsx
@@ -1,0 +1,134 @@
+// One human-input card. The router emits a `human_question` signal in
+// response to a worker's `ask_human`; the workspace replays the feed,
+// finds those events, and renders a card per still-pending question.
+//
+// Clicking a choice posts a `human_response` signal back through the
+// event log (router -> asker injection happens parent-side).
+
+import { useState } from "react";
+
+import { api } from "../lib/api";
+import type { HumanQuestionPayload } from "../lib/types";
+
+interface AskHumanCardProps {
+  missionId: string;
+  /** The `human_question` event id — used as `payload.question_id` per
+   *  arch §5.5.0 (the card id is the canonical question_id). */
+  questionId: string;
+  /** Handle of the runner that emitted the originating `ask_human`. The
+   *  router routes the response back to this handle's PTY. */
+  asker: string;
+  payload: HumanQuestionPayload;
+  ts: string;
+  /** When set, the card has been answered already (a `human_response`
+   *  with matching question_id was found in the feed). The card stays
+   *  visible read-only so reviewers can see the historical choice. */
+  resolvedChoice?: string | null;
+  onError?: (msg: string) => void;
+}
+
+export function AskHumanCard({
+  missionId,
+  questionId,
+  asker,
+  payload,
+  ts,
+  resolvedChoice,
+  onError,
+}: AskHumanCardProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const [pickedChoice, setPickedChoice] = useState<string | null>(null);
+  const choices = payload.choices && payload.choices.length > 0
+    ? payload.choices
+    : ["yes", "no"]; // sensible fallback so the card always has buttons
+
+  const onBehalf = payload.on_behalf_of;
+  // Attribution chain: when an `ask_human` carries `on_behalf_of`, the
+  // worker who originally asked is shown alongside the lead so the human
+  // sees `*@impl → @architect → you*` (per design frame `Z7Dbo`).
+  const chain = onBehalf ? `@${onBehalf} → @${asker} → you` : `@${asker} → you`;
+
+  const resolved = resolvedChoice != null;
+
+  async function submit(choice: string) {
+    if (submitting || resolved) return;
+    setSubmitting(true);
+    setPickedChoice(choice);
+    try {
+      await api.mission.postHumanSignal({
+        mission_id: missionId,
+        signal_type: "human_response",
+        payload: { question_id: questionId, choice },
+      });
+    } catch (e) {
+      setPickedChoice(null);
+      onError?.(String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-warn/60 bg-warn/10 p-4">
+      <div className="flex items-baseline justify-between gap-2">
+        <div className="flex items-baseline gap-2 min-w-0">
+          <span className="text-[12px] font-semibold text-warn">
+            needs your input
+          </span>
+          <span className="text-[11px] font-mono text-fg-2 truncate">
+            {chain}
+          </span>
+        </div>
+        <span className="text-[11px] text-fg-3">{formatTs(ts)}</span>
+      </div>
+      <p className="mt-2 text-[13px] leading-relaxed text-fg">
+        {payload.prompt || "(no prompt)"}
+      </p>
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        {choices.map((c, idx) => {
+          const isPrimary = idx === 0;
+          const isPicked = resolved
+            ? c === resolvedChoice
+            : pickedChoice === c;
+          return (
+            <button
+              key={c}
+              type="button"
+              onClick={() => submit(c)}
+              disabled={submitting || resolved}
+              className={
+                isPrimary
+                  ? `rounded-md px-3.5 py-1.5 text-[12px] font-semibold transition-colors ${
+                      isPicked
+                        ? "bg-accent text-accent-ink"
+                        : "bg-accent text-accent-ink hover:bg-accent/90"
+                    } disabled:cursor-not-allowed disabled:opacity-60`
+                  : `rounded-md border border-line bg-panel px-3.5 py-1.5 text-[12px] font-medium text-fg transition-colors ${
+                      isPicked ? "border-accent text-accent" : ""
+                    } hover:border-line-strong disabled:cursor-not-allowed disabled:opacity-60`
+              }
+            >
+              {c}
+            </button>
+          );
+        })}
+        {resolved ? (
+          <span className="ml-1 text-[11px] text-fg-3">
+            answered: <span className="text-fg-2">{resolvedChoice}</span>
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function formatTs(ts: string): string {
+  // Display the local-time HH:MM:SS slice only — the workspace feed is
+  // always anchored to "now" so the date is implied.
+  try {
+    const d = new Date(ts);
+    return d.toLocaleTimeString();
+  } catch {
+    return ts;
+  }
+}

--- a/src/components/EventFeed.tsx
+++ b/src/components/EventFeed.tsx
@@ -1,0 +1,218 @@
+// Scrollable feed that renders one row per appended event. Three variants
+// align with arch §5.2 + design frame `5DIkl`:
+//   - message rows (kind: message): from / to / payload.text
+//   - signal rows (kind: signal): from / signal type, JSON-ish payload
+//   - ask-human cards (signal type: human_question): rich card variant
+//     consumed by AskHumanCard
+//
+// Router-internal noise (`mission_warning`, `inbox_read`) is muted: the
+// rows are still present but de-emphasized so they don't dominate the
+// feed. We never silently drop events — the audit-trail invariant means
+// every line in the log surfaces somewhere.
+
+import { useEffect, useRef } from "react";
+
+import { AskHumanCard } from "./AskHumanCard";
+import type { Event, HumanQuestionPayload } from "../lib/types";
+
+interface EventFeedProps {
+  missionId: string;
+  events: Event[];
+  /** question_id → choice. When a question has been answered, the card
+   *  goes read-only with the choice surfaced. */
+  resolvedAsks: Record<string, string>;
+  /** asker handle for each pending `human_question`, derived in the
+   *  workspace by walking ask_human → human_question chains. */
+  askersByQuestion: Record<string, string>;
+  onError?: (msg: string) => void;
+}
+
+export function EventFeed({
+  missionId,
+  events,
+  resolvedAsks,
+  askersByQuestion,
+  onError,
+}: EventFeedProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const wasNearBottomRef = useRef(true);
+
+  // Auto-stick to the bottom unless the user has scrolled away. Without
+  // this the feed just keeps appending offscreen and the workspace looks
+  // dead from the human's perspective.
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    if (wasNearBottomRef.current) {
+      el.scrollTop = el.scrollHeight;
+    }
+  }, [events.length]);
+
+  const onScroll = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const distance = el.scrollHeight - el.scrollTop - el.clientHeight;
+    wasNearBottomRef.current = distance < 80;
+  };
+
+  return (
+    <div
+      ref={scrollRef}
+      onScroll={onScroll}
+      className="flex flex-1 flex-col gap-4 overflow-y-auto px-10 py-6"
+    >
+      {events.length === 0 ? (
+        <p className="text-[12px] text-fg-3">No events yet.</p>
+      ) : (
+        events.map((ev) => (
+          <EventRow
+            key={ev.id}
+            event={ev}
+            missionId={missionId}
+            resolvedAsks={resolvedAsks}
+            askersByQuestion={askersByQuestion}
+            onError={onError}
+          />
+        ))
+      )}
+    </div>
+  );
+}
+
+function EventRow({
+  event,
+  missionId,
+  resolvedAsks,
+  askersByQuestion,
+  onError,
+}: {
+  event: Event;
+  missionId: string;
+  resolvedAsks: Record<string, string>;
+  askersByQuestion: Record<string, string>;
+  onError?: (msg: string) => void;
+}) {
+  // human_question — render the rich card. Asker derived from the
+  // originating ask_human (via askersByQuestion). Fall back to the
+  // event's `from` (which is "router") if we haven't paired it yet.
+  if (event.kind === "signal" && event.type === "human_question") {
+    const payload = event.payload as HumanQuestionPayload;
+    const asker = askersByQuestion[event.id] ?? "?";
+    const resolvedChoice = resolvedAsks[event.id] ?? null;
+    return (
+      <AskHumanCard
+        missionId={missionId}
+        questionId={event.id}
+        asker={asker}
+        payload={payload}
+        ts={event.ts}
+        resolvedChoice={resolvedChoice}
+        onError={onError}
+      />
+    );
+  }
+
+  if (event.kind === "message") {
+    const text = (event.payload as { text?: string })?.text ?? "";
+    return (
+      <div className="flex flex-col gap-1">
+        <div className="flex items-baseline gap-2 text-[11px] text-fg-3">
+          <span className="font-mono text-[12px] font-semibold text-accent">
+            @{event.from}
+          </span>
+          <span>message</span>
+          {event.to ? (
+            <>
+              <span>→</span>
+              <span className="font-mono text-fg-2">@{event.to}</span>
+            </>
+          ) : null}
+          <span>·</span>
+          <span>{formatTs(event.ts)}</span>
+        </div>
+        <div className="text-[13px] leading-relaxed text-fg">{text}</div>
+      </div>
+    );
+  }
+
+  // Default signal row.
+  const isQuiet =
+    event.type === "inbox_read" ||
+    event.type === "mission_warning" ||
+    event.type === "runner_status";
+  return (
+    <div
+      className={`flex flex-col gap-1 ${
+        isQuiet ? "opacity-60" : ""
+      }`}
+    >
+      <div className="flex items-baseline gap-2 text-[11px] text-fg-3">
+        <span className="font-mono text-[12px] font-semibold text-accent">
+          @{event.from}
+        </span>
+        <span>signal · {event.type ?? "?"}</span>
+        <span>·</span>
+        <span>{formatTs(event.ts)}</span>
+      </div>
+      <div className="rounded-md border border-line bg-bg p-3 font-mono text-[12px] leading-snug text-fg-2">
+        {renderPayload(event)}
+      </div>
+    </div>
+  );
+}
+
+function renderPayload(event: Event): React.ReactNode {
+  // Common signal shapes get shorter inline renderings; everything else
+  // falls back to formatted JSON. The v0 router never emits opaque blobs
+  // so this stays readable.
+  const p = event.payload as Record<string, unknown> | null | undefined;
+  if (!p || typeof p !== "object") {
+    return <span>{String(p ?? "")}</span>;
+  }
+  if (event.type === "mission_goal" || event.type === "human_said") {
+    const text = typeof p.text === "string" ? p.text : "";
+    const target = typeof p.target === "string" ? p.target : null;
+    return (
+      <>
+        <span className="text-fg">{text || "(no text)"}</span>
+        {target ? (
+          <span className="ml-2 text-fg-3">→ @{target}</span>
+        ) : null}
+      </>
+    );
+  }
+  if (event.type === "ask_lead") {
+    const q = typeof p.question === "string" ? p.question : "";
+    return <span className="text-fg">{q}</span>;
+  }
+  if (event.type === "runner_status") {
+    const state = typeof p.state === "string" ? p.state : "?";
+    const note = typeof p.note === "string" ? ` — ${p.note}` : "";
+    return (
+      <span>
+        {state}
+        {note}
+      </span>
+    );
+  }
+  if (event.type === "human_response") {
+    const choice = typeof p.choice === "string" ? p.choice : "";
+    const qid = typeof p.question_id === "string" ? p.question_id : "";
+    return (
+      <span>
+        chose <span className="text-fg">{choice || "?"}</span>
+        {qid ? <span className="text-fg-3"> · q={qid.slice(-6)}</span> : null}
+      </span>
+    );
+  }
+  return <pre className="whitespace-pre-wrap break-all">{JSON.stringify(p, null, 2)}</pre>;
+}
+
+function formatTs(ts: string): string {
+  try {
+    const d = new Date(ts);
+    return d.toLocaleTimeString();
+  } catch {
+    return ts;
+  }
+}

--- a/src/components/MissionInput.tsx
+++ b/src/components/MissionInput.tsx
@@ -1,0 +1,188 @@
+// Slack-style channel input docked at the bottom of the workspace center
+// column. Submitting always emits a `human_said` *signal* (not a message
+// event) so the router wakes the recipient — per arch §5.5.0, messages
+// are pull-based and never trigger router actions.
+//
+// Recipient semantics: default is `@<lead>`. Switching the chip to a
+// non-lead handle scopes `payload.target` to that worker; clearing the
+// chip with the × icon broadcasts (omits payload.target — the router
+// then defaults to the lead anyway, so for v0 the behaviour is the same
+// as the default).
+
+import { useEffect, useRef, useState } from "react";
+
+import { api } from "../lib/api";
+
+interface MissionInputProps {
+  missionId: string;
+  /** Stable lead handle — default recipient. */
+  leadHandle: string;
+  /** All non-human handles in the roster. The recipient picker offers
+   *  these; the human can also broadcast (clear the chip). */
+  handles: string[];
+  /** Set when the mission is no longer running. The input still renders
+   *  (so the feed below it stays visible) but submission is disabled. */
+  disabled?: boolean;
+  onError?: (msg: string) => void;
+}
+
+export function MissionInput({
+  missionId,
+  leadHandle,
+  handles,
+  disabled,
+  onError,
+}: MissionInputProps) {
+  const [text, setText] = useState("");
+  const [target, setTarget] = useState<string | null>(leadHandle);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const pickerRef = useRef<HTMLDivElement | null>(null);
+
+  // Sync with new lead if the prop changes (rare — but harmless to keep).
+  useEffect(() => {
+    setTarget((cur) => (cur === null ? null : leadHandle));
+  }, [leadHandle]);
+
+  useEffect(() => {
+    if (!pickerOpen) return;
+    const onDoc = (e: MouseEvent) => {
+      if (!pickerRef.current?.contains(e.target as Node)) setPickerOpen(false);
+    };
+    window.addEventListener("mousedown", onDoc);
+    return () => window.removeEventListener("mousedown", onDoc);
+  }, [pickerOpen]);
+
+  async function submit() {
+    const body = text.trim();
+    if (!body || submitting || disabled) return;
+    setSubmitting(true);
+    try {
+      const payload = target ? { text: body, target } : { text: body };
+      await api.mission.postHumanSignal({
+        mission_id: missionId,
+        signal_type: "human_said",
+        payload,
+      });
+      setText("");
+    } catch (e) {
+      onError?.(String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function onKeyDown(e: React.KeyboardEvent<HTMLTextAreaElement>) {
+    // Enter sends, Shift-Enter inserts a newline. Mirrors the Slack /
+    // Linear chat affordance the design references in frame `cFfYe`.
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      void submit();
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2.5 border-t border-line bg-bg px-10 pb-5 pt-3.5">
+      <div className="flex items-center gap-2.5 text-[11px] text-fg-2">
+        <span>Post to mission log as</span>
+        <span className="rounded bg-warn/20 px-2 py-0.5 text-[11px] font-semibold text-warn">
+          @human
+        </span>
+        <span className="text-fg-3">· visible to the crew</span>
+      </div>
+      <div className="flex flex-wrap items-center gap-2 text-[11px]" ref={pickerRef}>
+        <span className="text-fg-3">to:</span>
+        <button
+          type="button"
+          onClick={() => setPickerOpen((v) => !v)}
+          className="inline-flex items-center gap-1.5 rounded border border-line bg-panel px-2.5 py-1 font-mono text-[11px] text-fg hover:border-line-strong"
+        >
+          {target ? (
+            <>
+              @{target}
+              {target === leadHandle ? (
+                <span className="text-fg-3">(lead)</span>
+              ) : null}
+            </>
+          ) : (
+            <span className="text-fg-2">broadcast</span>
+          )}
+          <span className="text-fg-3">▾</span>
+        </button>
+        {target ? (
+          <button
+            type="button"
+            onClick={() => setTarget(null)}
+            title="Clear recipient (broadcast)"
+            className="text-fg-3 hover:text-fg"
+          >
+            ×
+          </button>
+        ) : null}
+        {pickerOpen ? (
+          <div className="relative">
+            <div className="absolute left-0 top-1.5 z-20 flex w-44 flex-col overflow-hidden rounded border border-line-strong bg-panel py-1 shadow-xl">
+              {handles.map((h) => (
+                <button
+                  key={h}
+                  type="button"
+                  onClick={() => {
+                    setTarget(h);
+                    setPickerOpen(false);
+                  }}
+                  className={`flex w-full items-center justify-between px-3 py-1.5 text-left font-mono text-[11px] hover:bg-raised ${
+                    h === target ? "text-accent" : "text-fg"
+                  }`}
+                >
+                  <span>@{h}</span>
+                  {h === leadHandle ? (
+                    <span className="text-[10px] text-fg-3">lead</span>
+                  ) : null}
+                </button>
+              ))}
+              <div className="border-t border-line my-1" />
+              <button
+                type="button"
+                onClick={() => {
+                  setTarget(null);
+                  setPickerOpen(false);
+                }}
+                className="px-3 py-1.5 text-left text-[11px] text-fg-2 hover:bg-raised"
+              >
+                broadcast
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+      <div className="flex items-end gap-3 rounded-lg border border-line bg-panel px-4 py-3">
+        <textarea
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={
+            disabled
+              ? "Mission stopped — input disabled."
+              : "Talk to the crew…"
+          }
+          disabled={disabled}
+          rows={1}
+          className="flex-1 resize-none bg-transparent text-[13px] text-fg placeholder:text-fg-3 focus:outline-none disabled:cursor-not-allowed"
+          style={{ minHeight: "24px", maxHeight: "240px" }}
+        />
+        <button
+          type="button"
+          onClick={() => void submit()}
+          disabled={!text.trim() || submitting || disabled}
+          className="rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-accent-ink transition-opacity disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          Send
+        </button>
+      </div>
+      <div className="flex flex-wrap gap-3.5 text-[11px] text-fg-3">
+        <span>↵ send</span>
+        <span>⇧↵ newline</span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -41,6 +41,11 @@ interface RunnerTerminalProps {
   onExit?: (ev: ExitEvent) => void;
   /** Surface terminal-side errors (stdin push failures, resize errors). */
   onError?: (msg: string) => void;
+  /** True while this terminal's tab is the foremost one in the workspace.
+   *  Every terminal stays mounted (z-stacked) so each PTY's xterm
+   *  scrollback survives tab-switching, but only the active one needs to
+   *  refresh + claim focus when the user comes back to it. */
+  active?: boolean;
 }
 
 const TERMINAL_THEME = {
@@ -80,6 +85,7 @@ export function RunnerTerminal({
   sessionId,
   onExit,
   onError,
+  active,
 }: RunnerTerminalProps) {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
@@ -117,6 +123,11 @@ export function RunnerTerminal({
       // No WebGL — fall through to canvas. RunnerChat does the same.
     }
     fit.fit();
+    // Don't auto-focus on mount: in the workspace, multiple
+    // RunnerTerminals mount at once before any tab is selected, and the
+    // last-mounted one would steal focus and shove the page into its
+    // own scroll position. The activation effect below grabs focus when
+    // the tab becomes active.
 
     const onDataDisposable = term.onData((data) => {
       const sid = sessionIdRef.current;
@@ -223,6 +234,30 @@ export function RunnerTerminal({
       unlistenExit?.();
     };
   }, [sessionId, onExit]);
+
+  // Activation effect: when this tab moves to the front, fit to the
+  // (possibly newly-laid-out) container, repaint the WebGL canvas with
+  // the current scrollback, and grab focus so keystrokes flow into the
+  // expected PTY. Stacked-but-occluded panes can have stale layout
+  // dimensions, so we always re-fit before refreshing.
+  useEffect(() => {
+    if (!active) return;
+    const t = termRef.current;
+    const fit = fitRef.current;
+    if (!t || !fit) return;
+    try {
+      fit.fit();
+      t.refresh(0, t.rows - 1);
+      t.focus();
+    } catch {
+      // Layout not ready yet — the next focus / resize will drive it.
+    }
+    // Also push the (possibly changed) grid down to the PTY so the
+    // agent renders at full width.
+    void api.session.resize(sessionId, t.cols, t.rows).catch(() => {
+      // session may have exited
+    });
+  }, [active, sessionId]);
 
   return (
     <div className="h-full w-full overflow-hidden">

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -1,16 +1,12 @@
 // Embedded xterm.js bound to a single live session.
 //
-// The mission workspace mounts one of these per session in the roster and
-// keeps them all alive simultaneously (stacked via absolute positioning).
-// Output keeps streaming into hidden instances so switching tabs preserves
-// each PTY's scrollback — without that, a `echo hi` typed in @lead while
-// @impl was the active tab would be lost from xterm's buffer the moment
-// the user switched back.
+// Direct chat and the mission workspace mount one of these per session and
+// keep them alive while switching between tabs/routes. Output keeps streaming
+// into hidden instances so each PTY's scrollback survives UI switches.
 //
-// This component is the second xterm consumer in the app — RunnerChat is
-// the first. Setup mirrors RunnerChat's: WebGL renderer for cell-row
-// alignment, base64 PTY frames to preserve raw bytes, SIGWINCH dance on
-// attach so claude-code repaints onto a fresh grid.
+// Setup: WebGL renderer for cell-row alignment, base64 PTY frames to preserve
+// raw bytes, backend snapshot replay for late attach, and SIGWINCH dance on
+// attach so claude-code/codex repaint onto a fresh grid.
 
 import { useEffect, useRef } from "react";
 
@@ -25,6 +21,7 @@ import { api } from "../lib/api";
 interface OutputEvent {
   session_id: string;
   mission_id: string | null;
+  seq: number;
   data: string;
 }
 
@@ -91,6 +88,8 @@ export function RunnerTerminal({
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
   const sessionIdRef = useRef<string>(sessionId);
+  const onExitRef = useRef(onExit);
+  const onErrorRef = useRef(onError);
 
   // Keep the latest sessionId visible to the data/resize callbacks without
   // re-creating the terminal on prop change. The session listener below
@@ -99,6 +98,14 @@ export function RunnerTerminal({
   useEffect(() => {
     sessionIdRef.current = sessionId;
   }, [sessionId]);
+
+  useEffect(() => {
+    onExitRef.current = onExit;
+  }, [onExit]);
+
+  useEffect(() => {
+    onErrorRef.current = onError;
+  }, [onError]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -133,7 +140,7 @@ export function RunnerTerminal({
       const sid = sessionIdRef.current;
       if (!sid) return;
       void api.session.injectStdin(sid, data).catch((e) => {
-        onError?.(String(e));
+        onErrorRef.current?.(String(e));
       });
     });
 
@@ -182,26 +189,38 @@ export function RunnerTerminal({
       termRef.current = null;
       fitRef.current = null;
     };
-  }, [onError]);
+  }, []);
 
-  // Subscribe to the bound session's output + exit. Re-runs on sessionId
-  // change, which means the workspace can recycle a RunnerTerminal across
-  // sessions if it ever needs to (currently it mounts one per session and
-  // keeps it for the mission's lifetime).
+  // Subscribe to the bound session's output + exit. The listener is registered
+  // before snapshot replay so live chunks that arrive during the command round
+  // trip are buffered and merged by seq.
   useEffect(() => {
     let unlistenOutput: (() => void) | null = null;
     let unlistenExit: (() => void) | null = null;
     let cancelled = false;
+    let replayDone = false;
+    let lastWrittenSeq = 0;
+    const pendingLive: OutputEvent[] = [];
+
+    const writeOutput = (ev: OutputEvent) => {
+      termRef.current?.write(decodeBase64Chunk(ev.data));
+    };
 
     void (async () => {
       const [fnOut, fnExit] = await Promise.all([
         listen<OutputEvent>("session/output", (event) => {
           if (event.payload.session_id !== sessionId) return;
-          termRef.current?.write(decodeBase64Chunk(event.payload.data));
+          if (!replayDone) {
+            pendingLive.push(event.payload);
+            return;
+          }
+          if (event.payload.seq <= lastWrittenSeq) return;
+          writeOutput(event.payload);
+          lastWrittenSeq = event.payload.seq;
         }),
         listen<ExitEvent>("session/exit", (event) => {
           if (event.payload.session_id !== sessionId) return;
-          onExit?.(event.payload);
+          onExitRef.current?.(event.payload);
         }),
       ]);
       if (cancelled) {
@@ -211,6 +230,27 @@ export function RunnerTerminal({
       }
       unlistenOutput = fnOut;
       unlistenExit = fnExit;
+
+      let snapshot: OutputEvent[] = [];
+      try {
+        snapshot = await api.session.outputSnapshot(sessionId);
+      } catch (e) {
+        onErrorRef.current?.(String(e));
+      }
+      if (cancelled) return;
+
+      termRef.current?.reset();
+      for (const ev of snapshot) {
+        writeOutput(ev);
+        lastWrittenSeq = Math.max(lastWrittenSeq, ev.seq);
+      }
+      replayDone = true;
+      for (const ev of pendingLive) {
+        if (ev.seq <= lastWrittenSeq) continue;
+        writeOutput(ev);
+        lastWrittenSeq = ev.seq;
+      }
+      pendingLive.length = 0;
 
       // SIGWINCH dance: nudge cols by -1 and back so the agent (claude-code,
       // codex, etc.) emits a fresh redraw onto our blank grid. Without
@@ -233,30 +273,44 @@ export function RunnerTerminal({
       unlistenOutput?.();
       unlistenExit?.();
     };
-  }, [sessionId, onExit]);
+  }, [sessionId]);
 
-  // Activation effect: when this tab moves to the front, fit to the
-  // (possibly newly-laid-out) container, repaint the WebGL canvas with
-  // the current scrollback, and grab focus so keystrokes flow into the
-  // expected PTY. Stacked-but-occluded panes can have stale layout
-  // dimensions, so we always re-fit before refreshing.
+  // Activation effect: when this tab moves to the front, wait for the pane
+  // to become measurable, fit to its container, repaint the WebGL/canvas
+  // renderer with the current scrollback, and grab focus so keystrokes flow
+  // into the expected PTY.
   useEffect(() => {
     if (!active) return;
-    const t = termRef.current;
-    const fit = fitRef.current;
-    if (!t || !fit) return;
-    try {
-      fit.fit();
-      t.refresh(0, t.rows - 1);
-      t.focus();
-    } catch {
-      // Layout not ready yet — the next focus / resize will drive it.
-    }
-    // Also push the (possibly changed) grid down to the PTY so the
-    // agent renders at full width.
-    void api.session.resize(sessionId, t.cols, t.rows).catch(() => {
-      // session may have exited
+    let cancelled = false;
+    let raf1 = 0;
+    let raf2 = 0;
+
+    const activate = () => {
+      if (cancelled) return;
+      const t = termRef.current;
+      const fit = fitRef.current;
+      if (!t || !fit) return;
+      try {
+        fit.fit();
+        t.refresh(0, t.rows - 1);
+        t.focus();
+        void api.session.resize(sessionId, t.cols, t.rows).catch(() => {
+          // session may have exited
+        });
+      } catch {
+        // Layout not ready yet — the next activation / resize will drive it.
+      }
+    };
+
+    raf1 = window.requestAnimationFrame(() => {
+      raf2 = window.requestAnimationFrame(activate);
     });
+
+    return () => {
+      cancelled = true;
+      window.cancelAnimationFrame(raf1);
+      window.cancelAnimationFrame(raf2);
+    };
   }, [active, sessionId]);
 
   return (

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -1,0 +1,232 @@
+// Embedded xterm.js bound to a single live session.
+//
+// The mission workspace mounts one of these per session in the roster and
+// keeps them all alive simultaneously (stacked via absolute positioning).
+// Output keeps streaming into hidden instances so switching tabs preserves
+// each PTY's scrollback — without that, a `echo hi` typed in @lead while
+// @impl was the active tab would be lost from xterm's buffer the moment
+// the user switched back.
+//
+// This component is the second xterm consumer in the app — RunnerChat is
+// the first. Setup mirrors RunnerChat's: WebGL renderer for cell-row
+// alignment, base64 PTY frames to preserve raw bytes, SIGWINCH dance on
+// attach so claude-code repaints onto a fresh grid.
+
+import { useEffect, useRef } from "react";
+
+import { listen } from "@tauri-apps/api/event";
+import { Terminal } from "@xterm/xterm";
+import { FitAddon } from "@xterm/addon-fit";
+import { WebglAddon } from "@xterm/addon-webgl";
+import "@xterm/xterm/css/xterm.css";
+
+import { api } from "../lib/api";
+
+interface OutputEvent {
+  session_id: string;
+  mission_id: string | null;
+  data: string;
+}
+
+interface ExitEvent {
+  session_id: string;
+  mission_id: string | null;
+  exit_code: number | null;
+  success: boolean;
+}
+
+interface RunnerTerminalProps {
+  sessionId: string;
+  /** Notified when the bound session emits an exit event. */
+  onExit?: (ev: ExitEvent) => void;
+  /** Surface terminal-side errors (stdin push failures, resize errors). */
+  onError?: (msg: string) => void;
+}
+
+const TERMINAL_THEME = {
+  background: "#0E0E10",
+  foreground: "#EDEDF0",
+  cursor: "#00FF9C",
+  cursorAccent: "#0E0E10",
+  selectionBackground: "#1F2127",
+  black: "#0E0E10",
+  red: "#FF4D6D",
+  green: "#00FF9C",
+  yellow: "#FFB020",
+  blue: "#39E5FF",
+  magenta: "#C792EA",
+  cyan: "#39E5FF",
+  white: "#EDEDF0",
+  brightBlack: "#5A5C66",
+  brightRed: "#FF7B8E",
+  brightGreen: "#5FFFB8",
+  brightYellow: "#FFCB6B",
+  brightBlue: "#82AAFF",
+  brightMagenta: "#C792EA",
+  brightCyan: "#89DDFF",
+  brightWhite: "#FFFFFF",
+};
+
+function decodeBase64Chunk(data: string): Uint8Array {
+  const raw = atob(data);
+  const bytes = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i += 1) {
+    bytes[i] = raw.charCodeAt(i);
+  }
+  return bytes;
+}
+
+export function RunnerTerminal({
+  sessionId,
+  onExit,
+  onError,
+}: RunnerTerminalProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const termRef = useRef<Terminal | null>(null);
+  const fitRef = useRef<FitAddon | null>(null);
+  const sessionIdRef = useRef<string>(sessionId);
+
+  // Keep the latest sessionId visible to the data/resize callbacks without
+  // re-creating the terminal on prop change. The session listener below
+  // re-binds when sessionId changes — and so does the SIGWINCH attach
+  // dance that wakes claude-code into repainting.
+  useEffect(() => {
+    sessionIdRef.current = sessionId;
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const term = new Terminal({
+      cols: 80,
+      rows: 24,
+      theme: TERMINAL_THEME,
+      fontFamily:
+        'Menlo, "SF Mono", Monaco, Consolas, "Liberation Mono", monospace',
+      fontSize: 13,
+      cursorBlink: true,
+      scrollback: 5000,
+      allowProposedApi: true,
+    });
+    const fit = new FitAddon();
+    term.loadAddon(fit);
+    term.open(containerRef.current);
+    try {
+      const webgl = new WebglAddon();
+      term.loadAddon(webgl);
+    } catch {
+      // No WebGL — fall through to canvas. RunnerChat does the same.
+    }
+    fit.fit();
+
+    const onDataDisposable = term.onData((data) => {
+      const sid = sessionIdRef.current;
+      if (!sid) return;
+      void api.session.injectStdin(sid, data).catch((e) => {
+        onError?.(String(e));
+      });
+    });
+
+    const pushSize = () => {
+      const t = termRef.current;
+      const sid = sessionIdRef.current;
+      if (!t || !sid) return;
+      void api.session.resize(sid, t.cols, t.rows).catch(() => {
+        // session may have exited
+      });
+    };
+    const onResize = () => {
+      try {
+        fit.fit();
+        pushSize();
+      } catch {
+        // teardown
+      }
+    };
+    window.addEventListener("resize", onResize);
+
+    const refreshTerm = () => {
+      const t = termRef.current;
+      if (!t) return;
+      try {
+        t.refresh(0, t.rows - 1);
+      } catch {
+        // teardown
+      }
+    };
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") refreshTerm();
+    };
+    window.addEventListener("focus", refreshTerm);
+    document.addEventListener("visibilitychange", onVisibility);
+
+    termRef.current = term;
+    fitRef.current = fit;
+
+    return () => {
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("focus", refreshTerm);
+      document.removeEventListener("visibilitychange", onVisibility);
+      onDataDisposable.dispose();
+      term.dispose();
+      termRef.current = null;
+      fitRef.current = null;
+    };
+  }, [onError]);
+
+  // Subscribe to the bound session's output + exit. Re-runs on sessionId
+  // change, which means the workspace can recycle a RunnerTerminal across
+  // sessions if it ever needs to (currently it mounts one per session and
+  // keeps it for the mission's lifetime).
+  useEffect(() => {
+    let unlistenOutput: (() => void) | null = null;
+    let unlistenExit: (() => void) | null = null;
+    let cancelled = false;
+
+    void (async () => {
+      const [fnOut, fnExit] = await Promise.all([
+        listen<OutputEvent>("session/output", (event) => {
+          if (event.payload.session_id !== sessionId) return;
+          termRef.current?.write(decodeBase64Chunk(event.payload.data));
+        }),
+        listen<ExitEvent>("session/exit", (event) => {
+          if (event.payload.session_id !== sessionId) return;
+          onExit?.(event.payload);
+        }),
+      ]);
+      if (cancelled) {
+        fnOut();
+        fnExit();
+        return;
+      }
+      unlistenOutput = fnOut;
+      unlistenExit = fnExit;
+
+      // SIGWINCH dance: nudge cols by -1 and back so the agent (claude-code,
+      // codex, etc.) emits a fresh redraw onto our blank grid. Without
+      // this, the pane sits empty until the user types.
+      const t = termRef.current;
+      if (t) {
+        const cols = t.cols;
+        const rows = t.rows;
+        try {
+          await api.session.resize(sessionId, Math.max(2, cols - 1), rows);
+          await api.session.resize(sessionId, cols, rows);
+        } catch {
+          // session may have exited
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      unlistenOutput?.();
+      unlistenExit?.();
+    };
+  }, [sessionId, onExit]);
+
+  return (
+    <div className="h-full w-full overflow-hidden">
+      <div ref={containerRef} className="h-full w-full" />
+    </div>
+  );
+}

--- a/src/components/RunnersRail.tsx
+++ b/src/components/RunnersRail.tsx
@@ -1,0 +1,92 @@
+// Right-hand rail in the mission workspace — one card per runner in the
+// roster, showing PTY status (running / stopped / crashed), last
+// `runner_status` (busy / idle), the LEAD badge, and an "open pty" link
+// that switches the center column to that runner's terminal tab.
+
+import type { SessionRow } from "../lib/api";
+
+interface RunnersRailProps {
+  sessions: SessionRow[];
+  /** Selected tab in the workspace. `null` means the feed tab is active. */
+  selectedSessionId: string | null;
+  /** Latest `runner_status` (busy/idle) per handle, projected from the
+   *  event feed by the workspace. Missing handles render as no badge. */
+  status: Record<string, "busy" | "idle">;
+  /** Stable lead handle for the mission, used to badge the right card. */
+  leadHandle: string;
+  onOpenPty: (sessionId: string) => void;
+}
+
+export function RunnersRail({
+  sessions,
+  selectedSessionId,
+  status,
+  leadHandle,
+  onOpenPty,
+}: RunnersRailProps) {
+  return (
+    <aside className="flex w-72 shrink-0 flex-col gap-3 border-l border-line bg-panel p-5">
+      <div className="text-[10px] font-semibold uppercase tracking-[0.15em] text-fg-3">
+        Runners
+      </div>
+      {sessions.length === 0 ? (
+        <p className="text-xs text-fg-3">No runners spawned.</p>
+      ) : (
+        sessions.map((s) => {
+          const isLead = s.handle === leadHandle;
+          const ptyStatus = s.status;
+          const dotClass =
+            ptyStatus === "running"
+              ? "bg-accent"
+              : ptyStatus === "crashed"
+                ? "bg-danger"
+                : "bg-fg-3";
+          const runnerStatus = status[s.handle];
+          const subtitle =
+            ptyStatus === "running"
+              ? runnerStatus
+                ? runnerStatus
+                : "running"
+              : ptyStatus;
+          const selected = selectedSessionId === s.id;
+          return (
+            <div
+              key={s.id}
+              className={`flex flex-col gap-1.5 rounded-md border bg-bg p-3 transition-colors ${
+                selected
+                  ? "border-accent/60"
+                  : "border-line hover:border-line-strong"
+              }`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center gap-1.5 min-w-0">
+                  <span
+                    className={`inline-flex h-1.5 w-1.5 shrink-0 rounded-full ${dotClass}`}
+                    title={ptyStatus}
+                  />
+                  <span className="truncate font-mono text-[13px] font-semibold text-fg">
+                    @{s.handle}
+                  </span>
+                  {isLead ? (
+                    <span className="rounded bg-warn/20 px-1.5 py-px text-[9px] font-bold uppercase tracking-wide text-warn">
+                      Lead
+                    </span>
+                  ) : null}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => onOpenPty(s.id)}
+                  disabled={ptyStatus !== "running"}
+                  className="text-[11px] font-medium text-accent hover:underline disabled:cursor-not-allowed disabled:text-fg-3 disabled:no-underline"
+                >
+                  {selected ? "open" : "open pty"}
+                </button>
+              </div>
+              <div className="text-[11px] text-fg-2">{subtitle}</div>
+            </div>
+          );
+        })
+      )}
+    </aside>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -64,17 +64,15 @@ export function Sidebar() {
   // the backend doesn't expose a "list running sessions" query yet);
   // otherwise fall back to the runner detail page.
   //
-  // If we're already on this chat route, no-op: re-navigating with new
-  // location.state would tear down the chat page's output/exit
-  // listeners (effect deps include state.sessionId) without re-spawning
-  // anything, leaving the pane blank.
   const openSession = useCallback(
     (handle: string) => {
       const target = `/runners/${handle}/chat`;
-      if (location.pathname === target) return;
       const sessionId = getActiveSession(handle);
       if (sessionId) {
-        navigate(target, { state: { sessionId } });
+        navigate(target, {
+          state: { sessionId },
+          replace: location.pathname === target,
+        });
       } else {
         navigate(`/runners/${handle}`);
       }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -22,6 +22,7 @@ import type {
   RunnerActivity,
   RunnerWithActivity,
   Session,
+  SessionOutputEvent,
   SpawnedSession,
   StartMissionInput,
   StartMissionOutput,
@@ -91,6 +92,8 @@ export const api = {
     kill: (sessionId: string) => invoke<void>("session_kill", { sessionId }),
     resize: (sessionId: string, cols: number, rows: number) =>
       invoke<void>("session_resize", { sessionId, cols, rows }),
+    outputSnapshot: (sessionId: string) =>
+      invoke<SessionOutputEvent[]>("session_output_snapshot", { sessionId }),
     startDirect: (
       runnerId: string,
       cwd: string | null,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -15,7 +15,9 @@ import type {
   CrewListItem,
   CrewMembership,
   CrewRunner,
+  Event,
   Mission,
+  PostHumanSignalInput,
   Runner,
   RunnerActivity,
   RunnerWithActivity,
@@ -76,6 +78,10 @@ export const api = {
     start: (input: StartMissionInput) =>
       invoke<StartMissionOutput>("mission_start", { input }),
     stop: (id: string) => invoke<Mission>("mission_stop", { id }),
+    eventsReplay: (missionId: string) =>
+      invoke<Event[]>("mission_events_replay", { missionId }),
+    postHumanSignal: (input: PostHumanSignalInput) =>
+      invoke<Event>("mission_post_human_signal", { input }),
   },
   session: {
     list: (missionId: string) =>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -33,6 +33,7 @@ import type {
 /** Session row joined with the runner's handle for UI labels. */
 export interface SessionRow extends Session {
   handle: string;
+  lead: boolean;
 }
 
 export const api = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -91,6 +91,13 @@ export interface SpawnedSession {
   pid: number | null;
 }
 
+export interface SessionOutputEvent {
+  session_id: string;
+  mission_id: string | null;
+  seq: number;
+  data: string;
+}
+
 export type MissionStatus = "running" | "completed" | "aborted";
 
 export interface Mission {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -194,3 +194,43 @@ export interface StartMissionOutput {
   mission: Mission;
   goal: string;
 }
+
+// Tauri payload for `event/appended` — the bus emits this on every newly
+// observed envelope, plus once per historical event during initial replay
+// (so the UI can rehydrate without an extra round-trip).
+export interface AppendedEvent {
+  mission_id: string;
+  event: Event;
+}
+
+// `human_said` payload sent from the workspace's MissionInput.
+//   - text: the human's message
+//   - target: handle of the recipient runner; omit for broadcast (router
+//     defaults to the lead per arch §5.5)
+export interface HumanSaidPayload {
+  text: string;
+  target?: string;
+}
+
+// `human_response` payload — the workspace's AskHumanCard emits this when
+// the user picks one of the choices. `question_id` is the appended
+// `human_question` event's id (see arch §5.5.0).
+export interface HumanResponsePayload {
+  question_id: string;
+  choice: string;
+}
+
+// Decoded shape of a `human_question` event's payload — the card the UI
+// renders from the appended signal.
+export interface HumanQuestionPayload {
+  triggered_by: string;
+  prompt: string;
+  choices?: string[];
+  on_behalf_of?: string;
+}
+
+export interface PostHumanSignalInput {
+  mission_id: string;
+  signal_type: "human_said" | "human_response";
+  payload: HumanSaidPayload | HumanResponsePayload;
+}

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -290,13 +290,11 @@ export default function MissionWorkspace() {
             </div>
 
             <div className="relative flex flex-1 min-h-0 flex-col">
-              {/* All panes stay mounted. The active one is on top via
-                  z-index; inactive ones are rendered behind it (so
-                  xterm's WebGL canvas keeps its scrollback intact) but
-                  occluded by the active pane's opaque bg-bg. We don't
-                  use visibility:hidden because it leaves WebGL canvas
-                  state in an inconsistent place — when the user
-                  switched back the buffer was visible-but-blank. */}
+              {/* All panes stay mounted so xterm's in-memory scrollback
+                  survives tab switches. Inactive panes use display:none:
+                  that keeps the React/xterm instances alive while making
+                  the visible session unambiguous. The terminal activation
+                  effect refits + repaints after the pane is shown. */}
               <Pane active={activeTab === "feed"}>
                 <EventFeed
                   missionId={mission.id}
@@ -350,14 +348,9 @@ function Pane({
 }) {
   return (
     <div
-      className="absolute inset-0 flex flex-col bg-bg"
-      style={{
-        zIndex: active ? 1 : 0,
-        // Inactive panes are visually occluded by the active one's
-        // opaque background, but we also disable pointer events so
-        // clicks/keystrokes can't leak to the panes underneath.
-        pointerEvents: active ? "auto" : "none",
-      }}
+      className={`absolute inset-0 flex-col bg-bg ${
+        active ? "flex" : "hidden"
+      }`}
     >
       {children}
     </div>

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -6,10 +6,9 @@
 //   - right rail: RunnersRail with status dots + LEAD badge + open pty
 //
 // The rail's "open pty" link selects the runner's terminal tab.
-// Terminals are stacked in the DOM (visibility toggled via z-index +
-// invisible Tailwind class) so each PTY's xterm scrollback survives
-// tab-switching — without that, `echo hi` typed in @lead disappears
-// the moment the user clicks @impl and back.
+// Terminals stay mounted and inactive panes are hidden with display:none, so
+// each PTY's xterm scrollback survives tab-switching. The backend terminal
+// snapshot covers bytes emitted before a pane first mounts.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useParams } from "react-router-dom";
@@ -49,6 +48,12 @@ export default function MissionWorkspace() {
     if (!id) return;
     let unlisten: (() => void) | null = null;
     let cancelled = false;
+    seenIdsRef.current = new Set();
+    setMission(null);
+    setSessions([]);
+    setEvents([]);
+    setActiveTab("feed");
+    setError(null);
     setLoading(true);
 
     const ingest = (newEvents: Event[]) => {
@@ -137,17 +142,25 @@ export default function MissionWorkspace() {
     };
   }, [id]);
 
-  // Lead handle resolved off the sessions list. The DB's
-  // one_lead_per_crew invariant guarantees at most one is flagged via
-  // crew_runners.lead — but session_list doesn't carry that flag, so we
-  // fall back to deriving it from the latest router-bridged events. For
-  // v0 we just use the first session whose handle matches the
-  // mission_goal recipient, which the router writes to the lead. As a
-  // last resort, the first session in roster order.
+  // Lead handle resolved from the crew_runners.lead flag returned by
+  // session_list. Fall back to roster order only for malformed/old rows.
   const leadHandle = useMemo(() => {
     if (sessions.length === 0) return "";
-    return sessions[0].handle;
+    return sessions.find((s) => s.lead)?.handle ?? sessions[0].handle;
   }, [sessions]);
+
+  const stopMission = useCallback(async () => {
+    if (!mission) return;
+    if (!confirm("Stop this mission?")) return;
+    try {
+      const stopped = await api.mission.stop(mission.id);
+      setMission(stopped);
+      const rows = await api.session.list(mission.id);
+      setSessions(rows);
+    } catch (e) {
+      setError(String(e));
+    }
+  }, [mission]);
 
   // Project ask_human → human_question pairings + human_response
   // resolutions out of the feed. Mirrors the router's reconstruct_from_log
@@ -247,11 +260,7 @@ export default function MissionWorkspace() {
           {mission?.status === "running" ? (
             <button
               type="button"
-              onClick={() => {
-                if (!mission) return;
-                if (!confirm("Stop this mission?")) return;
-                void api.mission.stop(mission.id).catch((e) => setError(String(e)));
-              }}
+              onClick={() => void stopMission()}
               className="rounded border border-line-strong bg-raised px-3 py-1 text-[11px] font-semibold text-fg hover:border-fg-3"
             >
               Stop

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -290,15 +290,14 @@ export default function MissionWorkspace() {
             </div>
 
             <div className="relative flex flex-1 min-h-0 flex-col">
-              {/* Feed tab. Hidden when a terminal tab is active so the
-                  feed's auto-scroll doesn't fight the terminal's xterm
-                  layout, but kept mounted so its event log subscription
-                  state is preserved. */}
-              <div
-                className={`absolute inset-0 flex flex-col ${
-                  activeTab === "feed" ? "" : "invisible pointer-events-none"
-                }`}
-              >
+              {/* All panes stay mounted. The active one is on top via
+                  z-index; inactive ones are rendered behind it (so
+                  xterm's WebGL canvas keeps its scrollback intact) but
+                  occluded by the active pane's opaque bg-bg. We don't
+                  use visibility:hidden because it leaves WebGL canvas
+                  state in an inconsistent place — when the user
+                  switched back the buffer was visible-but-blank. */}
+              <Pane active={activeTab === "feed"}>
                 <EventFeed
                   missionId={mission.id}
                   events={events}
@@ -313,27 +312,18 @@ export default function MissionWorkspace() {
                   disabled={mission.status !== "running"}
                   onError={setError}
                 />
-              </div>
+              </Pane>
 
-              {/* Terminal tabs — stacked, visibility-toggled. xterm keeps
-                  rendering output into hidden tabs so scrollback is
-                  preserved across switches. */}
               {sessions.map((s) => (
-                <div
-                  key={s.id}
-                  className={`absolute inset-0 flex flex-col bg-bg ${
-                    activeTab === s.id
-                      ? ""
-                      : "invisible pointer-events-none"
-                  }`}
-                >
+                <Pane key={s.id} active={activeTab === s.id}>
                   <div className="flex flex-1 min-h-0 p-3">
                     <RunnerTerminal
                       sessionId={s.id}
                       onError={setError}
+                      active={activeTab === s.id}
                     />
                   </div>
-                </div>
+                </Pane>
               ))}
             </div>
           </div>
@@ -347,6 +337,29 @@ export default function MissionWorkspace() {
           />
         </div>
       )}
+    </div>
+  );
+}
+
+function Pane({
+  active,
+  children,
+}: {
+  active: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="absolute inset-0 flex flex-col bg-bg"
+      style={{
+        zIndex: active ? 1 : 0,
+        // Inactive panes are visually occluded by the active one's
+        // opaque background, but we also disable pointer events so
+        // clicks/keystrokes can't leak to the panes underneath.
+        pointerEvents: active ? "auto" : "none",
+      }}
+    >
+      {children}
     </div>
   );
 }

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -1,0 +1,392 @@
+// Mission workspace page (`/missions/:id`) — the live view the human
+// works in once a mission is running. Three columns:
+//   - left sidebar (the AppShell's persistent Sidebar)
+//   - center: tab strip ("Feed" + one per runner pty) over either the
+//     EventFeed + MissionInput dock, or one of the runner terminals
+//   - right rail: RunnersRail with status dots + LEAD badge + open pty
+//
+// The rail's "open pty" link selects the runner's terminal tab.
+// Terminals are stacked in the DOM (visibility toggled via z-index +
+// invisible Tailwind class) so each PTY's xterm scrollback survives
+// tab-switching — without that, `echo hi` typed in @lead disappears
+// the moment the user clicks @impl and back.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+
+import { listen } from "@tauri-apps/api/event";
+
+import { api, type SessionRow } from "../lib/api";
+import type {
+  AppendedEvent,
+  Event,
+  HumanQuestionPayload,
+  Mission,
+} from "../lib/types";
+import { EventFeed } from "../components/EventFeed";
+import { MissionInput } from "../components/MissionInput";
+import { RunnersRail } from "../components/RunnersRail";
+import { RunnerTerminal } from "../components/RunnerTerminal";
+
+export default function MissionWorkspace() {
+  const { id } = useParams<{ id: string }>();
+  const [mission, setMission] = useState<Mission | null>(null);
+  const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const [events, setEvents] = useState<Event[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [activeTab, setActiveTab] = useState<"feed" | string>("feed"); // string = sessionId
+  const seenIdsRef = useRef<Set<string>>(new Set());
+
+  // Combined: subscribe to `event/appended` BEFORE running the
+  // events_replay query, then merge both into a single ULID-deduped
+  // event list. Without this ordering, an event the worker appends
+  // between the replay query returning and the listener attaching falls
+  // through to the floor — the bus already delivered it, but no one was
+  // listening yet. The bus's initial replay also hands back historical
+  // events via the same listener, so we dedup on both sides.
+  useEffect(() => {
+    if (!id) return;
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    setLoading(true);
+
+    const ingest = (newEvents: Event[]) => {
+      if (newEvents.length === 0) return;
+      const seen = seenIdsRef.current;
+      const fresh = newEvents.filter((e) => !seen.has(e.id));
+      if (fresh.length === 0) return;
+      for (const e of fresh) seen.add(e.id);
+      // Preserve append order: events from the replay are already
+      // sorted by ULID; events from the bus arrive in append order.
+      // Re-sort the merged tail so we never display out-of-order rows
+      // (a late-arriving replay event whose id sorts before a
+      // bus-delivered one would otherwise show up at the bottom).
+      setEvents((prev) => {
+        const merged = [...prev, ...fresh];
+        merged.sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+        return merged;
+      });
+    };
+
+    void (async () => {
+      try {
+        const fn = await listen<AppendedEvent>("event/appended", (msg) => {
+          const ev = msg.payload;
+          if (ev.mission_id !== id) return;
+          ingest([ev.event]);
+        });
+        if (cancelled) {
+          fn();
+          return;
+        }
+        unlisten = fn;
+
+        const [m, ss, evs] = await Promise.all([
+          api.mission.get(id),
+          api.session.list(id),
+          api.mission.eventsReplay(id),
+        ]);
+        if (cancelled) return;
+        setMission(m);
+        setSessions(ss);
+        ingest(evs);
+      } catch (e) {
+        if (!cancelled) setError(String(e));
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+      seenIdsRef.current = new Set();
+    };
+  }, [id]);
+
+  // Refresh session statuses when a session/exit event lands. Without
+  // this, the rail's status dots stay green even after a runner crashes
+  // — the bus's `event/appended` doesn't tell us about PTY-level state,
+  // only about the audit-log envelopes.
+  useEffect(() => {
+    if (!id) return;
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    void listen<{ session_id: string }>("session/exit", () => {
+      void api.session
+        .list(id)
+        .then((rows) => {
+          if (cancelled) return;
+          setSessions(rows);
+        })
+        .catch(() => {
+          // best-effort — surface only persistent failures via the
+          // initial-load error path
+        });
+    }).then((fn) => {
+      if (cancelled) {
+        fn();
+        return;
+      }
+      unlisten = fn;
+    });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [id]);
+
+  // Lead handle resolved off the sessions list. The DB's
+  // one_lead_per_crew invariant guarantees at most one is flagged via
+  // crew_runners.lead — but session_list doesn't carry that flag, so we
+  // fall back to deriving it from the latest router-bridged events. For
+  // v0 we just use the first session whose handle matches the
+  // mission_goal recipient, which the router writes to the lead. As a
+  // last resort, the first session in roster order.
+  const leadHandle = useMemo(() => {
+    if (sessions.length === 0) return "";
+    return sessions[0].handle;
+  }, [sessions]);
+
+  // Project ask_human → human_question pairings + human_response
+  // resolutions out of the feed. Mirrors the router's reconstruct_from_log
+  // logic so the UI can render the right state on reopen even before the
+  // bus has redelivered anything.
+  const { askersByQuestion, resolvedAsks } = useMemo(() => {
+    const askHumanAskers: Record<string, string> = {};
+    const askersByQuestion: Record<string, string> = {};
+    const resolvedAsks: Record<string, string> = {};
+    for (const ev of events) {
+      if (ev.kind !== "signal" || !ev.type) continue;
+      if (ev.type === "ask_human") {
+        askHumanAskers[ev.id] = ev.from;
+      } else if (ev.type === "human_question") {
+        const p = ev.payload as HumanQuestionPayload | null;
+        const askId = p?.triggered_by;
+        if (askId && askHumanAskers[askId]) {
+          askersByQuestion[ev.id] = askHumanAskers[askId];
+          delete askHumanAskers[askId];
+        }
+      } else if (ev.type === "human_response") {
+        const p = ev.payload as { question_id?: string; choice?: string } | null;
+        if (p?.question_id) {
+          resolvedAsks[p.question_id] = p.choice ?? "";
+        }
+      }
+    }
+    return { askersByQuestion, resolvedAsks };
+  }, [events]);
+
+  // Latest runner_status (busy/idle) per handle for the rail badge.
+  const runnerStatusMap = useMemo(() => {
+    const map: Record<string, "busy" | "idle"> = {};
+    for (const ev of events) {
+      if (
+        ev.kind === "signal" &&
+        ev.type === "runner_status" &&
+        ev.from
+      ) {
+        const state = (ev.payload as { state?: string } | null)?.state;
+        if (state === "busy" || state === "idle") map[ev.from] = state;
+      }
+    }
+    return map;
+  }, [events]);
+
+  const onOpenPty = useCallback((sessionId: string) => {
+    setActiveTab(sessionId);
+  }, []);
+
+  const handles = sessions.map((s) => s.handle);
+  const startedAt = mission ? formatRelativeTime(mission.started_at) : "";
+
+  return (
+    <div className="flex h-full flex-1 flex-col bg-bg">
+      <header className="flex items-start justify-between gap-4 border-b border-line bg-panel px-8 pb-4 pt-9">
+        <div className="flex flex-col gap-1 min-w-0">
+          <Link
+            to="/runners"
+            className="text-[12px] text-fg-2 hover:text-fg"
+          >
+            ← Runners
+          </Link>
+          <div className="flex items-baseline gap-3 min-w-0">
+            <h1 className="truncate text-[15px] font-semibold text-fg">
+              {mission?.title ?? "…"}
+            </h1>
+            <span className="truncate text-[11px] text-fg-3">
+              {sessions.length} runner{sessions.length === 1 ? "" : "s"}
+              {startedAt ? ` · started ${startedAt}` : ""}
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          {mission ? (
+            <span
+              className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium ${
+                mission.status === "running"
+                  ? "bg-accent/10 text-accent"
+                  : mission.status === "aborted"
+                    ? "bg-danger/10 text-danger"
+                    : "bg-raised text-fg-2"
+              }`}
+            >
+              <span
+                className={`inline-flex h-1.5 w-1.5 rounded-full ${
+                  mission.status === "running"
+                    ? "bg-accent"
+                    : mission.status === "aborted"
+                      ? "bg-danger"
+                      : "bg-fg-3"
+                }`}
+              />
+              {mission.status}
+            </span>
+          ) : null}
+          {mission?.status === "running" ? (
+            <button
+              type="button"
+              onClick={() => {
+                if (!mission) return;
+                if (!confirm("Stop this mission?")) return;
+                void api.mission.stop(mission.id).catch((e) => setError(String(e)));
+              }}
+              className="rounded border border-line-strong bg-raised px-3 py-1 text-[11px] font-semibold text-fg hover:border-fg-3"
+            >
+              Stop
+            </button>
+          ) : null}
+        </div>
+      </header>
+
+      {error ? (
+        <div className="mx-8 mt-3 rounded border border-danger/40 bg-danger/10 px-3 py-2 text-sm text-danger">
+          {error}
+        </div>
+      ) : null}
+
+      {loading || !mission ? (
+        <div className="px-8 py-8 text-sm text-fg-2">Loading mission…</div>
+      ) : (
+        <div className="flex flex-1 min-h-0">
+          <div className="flex flex-1 min-w-0 flex-col">
+            <div className="flex items-center gap-1 border-b border-line bg-panel px-6">
+              <TabButton
+                active={activeTab === "feed"}
+                onClick={() => setActiveTab("feed")}
+              >
+                feed
+              </TabButton>
+              {sessions.map((s) => (
+                <TabButton
+                  key={s.id}
+                  active={activeTab === s.id}
+                  onClick={() => setActiveTab(s.id)}
+                >
+                  @{s.handle} pty
+                </TabButton>
+              ))}
+            </div>
+
+            <div className="relative flex flex-1 min-h-0 flex-col">
+              {/* Feed tab. Hidden when a terminal tab is active so the
+                  feed's auto-scroll doesn't fight the terminal's xterm
+                  layout, but kept mounted so its event log subscription
+                  state is preserved. */}
+              <div
+                className={`absolute inset-0 flex flex-col ${
+                  activeTab === "feed" ? "" : "invisible pointer-events-none"
+                }`}
+              >
+                <EventFeed
+                  missionId={mission.id}
+                  events={events}
+                  resolvedAsks={resolvedAsks}
+                  askersByQuestion={askersByQuestion}
+                  onError={setError}
+                />
+                <MissionInput
+                  missionId={mission.id}
+                  leadHandle={leadHandle}
+                  handles={handles}
+                  disabled={mission.status !== "running"}
+                  onError={setError}
+                />
+              </div>
+
+              {/* Terminal tabs — stacked, visibility-toggled. xterm keeps
+                  rendering output into hidden tabs so scrollback is
+                  preserved across switches. */}
+              {sessions.map((s) => (
+                <div
+                  key={s.id}
+                  className={`absolute inset-0 flex flex-col bg-bg ${
+                    activeTab === s.id
+                      ? ""
+                      : "invisible pointer-events-none"
+                  }`}
+                >
+                  <div className="flex flex-1 min-h-0 p-3">
+                    <RunnerTerminal
+                      sessionId={s.id}
+                      onError={setError}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <RunnersRail
+            sessions={sessions}
+            selectedSessionId={activeTab === "feed" ? null : activeTab}
+            status={runnerStatusMap}
+            leadHandle={leadHandle}
+            onOpenPty={onOpenPty}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`-mb-px border-b-2 px-3 py-2 text-[12px] transition-colors ${
+        active
+          ? "border-accent text-fg"
+          : "border-transparent text-fg-2 hover:text-fg"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function formatRelativeTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    const diffMs = Date.now() - d.getTime();
+    const minutes = Math.floor(diffMs / 60000);
+    if (minutes < 1) return "just now";
+    if (minutes < 60) return `${minutes}m ago`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return `${hours}h ago`;
+    const days = Math.floor(hours / 24);
+    return `${days}d ago`;
+  } catch {
+    return iso;
+  }
+}

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -118,7 +118,8 @@ export default function MissionWorkspace() {
     if (!id) return;
     let unlisten: (() => void) | null = null;
     let cancelled = false;
-    void listen<{ session_id: string }>("session/exit", () => {
+    void listen<{ mission_id: string | null }>("session/exit", (event) => {
+      if (event.payload.mission_id !== id) return;
       void api.session
         .list(id)
         .then((rows) => {

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -1,38 +1,24 @@
 // Direct-chat pane (C8.5) — `/runners/:handle/chat`.
 //
 // One-on-one PTY between the human and the runner's CLI. No mission, no
-// orchestrator, no event bus. The chat page spawns the session itself
-// (rather than the Runner Detail page doing it before navigating) so the
-// event listener attaches BEFORE the PTY's reader thread starts emitting
-// — without that ordering, fast-exit runners or startup failures can
-// finish before the listener exists, leaving the pane stuck at
-// "running" with no output.
+// orchestrator, no event bus. Each direct session gets its own mounted
+// RunnerTerminal pane so switching chats preserves xterm's real screen and
+// scrollback while the backend output snapshot covers late attach / reload.
 //
 // Uses xterm.js so real TUIs (claude-code, codex) render correctly with
 // ANSI colors, cursor movement, and mouse tracking. A plain `<pre>`
 // can't interpret the control sequences these agents emit.
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 
-import { listen } from "@tauri-apps/api/event";
-import { Terminal } from "@xterm/xterm";
-import { FitAddon } from "@xterm/addon-fit";
-import { WebglAddon } from "@xterm/addon-webgl";
-import "@xterm/xterm/css/xterm.css";
-
+import { RunnerTerminal } from "../components/RunnerTerminal";
 import { api } from "../lib/api";
 import {
   clearActiveSession,
   setActiveSession,
 } from "../lib/activeSessions";
 import type { SessionStatus } from "../lib/types";
-
-interface OutputEvent {
-  session_id: string;
-  mission_id: string | null;
-  data: string;
-}
 
 interface ExitEvent {
   session_id: string;
@@ -55,40 +41,11 @@ interface RunnerChatLocationState {
   sessionId?: string;
 }
 
-const TERMINAL_THEME = {
-  // Carbon & Plasma palette. Background matches the page bg so the
-  // xterm canvas blends with the chrome instead of looking like a
-  // pasted-in box.
-  background: "#0E0E10",
-  foreground: "#EDEDF0",
-  cursor: "#00FF9C",
-  cursorAccent: "#0E0E10",
-  selectionBackground: "#1F2127",
-  black: "#0E0E10",
-  red: "#FF4D6D",
-  green: "#00FF9C",
-  yellow: "#FFB020",
-  blue: "#39E5FF",
-  magenta: "#C792EA",
-  cyan: "#39E5FF",
-  white: "#EDEDF0",
-  brightBlack: "#5A5C66",
-  brightRed: "#FF7B8E",
-  brightGreen: "#5FFFB8",
-  brightYellow: "#FFCB6B",
-  brightBlue: "#82AAFF",
-  brightMagenta: "#C792EA",
-  brightCyan: "#89DDFF",
-  brightWhite: "#FFFFFF",
-};
-
-function decodeBase64Chunk(data: string): Uint8Array {
-  const raw = atob(data);
-  const bytes = new Uint8Array(raw.length);
-  for (let i = 0; i < raw.length; i += 1) {
-    bytes[i] = raw.charCodeAt(i);
-  }
-  return bytes;
+interface DirectSessionPane {
+  id: string;
+  handle: string;
+  status: SessionStatus;
+  exitCode: number | null;
 }
 
 export default function RunnerChat() {
@@ -98,254 +55,108 @@ export default function RunnerChat() {
   const state = location.state as RunnerChatLocationState | null;
 
   const [sessionId, setSessionId] = useState<string | null>(null);
-  const [status, setStatus] = useState<SessionStatus>("running");
-  const [exitCode, setExitCode] = useState<number | null>(null);
+  const [directSessions, setDirectSessions] = useState<DirectSessionPane[]>([]);
   const [err, setErr] = useState<string | null>(null);
 
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const termRef = useRef<Terminal | null>(null);
-  const fitRef = useRef<FitAddon | null>(null);
-  const sessionIdRef = useRef<string | null>(null);
   // Set by `End chat` so the exit handler can distinguish a user-
   // initiated kill (we want it to read as "stopped") from an actual
   // crash. Without this, every End chat lands on status="crashed"
   // because SIGKILL bubbles up as a non-zero exit.
-  const userEndedRef = useRef(false);
-  // Pre-spawn buffer: the listener attaches before we have a session
-  // id, but the PTY's reader thread can emit between `spawn_direct`
-  // returning and our promise resolving. Anything that arrives in that
-  // window goes here and is replayed once we know our id.
-  const preSpawnBuffer = useRef<{
-    outputs: OutputEvent[];
-    exits: ExitEvent[];
-  }>({ outputs: [], exits: [] });
-  // Guard against React strict-mode double-mount re-spawning the PTY.
-  const startedRef = useRef(false);
+  const killedSessionsRef = useRef<Set<string>>(new Set());
+  // Last route/session request this component attached or spawned for.
+  // React Router reuses RunnerChat when moving between
+  // `/runners/:handle/chat` routes, so this must be keyed by handle and
+  // session state instead of a one-shot boolean.
+  const startedKeyRef = useRef<string | null>(null);
 
-  // Mount xterm once.
-  useEffect(() => {
-    if (!containerRef.current) return;
-    const term = new Terminal({
-      cols: 80,
-      rows: 24,
-      theme: TERMINAL_THEME,
-      // System monospace stack. Menlo ships with macOS and carries full
-      // Unicode box-drawing + braille ranges, so claude-code's dividers
-      // and spinner glyphs render without fallback to a proportional
-      // font (which would blow out cell metrics and misalign rows).
-      fontFamily:
-        'Menlo, "SF Mono", Monaco, Consolas, "Liberation Mono", monospace',
-      fontSize: 13,
-      cursorBlink: true,
-      scrollback: 5000,
-      allowProposedApi: true,
+  const activeSession = directSessions.find((s) => s.id === sessionId) ?? null;
+  const status = activeSession?.status ?? "running";
+  const exitCode = activeSession?.exitCode ?? null;
+
+  const upsertSession = useCallback((next: DirectSessionPane) => {
+    setDirectSessions((prev) => {
+      const found = prev.find((s) => s.id === next.id);
+      if (!found) return [...prev, next];
+      return prev.map((s) =>
+        s.id === next.id
+          ? {
+              ...s,
+              handle: next.handle,
+              status: next.status,
+              exitCode: next.exitCode,
+            }
+          : s,
+      );
     });
-    const fit = new FitAddon();
-    term.loadAddon(fit);
-    term.open(containerRef.current);
-    // WebGL renderer mounts after `open` — it needs the DOM context.
-    // The default canvas renderer in xterm v6 has a known cursor-row
-    // misalignment when the host font's reported metrics disagree with
-    // its measured cell box; WebGL bypasses that path entirely.
-    try {
-      const webgl = new WebglAddon();
-      term.loadAddon(webgl);
-    } catch {
-      // No WebGL context (rare in Tauri's webview, but fall through to
-      // canvas if so).
-    }
-    fit.fit();
-    term.focus();
-
-    // Forward keystrokes to the PTY. xterm converts arrow keys, ctrl
-    // chords, etc. into the right escape sequences before this fires,
-    // so we just pipe the resulting string straight through.
-    const onDataDisposable = term.onData((data) => {
-      const sid = sessionIdRef.current;
-      if (!sid) return;
-      void api.session.injectStdin(sid, data).catch((e) => {
-        setErr(String(e));
-      });
-    });
-
-    // Refit on window resize. We push the new grid down to the PTY so
-    // claude-code (and friends) re-render at full width instead of
-    // staying boxed at the spawn-time 80×24.
-    const pushSize = () => {
-      const t = termRef.current;
-      const sid = sessionIdRef.current;
-      if (!t || !sid) return;
-      void api.session
-        .resize(sid, t.cols, t.rows)
-        .catch(() => {
-          // ignore — session may have already exited
-        });
-    };
-    const onResize = () => {
-      try {
-        fit.fit();
-        pushSize();
-      } catch {
-        // ignore — happens during teardown
-      }
-    };
-    window.addEventListener("resize", onResize);
-
-    // Repaint when the window comes back to the foreground. macOS
-    // discards the canvas layer's contents while the Tauri window is
-    // backgrounded, so on return the xterm grid would otherwise show
-    // blank until the next byte of PTY output arrives. `refresh` walks
-    // xterm's in-memory buffer and re-renders every visible row.
-    const refreshTerm = () => {
-      const t = termRef.current;
-      if (!t) return;
-      try {
-        t.refresh(0, t.rows - 1);
-      } catch {
-        // ignore — happens during teardown
-      }
-    };
-    const onVisibility = () => {
-      if (document.visibilityState === "visible") refreshTerm();
-    };
-    window.addEventListener("focus", refreshTerm);
-    document.addEventListener("visibilitychange", onVisibility);
-
-    termRef.current = term;
-    fitRef.current = fit;
-
-    return () => {
-      window.removeEventListener("resize", onResize);
-      window.removeEventListener("focus", refreshTerm);
-      document.removeEventListener("visibilitychange", onVisibility);
-      onDataDisposable.dispose();
-      term.dispose();
-      termRef.current = null;
-      fitRef.current = null;
-    };
   }, []);
 
-  // Subscribe + spawn.
+  const attach = useCallback(
+    (id: string, sessionHandle: string) => {
+      setSessionId(id);
+      setErr(null);
+      upsertSession({
+        id,
+        handle: sessionHandle,
+        status: "running",
+        exitCode: null,
+      });
+      setActiveSession(sessionHandle, id);
+    },
+    [upsertSession],
+  );
+
+  const onTerminalExit = useCallback((sessionHandle: string, ev: ExitEvent) => {
+    const userEnded = killedSessionsRef.current.has(ev.session_id);
+    const nextStatus = ev.success || userEnded ? "stopped" : "crashed";
+    killedSessionsRef.current.delete(ev.session_id);
+    setDirectSessions((prev) =>
+      prev.map((s) =>
+        s.id === ev.session_id
+          ? { ...s, status: nextStatus, exitCode: ev.exit_code }
+          : s,
+      ),
+    );
+    clearActiveSession(sessionHandle);
+  }, []);
+
+  // Attach or spawn for the current route request. Each session gets its own
+  // mounted RunnerTerminal pane, so switching between direct chats preserves
+  // xterm's real in-memory screen and scrollback instead of trying to replay
+  // raw PTY bytes into a shared terminal.
   useEffect(() => {
-    let unlistenOutput: (() => void) | null = null;
-    let unlistenExit: (() => void) | null = null;
     let cancelled = false;
 
-    const consumeOutput = (ev: OutputEvent) => {
-      termRef.current?.write(decodeBase64Chunk(ev.data));
-    };
-    const consumeExit = (ev: ExitEvent) => {
-      setStatus(ev.success || userEndedRef.current ? "stopped" : "crashed");
-      setExitCode(ev.exit_code);
-      if (handle) clearActiveSession(handle);
-    };
-
-    const attach = (id: string) => {
-      sessionIdRef.current = id;
-      setSessionId(id);
-      void api.session.injectStdin(id, "").catch((e: unknown) => {
-        const msg = String(e);
-        if (msg.toLowerCase().includes("session not found")) {
-          setStatus("stopped");
-          if (handle) clearActiveSession(handle);
-        } else {
-          setErr(msg);
-        }
-      });
-      // Re-attach lands on a fresh xterm with no scrollback. SIGWINCH
-      // dance (one col narrower, then back) makes claude-code redraw
-      // its live state onto the blank grid. Without this, the pane
-      // stays empty until the user types and forces an emit.
-      const t = termRef.current;
-      if (t) {
-        const cols = t.cols;
-        const rows = t.rows;
-        void api.session
-          .resize(id, Math.max(2, cols - 1), rows)
-          .then(() => api.session.resize(id, cols, rows))
-          .catch(() => {});
-      }
-      for (const ev of preSpawnBuffer.current.outputs) {
-        if (ev.session_id === id) consumeOutput(ev);
-      }
-      for (const ev of preSpawnBuffer.current.exits) {
-        if (ev.session_id === id) consumeExit(ev);
-      }
-      preSpawnBuffer.current = { outputs: [], exits: [] };
-    };
-
-    // Critical ordering: register both event listeners BEFORE any
-    // spawn/attach call. Tauri's `listen()` is async — if we kick off
-    // `session_start_direct` first, the child can emit its first output
-    // (or exit, for fast-fail runners) before the listener exists, and
-    // the pane stays stuck on "starting…" with the bytes on the floor.
     void (async () => {
-      const [fnOut, fnExit] = await Promise.all([
-        listen<OutputEvent>("session/output", (event) => {
-          const sid = sessionIdRef.current;
-          if (sid === null) {
-            preSpawnBuffer.current.outputs.push(event.payload);
-            return;
-          }
-          if (event.payload.session_id !== sid) return;
-          consumeOutput(event.payload);
-        }),
-        listen<ExitEvent>("session/exit", (event) => {
-          const sid = sessionIdRef.current;
-          if (sid === null) {
-            preSpawnBuffer.current.exits.push(event.payload);
-            return;
-          }
-          if (event.payload.session_id !== sid) return;
-          consumeExit(event.payload);
-        }),
-      ]);
-      if (cancelled) {
-        fnOut();
-        fnExit();
-        return;
-      }
-      unlistenOutput = fnOut;
-      unlistenExit = fnExit;
-
-      if (startedRef.current) return;
-      startedRef.current = true;
+      const requestKey = [
+        handle ?? "",
+        state?.sessionId ?? "",
+        state?.runnerId ?? "",
+        state?.cwd ?? "",
+      ].join("\u0000");
+      if (startedKeyRef.current === requestKey) return;
+      startedKeyRef.current = requestKey;
+      setSessionId(null);
+      setErr(null);
 
       // Attach mode — caller already knows the session id (sidebar
       // re-entry).
-      if (state?.sessionId) {
-        attach(state.sessionId);
+      if (state?.sessionId && handle) {
+        attach(state.sessionId, handle);
         return;
       }
 
       // Spawn mode — first entry from the runner detail page.
-      if (state?.runnerId) {
+      if (state?.runnerId && handle) {
         const runnerId = state.runnerId;
-        const initTerm = termRef.current;
         try {
           const spawned = await api.session.startDirect(
             runnerId,
             state.cwd ?? null,
-            initTerm?.cols ?? null,
-            initTerm?.rows ?? null,
+            null,
+            null,
           );
           if (cancelled) return;
-          sessionIdRef.current = spawned.id;
-          setSessionId(spawned.id);
-          if (handle) setActiveSession(handle, spawned.id);
-          const t = termRef.current;
-          if (t) {
-            void api.session
-              .resize(spawned.id, t.cols, t.rows)
-              .catch(() => {});
-          }
-          for (const ev of preSpawnBuffer.current.outputs) {
-            if (ev.session_id === spawned.id) consumeOutput(ev);
-          }
-          for (const ev of preSpawnBuffer.current.exits) {
-            if (ev.session_id === spawned.id) consumeExit(ev);
-          }
-          preSpawnBuffer.current = { outputs: [], exits: [] };
+          attach(spawned.id, handle);
         } catch (e) {
           setErr(String(e));
         }
@@ -368,7 +179,7 @@ export default function RunnerChat() {
         const activity = await api.runner.activity(runner.id);
         if (cancelled) return;
         if (activity.direct_session_id) {
-          attach(activity.direct_session_id);
+          attach(activity.direct_session_id, handle);
         } else {
           setErr(
             "No live direct-chat session for this runner. Start one from the runner detail page.",
@@ -381,15 +192,12 @@ export default function RunnerChat() {
 
     return () => {
       cancelled = true;
-      unlistenOutput?.();
-      unlistenExit?.();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state?.runnerId, state?.cwd, state?.sessionId]);
+  }, [attach, handle, state?.runnerId, state?.cwd, state?.sessionId]);
 
   async function endChat() {
     if (!sessionId) return;
-    userEndedRef.current = true;
+    killedSessionsRef.current.add(sessionId);
     try {
       await api.session.kill(sessionId);
     } catch (e) {
@@ -406,61 +214,81 @@ export default function RunnerChat() {
 
   return (
     <div className="flex h-full flex-1 flex-col bg-bg">
-        <header className="flex items-center justify-between gap-4 border-b border-line bg-panel px-8 pb-4 pt-9">
-          <div className="flex items-baseline gap-2 text-sm text-fg-2">
-            <Link to="/runners" className="hover:text-fg">
-              Runners
-            </Link>
-            <span className="text-line-strong">›</span>
-            <Link to={`/runners/${handle}`} className="hover:text-fg">
-              @{handle}
-            </Link>
-            <span className="text-line-strong">›</span>
-            <span className="text-fg">direct chat</span>
-            <span className="ml-2 text-[11px]">
-              {sessionId ? (
-                <>
-                  <span className="text-fg-3">session {sessionId.slice(-6)} · </span>
-                  <span className={statusColor}>{status}</span>
-                </>
-              ) : (
-                <span className="text-fg-3">starting…</span>
-              )}
-              {exitCode != null ? (
-                <span className="text-fg-3"> · exit {exitCode}</span>
-              ) : null}
-            </span>
-          </div>
-          <div className="flex gap-2">
-            {status === "running" && sessionId ? (
-              <button
-                onClick={() => void endChat()}
-                className="cursor-pointer rounded border border-line-strong bg-raised px-3 py-1.5 text-xs font-semibold text-fg hover:border-fg-3"
-              >
-                End chat
-              </button>
+      <header className="flex items-center justify-between gap-4 border-b border-line bg-panel px-8 pb-4 pt-9">
+        <div className="flex items-baseline gap-2 text-sm text-fg-2">
+          <Link to="/runners" className="hover:text-fg">
+            Runners
+          </Link>
+          <span className="text-line-strong">›</span>
+          <Link to={`/runners/${handle}`} className="hover:text-fg">
+            @{handle}
+          </Link>
+          <span className="text-line-strong">›</span>
+          <span className="text-fg">direct chat</span>
+          <span className="ml-2 text-[11px]">
+            {sessionId ? (
+              <>
+                <span className="text-fg-3">session {sessionId.slice(-6)} · </span>
+                <span className={statusColor}>{status}</span>
+              </>
             ) : (
-              <button
-                onClick={() => navigate(`/runners/${handle}`)}
-                className="cursor-pointer rounded border border-line-strong bg-raised px-3 py-1.5 text-xs font-semibold text-fg hover:border-fg-3"
-              >
-                Back to runner
-              </button>
+              <span className="text-fg-3">starting…</span>
             )}
-          </div>
-        </header>
-
-        {err ? (
-          <div className="mx-8 mt-4 rounded border border-danger/40 bg-danger/10 px-3 py-2 text-sm text-danger">
-            {err}
-          </div>
-        ) : null}
-
-        {/* Terminal pane fills the remaining height. xterm renders into
-            this div; we don't put any other content inside. */}
-        <div className="flex-1 overflow-hidden p-4">
-          <div ref={containerRef} className="h-full w-full" />
+            {exitCode != null ? (
+              <span className="text-fg-3"> · exit {exitCode}</span>
+            ) : null}
+          </span>
         </div>
+        <div className="flex gap-2">
+          {status === "running" && sessionId ? (
+            <button
+              onClick={() => void endChat()}
+              className="cursor-pointer rounded border border-line-strong bg-raised px-3 py-1.5 text-xs font-semibold text-fg hover:border-fg-3"
+            >
+              End chat
+            </button>
+          ) : (
+            <button
+              onClick={() => navigate(`/runners/${handle}`)}
+              className="cursor-pointer rounded border border-line-strong bg-raised px-3 py-1.5 text-xs font-semibold text-fg hover:border-fg-3"
+            >
+              Back to runner
+            </button>
+          )}
+        </div>
+      </header>
+
+      {err ? (
+        <div className="mx-8 mt-4 rounded border border-danger/40 bg-danger/10 px-3 py-2 text-sm text-danger">
+          {err}
+        </div>
+      ) : null}
+
+      {/* Keep one xterm mounted per direct session. Hidden panes still receive
+          PTY output into their buffers, so switching sessions preserves the
+          real terminal state. */}
+      <div className="relative flex-1 overflow-hidden p-4">
+        {directSessions.length === 0 ? (
+          <div className="text-sm text-fg-3">Starting…</div>
+        ) : (
+          directSessions.map((s) => {
+            const active = s.id === sessionId;
+            return (
+              <div
+                key={s.id}
+                className={`absolute inset-4 ${active ? "block" : "hidden"}`}
+              >
+                <RunnerTerminal
+                  sessionId={s.id}
+                  active={active}
+                  onExit={(ev) => onTerminalExit(s.handle, ev)}
+                  onError={setErr}
+                />
+              </div>
+            );
+          })
+        )}
+      </div>
     </div>
   );
 }

--- a/src/pages/Runners.tsx
+++ b/src/pages/Runners.tsx
@@ -251,7 +251,7 @@ function RunnerCard({
                 e.stopPropagation();
                 onChat();
               }}
-              className="ml-1 inline-flex items-center gap-1.5 text-[11px] font-medium text-accent hover:opacity-80"
+              className="ml-1 inline-flex cursor-pointer items-center gap-1.5 rounded px-1.5 py-0.5 text-[11px] font-medium text-accent transition-colors hover:bg-accent/10 active:bg-accent/20"
               title={
                 item.direct_session_id
                   ? "Re-attach to live chat"

--- a/src/pages/Runners.tsx
+++ b/src/pages/Runners.tsx
@@ -10,6 +10,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { listen } from "@tauri-apps/api/event";
+import { MessageSquare } from "lucide-react";
 
 import { api } from "../lib/api";
 import type { RunnerActivityEvent, RunnerWithActivity } from "../lib/types";
@@ -68,7 +69,21 @@ export default function Runners() {
     };
   }, []);
 
-  const onChat = (handle: string) => navigate(`/runners/${handle}`);
+  // The Chat pill on a runner card takes you straight into a PTY — not
+  // a detour through the runner detail page. Re-attach if a live direct
+  // session already exists; otherwise spawn a fresh one and let the
+  // chat page take over.
+  const onChat = (item: RunnerWithActivity) => {
+    if (item.direct_session_id) {
+      navigate(`/runners/${item.handle}/chat`, {
+        state: { sessionId: item.direct_session_id },
+      });
+    } else {
+      navigate(`/runners/${item.handle}/chat`, {
+        state: { runnerId: item.id, cwd: null },
+      });
+    }
+  };
 
   const onDelete = async (id: string, handle: string) => {
     if (
@@ -134,7 +149,7 @@ export default function Runners() {
                   key={r.id}
                   item={r}
                   onOpen={() => navigate(`/runners/${r.handle}`)}
-                  onChat={() => onChat(r.handle)}
+                  onChat={() => onChat(r)}
                   onDelete={() => onDelete(r.id, r.handle)}
                 />
               ))}
@@ -236,10 +251,14 @@ function RunnerCard({
                 e.stopPropagation();
                 onChat();
               }}
-              className="ml-1 inline-flex items-center gap-1 rounded bg-accent/10 px-2 py-0.5 text-[11px] font-semibold text-accent hover:bg-accent/20"
-              title="Open runner detail · Chat now"
+              className="ml-1 inline-flex items-center gap-1.5 text-[11px] font-medium text-accent hover:opacity-80"
+              title={
+                item.direct_session_id
+                  ? "Re-attach to live chat"
+                  : "Spawn a new direct chat"
+              }
             >
-              <span aria-hidden>💬</span>
+              <MessageSquare aria-hidden className="h-3 w-3" />
               <span>Chat</span>
             </button>
           </div>


### PR DESCRIPTION
Implements C10 from \`docs/impls/v0-mvp.md\`: the \`/missions/:id\` workspace pane that surfaces the live mission — event feed, ask-human cards, runner rail, and embedded xterms — and reattaches cleanly on reopen. See the first PR comment for the implementation plan.