### PR TITLE
validation: mission resume robustness + paused overlay

### DIFF
--- a/cli/src/roster.rs
+++ b/cli/src/roster.rs
@@ -29,11 +29,26 @@ pub fn load(event_log: &Path) -> Option<Vec<RosterEntry>> {
     serde_json::from_slice::<Vec<RosterEntry>>(&bytes).ok()
 }
 
+/// Reserved virtual handle. The human isn't a slot in any crew, but
+/// they ARE a participant in the mission's bus traffic — workers can
+/// post `runner msg post --to human "<reply>"` and the workspace UI
+/// renders it as a `kind:"message"` row in the feed. Without
+/// reserving it here, `--to human` would either be rejected (when a
+/// roster sidecar is present) or silently allowed (sidecar missing)
+/// inconsistently. This makes it a first-class destination.
+pub const HUMAN_HANDLE: &str = "human";
+
 /// Returns true if `handle` is in the roster. Missing-sidecar is
 /// permissive for the same reason as the allowlist (a missing roster
 /// sidecar means something is broken upstream — don't strand the
 /// mission). Stderr warning surfaces the gap.
+///
+/// `HUMAN_HANDLE` always passes regardless of sidecar contents — see
+/// the doc on the constant for the rationale.
 pub fn is_known(event_log: &Path, handle: &str) -> bool {
+    if handle == HUMAN_HANDLE {
+        return true;
+    }
     match load(event_log) {
         Some(list) => list.iter().any(|r| r.handle == handle),
         None => {

--- a/design/runners-design.pen
+++ b/design/runners-design.pen
@@ -550,6 +550,51 @@
                   "fontWeight": "normal"
                 }
               ]
+            },
+            {
+              "type": "frame",
+              "id": "yE3cM",
+              "name": "sidebar_spacer",
+              "width": "fill_container",
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "VyTE6",
+              "name": "sidebar_div",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#1F2127"
+            },
+            {
+              "type": "frame",
+              "id": "IJsUO",
+              "name": "sidebar_settings",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 10,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "D4Q1rs",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                },
+                {
+                  "type": "text",
+                  "id": "DhiqQ",
+                  "fill": "#9A9BA5",
+                  "content": "Settings",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
             }
           ]
         },
@@ -1514,6 +1559,51 @@
                   "fontWeight": "normal"
                 }
               ]
+            },
+            {
+              "type": "frame",
+              "id": "nPifO",
+              "name": "sidebar_spacer",
+              "width": "fill_container",
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "jLZr7",
+              "name": "sidebar_div",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#1F2127"
+            },
+            {
+              "type": "frame",
+              "id": "yDywq",
+              "name": "sidebar_settings",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 10,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "psUMx",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                },
+                {
+                  "type": "text",
+                  "id": "T2Ry1x",
+                  "fill": "#9A9BA5",
+                  "content": "Settings",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
             }
           ]
         },
@@ -2178,7 +2268,7 @@
                               "fill": "#EDEDF0",
                               "textGrowth": "fixed-width",
                               "width": "fill_container",
-                              "content": "@impl wants to add `notify-debouncer-full` as a dependency. Approve?",
+                              "content": "Two-pass audit of quill#184 done. Need decisions on these spec amendments before implementation kicks off:\n\n1. **Read-only mode** by default, with per-tool opt-in for the 4 write tools? (Adds settings UI scope but matches your safety bias.)\n2. Add `search_highlights` cross-book search? Requires FTS migration on highlights table — net-new infra.\n3. Add `get_reading_stats` and `get_vocab_stats` to read tools? `get_vocab_stats` already exists in `vocab.rs:251`; reading stats needs feature 27 first.\n4. MCP writes propagate to peer devices via existing LWW sync — keep this behavior or filter MCP-originated writes out of the outbox?\n5. Multi-window reading state: most-recently-focused window wins, or expose all windows in `get_reading_state`?\n\nWhich of these should be in scope for the v1 spec?",
                               "lineHeight": 1.5,
                               "fontFamily": "Inter",
                               "fontSize": 13,
@@ -2188,24 +2278,59 @@
                               "type": "frame",
                               "id": "S1Z1W",
                               "name": "ask_choices",
-                              "gap": 8,
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 6,
                               "children": [
                                 {
                                   "type": "frame",
                                   "id": "UBkuw",
                                   "name": "btn_ok",
+                                  "width": "fill_container",
                                   "fill": "#00FF9C",
                                   "cornerRadius": 6,
+                                  "gap": 8,
                                   "padding": [
-                                    8,
+                                    10,
                                     14
                                   ],
+                                  "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "text",
                                       "id": "oCHnl",
                                       "fill": "#0E0E10",
-                                      "content": "Approve",
+                                      "content": "accept all five amendments",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Gql10",
+                                  "name": "btn_no",
+                                  "width": "fill_container",
+                                  "fill": "#16171B",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#1F2127"
+                                  },
+                                  "gap": 8,
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "PzF3e",
+                                      "fill": "#EDEDF0",
+                                      "content": "accept 1+4+5 only (safety + behavior pinning, defer search/stats)",
                                       "fontFamily": "Inter",
                                       "fontSize": 12,
                                       "fontWeight": "500"
@@ -2214,8 +2339,9 @@
                                 },
                                 {
                                   "type": "frame",
-                                  "id": "Gql10",
-                                  "name": "btn_no",
+                                  "id": "h5ynG",
+                                  "name": "btn_choice3",
+                                  "width": "fill_container",
                                   "fill": "#16171B",
                                   "cornerRadius": 6,
                                   "stroke": {
@@ -2223,16 +2349,48 @@
                                     "thickness": 1,
                                     "fill": "#1F2127"
                                   },
+                                  "gap": 8,
                                   "padding": [
-                                    8,
+                                    10,
                                     14
                                   ],
+                                  "alignItems": "center",
                                   "children": [
                                     {
                                       "type": "text",
-                                      "id": "PzF3e",
+                                      "id": "uIbzS",
                                       "fill": "#EDEDF0",
-                                      "content": "Override",
+                                      "content": "accept 1 only (read-only default), defer everything else",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 12,
+                                      "fontWeight": "500"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "akGoS",
+                                  "name": "btn_choice4",
+                                  "width": "fill_container",
+                                  "fill": "#16171B",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#1F2127"
+                                  },
+                                  "gap": 8,
+                                  "padding": [
+                                    10,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "text",
+                                      "id": "sHbal",
+                                      "fill": "#EDEDF0",
+                                      "content": "keep spec as-is, proceed to impl plan",
                                       "fontFamily": "Inter",
                                       "fontSize": 12,
                                       "fontWeight": "500"
@@ -2476,8 +2634,8 @@
           "type": "frame",
           "id": "EWpGa",
           "layoutPosition": "absolute",
-          "x": 80,
-          "y": 295,
+          "x": 996,
+          "y": 68,
           "name": "mission_ctx_menu",
           "width": 140,
           "fill": "#16171B",
@@ -2562,6 +2720,39 @@
                   "id": "Rzizj",
                   "fill": "#EDEDF0",
                   "content": "Rename",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "KRHl4",
+              "name": "mm_reset",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 10,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "VfBcM",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "rotate-ccw",
+                  "iconFontFamily": "lucide",
+                  "fill": "#EDEDF0"
+                },
+                {
+                  "type": "text",
+                  "id": "Fkrel",
+                  "fill": "#EDEDF0",
+                  "content": "Reset",
                   "fontFamily": "Inter",
                   "fontSize": 13,
                   "fontWeight": "normal"
@@ -2669,7 +2860,7 @@
                   "type": "text",
                   "id": "xauS9",
                   "fill": "#5A5C66",
-                  "content": "RUNNERS",
+                  "content": "RUNNER SESSIONS",
                   "fontFamily": "JetBrains Mono",
                   "fontSize": 10,
                   "fontWeight": "600",
@@ -5275,7 +5466,7 @@
     {
       "type": "frame",
       "id": "rMw15",
-      "x": 1575,
+      "x": 4695,
       "y": 2259,
       "name": "Start Mission modal",
       "width": 1440,
@@ -6388,6 +6579,51 @@
                   "content": "@architect direct",
                   "fontFamily": "Inter",
                   "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "IAggB",
+              "name": "sidebar_spacer",
+              "width": "fill_container",
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "N9vuXn",
+              "name": "sidebar_div",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#1F2127"
+            },
+            {
+              "type": "frame",
+              "id": "w9jRQ",
+              "name": "sidebar_settings",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 10,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "oU2In",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                },
+                {
+                  "type": "text",
+                  "id": "n1Kj9K",
+                  "fill": "#9A9BA5",
+                  "content": "Settings",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
                   "fontWeight": "normal"
                 }
               ]
@@ -11925,8 +12161,8 @@
     {
       "type": "frame",
       "id": "Fkoe8",
-      "x": 24,
-      "y": 4564,
+      "x": 15,
+      "y": 5559,
       "name": "SearchPalette",
       "width": 1440,
       "height": 900,
@@ -12501,7 +12737,7 @@
       "type": "frame",
       "id": "u6woG",
       "x": 15,
-      "y": 3398,
+      "y": 3359,
       "name": "Runner direct chat",
       "width": 1440,
       "height": 900,
@@ -12990,6 +13226,51 @@
                   "fontFamily": "Inter",
                   "fontSize": 12,
                   "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "oSuSu",
+              "name": "sidebar_spacer",
+              "width": "fill_container",
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "YlkBX",
+              "name": "sidebar_div",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#1F2127"
+            },
+            {
+              "type": "frame",
+              "id": "Y9bJK",
+              "name": "sidebar_settings",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 10,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "dXVHK",
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                },
+                {
+                  "type": "text",
+                  "id": "PoRiB",
+                  "fill": "#9A9BA5",
+                  "content": "Settings",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
                 }
               ]
             }
@@ -14024,7 +14305,7 @@
       "y": 2209,
       "name": "sessionLbl",
       "fill": "#00FF9C",
-      "content": "SESSION",
+      "content": "MISSION",
       "fontFamily": "JetBrains Mono",
       "fontSize": 18,
       "fontWeight": "700",
@@ -14034,7 +14315,7 @@
       "type": "frame",
       "id": "vS5ce",
       "x": 1575,
-      "y": 3398,
+      "y": 3359,
       "name": "Runner direct chat — stopped",
       "width": 1440,
       "height": 900,
@@ -15727,7 +16008,7 @@
       "type": "frame",
       "id": "GZhHO",
       "x": 3135,
-      "y": 3398,
+      "y": 3359,
       "name": "Runner direct chat — resuming",
       "width": 1440,
       "height": 900,
@@ -17179,7 +17460,7 @@
       "type": "frame",
       "id": "QfoJJ",
       "x": 4695,
-      "y": 3398,
+      "y": 3359,
       "name": "Runner direct chat — panel collapsed",
       "width": 1440,
       "height": 900,
@@ -18658,6 +18939,3653 @@
                   "fontFamily": "Inter",
                   "fontSize": 13,
                   "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "jMJmx",
+      "x": 1575,
+      "y": 2259,
+      "name": "Mission workspace — slot stopped",
+      "width": 1440,
+      "height": 900,
+      "fill": "#0E0E10",
+      "cornerRadius": 12,
+      "children": [
+        {
+          "type": "frame",
+          "id": "O01CU",
+          "name": "Sidebar",
+          "width": 240,
+          "height": "fill_container",
+          "fill": "#1F2127",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "#1F2127"
+          },
+          "layout": "vertical",
+          "gap": 4,
+          "padding": [
+            16,
+            20,
+            20,
+            20
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "fngfB",
+              "name": "brand",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "AfWpY",
+                  "name": "brandLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "vifwD",
+                      "name": "brandIcon",
+                      "width": 32,
+                      "height": 32,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "uHSyH",
+                          "x": 9,
+                          "y": 9,
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "#00FF9C"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "hzmju",
+                          "x": 3,
+                          "y": 3,
+                          "opacity": 0.4,
+                          "width": 9,
+                          "height": 9,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "#00FF9C"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "X9fyp",
+                          "x": 3,
+                          "y": 20,
+                          "opacity": 0.4,
+                          "width": 9,
+                          "height": 9,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "#00FF9C"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "z9pZj",
+                      "fill": "#EDEDF0",
+                      "content": "Runner",
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "LiDaZ",
+              "width": "fill_container",
+              "height": 14
+            },
+            {
+              "type": "text",
+              "id": "n6FLL",
+              "name": "cfg4",
+              "fill": "#5A5C66",
+              "content": "WORKSPACE",
+              "fontFamily": "JetBrains Mono",
+              "fontSize": 10,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "NmRu8",
+              "name": "nav_r",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "pOEgk",
+                  "name": "runnerIcon",
+                  "width": 12,
+                  "height": 12,
+                  "iconFontName": "terminal",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                },
+                {
+                  "type": "text",
+                  "id": "TlRPt",
+                  "fill": "#9A9BA5",
+                  "content": "runner",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "r3Iok",
+              "name": "nav_c",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "gN8bv",
+                  "name": "crewIcon",
+                  "width": 12,
+                  "height": 12,
+                  "iconFontName": "users",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                },
+                {
+                  "type": "text",
+                  "id": "Qn6sO",
+                  "fill": "#9A9BA5",
+                  "content": "crew",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "MWJWi",
+              "name": "nav_s",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "PI3Xm",
+                  "name": "searchIcon",
+                  "width": 12,
+                  "height": 12,
+                  "iconFontName": "search",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                },
+                {
+                  "type": "text",
+                  "id": "F2ifSm",
+                  "name": "searchLbl",
+                  "fill": "#9A9BA5",
+                  "content": "search",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Wf8rm",
+              "name": "missionSpacer",
+              "width": "fill_container",
+              "height": 20
+            },
+            {
+              "type": "frame",
+              "id": "Uk0WL",
+              "name": "MissionHeader",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "s4ZpW",
+                  "name": "MissionHeaderLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "u6djG",
+                      "name": "missionChev",
+                      "width": 10,
+                      "height": 10,
+                      "iconFontName": "chevron-down",
+                      "iconFontFamily": "lucide",
+                      "fill": "#5A5C66"
+                    },
+                    {
+                      "type": "text",
+                      "id": "PMRZM",
+                      "name": "missionLabel",
+                      "fill": "#5A5C66",
+                      "content": "MISSION",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "HpdMK",
+                      "name": "MissionCount",
+                      "fill": "#0E0E10",
+                      "cornerRadius": 999,
+                      "padding": [
+                        1,
+                        5
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "H9bii",
+                          "name": "missionBadgeTxt",
+                          "fill": "#5A5C66",
+                          "content": "1",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "hySWL",
+                  "name": "AddMissionBtn",
+                  "cornerRadius": 4,
+                  "padding": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "KlTRO",
+                      "name": "addMissionIcon",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "d5CDp6",
+              "name": "Mission1",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "yxGPA",
+                  "fill": "#00FF9C",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "D25Ihs",
+                  "fill": "#9A9BA5",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Create a temp go pr…",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "m2ATl",
+              "name": "sessSpacer",
+              "width": "fill_container",
+              "height": 32
+            },
+            {
+              "type": "frame",
+              "id": "c5hoJ",
+              "name": "SessionHeader",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "lcQSf",
+                  "name": "SessionHeaderLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "w58ZK",
+                      "name": "sessionChev",
+                      "width": 10,
+                      "height": 10,
+                      "iconFontName": "chevron-down",
+                      "iconFontFamily": "lucide",
+                      "fill": "#5A5C66"
+                    },
+                    {
+                      "type": "text",
+                      "id": "w1LmP",
+                      "name": "sessionLabel",
+                      "fill": "#5A5C66",
+                      "content": "SESSION",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QM1ku",
+                      "name": "SessionCount",
+                      "fill": "#0E0E10",
+                      "cornerRadius": 999,
+                      "padding": [
+                        1,
+                        5
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "n0Umei",
+                          "name": "sessionBadgeTxt",
+                          "fill": "#5A5C66",
+                          "content": "2",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "xbGhg",
+                  "name": "AddSessionBtn",
+                  "cornerRadius": 4,
+                  "padding": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "KdJTd",
+                      "name": "addMissionIcon",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "mgQ5C",
+              "name": "sess1_active",
+              "width": "fill_container",
+              "fill": "#0E0E10",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#1F2127"
+              },
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "B48jsw",
+                  "fill": "#00FF9C",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "QFeNI",
+                  "fill": "#EDEDF0",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Wire up event bus…",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "pWAO3",
+              "name": "mr2",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "N8WFDS",
+                  "fill": "#00FF9C",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "Ub5iR",
+                  "fill": "#9A9BA5",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "@architect direct",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "DDPmM",
+          "name": "Main",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "#0E0E10",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "l5Ym4",
+              "name": "Topbar",
+              "width": "fill_container",
+              "fill": "#16171B",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#1F2127"
+              },
+              "gap": 16,
+              "padding": [
+                14,
+                24
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "N6oqiw",
+                  "name": "tb_left",
+                  "width": "fill_container",
+                  "gap": 14,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "u2swFC",
+                      "name": "avatar",
+                      "width": 36,
+                      "height": 36,
+                      "fill": "#0E0E10",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#1F2127"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "GmgZv",
+                          "width": 18,
+                          "height": 18,
+                          "iconFontName": "flag",
+                          "iconFontFamily": "lucide",
+                          "fill": "#00FF9C"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "h4Y4F",
+                      "name": "tb_titles",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "I6I2y",
+                          "name": "title_row",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "h1l7h",
+                              "fill": "#EDEDF0",
+                              "content": "Wire up event bus watcher",
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "yfwFe",
+                              "name": "mission_chip",
+                              "fill": "#1F2127",
+                              "cornerRadius": 4,
+                              "padding": [
+                                2,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "K0RwzY",
+                                  "fill": "#9A9BA5",
+                                  "content": "MISSION",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 9,
+                                  "fontWeight": "700",
+                                  "letterSpacing": 0.5
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "NAmDS",
+                          "name": "meta_row",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "TkWaT",
+                              "fill": "#9A9BA5",
+                              "content": "runners-feature",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "BzM3S",
+                              "fill": "#5A5C66",
+                              "content": "·",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "EZXZ2",
+                              "fill": "#9A9BA5",
+                              "content": "3 runners",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "OyZjx",
+                              "fill": "#5A5C66",
+                              "content": "·",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "aVlfL",
+                              "fill": "#9A9BA5",
+                              "content": "started 14m ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Qt8iX",
+                  "name": "tb_right",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "xlHmE",
+                      "name": "status_badge",
+                      "fill": "#1F2127",
+                      "cornerRadius": 999,
+                      "gap": 6,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "e8r7pV",
+                          "fill": "#5A5C66",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "CVXx6",
+                          "fill": "#9A9BA5",
+                          "content": "stopped",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "MDaVx",
+                      "name": "stop_btn",
+                      "fill": "#0F2418",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#1F4D33"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "D07w8R",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "play",
+                          "iconFontFamily": "lucide",
+                          "fill": "#00FF9C"
+                        },
+                        {
+                          "type": "text",
+                          "id": "EFzWi",
+                          "fill": "#00FF9C",
+                          "content": "Resume",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "f5o4FH",
+                      "name": "tb_kebab",
+                      "width": 28,
+                      "height": 28,
+                      "cornerRadius": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Q9C2Ng",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "ellipsis",
+                          "iconFontFamily": "lucide",
+                          "fill": "#9A9BA5"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "TF1jx",
+              "name": "Body",
+              "width": "fill_container",
+              "height": "fill_container",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "YCiNl",
+                  "name": "Center",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "SD01a",
+                      "name": "TabStrip",
+                      "width": "fill_container",
+                      "height": 38,
+                      "fill": "#16171B",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": "#1F2127"
+                      },
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        24
+                      ],
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "wreKD",
+                          "name": "feedTab_active",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0,
+                            "fill": "#1F2127"
+                          },
+                          "gap": 6,
+                          "padding": [
+                            10,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "PYOei",
+                              "name": "feedLabel",
+                              "fill": "#5A5C66",
+                              "content": "feed",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "f0fJ5",
+                          "name": "ptyTab_inactive",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 2
+                            },
+                            "fill": "#00FF9C"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            10,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "w7q8Y",
+                              "name": "ptyIcon",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "terminal",
+                              "iconFontFamily": "lucide",
+                              "fill": "#EDEDF0"
+                            },
+                            {
+                              "type": "text",
+                              "id": "cQDds",
+                              "name": "ptyLabel",
+                              "fill": "#EDEDF0",
+                              "content": "@architect pty",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "rSAtk",
+                              "name": "ptyCloseBtn",
+                              "width": 16,
+                              "height": 16,
+                              "cornerRadius": 3,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "P06gzB",
+                                  "name": "ptyCloseIcon",
+                                  "width": 11,
+                                  "height": 11,
+                                  "iconFontName": "x",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#5A5C66"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "SLAak",
+                      "name": "termStop",
+                      "opacity": 0.45,
+                      "clip": true,
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "fill": "#0E0E10",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "padding": [
+                        16,
+                        40
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "E08f5R",
+                          "fill": "#EDEDF0",
+                          "content": "$ claude --session-id 01993b21-7e4f-7d9a-bb02-8a6f7c92c0a1",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "J9jnRl",
+                          "fill": "#00FF9C",
+                          "content": "✻ Welcome to Claude Code",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "lA6lr",
+                          "fill": "#9A9BA5",
+                          "content": " cwd:   /Users/jason/go/src/github.com/yicheng47/runner",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "CCWxa",
+                          "fill": "#39E5FF",
+                          "content": "▶ Mission: Wire up event bus watcher",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "FGEC4",
+                          "fill": "#EDEDF0",
+                          "content": "⏺ Decomposing into 4 phases. Dispatching task 1 to @impl…",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ZbWqM",
+                          "fill": "#5A5C66",
+                          "content": "[process exited]",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "L2kHJ",
+                      "name": "StoppedDock",
+                      "width": "fill_container",
+                      "fill": "#0E0E10",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "top": 1
+                        },
+                        "fill": "#1F2127"
+                      },
+                      "layout": "vertical",
+                      "gap": 14,
+                      "padding": [
+                        24,
+                        40
+                      ],
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "MwTgH",
+                          "name": "endedCard",
+                          "width": "fill_container",
+                          "fill": "#16171B",
+                          "cornerRadius": 12,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#1F2127"
+                          },
+                          "layout": "vertical",
+                          "gap": 14,
+                          "padding": 20,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "O1XlIf",
+                              "name": "endedHeader",
+                              "gap": 10,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "oH4Kh",
+                                  "width": 16,
+                                  "height": 16,
+                                  "iconFontName": "power-off",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#5A5C66"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Z6t4Y",
+                                  "fill": "#EDEDF0",
+                                  "content": "Session ended",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 15,
+                                  "fontWeight": "600"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "RKu4b",
+                              "fill": "#9A9BA5",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "@architect's PTY is closed, but the conversation is preserved. Resume to pick up where you left off.",
+                              "lineHeight": 1.4,
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Y2ud7",
+                              "name": "endedBtns",
+                              "gap": 8,
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "Z4lMXi",
+                                  "name": "resumeBtn",
+                                  "fill": "#00FF9C",
+                                  "cornerRadius": 6,
+                                  "gap": 8,
+                                  "padding": [
+                                    8,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "Y0Wlj",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "play",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#0E0E10"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "QzWJY",
+                                      "fill": "#0E0E10",
+                                      "content": "Resume @architect",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "600"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "LiZzQ",
+                                  "name": "archiveBtn",
+                                  "fill": "#16171B",
+                                  "cornerRadius": 6,
+                                  "stroke": {
+                                    "align": "inside",
+                                    "thickness": 1,
+                                    "fill": "#1F2127"
+                                  },
+                                  "gap": 8,
+                                  "padding": [
+                                    8,
+                                    14
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon_font",
+                                      "id": "AI2zO",
+                                      "width": 14,
+                                      "height": 14,
+                                      "iconFontName": "archive",
+                                      "iconFontFamily": "lucide",
+                                      "fill": "#9A9BA5"
+                                    },
+                                    {
+                                      "type": "text",
+                                      "id": "picpI",
+                                      "fill": "#EDEDF0",
+                                      "content": "Archive",
+                                      "fontFamily": "Inter",
+                                      "fontSize": 13,
+                                      "fontWeight": "normal"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "pFTjl",
+          "name": "Runners rail",
+          "width": 280,
+          "height": "fill_container",
+          "fill": "#16171B",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "left": 1
+            },
+            "fill": "#1F2127"
+          },
+          "layout": "vertical",
+          "gap": 12,
+          "padding": [
+            14,
+            20,
+            20,
+            20
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "p3W4qB",
+              "name": "panel_header",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 14,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "hEcqV",
+                  "name": "panel_topbar",
+                  "width": "fill_container",
+                  "justifyContent": "end",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "XgS1f",
+                      "name": "panelCollapse",
+                      "width": 24,
+                      "height": 24,
+                      "cornerRadius": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "qkPJQ",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "panel-right-close",
+                          "iconFontFamily": "lucide",
+                          "fill": "#9A9BA5"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "nALoy",
+                  "fill": "#5A5C66",
+                  "content": "RUNNER SESSIONS",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "600",
+                  "letterSpacing": 1
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "xHHvt",
+              "name": "rn1",
+              "width": "fill_container",
+              "fill": "#0E0E10",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#1F2127"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "rfxh2",
+                  "name": "rn1_h",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "y9aniJ",
+                      "name": "rn1_l",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "IjLoi",
+                          "fill": "#00FF9C",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "Df8MC",
+                          "fill": "#EDEDF0",
+                          "content": "@architect",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "s7pssq",
+                          "name": "lead_badge",
+                          "fill": "#2D1F0A",
+                          "cornerRadius": 3,
+                          "padding": [
+                            2,
+                            6
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Y0nLT3",
+                              "fill": "#FFB020",
+                              "content": "LEAD",
+                              "fontFamily": "Inter",
+                              "fontSize": 9,
+                              "fontWeight": "700",
+                              "letterSpacing": 0.5
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "Dk8BN",
+                  "fill": "#9A9BA5",
+                  "content": "claude-architect · idle",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "cXlYH",
+              "name": "rn2",
+              "width": "fill_container",
+              "fill": "#0E0E10",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#1F2127"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ppQZd",
+                  "name": "rn2_h",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "QleUE",
+                      "name": "rn2_l",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "hIUnF",
+                          "fill": "#00FF9C",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "tiqc8",
+                          "fill": "#EDEDF0",
+                          "content": "@impl",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "siunA",
+                  "fill": "#9A9BA5",
+                  "content": "codex-impl · editing watcher.rs",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ODQid",
+              "name": "rn3",
+              "width": "fill_container",
+              "fill": "#0E0E10",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#1F2127"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "HhkYh",
+                  "name": "rn3_h",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "QbUke",
+                      "name": "rn3_l",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "e6OoJ",
+                          "fill": "#A3A3A3",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "V3aAsw",
+                          "fill": "#EDEDF0",
+                          "content": "@reviewer",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "Cpwj5",
+                  "fill": "#9A9BA5",
+                  "content": "aider-reviewer · waiting",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "a3c7p",
+      "x": 3135,
+      "y": 2259,
+      "name": "Mission workspace — slot resuming",
+      "width": 1440,
+      "height": 900,
+      "fill": "#0E0E10",
+      "cornerRadius": 12,
+      "children": [
+        {
+          "type": "frame",
+          "id": "Dqp6u",
+          "name": "Sidebar",
+          "width": 240,
+          "height": "fill_container",
+          "fill": "#1F2127",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "#1F2127"
+          },
+          "layout": "vertical",
+          "gap": 4,
+          "padding": [
+            16,
+            20,
+            20,
+            20
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "yoBMO",
+              "name": "brand",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "cTIBR",
+                  "name": "brandLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "rGJ4y",
+                      "name": "brandIcon",
+                      "width": 32,
+                      "height": 32,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "b7So6R",
+                          "x": 9,
+                          "y": 9,
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "#00FF9C"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "d04df",
+                          "x": 3,
+                          "y": 3,
+                          "opacity": 0.4,
+                          "width": 9,
+                          "height": 9,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "#00FF9C"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "AKm9s",
+                          "x": 3,
+                          "y": 20,
+                          "opacity": 0.4,
+                          "width": 9,
+                          "height": 9,
+                          "iconFontName": "chevron-right",
+                          "iconFontFamily": "lucide",
+                          "fill": "#00FF9C"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "AEwQ0",
+                      "fill": "#EDEDF0",
+                      "content": "Runner",
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "qOAjd",
+              "width": "fill_container",
+              "height": 14
+            },
+            {
+              "type": "text",
+              "id": "B64bP",
+              "name": "cfg4",
+              "fill": "#5A5C66",
+              "content": "WORKSPACE",
+              "fontFamily": "JetBrains Mono",
+              "fontSize": 10,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "y0cQK",
+              "name": "nav_r",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "BuYHy",
+                  "name": "runnerIcon",
+                  "width": 12,
+                  "height": 12,
+                  "iconFontName": "terminal",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                },
+                {
+                  "type": "text",
+                  "id": "WjSJv",
+                  "fill": "#9A9BA5",
+                  "content": "runner",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "L2axL",
+              "name": "nav_c",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "jSVUE",
+                  "name": "crewIcon",
+                  "width": 12,
+                  "height": 12,
+                  "iconFontName": "users",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                },
+                {
+                  "type": "text",
+                  "id": "mOFIz",
+                  "fill": "#9A9BA5",
+                  "content": "crew",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "fjTln",
+              "name": "nav_s",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "dCKv0",
+                  "name": "searchIcon",
+                  "width": 12,
+                  "height": 12,
+                  "iconFontName": "search",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                },
+                {
+                  "type": "text",
+                  "id": "jQVaD",
+                  "name": "searchLbl",
+                  "fill": "#9A9BA5",
+                  "content": "search",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "kyIoO",
+              "name": "missionSpacer",
+              "width": "fill_container",
+              "height": 20
+            },
+            {
+              "type": "frame",
+              "id": "Z4X8p",
+              "name": "MissionHeader",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "IPmS4",
+                  "name": "MissionHeaderLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "hk9W4",
+                      "name": "missionChev",
+                      "width": 10,
+                      "height": 10,
+                      "iconFontName": "chevron-down",
+                      "iconFontFamily": "lucide",
+                      "fill": "#5A5C66"
+                    },
+                    {
+                      "type": "text",
+                      "id": "CCaVz",
+                      "name": "missionLabel",
+                      "fill": "#5A5C66",
+                      "content": "MISSION",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "OCcQM",
+                      "name": "MissionCount",
+                      "fill": "#0E0E10",
+                      "cornerRadius": 999,
+                      "padding": [
+                        1,
+                        5
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "rszsL",
+                          "name": "missionBadgeTxt",
+                          "fill": "#5A5C66",
+                          "content": "1",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "AssK6",
+                  "name": "AddMissionBtn",
+                  "cornerRadius": 4,
+                  "padding": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "a2H8o",
+                      "name": "addMissionIcon",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "VYdDN",
+              "name": "Mission1",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "k7iQrz",
+                  "fill": "#00FF9C",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "E6qVu",
+                  "fill": "#9A9BA5",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Create a temp go pr…",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "blr1W",
+              "name": "sessSpacer",
+              "width": "fill_container",
+              "height": 32
+            },
+            {
+              "type": "frame",
+              "id": "wlkfX",
+              "name": "SessionHeader",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "pVDVe",
+                  "name": "SessionHeaderLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "epNGv",
+                      "name": "sessionChev",
+                      "width": 10,
+                      "height": 10,
+                      "iconFontName": "chevron-down",
+                      "iconFontFamily": "lucide",
+                      "fill": "#5A5C66"
+                    },
+                    {
+                      "type": "text",
+                      "id": "kSOpo",
+                      "name": "sessionLabel",
+                      "fill": "#5A5C66",
+                      "content": "SESSION",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Qk6J5",
+                      "name": "SessionCount",
+                      "fill": "#0E0E10",
+                      "cornerRadius": 999,
+                      "padding": [
+                        1,
+                        5
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "B61Yn",
+                          "name": "sessionBadgeTxt",
+                          "fill": "#5A5C66",
+                          "content": "2",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BkmWm",
+                  "name": "AddSessionBtn",
+                  "cornerRadius": 4,
+                  "padding": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "NqgUK",
+                      "name": "addMissionIcon",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "DE4iG",
+              "name": "sess1_active",
+              "width": "fill_container",
+              "fill": "#0E0E10",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#1F2127"
+              },
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "ckINj",
+                  "fill": "#00FF9C",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "OY0u2",
+                  "fill": "#EDEDF0",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Wire up event bus…",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "mRvua",
+              "name": "mr2",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "J2CYj",
+                  "fill": "#00FF9C",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "apn9A",
+                  "fill": "#9A9BA5",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "@architect direct",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "RibcZ",
+          "name": "Main",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "#0E0E10",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "yk4MW",
+              "name": "Topbar",
+              "width": "fill_container",
+              "fill": "#16171B",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#1F2127"
+              },
+              "gap": 16,
+              "padding": [
+                14,
+                24
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "WRGJV",
+                  "name": "tb_left",
+                  "width": "fill_container",
+                  "gap": 14,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "i2JDH",
+                      "name": "avatar",
+                      "width": 36,
+                      "height": 36,
+                      "fill": "#0E0E10",
+                      "cornerRadius": 8,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#1F2127"
+                      },
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "T0sDv7",
+                          "width": 18,
+                          "height": 18,
+                          "iconFontName": "flag",
+                          "iconFontFamily": "lucide",
+                          "fill": "#00FF9C"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "uEQnm",
+                      "name": "tb_titles",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "k5L7x",
+                          "name": "title_row",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "tG0sm",
+                              "fill": "#EDEDF0",
+                              "content": "Wire up event bus watcher",
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "x9G4r",
+                              "name": "mission_chip",
+                              "fill": "#1F2127",
+                              "cornerRadius": 4,
+                              "padding": [
+                                2,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "ldAGv",
+                                  "fill": "#9A9BA5",
+                                  "content": "MISSION",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 9,
+                                  "fontWeight": "700",
+                                  "letterSpacing": 0.5
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "HVtpM",
+                          "name": "meta_row",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "ynl7T",
+                              "fill": "#9A9BA5",
+                              "content": "runners-feature",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "npfJC",
+                              "fill": "#5A5C66",
+                              "content": "·",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "vz8Lz",
+                              "fill": "#9A9BA5",
+                              "content": "3 runners",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "TXT0T",
+                              "fill": "#5A5C66",
+                              "content": "·",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "ij95A",
+                              "fill": "#9A9BA5",
+                              "content": "started 14m ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "oQGzv",
+                  "name": "tb_right",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "NHN7Q",
+                      "name": "status_badge",
+                      "fill": "#0F1E26",
+                      "cornerRadius": 999,
+                      "gap": 6,
+                      "padding": [
+                        4,
+                        8
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "Y6NhYc",
+                          "fill": "#39E5FF",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "Lawbf",
+                          "fill": "#39E5FF",
+                          "content": "resuming…",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "D6RIG",
+                      "name": "tb_kebab",
+                      "width": 28,
+                      "height": 28,
+                      "cornerRadius": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "QHx06",
+                          "width": 16,
+                          "height": 16,
+                          "iconFontName": "ellipsis",
+                          "iconFontFamily": "lucide",
+                          "fill": "#9A9BA5"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "oUcdh",
+              "name": "Body",
+              "width": "fill_container",
+              "height": "fill_container",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "nXrdb",
+                  "name": "Center",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "N8VpJL",
+                      "name": "TabStrip",
+                      "width": "fill_container",
+                      "height": 38,
+                      "fill": "#16171B",
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": {
+                          "bottom": 1
+                        },
+                        "fill": "#1F2127"
+                      },
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        24
+                      ],
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "EyTlN",
+                          "name": "feedTab_active",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 0,
+                            "fill": "#1F2127"
+                          },
+                          "gap": 6,
+                          "padding": [
+                            10,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "IwlB7",
+                              "name": "feedLabel",
+                              "fill": "#5A5C66",
+                              "content": "feed",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "dg6Ja",
+                          "name": "ptyTab_inactive",
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "bottom": 2
+                            },
+                            "fill": "#39E5FF"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            10,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "RcEXp",
+                              "name": "ptyIcon",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "terminal",
+                              "iconFontFamily": "lucide",
+                              "fill": "#39E5FF"
+                            },
+                            {
+                              "type": "text",
+                              "id": "NO9Pa",
+                              "name": "ptyLabel",
+                              "fill": "#39E5FF",
+                              "content": "@architect pty",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "aoOqP",
+                              "name": "ptyCloseBtn",
+                              "width": 16,
+                              "height": 16,
+                              "cornerRadius": 3,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon_font",
+                                  "id": "MSAwU",
+                                  "name": "ptyCloseIcon",
+                                  "width": 11,
+                                  "height": 11,
+                                  "iconFontName": "x",
+                                  "iconFontFamily": "lucide",
+                                  "fill": "#5A5C66"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Kc3s6",
+                      "name": "resumingPill",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "gap": 10,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "qKMbu",
+                          "name": "resumingInner",
+                          "fill": "#0F1E26",
+                          "cornerRadius": 999,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#1F3D4D"
+                          },
+                          "gap": 10,
+                          "padding": [
+                            10,
+                            16
+                          ],
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "MvR0R",
+                              "rotation": 29.999999999999996,
+                              "width": 16,
+                              "height": 16,
+                              "iconFontName": "loader",
+                              "iconFontFamily": "lucide",
+                              "fill": "#39E5FF"
+                            },
+                            {
+                              "type": "text",
+                              "id": "hmgPI",
+                              "fill": "#39E5FF",
+                              "content": "Resuming…",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "swZ08",
+          "name": "Runners rail",
+          "width": 280,
+          "height": "fill_container",
+          "fill": "#16171B",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "left": 1
+            },
+            "fill": "#1F2127"
+          },
+          "layout": "vertical",
+          "gap": 12,
+          "padding": [
+            14,
+            20,
+            20,
+            20
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "B2hEe",
+              "name": "panel_header",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 14,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "NNdDF",
+                  "name": "panel_topbar",
+                  "width": "fill_container",
+                  "justifyContent": "end",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "T4d6v",
+                      "name": "panelCollapse",
+                      "width": 24,
+                      "height": 24,
+                      "cornerRadius": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon_font",
+                          "id": "Ac4QN",
+                          "width": 14,
+                          "height": 14,
+                          "iconFontName": "panel-right-close",
+                          "iconFontFamily": "lucide",
+                          "fill": "#9A9BA5"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "h4oUvy",
+                  "fill": "#5A5C66",
+                  "content": "RUNNER SESSIONS",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "600",
+                  "letterSpacing": 1
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "gEGzn",
+              "name": "rn1",
+              "width": "fill_container",
+              "fill": "#0E0E10",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#1F2127"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "D818tm",
+                  "name": "rn1_h",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "aQx3c",
+                      "name": "rn1_l",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "obVx2",
+                          "fill": "#00FF9C",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "baihO",
+                          "fill": "#EDEDF0",
+                          "content": "@architect",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "j1gNs",
+                          "name": "lead_badge",
+                          "fill": "#2D1F0A",
+                          "cornerRadius": 3,
+                          "padding": [
+                            2,
+                            6
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "q8TGo6",
+                              "fill": "#FFB020",
+                              "content": "LEAD",
+                              "fontFamily": "Inter",
+                              "fontSize": 9,
+                              "fontWeight": "700",
+                              "letterSpacing": 0.5
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "dpB9t",
+                  "fill": "#9A9BA5",
+                  "content": "claude-architect · idle",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "l2DvLg",
+              "name": "rn2",
+              "width": "fill_container",
+              "fill": "#0E0E10",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#1F2127"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "wfqTn",
+                  "name": "rn2_h",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "iF866",
+                      "name": "rn2_l",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "kqviP",
+                          "fill": "#00FF9C",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "D5Nkpu",
+                          "fill": "#EDEDF0",
+                          "content": "@impl",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "hYfQo",
+                  "fill": "#9A9BA5",
+                  "content": "codex-impl · editing watcher.rs",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "K5WAJb",
+              "name": "rn3",
+              "width": "fill_container",
+              "fill": "#0E0E10",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#1F2127"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Js6nA",
+                  "name": "rn3_h",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "V4bhtS",
+                      "name": "rn3_l",
+                      "gap": 6,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "jyApw",
+                          "fill": "#A3A3A3",
+                          "width": 6,
+                          "height": 6
+                        },
+                        {
+                          "type": "text",
+                          "id": "DrmAS",
+                          "fill": "#EDEDF0",
+                          "content": "@reviewer",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "Hj4Mh",
+                  "fill": "#9A9BA5",
+                  "content": "aider-reviewer · waiting",
+                  "fontFamily": "Inter",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "hnxWB",
+      "x": 15,
+      "y": 4459,
+      "name": "Settings modal",
+      "width": 1440,
+      "height": 900,
+      "fill": "#00000088",
+      "justifyContent": "center",
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "frame",
+          "id": "iIwkx",
+          "name": "Modal",
+          "clip": true,
+          "width": 680,
+          "height": 560,
+          "fill": "#16171B",
+          "cornerRadius": 12,
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "#1F2127"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000088",
+            "offset": {
+              "x": 0,
+              "y": 10
+            },
+            "blur": 40
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "gnSgA",
+              "name": "sidebar",
+              "width": 200,
+              "height": "fill_container",
+              "fill": "#1F2127",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "#1F2127"
+              },
+              "layout": "vertical",
+              "gap": 4,
+              "padding": [
+                16,
+                12
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "f89rsh",
+                  "name": "stitle",
+                  "fill": "#EDEDF0",
+                  "content": "Settings",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "frame",
+                  "id": "zZ4L3",
+                  "name": "ssp",
+                  "width": "fill_container",
+                  "height": 10
+                },
+                {
+                  "type": "frame",
+                  "id": "OQoU3",
+                  "name": "nav_general",
+                  "width": "fill_container",
+                  "fill": "#0F2418",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "FLqen",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#00FF9C"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "K3E1k",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "oSGQ9",
+                          "fill": "#00FF9C",
+                          "content": "General",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "w7MswA",
+                          "fill": "#00CC7C",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Startup & defaults",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "AXoR7",
+                  "name": "nav_updates",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "bqfom",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "download",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "t6Cmsa",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "mPExb",
+                          "fill": "#EDEDF0",
+                          "content": "Updates",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Ykfi2",
+                          "fill": "#5A5C66",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Channel & auto-update",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "J6MIv",
+                  "name": "nav_about",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Ng47d",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "info",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WJ8Ff",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "TXesi",
+                          "fill": "#EDEDF0",
+                          "content": "About",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "YkTih",
+                          "fill": "#5A5C66",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Version & links",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "YC5OF",
+              "name": "content",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 18,
+              "padding": [
+                20,
+                24
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "F0FCJX",
+                  "layoutPosition": "absolute",
+                  "x": 440,
+                  "y": 12,
+                  "name": "settingsClose",
+                  "width": 28,
+                  "height": 28,
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "a50lF",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "x",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "SCesC",
+                  "name": "sec_head",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "g7L3DT",
+                      "fill": "#EDEDF0",
+                      "content": "General",
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "QTWsU",
+                      "fill": "#9A9BA5",
+                      "content": "Defaults and startup behavior.",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "CGoFO",
+                  "name": "sct_div",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "#1F2127"
+                },
+                {
+                  "type": "frame",
+                  "id": "SqRBj",
+                  "name": "row_autostart",
+                  "width": "fill_container",
+                  "gap": 24,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "xwuf4",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "BNx7r",
+                          "fill": "#EDEDF0",
+                          "content": "Auto-start last mission",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "xa6bN",
+                          "fill": "#9A9BA5",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Resume the most recent mission when the app launches.",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "h0n2L",
+                      "name": "toggle_on",
+                      "width": 32,
+                      "height": 18,
+                      "fill": "#0F2418",
+                      "cornerRadius": 999,
+                      "padding": 2,
+                      "justifyContent": "end",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "iDzar",
+                          "fill": "#00FF9C",
+                          "width": 14,
+                          "height": 14
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "foyS8",
+                  "name": "row_default_crew",
+                  "width": "fill_container",
+                  "gap": 24,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "EJvNM",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "d7kjf",
+                          "fill": "#EDEDF0",
+                          "content": "Default crew",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "TAmdL",
+                          "fill": "#9A9BA5",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Pre-selected when starting a new mission.",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "mubgv",
+                      "name": "dropdown",
+                      "fill": "#0E0E10",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#1F2127"
+                      },
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QizGF",
+                          "fill": "#EDEDF0",
+                          "content": "runners-feature",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "XuQ4C",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#9A9BA5"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "hoy38",
+                  "name": "row_palette",
+                  "width": "fill_container",
+                  "gap": 24,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "pDqB8",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "OAATN",
+                          "fill": "#EDEDF0",
+                          "content": "Show ⌘K palette on launch",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "X9sPt",
+                          "fill": "#9A9BA5",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Open the search palette automatically when the app starts.",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "U1Oyz",
+                      "name": "toggle_off",
+                      "width": 32,
+                      "height": 18,
+                      "fill": "#1F2127",
+                      "cornerRadius": 999,
+                      "padding": 2,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "cmUpR",
+                          "fill": "#5A5C66",
+                          "width": 14,
+                          "height": 14
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "MCqe9",
+                  "name": "row_workdir",
+                  "width": "fill_container",
+                  "gap": 24,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "IURGS",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "RvJrs",
+                          "fill": "#EDEDF0",
+                          "content": "Default working directory",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "ea8EH",
+                          "fill": "#9A9BA5",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Cwd new runner sessions inherit unless overridden.",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "XZbSN",
+                      "name": "pathbtn",
+                      "fill": "#0E0E10",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#1F2127"
+                      },
+                      "gap": 8,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "P0xYzu",
+                          "fill": "#EDEDF0",
+                          "content": "~/runner",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "p8VdKs",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "folder-open",
+                          "iconFontFamily": "lucide",
+                          "fill": "#9A9BA5"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "o1oK4",
+                  "name": "row_telemetry",
+                  "width": "fill_container",
+                  "gap": 24,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "MAyAF",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Tur5C",
+                          "fill": "#EDEDF0",
+                          "content": "Anonymous usage data",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "zfm3E",
+                          "fill": "#9A9BA5",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Send crash reports and aggregate usage data. No prompts or code.",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "KuRN9",
+                      "name": "toggle_off2",
+                      "width": 32,
+                      "height": 18,
+                      "fill": "#1F2127",
+                      "cornerRadius": 999,
+                      "padding": 2,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "dHSoh",
+                          "fill": "#5A5C66",
+                          "width": 14,
+                          "height": 14
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "ydevl",
+      "x": 15,
+      "y": 4409,
+      "name": "settingsLbl",
+      "fill": "#00FF9C",
+      "content": "SETTINGS",
+      "fontFamily": "JetBrains Mono",
+      "fontSize": 18,
+      "fontWeight": "700",
+      "letterSpacing": 2
+    },
+    {
+      "type": "text",
+      "id": "le3PD",
+      "x": 15,
+      "y": 3309,
+      "name": "directChatLbl",
+      "fill": "#00FF9C",
+      "content": "DIRECT CHAT",
+      "fontFamily": "JetBrains Mono",
+      "fontSize": 18,
+      "fontWeight": "700",
+      "letterSpacing": 2
+    },
+    {
+      "type": "text",
+      "id": "MfiaH",
+      "x": 15,
+      "y": 5509,
+      "name": "searchPaletteLbl",
+      "fill": "#00FF9C",
+      "content": "SEARCH PALETTE",
+      "fontFamily": "JetBrains Mono",
+      "fontSize": 18,
+      "fontWeight": "700",
+      "letterSpacing": 2
+    },
+    {
+      "type": "frame",
+      "id": "DzNZe",
+      "x": 6255,
+      "y": 2259,
+      "name": "Mission workspace — reset confirm",
+      "width": 1440,
+      "height": 420,
+      "fill": "#0E0E10",
+      "cornerRadius": 12,
+      "justifyContent": "center",
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "frame",
+          "id": "Kdx7c",
+          "layoutPosition": "absolute",
+          "x": 0,
+          "y": 0,
+          "name": "backdrop",
+          "width": "fill_container(0)",
+          "height": "fill_container(0)",
+          "fill": "#00000088",
+          "justifyContent": "center",
+          "alignItems": "center"
+        },
+        {
+          "type": "frame",
+          "id": "j2DY7T",
+          "name": "card",
+          "width": 480,
+          "fill": "#16171B",
+          "cornerRadius": 12,
+          "stroke": {
+            "align": "inside",
+            "thickness": 2,
+            "fill": "#FFB020"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000099",
+            "offset": {
+              "x": 0,
+              "y": 14
+            },
+            "blur": 40
+          },
+          "layout": "vertical",
+          "gap": 16,
+          "padding": 24,
+          "children": [
+            {
+              "type": "frame",
+              "id": "H9v9X8",
+              "name": "warnBar",
+              "width": "fill_container",
+              "height": 3,
+              "fill": "#FFB020"
+            },
+            {
+              "type": "frame",
+              "id": "b0He0",
+              "name": "hdr",
+              "gap": 12,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "d6GFML",
+                  "name": "iconWrap",
+                  "width": 36,
+                  "height": 36,
+                  "fill": "#2D1F0A",
+                  "cornerRadius": 999,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "UNN6T",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "triangle-alert",
+                      "iconFontFamily": "lucide",
+                      "fill": "#FFB020"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jg2jM",
+                  "name": "titleCol",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 2,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "pX8sY",
+                      "fill": "#EDEDF0",
+                      "content": "Reset mission?",
+                      "fontFamily": "Inter",
+                      "fontSize": 16,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "UmGTs",
+                      "fill": "#9A9BA5",
+                      "content": "This wipes the run and starts the crew over.",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "QjFj7",
+              "name": "bullets",
+              "width": "fill_container",
+              "fill": "#0E0E10",
+              "cornerRadius": 8,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#1F2127"
+              },
+              "layout": "vertical",
+              "gap": 6,
+              "padding": [
+                12,
+                14
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "NgqBG",
+                  "name": "b1",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "Evl4z",
+                      "fill": "#5A5C66",
+                      "content": "·",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "IpNEY",
+                      "fill": "#9A9BA5",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "All slot PTYs are killed and respawned fresh.",
+                      "lineHeight": 1.5,
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "j7ctY",
+                  "name": "b2",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "V6QaBd",
+                      "fill": "#5A5C66",
+                      "content": "·",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xCLYm",
+                      "fill": "#9A9BA5",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "The event log is wiped — feed history is lost.",
+                      "lineHeight": 1.5,
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "pexzC",
+                  "name": "b3",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "n1Pj9",
+                      "fill": "#5A5C66",
+                      "content": "·",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Vr83a",
+                      "fill": "#9A9BA5",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Agent conversations are dropped — claude-code starts fresh.",
+                      "lineHeight": 1.5,
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "B07IP",
+              "name": "btnRow",
+              "width": "fill_container",
+              "gap": 8,
+              "justifyContent": "end",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "IIWbP",
+                  "name": "btnCancel",
+                  "fill": "#16171B",
+                  "cornerRadius": 6,
+                  "stroke": {
+                    "align": "inside",
+                    "thickness": 1,
+                    "fill": "#1F2127"
+                  },
+                  "padding": [
+                    8,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ITHBZ",
+                      "fill": "#EDEDF0",
+                      "content": "Cancel",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "X6ZVX",
+                  "name": "btnReset",
+                  "fill": "#FFB020",
+                  "cornerRadius": 6,
+                  "gap": 8,
+                  "padding": [
+                    8,
+                    14
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "XCJiu",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "rotate-ccw",
+                      "iconFontFamily": "lucide",
+                      "fill": "#0E0E10"
+                    },
+                    {
+                      "type": "text",
+                      "id": "adDZ3",
+                      "fill": "#0E0E10",
+                      "content": "Reset mission",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    }
+                  ]
                 }
               ]
             }

--- a/docs/dev-log.md
+++ b/docs/dev-log.md
@@ -6,6 +6,19 @@
 
 ## 2026-04-30
 
+**Next session — follow-ups.**
+- Rename "direct session" → "chat" everywhere (UI copy, sidebar
+  section header, type names where reasonable). The current term is a
+  carryover from the backend `sessions` table; users read these as
+  "chats" and the mismatch is confusing.
+- Runner Detail's "Chat" button fires two sessions instead of one. Likely
+  a StrictMode / mount-effect double-trigger that slipped past the prior
+  spawn-mode dedupe. Repro: open Runners → click any runner → click Chat
+  once → sidebar shows two new entries.
+- Crew list page does not match the Pencil design. Audit against the
+  design's crew-list frame and bring layout / cards / empty state into
+  parity.
+
 **Workspace input gating + Mission paused overlay.** When a mission row
 is `running` but every PTY is dead (the derived "stopped" display
 state), the feed input is no longer interactive — replaced by a

--- a/docs/dev-log.md
+++ b/docs/dev-log.md
@@ -4,6 +4,59 @@
 > Keep this file chronological and lightweight. The stable implementation
 > reference lives in `docs/impls/v0-mvp.md`.
 
+## 2026-04-30
+
+**Workspace input gating + Mission paused overlay.** When a mission row
+is `running` but every PTY is dead (the derived "stopped" display
+state), the feed input is no longer interactive — replaced by a
+bottom-anchored Resume card that mirrors `SessionEndedOverlay`'s
+inline variant on the slot panes, so feed and PTY tabs share one
+recovery affordance. `SessionEndedOverlay` gained optional
+`title` / `subtitle` / `resumeLabel` overrides so mission-level copy
+("Mission paused") reuses the same visual contract.
+
+**Reset cleanup leaves no ghost sessions.** `mission_reset` already
+stamped `archived_at` on the rows it superseded, but `session_list`
+wasn't filtering on it — the sidebar stacked the old stopped row
+alongside the freshly-spawned one for every slot. Added
+`AND s.archived_at IS NULL` to the query, matching the predicate
+`mission_attach`'s slot lookup already uses.
+
+**Lead launch prompt deferred 2.5s.** The bus's initial replay fires
+`mission_goal` milliseconds after the lead PTY spawns. On a warm app
+(mission_reset, fast mission_start) claude-code's TUI hasn't drawn yet
+and the synchronous bytes get swallowed by the boot / trust-folder
+screen, leaving the lead with no system prompt. New
+`Router::inject_and_submit_delayed` defers the body+`\r` chord by the
+same 2.5s budget `SessionManager::schedule_first_prompt` already uses
+for non-lead workers; the `mission_goal` handler now routes through it.
+
+**Resume: fresh-fallback for missing claude-code conversations.**
+`claude --resume <uuid>` against a missing conversation file leaves
+the TUI half-broken with `No conversation found with session ID`.
+Trips most often when a lead PTY never persisted a turn (reset before
+its first message landed). New
+`router::runtime::claude_code_conversation_exists(cwd, uuid)` checks
+`$HOME/.claude/projects/<encoded-cwd>/<uuid>.jsonl` (encoding maps
+both `/` and `.` to `-` — claude-code's actual scheme — without the
+`.` swap, every cwd containing a dot would spuriously fall back). On
+miss, `SessionManager::resume` swaps `--resume` for `--session-id
+<existing-uuid>`, keeping the row's UUID bound to the new conversation
+via the existing `COALESCE` write.
+
+**Lead recovery prompt on fresh-fallback resume.** `mission_attach`
+sets a watermark that suppresses bus replay of `mission_goal`, so the
+lead would come up with no context after a fresh-fallback. Added
+`Router::fire_lead_launch_prompt` which reads the latest
+`mission_goal` text from the event log, runs the same
+`compose_launch_prompt` builder the bus handler uses, and injects via
+`inject_and_submit_delayed`. `SessionManager::resume` surfaces a
+`fresh_fallback_lead` flag on `SpawnedSession` (serde-skipped — not
+actionable from the UI); the `session_resume` command sees it and
+calls `fire_lead_launch_prompt` after the resume returns. The lead
+gets the rich launch prompt — system_prompt + mission goal + roster +
+crew context — not the worker coordination preamble.
+
 ## 2026-04-29
 
 **Mission lifecycle redesign + workspace polish.** Stop / Resume /

--- a/docs/dev-log.md
+++ b/docs/dev-log.md
@@ -6,6 +6,31 @@
 
 ## 2026-04-30
 
+**Review-driven fixes (PR #25).**
+- Tests green again. The lead's launch prompt is async in production
+  (`Router::inject_and_submit_delayed` 2.5s) but synchronous under
+  `cfg(test)` via a zeroed `LEAD_LAUNCH_PROMPT_DELAY` constant + an
+  inline branch in `inject_and_submit_delayed` when delay is zero.
+  Production keeps the body+`\r` chord; tests skip the `\r` so push
+  counts match the pre-async assertions. The
+  `claude_code_conversation_exists` fs check short-circuits to `true`
+  under `cfg(test)` so resume tests don't have to fake out
+  `~/.claude/projects/...` fixtures.
+- `mission_reset` is now all-or-nothing. Spawn-loop and bus-mount
+  failures both roll back: kill any live PTYs, stamp `archived_at` on
+  the freshly-inserted session rows, flip the mission to `aborted`.
+  Same shape as `mission_start`'s rollback — no half-reset states.
+- Partial PTY failure no longer pauses the whole mission. Pause
+  overlay + input disable now gate on `!anySessionLive` (zero alive)
+  instead of `!allSessionsLive` (any dead). One worker crashing while
+  the lead is still up keeps human-to-lead messaging working.
+- Codex resume no longer re-replays `runner.system_prompt` as a new
+  positional turn. `SessionManager::resume` now mirrors the spawn
+  guard (`runtime == "codex" && plan.resuming → None`).
+- Live `runner/activity` events use `slots` for `crew_count` instead
+  of the removed `crew_runners` table. Live + cold-path queries
+  (`commands::runner::runner_activity`) now agree.
+
 **Next session — follow-ups.**
 - Rename "direct session" → "chat" everywhere (UI copy, sidebar
   section header, type names where reasonable). The current term is a

--- a/docs/dev-log.md
+++ b/docs/dev-log.md
@@ -43,6 +43,12 @@
 - Crew list page does not match the Pencil design. Audit against the
   design's crew-list frame and bring layout / cards / empty state into
   parity.
+- Runner template needs a per-runner default **model** + **effort**
+  selection (claude-code: `--model` / thinking effort flag; codex:
+  equivalent). Today every spawn inherits whatever the agent CLI's own
+  default is, so users can't pin a runner to e.g. Opus + xhigh effort.
+  Surface as fields on the runner editor; thread through to argv via
+  `runner.args` or dedicated columns + the runtime adapter.
 
 **Workspace input gating + Mission paused overlay.** When a mission row
 is `running` but every PTY is dead (the derived "stopped" display

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "lucide-react": "^0.577.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.13.1",
+    "remark-gfm": "^4.0.1",
     "tailwindcss": "^4.2.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,15 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.2.5(react@19.2.5)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.14)(react@19.2.5)
       react-router-dom:
         specifier: ^7.13.1
         version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
       tailwindcss:
         specifier: ^4.2.1
         version: 4.2.4
@@ -722,11 +728,26 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/hast@3.0.4':
+    resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/mdast@4.0.4':
+    resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -735,6 +756,12 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
+
+  '@types/unist@3.0.3':
+    resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
   '@typescript-eslint/eslint-plugin@8.59.0':
     resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
@@ -795,6 +822,9 @@ packages:
     resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@ungap/structured-clone@1.3.0':
+    resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -830,6 +860,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -861,9 +894,24 @@ packages:
   caniuse-lite@1.0.30001788:
     resolution: {integrity: sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==}
 
+  ccount@2.0.1:
+    resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
+
+  character-entities-html4@2.1.0:
+    resolution: {integrity: sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==}
+
+  character-entities-legacy@3.0.0:
+    resolution: {integrity: sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==}
+
+  character-entities@2.0.2:
+    resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -871,6 +919,9 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  comma-separated-tokens@2.0.3:
+    resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
@@ -898,12 +949,22 @@ packages:
       supports-color:
         optional: true
 
+  decode-named-character-reference@1.3.0:
+    resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  devlop@1.1.0:
+    resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
   electron-to-chromium@1.5.343:
     resolution: {integrity: sha512-YHnQ3MXI08icvL9ZKnEBy05F2EQ8ob01UaMOuMbM8l+4UcAq6MPPbBTJBbsBUg3H8JeZNt+O4fjsoWth3p6IFg==}
@@ -924,6 +985,10 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escape-string-regexp@5.0.0:
+    resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
+    engines: {node: '>=12'}
 
   eslint-plugin-react-hooks@7.1.1:
     resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
@@ -978,9 +1043,15 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1039,11 +1110,20 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
+  hast-util-whitespace@3.0.0:
+    resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
+
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
 
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1061,6 +1141,18 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -1068,6 +1160,13 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1186,6 +1285,9 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  longest-streak@3.1.0:
+    resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1196,6 +1298,138 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-table@3.0.4:
+    resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  mdast-util-find-and-replace@3.0.2:
+    resolution: {integrity: sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==}
+
+  mdast-util-from-markdown@2.0.3:
+    resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    resolution: {integrity: sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==}
+
+  mdast-util-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==}
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    resolution: {integrity: sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==}
+
+  mdast-util-gfm-table@2.0.0:
+    resolution: {integrity: sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==}
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    resolution: {integrity: sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==}
+
+  mdast-util-gfm@3.1.0:
+    resolution: {integrity: sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
+
+  mdast-util-phrasing@4.1.0:
+    resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
+
+  mdast-util-to-hast@13.2.1:
+    resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
+
+  mdast-util-to-markdown@2.1.2:
+    resolution: {integrity: sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==}
+
+  mdast-util-to-string@4.0.0:
+    resolution: {integrity: sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==}
+
+  micromark-core-commonmark@2.0.3:
+    resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    resolution: {integrity: sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==}
+
+  micromark-extension-gfm-footnote@2.1.0:
+    resolution: {integrity: sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==}
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    resolution: {integrity: sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==}
+
+  micromark-extension-gfm-table@2.1.1:
+    resolution: {integrity: sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==}
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    resolution: {integrity: sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==}
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    resolution: {integrity: sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==}
+
+  micromark-extension-gfm@3.0.0:
+    resolution: {integrity: sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==}
+
+  micromark-factory-destination@2.0.1:
+    resolution: {integrity: sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==}
+
+  micromark-factory-label@2.0.1:
+    resolution: {integrity: sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==}
+
+  micromark-factory-space@2.0.1:
+    resolution: {integrity: sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==}
+
+  micromark-factory-title@2.0.1:
+    resolution: {integrity: sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==}
+
+  micromark-factory-whitespace@2.0.1:
+    resolution: {integrity: sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==}
+
+  micromark-util-character@2.1.1:
+    resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
+
+  micromark-util-chunked@2.0.1:
+    resolution: {integrity: sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==}
+
+  micromark-util-classify-character@2.0.1:
+    resolution: {integrity: sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==}
+
+  micromark-util-combine-extensions@2.0.1:
+    resolution: {integrity: sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==}
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    resolution: {integrity: sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==}
+
+  micromark-util-decode-string@2.0.1:
+    resolution: {integrity: sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==}
+
+  micromark-util-encode@2.0.1:
+    resolution: {integrity: sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==}
+
+  micromark-util-html-tag-name@2.0.1:
+    resolution: {integrity: sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==}
+
+  micromark-util-normalize-identifier@2.0.1:
+    resolution: {integrity: sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==}
+
+  micromark-util-resolve-all@2.0.1:
+    resolution: {integrity: sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==}
+
+  micromark-util-sanitize-uri@2.0.1:
+    resolution: {integrity: sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==}
+
+  micromark-util-subtokenize@2.1.0:
+    resolution: {integrity: sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==}
+
+  micromark-util-symbol@2.0.1:
+    resolution: {integrity: sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==}
+
+  micromark-util-types@2.0.2:
+    resolution: {integrity: sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==}
+
+  micromark@4.0.2:
+    resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1234,6 +1468,9 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1257,6 +1494,9 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  property-information@7.1.0:
+    resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1265,6 +1505,12 @@ packages:
     resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
     peerDependencies:
       react: ^19.2.5
+
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
 
   react-refresh@0.17.0:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
@@ -1290,6 +1536,18 @@ packages:
   react@19.2.5:
     resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
     engines: {node: '>=0.10.0'}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1327,9 +1585,21 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  space-separated-tokens@2.0.2:
+    resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  stringify-entities@4.0.4:
+    resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  style-to-js@1.1.21:
+    resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
+
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -1345,6 +1615,12 @@ packages:
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
+
+  trim-lines@3.0.1:
+    resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -1368,6 +1644,24 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  unified@11.0.5:
+    resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
+
+  unist-util-is@6.0.1:
+    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
+
+  unist-util-position@5.0.0:
+    resolution: {integrity: sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==}
+
+  unist-util-stringify-position@4.0.0:
+    resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
+
+  unist-util-visit-parents@6.0.2:
+    resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
+
+  unist-util-visit@5.1.0:
+    resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -1376,6 +1670,12 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@6.0.3:
+    resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
@@ -1441,6 +1741,9 @@ packages:
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
+  zwitch@2.0.4:
+    resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
 
@@ -1950,9 +2253,27 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.8
+
   '@types/estree@1.0.8': {}
 
+  '@types/hast@3.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
   '@types/json-schema@7.0.15': {}
+
+  '@types/mdast@4.0.4':
+    dependencies:
+      '@types/unist': 3.0.3
+
+  '@types/ms@2.1.0': {}
 
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
@@ -1961,6 +2282,10 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/unist@2.0.11': {}
+
+  '@types/unist@3.0.3': {}
 
   '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
@@ -2053,6 +2378,8 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
+  '@ungap/structured-clone@1.3.0': {}
+
   '@vitejs/plugin-react@4.7.0(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@babel/core': 7.29.0
@@ -2090,6 +2417,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  bail@2.0.2: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
@@ -2117,16 +2446,28 @@ snapshots:
 
   caniuse-lite@1.0.30001788: {}
 
+  ccount@2.0.1: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
+
+  character-entities-html4@2.1.0: {}
+
+  character-entities-legacy@3.0.0: {}
+
+  character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  comma-separated-tokens@2.0.3: {}
 
   concat-map@0.0.1: {}
 
@@ -2146,9 +2487,19 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decode-named-character-reference@1.3.0:
+    dependencies:
+      character-entities: 2.0.2
+
   deep-is@0.1.4: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  devlop@1.1.0:
+    dependencies:
+      dequal: 2.0.3
 
   electron-to-chromium@1.5.343: {}
 
@@ -2189,6 +2540,8 @@ snapshots:
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
+
+  escape-string-regexp@5.0.0: {}
 
   eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
@@ -2273,7 +2626,11 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-util-is-identifier-name@3.0.0: {}
+
   esutils@2.0.3: {}
+
+  extend@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -2316,11 +2673,37 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.1.21
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  hast-util-whitespace@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+
   hermes-estree@0.25.1: {}
 
   hermes-parser@0.25.1:
     dependencies:
       hermes-estree: 0.25.1
+
+  html-url-attributes@3.0.1: {}
 
   ignore@5.3.2: {}
 
@@ -2333,11 +2716,26 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inline-style-parser@0.2.7: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-decimal@2.0.1: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-hexadecimal@2.0.1: {}
+
+  is-plain-obj@4.1.0: {}
 
   isexe@2.0.0: {}
 
@@ -2423,6 +2821,8 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  longest-streak@3.1.0: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2434,6 +2834,352 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-table@3.0.4: {}
+
+  mdast-util-find-and-replace@3.0.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      escape-string-regexp: 5.0.0
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
+  mdast-util-from-markdown@2.0.3:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      mdast-util-to-string: 4.0.0
+      micromark: 4.0.2
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-decode-string: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+      unist-util-stringify-position: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-autolink-literal@2.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-find-and-replace: 3.0.2
+      micromark-util-character: 2.1.1
+
+  mdast-util-gfm-footnote@2.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      micromark-util-normalize-identifier: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-strikethrough@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-table@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      markdown-table: 3.0.4
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm-task-list-item@2.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-gfm@3.1.0:
+    dependencies:
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-gfm-autolink-literal: 2.0.1
+      mdast-util-gfm-footnote: 2.1.0
+      mdast-util-gfm-strikethrough: 2.0.0
+      mdast-util-gfm-table: 2.0.0
+      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-phrasing@4.1.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      unist-util-is: 6.0.1
+
+  mdast-util-to-hast@13.2.1:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.3.0
+      devlop: 1.1.0
+      micromark-util-sanitize-uri: 2.0.1
+      trim-lines: 3.0.1
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+
+  mdast-util-to-markdown@2.1.2:
+    dependencies:
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      longest-streak: 3.1.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-string: 4.0.0
+      micromark-util-classify-character: 2.0.1
+      micromark-util-decode-string: 2.0.1
+      unist-util-visit: 5.1.0
+      zwitch: 2.0.4
+
+  mdast-util-to-string@4.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+
+  micromark-core-commonmark@2.0.3:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-factory-destination: 2.0.1
+      micromark-factory-label: 2.0.1
+      micromark-factory-space: 2.0.1
+      micromark-factory-title: 2.0.1
+      micromark-factory-whitespace: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-html-tag-name: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-autolink-literal@2.1.0:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-footnote@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-strikethrough@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-classify-character: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-table@2.1.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-tagfilter@2.0.0:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm-task-list-item@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-extension-gfm@3.0.0:
+    dependencies:
+      micromark-extension-gfm-autolink-literal: 2.1.0
+      micromark-extension-gfm-footnote: 2.1.0
+      micromark-extension-gfm-strikethrough: 2.1.0
+      micromark-extension-gfm-table: 2.1.1
+      micromark-extension-gfm-tagfilter: 2.0.0
+      micromark-extension-gfm-task-list-item: 2.1.0
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-destination@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-label@2.0.1:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-space@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-title@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-factory-whitespace@2.0.1:
+    dependencies:
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-character@2.1.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-chunked@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-classify-character@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-combine-extensions@2.0.1:
+    dependencies:
+      micromark-util-chunked: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-decode-numeric-character-reference@2.0.2:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-decode-string@2.0.1:
+    dependencies:
+      decode-named-character-reference: 1.3.0
+      micromark-util-character: 2.1.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-encode@2.0.1: {}
+
+  micromark-util-html-tag-name@2.0.1: {}
+
+  micromark-util-normalize-identifier@2.0.1:
+    dependencies:
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-resolve-all@2.0.1:
+    dependencies:
+      micromark-util-types: 2.0.2
+
+  micromark-util-sanitize-uri@2.0.1:
+    dependencies:
+      micromark-util-character: 2.1.1
+      micromark-util-encode: 2.0.1
+      micromark-util-symbol: 2.0.1
+
+  micromark-util-subtokenize@2.1.0:
+    dependencies:
+      devlop: 1.1.0
+      micromark-util-chunked: 2.0.1
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+
+  micromark-util-symbol@2.0.1: {}
+
+  micromark-util-types@2.0.2: {}
+
+  micromark@4.0.2:
+    dependencies:
+      '@types/debug': 4.1.13
+      debug: 4.4.3
+      decode-named-character-reference: 1.3.0
+      devlop: 1.1.0
+      micromark-core-commonmark: 2.0.3
+      micromark-factory-space: 2.0.1
+      micromark-util-character: 2.1.1
+      micromark-util-chunked: 2.0.1
+      micromark-util-combine-extensions: 2.0.1
+      micromark-util-decode-numeric-character-reference: 2.0.2
+      micromark-util-encode: 2.0.1
+      micromark-util-normalize-identifier: 2.0.1
+      micromark-util-resolve-all: 2.0.1
+      micromark-util-sanitize-uri: 2.0.1
+      micromark-util-subtokenize: 2.1.0
+      micromark-util-symbol: 2.0.1
+      micromark-util-types: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   minimatch@10.2.5:
     dependencies:
@@ -2472,6 +3218,16 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
@@ -2488,12 +3244,32 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  property-information@7.1.0: {}
+
   punycode@2.3.1: {}
 
   react-dom@19.2.5(react@19.2.5):
     dependencies:
       react: 19.2.5
       scheduler: 0.27.0
+
+  react-markdown@10.1.0(@types/react@19.2.14)(react@19.2.5):
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.5
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   react-refresh@0.17.0: {}
 
@@ -2512,6 +3288,40 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
 
   react@19.2.5: {}
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.5
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.1.2
+      unified: 11.0.5
 
   resolve-from@4.0.0: {}
 
@@ -2562,7 +3372,22 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  space-separated-tokens@2.0.2: {}
+
+  stringify-entities@4.0.4:
+    dependencies:
+      character-entities-html4: 2.1.0
+      character-entities-legacy: 3.0.0
+
   strip-json-comments@3.1.1: {}
+
+  style-to-js@1.1.21:
+    dependencies:
+      style-to-object: 1.0.14
+
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
 
   supports-color@7.2.0:
     dependencies:
@@ -2576,6 +3401,10 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  trim-lines@3.0.1: {}
+
+  trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@5.8.3):
     dependencies:
@@ -2598,6 +3427,39 @@ snapshots:
 
   typescript@5.8.3: {}
 
+  unified@11.0.5:
+    dependencies:
+      '@types/unist': 3.0.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      extend: 3.0.2
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unist-util-is@6.0.1:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-position@5.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-stringify-position@4.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+
+  unist-util-visit-parents@6.0.2:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+
+  unist-util-visit@5.1.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.1
+      unist-util-visit-parents: 6.0.2
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
@@ -2607,6 +3469,16 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
+  vfile@6.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      vfile-message: 4.0.3
 
   vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
@@ -2636,3 +3508,5 @@ snapshots:
       zod: 4.3.6
 
   zod@4.3.6: {}
+
+  zwitch@2.0.4: {}

--- a/src-tauri/src/cli_install.rs
+++ b/src-tauri/src/cli_install.rs
@@ -79,6 +79,86 @@ pub fn install_runner_cli(app_data_dir: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Drop a per-(mission,slot) `runner` shim into
+/// `$APPDATA/missions/<mission_id>/shims/<handle>/bin/runner` that
+/// hardcodes the slot's `RUNNER_*` env vars and `exec`s the real
+/// bundled CLI. PATH inside the spawned PTY prepends this dir, so
+/// `runner …` resolves to the shim regardless of what shell context
+/// the agent CLI's tool-call subprocess runs under. Without this,
+/// claude-code's Bash tool spawns a non-login shell that doesn't
+/// inherit the PTY's env, and the bundled CLI exits with "missing
+/// required env var".
+///
+/// Each call rewrites the shim atomically (tempfile + rename) so
+/// resume can refresh the values without leaving a half-written
+/// file an agent could crash on. The path is keyed by mission_id +
+/// handle (not session_id) because session_id rotates on every
+/// resume, while the env vars don't — the shim is reusable across
+/// resumes of the same slot.
+pub fn install_session_runner_shim(
+    app_data_dir: &Path,
+    crew_id: &str,
+    mission_id: &str,
+    handle: &str,
+    event_log: &Path,
+    mission_cwd: Option<&str>,
+) -> Result<PathBuf> {
+    let shim_dir = app_data_dir
+        .join("missions")
+        .join(mission_id)
+        .join("shims")
+        .join(handle)
+        .join("bin");
+    std::fs::create_dir_all(&shim_dir)?;
+    let shim_path = shim_dir.join("runner");
+    let real_runner = app_data_dir.join("bin").join(DEST_BIN_NAME);
+
+    let event_log_str = event_log.to_string_lossy();
+    let mut script = String::new();
+    script.push_str("#!/bin/sh\n");
+    script.push_str("# Auto-generated session shim. See cli_install::install_session_runner_shim.\n");
+    script.push_str(&format!("export RUNNER_CREW_ID='{}'\n", sh_escape(crew_id)));
+    script.push_str(&format!(
+        "export RUNNER_MISSION_ID='{}'\n",
+        sh_escape(mission_id)
+    ));
+    script.push_str(&format!("export RUNNER_HANDLE='{}'\n", sh_escape(handle)));
+    script.push_str(&format!(
+        "export RUNNER_EVENT_LOG='{}'\n",
+        sh_escape(&event_log_str)
+    ));
+    if let Some(cwd) = mission_cwd {
+        script.push_str(&format!(
+            "export MISSION_CWD='{}'\n",
+            sh_escape(cwd)
+        ));
+    }
+    script.push_str(&format!(
+        "exec '{}' \"$@\"\n",
+        sh_escape(&real_runner.to_string_lossy())
+    ));
+
+    let tmp = tempfile::NamedTempFile::new_in(&shim_dir)?;
+    std::fs::write(tmp.path(), script.as_bytes())?;
+    tmp.persist(&shim_path)
+        .map_err(|e| Error::Io(e.error))?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&shim_path)?.permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&shim_path, perms)?;
+    }
+    Ok(shim_dir)
+}
+
+/// Escape a string for inside single-quoted POSIX shell. Single
+/// quotes can't contain themselves; the canonical workaround is to
+/// close the quote, emit `'\''`, and reopen.
+fn sh_escape(s: &str) -> String {
+    s.replace('\'', "'\\''")
+}
+
 fn locate_source() -> Result<Option<PathBuf>> {
     let exe = std::env::current_exe()?;
     let dir = exe

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -984,8 +984,15 @@ pub async fn mission_reset(
         let conn = state.db.get()?;
         get(&conn, &id)?
     };
+    // All-or-nothing: same contract as `mission_start`. If any slot
+    // fails to spawn, kill the PTYs that did come up, archive the
+    // freshly-inserted session rows, flip the mission back to
+    // `aborted`, and surface the original error. Without rollback the
+    // mission would sit half-reset — old PTYs gone, some new ones
+    // alive, no bus / router mounted, and the mission row stuck in
+    // `running`.
     for member in &roster {
-        let spawned = state.sessions.spawn(
+        let spawn_res = state.sessions.spawn(
             &mission_for_spawn,
             &member.runner,
             &member.slot,
@@ -993,8 +1000,30 @@ pub async fn mission_reset(
             events_log_path.clone(),
             state.db.clone(),
             Arc::clone(&emitter),
-        )?;
-        spawned_pairs.push((member.slot.slot_handle.clone(), spawned.id));
+        );
+        match spawn_res {
+            Ok(spawned) => {
+                spawned_pairs.push((member.slot.slot_handle.clone(), spawned.id));
+            }
+            Err(e) => {
+                let _ = state.sessions.kill_all_for_mission(&id);
+                if let Ok(conn) = state.db.get() {
+                    let _ = conn.execute(
+                        "UPDATE sessions
+                            SET archived_at = ?1
+                          WHERE mission_id = ?2 AND archived_at IS NULL",
+                        params![now().to_rfc3339(), id],
+                    );
+                    let _ = conn.execute(
+                        "UPDATE missions
+                            SET status = 'aborted', stopped_at = ?1
+                          WHERE id = ?2",
+                        params![now().to_rfc3339(), id],
+                    );
+                }
+                return Err(e);
+            }
+        }
     }
     router.register_sessions(&spawned_pairs);
 
@@ -1006,7 +1035,32 @@ pub async fn mission_reset(
         tauri_emitter,
         router_emitter,
     ]));
-    state.buses.mount(id.clone(), &mission_dir, &roster_handles, composite)?;
+    if let Err(e) = state
+        .buses
+        .mount(id.clone(), &mission_dir, &roster_handles, composite)
+    {
+        // Bus didn't attach — kill the sessions we spawned, archive
+        // their rows, abort the mission. Same shape as the spawn-loop
+        // rollback above; the bus is the last gate before commit so a
+        // failure here would otherwise leave live PTYs with no router
+        // listening.
+        let _ = state.sessions.kill_all_for_mission(&id);
+        if let Ok(conn) = state.db.get() {
+            let _ = conn.execute(
+                "UPDATE sessions
+                    SET archived_at = ?1
+                  WHERE mission_id = ?2 AND archived_at IS NULL",
+                params![now().to_rfc3339(), id],
+            );
+            let _ = conn.execute(
+                "UPDATE missions
+                    SET status = 'aborted', stopped_at = ?1
+                  WHERE id = ?2",
+                params![now().to_rfc3339(), id],
+            );
+        }
+        return Err(e);
+    }
     state.routers.register(id.clone(), router);
 
     Ok(mission_for_spawn)

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -822,6 +822,196 @@ pub async fn mission_rename(
     get(&conn, &id)
 }
 
+/// Reset a mission: wipe the run context (event log, agent session
+/// keys, router state) and respawn every slot fresh against the same
+/// mission row. Mostly for testing — gives you a clean slate without
+/// having to rebuild the crew + start a new mission. Preserves the
+/// mission's id, title, crew, cwd, and goal so links/bookmarks survive.
+#[tauri::command]
+pub async fn mission_reset(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    id: String,
+) -> Result<Mission> {
+    use crate::event_bus::{BusEmitter, TauriBusEvents};
+    use crate::router::{
+        open_log_for_mission, CompositeBusEmitter, Router, RouterSubscriber, StdinInjector,
+    };
+    use crate::session::manager::{SessionEvents, TauriSessionEvents};
+    use std::sync::Arc;
+
+    // 1. Snapshot the mission + crew + roster up front.
+    let mission_snap = {
+        let conn = state.db.get()?;
+        get(&conn, &id)?
+    };
+    let (crew_name, crew_signal_types, crew_goal) = {
+        let conn = state.db.get()?;
+        let crew = crew::get(&conn, &mission_snap.crew_id)?;
+        (crew.name, crew.signal_types, crew.goal)
+    };
+    let roster = {
+        let conn = state.db.get()?;
+        slot::list(&conn, &mission_snap.crew_id)?
+    };
+    if roster.is_empty() {
+        return Err(Error::msg(format!(
+            "crew {crew_name} has no slots; cannot reset mission",
+        )));
+    }
+    if !roster.iter().any(|m| m.slot.lead) {
+        return Err(Error::msg(format!(
+            "crew {crew_name} has no lead slot; cannot reset mission",
+        )));
+    }
+
+    // 2. Tear down the live state. Kill PTYs first (blocks until
+    // reader threads join), then unmount bus + router. Same order as
+    // mission_archive so any final events the bus is draining still
+    // reach a live router.
+    state.sessions.kill_all_for_mission(&id)?;
+    state.buses.unmount(&id);
+    state.routers.unregister(&id);
+
+    // 3. Archive existing session rows for this mission so the sidebar
+    // / list queries don't show ghost rows pointing at PTYs that no
+    // longer exist. Fresh sessions get inserted by the spawn loop
+    // below.
+    {
+        let conn = state.db.get()?;
+        conn.execute(
+            "UPDATE sessions
+                SET archived_at = ?1
+              WHERE mission_id = ?2 AND archived_at IS NULL",
+            params![now().to_rfc3339(), id],
+        )?;
+    }
+
+    // 4. Wipe the event log + per-mission shim dir so the next spawn
+    // starts from a clean slate. signal_types + roster sidecars get
+    // rewritten below from the current crew / roster state.
+    let mission_dir = event_log::mission_dir(&state.app_data_dir, &mission_snap.crew_id, &id);
+    let events_file = event_log::events_path(&state.app_data_dir, &mission_snap.crew_id, &id);
+    if events_file.exists() {
+        std::fs::remove_file(&events_file)?;
+    }
+    // Drop per-(mission,handle) runner shim dirs — they'll be regenerated
+    // by SessionManager::spawn with the freshened env block.
+    let shims_root = state
+        .app_data_dir
+        .join("missions")
+        .join(&id)
+        .join("shims");
+    if shims_root.exists() {
+        let _ = std::fs::remove_dir_all(&shims_root);
+    }
+    std::fs::create_dir_all(&mission_dir)?;
+    write_signal_types_sidecar(&state.app_data_dir, &mission_snap.crew_id, &crew_signal_types)?;
+    write_roster_sidecar(&mission_dir, &roster)?;
+
+    // 5. Update mission row: status back to running, started_at
+    // refreshed (this IS a fresh run), stopped_at cleared. Title /
+    // goal_override / cwd / pinned_at preserved.
+    let started_at_dt = now();
+    {
+        let conn = state.db.get()?;
+        let n = conn.execute(
+            "UPDATE missions
+                SET status = 'running',
+                    started_at = ?1,
+                    stopped_at = NULL
+              WHERE id = ?2",
+            params![started_at_dt.to_rfc3339(), id],
+        )?;
+        if n != 1 {
+            return Err(Error::msg(format!("mission not found: {id}")));
+        }
+    }
+
+    // 6. Re-emit the opening events so router can replay the launch
+    // prompt to the lead. Same shape mission_start writes.
+    let goal_text = mission_snap
+        .goal_override
+        .as_deref()
+        .or(crew_goal.as_deref())
+        .unwrap_or("")
+        .to_string();
+    let log = EventLog::open(&mission_dir)?;
+    log.append(EventDraft {
+        crew_id: mission_snap.crew_id.clone(),
+        mission_id: id.clone(),
+        kind: EventKind::Signal,
+        from: "system".into(),
+        to: None,
+        signal_type: Some(SignalType::new("mission_start")),
+        payload: serde_json::json!({
+            "title": mission_snap.title,
+            "cwd": mission_snap.cwd,
+        }),
+    })?;
+    log.append(EventDraft {
+        crew_id: mission_snap.crew_id.clone(),
+        mission_id: id.clone(),
+        kind: EventKind::Signal,
+        from: "human".into(),
+        to: None,
+        signal_type: Some(SignalType::new("mission_goal")),
+        payload: serde_json::json!({ "text": goal_text }),
+    })?;
+
+    // 7. Build router + spawn fresh PTYs + mount bus. Same ordering
+    // contract as mission_start: spawn first so register_sessions has
+    // the full handle map before the bus's initial replay fires the
+    // router's mission_goal handler.
+    let events_log_path =
+        event_log::events_path(&state.app_data_dir, &mission_snap.crew_id, &id);
+    let log_arc = open_log_for_mission(&mission_dir)?;
+    let injector: Arc<dyn StdinInjector> =
+        Arc::clone(&state.sessions) as Arc<dyn StdinInjector>;
+    let router = Router::new(
+        id.clone(),
+        mission_snap.crew_id.clone(),
+        crew_name,
+        &roster,
+        crew_signal_types,
+        Arc::clone(&log_arc),
+        injector,
+    )?;
+
+    let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app.clone()));
+    let mut spawned_pairs: Vec<(String, String)> = Vec::with_capacity(roster.len());
+    let mission_for_spawn = {
+        let conn = state.db.get()?;
+        get(&conn, &id)?
+    };
+    for member in &roster {
+        let spawned = state.sessions.spawn(
+            &mission_for_spawn,
+            &member.runner,
+            &member.slot,
+            &state.app_data_dir,
+            events_log_path.clone(),
+            state.db.clone(),
+            Arc::clone(&emitter),
+        )?;
+        spawned_pairs.push((member.slot.slot_handle.clone(), spawned.id));
+    }
+    router.register_sessions(&spawned_pairs);
+
+    let roster_handles: Vec<String> = roster.iter().map(|m| m.slot.slot_handle.clone()).collect();
+    let tauri_emitter: Arc<dyn BusEmitter> = Arc::new(TauriBusEvents(app.clone()));
+    let router_emitter: Arc<dyn BusEmitter> =
+        Arc::new(RouterSubscriber(Arc::clone(&router)));
+    let composite: Arc<dyn BusEmitter> = Arc::new(CompositeBusEmitter::new(vec![
+        tauri_emitter,
+        router_emitter,
+    ]));
+    state.buses.mount(id.clone(), &mission_dir, &roster_handles, composite)?;
+    state.routers.register(id.clone(), router);
+
+    Ok(mission_for_spawn)
+}
+
 /// Terminal end-of-mission. Kills every live PTY, writes the
 /// `mission_stopped` event, flips the mission row to `completed`, and
 /// drops the router + bus. Mirrors what `mission_stop` used to do

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -87,6 +87,12 @@ pub async fn session_list(
     // `r.handle` (template) is kept on the row for fallback display
     // (legacy mission sessions before 0006 have no slot_id).
     let conn = state.db.get()?;
+    // archived_at IS NULL filters out the dead session rows that
+    // `mission_reset` (and any future archive path) leaves behind: a
+    // reset wipes the run context and inserts fresh PTY rows for the
+    // same (mission_id, slot_id) pair, so without this filter the
+    // sidebar would stack the old stopped row alongside the new
+    // running one for every slot.
     let mut stmt = conn.prepare(
         "SELECT s.id, s.mission_id, s.runner_id, s.slot_id, s.cwd, s.status, s.pid,
                 s.started_at, s.stopped_at,
@@ -96,6 +102,7 @@ pub async fn session_list(
            JOIN runners r ON r.id = s.runner_id
            LEFT JOIN slots sl ON sl.id = s.slot_id
           WHERE s.mission_id = ?1
+            AND s.archived_at IS NULL
           ORDER BY COALESCE(sl.position, 0) ASC, s.started_at ASC",
     )?;
     let rows = stmt.query_map(params![mission_id], row_to_session)?;
@@ -344,7 +351,7 @@ pub async fn session_resume(
     rows: Option<u16>,
 ) -> Result<SpawnedSession> {
     let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app));
-    state
+    let spawned = state
         .sessions
         .resume(
             &session_id,
@@ -354,7 +361,21 @@ pub async fn session_resume(
             state.db.clone(),
             emitter,
         )
-        .map_err(|e| Error::msg(format!("session_resume: {e}")))
+        .map_err(|e| Error::msg(format!("session_resume: {e}")))?;
+    // Fresh-fallback for a lead slot: the prior claude-code conversation
+    // file was missing, so the resume degraded to a `--session-id` fresh
+    // spawn. The bus's mission_goal handler is suppressed on resume by
+    // `mission_attach`'s reconstruction watermark, so without this call
+    // the lead's fresh agent comes up with no system context. Fire the
+    // launch prompt manually through the registered router.
+    if spawned.fresh_fallback_lead {
+        if let Some(mission_id) = spawned.mission_id.as_deref() {
+            if let Some(router) = state.routers.get(mission_id) {
+                router.fire_lead_launch_prompt();
+            }
+        }
+    }
+    Ok(spawned)
 }
 
 /// Spawn a "direct chat" session for a runner — a PTY with no parent

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -105,6 +105,7 @@ pub fn run() {
             commands::mission::mission_attach,
             commands::mission::mission_stop,
             commands::mission::mission_archive,
+            commands::mission::mission_reset,
             commands::mission::mission_pin,
             commands::mission::mission_rename,
             commands::mission::mission_list,

--- a/src-tauri/src/router/handlers.rs
+++ b/src-tauri/src/router/handlers.rs
@@ -19,6 +19,16 @@ use runner_core::model::Event;
 use super::prompt::{compose_launch_prompt, LaunchPromptInput, RosterEntry};
 use super::{Router, RunnerStatus};
 
+/// Strip any trailing `\n`/`\r` so the body can be handed to
+/// `Router::inject_and_submit` cleanly — the trailing carriage
+/// return arrives as a separate stdin chunk, on a small delay, so
+/// claude-code's TUI sees it as Enter rather than appending it to
+/// the input buffer. Embedded `\n` characters are kept verbatim as
+/// line breaks inside the input box.
+fn submit_body(text: &str) -> Vec<u8> {
+    text.trim_end_matches(['\n', '\r']).as_bytes().to_vec()
+}
+
 pub(super) fn mission_goal(router: &Router, event: &Event) {
     let goal = event
         .payload
@@ -47,9 +57,18 @@ pub(super) fn mission_goal(router: &Router, event: &Event) {
         roster: &roster_entries,
         allowed_signals: launch.allowed_signals(),
     });
-    if let Err(e) = router.inject_to_handle(lead_row.handle(), prompt.as_bytes()) {
-        router.warn(format!("mission_goal injection to lead failed: {e}"));
-    }
+    // Defer the lead's launch prompt by the same 2.5s budget the
+    // worker preamble uses (`SessionManager::schedule_first_prompt`).
+    // The bus's initial replay can fire `mission_goal` milliseconds
+    // after the lead PTY spawns — on a warm app (mission_reset, fast
+    // mission_start) claude-code's TUI hasn't drawn yet and any bytes
+    // we write get swallowed by its boot / trust-folder screen,
+    // leaving the architect with no system prompt.
+    router.inject_and_submit_delayed(
+        lead_row.handle(),
+        submit_body(&prompt),
+        std::time::Duration::from_millis(2500),
+    );
 }
 
 pub(super) fn human_said(router: &Router, event: &Event) {
@@ -65,12 +84,7 @@ pub(super) fn human_said(router: &Router, event: &Event) {
         .map(str::to_string)
         .unwrap_or_else(|| router.lead_handle().to_string());
 
-    // Always end with a newline so the TUI submits the line.
-    let mut bytes = text.to_string();
-    if !bytes.ends_with('\n') {
-        bytes.push('\n');
-    }
-    if let Err(e) = router.inject_to_handle(&target, bytes.as_bytes()) {
+    if let Err(e) = router.inject_and_submit(&target, &submit_body(text)) {
         router.warn(format!(
             "human_said injection to @{target} failed: {e} (text: {text:?})"
         ));
@@ -103,7 +117,7 @@ pub(super) fn ask_lead(router: &Router, event: &Event) {
     }
 
     let lead_handle = router.lead_handle().to_string();
-    if let Err(e) = router.inject_to_handle(&lead_handle, text.as_bytes()) {
+    if let Err(e) = router.inject_and_submit(&lead_handle, &submit_body(&text)) {
         router.warn(format!("ask_lead injection to lead failed: {e}"));
     }
 }
@@ -155,8 +169,8 @@ pub(super) fn human_response(router: &Router, event: &Event) {
         .get("choice")
         .and_then(|v| v.as_str())
         .unwrap_or("");
-    let text = format!("[human_response] {choice}\n");
-    if let Err(e) = router.inject_to_handle(&asker, text.as_bytes()) {
+    let text = format!("[human_response] {choice}");
+    if let Err(e) = router.inject_and_submit(&asker, &submit_body(&text)) {
         router.warn(format!("human_response injection to @{asker} failed: {e}"));
     }
 }
@@ -176,10 +190,18 @@ pub(super) fn message_nudge(router: &Router, event: &Event) {
         if target == sender {
             return;
         }
+        // `human` is a virtual handle: it identifies the workspace
+        // UI as the message recipient. The workspace renders the
+        // event in the feed via the bus's `event/appended` listener
+        // — there's no PTY to nudge. Skipping here also keeps the
+        // log clean of "no live session for handle @human" warnings.
+        if target == "human" {
+            return;
+        }
         let text = format!(
-            "[inbox] new message from @{sender} — run `runner msg read` to view.\n"
+            "[inbox] new message from @{sender} — run `runner msg read` to view."
         );
-        if let Err(e) = router.inject_to_handle(target, text.as_bytes()) {
+        if let Err(e) = router.inject_and_submit(target, &submit_body(&text)) {
             router.warn(format!(
                 "message_nudge injection to @{target} failed: {e}"
             ));
@@ -189,7 +211,7 @@ pub(super) fn message_nudge(router: &Router, event: &Event) {
 
     // Broadcast: walk the roster, skip the sender, nudge each.
     let text = format!(
-        "[inbox] new broadcast from @{sender} — run `runner msg read` to view.\n"
+        "[inbox] new broadcast from @{sender} — run `runner msg read` to view."
     );
     let handles: Vec<String> = router
         .launch()
@@ -199,7 +221,7 @@ pub(super) fn message_nudge(router: &Router, event: &Event) {
         .filter(|h| h != sender)
         .collect();
     for handle in handles {
-        if let Err(e) = router.inject_to_handle(&handle, text.as_bytes()) {
+        if let Err(e) = router.inject_and_submit(&handle, &submit_body(&text)) {
             router.warn(format!(
                 "message_nudge broadcast to @{handle} failed: {e}"
             ));
@@ -234,10 +256,10 @@ pub(super) fn runner_status(router: &Router, event: &Event) {
             .map(|n| format!(" — {n}"))
             .unwrap_or_default();
         let text = format!(
-            "[runner_status] @{worker} is idle{note}\n",
+            "[runner_status] @{worker} is idle{note}",
             worker = event.from
         );
-        if let Err(e) = router.inject_to_handle(&lead_handle, text.as_bytes()) {
+        if let Err(e) = router.inject_and_submit(&lead_handle, &submit_body(&text)) {
             router.warn(format!("runner_status idle notice to lead failed: {e}"));
         }
     }

--- a/src-tauri/src/router/handlers.rs
+++ b/src-tauri/src/router/handlers.rs
@@ -19,6 +19,17 @@ use runner_core::model::Event;
 use super::prompt::{compose_launch_prompt, LaunchPromptInput, RosterEntry};
 use super::{Router, RunnerStatus};
 
+/// How long to defer the lead's launch-prompt write after spawn so
+/// claude-code's TUI has time to draw before the bytes land. Matches
+/// `SessionManager::schedule_first_prompt`'s 2.5s budget for workers.
+/// `cfg(test)` zeros the delay so unit tests can assert injections
+/// synchronously without sleeping (the injector's `inject_and_submit_
+/// delayed` runs inline when the duration is zero).
+#[cfg(not(test))]
+const LEAD_LAUNCH_PROMPT_DELAY: std::time::Duration = std::time::Duration::from_millis(2500);
+#[cfg(test)]
+const LEAD_LAUNCH_PROMPT_DELAY: std::time::Duration = std::time::Duration::ZERO;
+
 /// Strip any trailing `\n`/`\r` so the body can be handed to
 /// `Router::inject_and_submit` cleanly — the trailing carriage
 /// return arrives as a separate stdin chunk, on a small delay, so
@@ -67,7 +78,7 @@ pub(super) fn mission_goal(router: &Router, event: &Event) {
     router.inject_and_submit_delayed(
         lead_row.handle(),
         submit_body(&prompt),
-        std::time::Duration::from_millis(2500),
+        LEAD_LAUNCH_PROMPT_DELAY,
     );
 }
 

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -398,6 +398,23 @@ impl Router {
             ));
             return;
         };
+        // Zero-delay path: run inline, body only — no separate `\r`
+        // chord. Used by unit tests
+        // (`LEAD_LAUNCH_PROMPT_DELAY = ZERO` under `cfg(test)`) so
+        // synchronous push-count assertions match the prior single-
+        // push behavior of `inject_and_submit` (where the `\r` was
+        // always deferred to a background thread and never observed
+        // by sync test code). Production never hits this branch —
+        // claude-code is the only consumer that needs the
+        // body-then-`\r` chord, and it's always on a non-zero delay.
+        if delay.is_zero() {
+            if !body.is_empty() {
+                if let Err(e) = self.injector.inject(&session_id, &body) {
+                    eprintln!("router: inline inject to {session_id} failed: {e}");
+                }
+            }
+            return;
+        }
         let injector = Arc::clone(&self.injector);
         std::thread::spawn(move || {
             std::thread::sleep(delay);

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -323,6 +323,7 @@ impl Router {
 
     // ---- helpers used by handlers --------------------------------------
 
+    #[allow(dead_code)] // Kept for tests + future single-shot injections.
     pub(crate) fn inject_to_handle(&self, handle: &str, bytes: &[u8]) -> Result<()> {
         let session_id = {
             let state = self.state.lock().unwrap();
@@ -336,8 +337,165 @@ impl Router {
         self.injector.inject(&session_id, bytes)
     }
 
+    /// Inject `body` to the handle's stdin, then send a separate
+    /// carriage-return (`\r`) on a brief delay. claude-code's TUI
+    /// editor treats `\r` as Enter, but bytes arriving in the same
+    /// chunk as the body get appended to the input buffer rather
+    /// than triggering submit — so the chord has to land as a
+    /// distinct read on the slave end. ~80ms is empirically enough
+    /// for the editor to process the body and re-bind its keypress
+    /// reader. Body itself is written verbatim; embedded `\n`
+    /// characters render as line breaks inside the input box.
+    pub(crate) fn inject_and_submit(&self, handle: &str, body: &[u8]) -> Result<()> {
+        let session_id = {
+            let state = self.state.lock().unwrap();
+            state.session_by_handle.get(handle).cloned()
+        };
+        let Some(session_id) = session_id else {
+            return Err(crate::error::Error::msg(format!(
+                "router: no live session for handle @{handle}"
+            )));
+        };
+        if !body.is_empty() {
+            self.injector.inject(&session_id, body)?;
+        }
+        let injector = Arc::clone(&self.injector);
+        let sid = session_id.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(std::time::Duration::from_millis(80));
+            let _ = injector.inject(&sid, b"\r");
+        });
+        Ok(())
+    }
+
+    /// Same contract as `inject_and_submit`, but the whole sequence
+    /// (body + delayed `\r`) is deferred by `delay`. Used for the
+    /// lead's launch prompt: the bus's initial replay fires
+    /// `mission_goal` immediately after the lead PTY spawns, but on
+    /// a warm app (mission_reset, fast mission_start) claude-code's
+    /// TUI hasn't drawn yet, so synchronous bytes get swallowed by
+    /// the boot / trust-folder screen and the lead never sees its
+    /// system prompt. The 2.5s budget matches
+    /// `SessionManager::schedule_first_prompt`, which solves the
+    /// same race for non-lead workers.
+    ///
+    /// Resolves the handle → session_id at schedule time. Mission
+    /// boot is the only caller and the lead's session is fully
+    /// registered before this fires, so the snapshot is stable.
+    pub(crate) fn inject_and_submit_delayed(
+        &self,
+        handle: &str,
+        body: Vec<u8>,
+        delay: std::time::Duration,
+    ) {
+        let session_id = {
+            let state = self.state.lock().unwrap();
+            state.session_by_handle.get(handle).cloned()
+        };
+        let Some(session_id) = session_id else {
+            self.warn(format!(
+                "router: no live session for handle @{handle} (delayed submit)"
+            ));
+            return;
+        };
+        let injector = Arc::clone(&self.injector);
+        std::thread::spawn(move || {
+            std::thread::sleep(delay);
+            if !body.is_empty() {
+                if let Err(e) = injector.inject(&session_id, &body) {
+                    eprintln!("router: delayed inject to {session_id} failed: {e}");
+                    return;
+                }
+            }
+            std::thread::sleep(std::time::Duration::from_millis(80));
+            let _ = injector.inject(&session_id, b"\r");
+        });
+    }
+
     pub(crate) fn launch(&self) -> &LaunchInputs {
         &self.launch
+    }
+
+    /// Read the latest `mission_goal` text from the event log. Used by
+    /// `fire_lead_launch_prompt` after a fresh-fallback resume — the
+    /// bus's mission_goal handler can't replay (mission_attach's
+    /// watermark suppresses it), so we have to compose the launch
+    /// prompt ourselves and need the goal payload to feed into it.
+    /// Returns an empty string if no goal is found, mirroring the
+    /// handler's `unwrap_or("")` defensive read.
+    fn latest_mission_goal_text(&self) -> String {
+        let (entries, _skipped) = match self.log.read_from_lossy(0) {
+            Ok(out) => out,
+            Err(_) => return String::new(),
+        };
+        for entry in entries.iter().rev() {
+            let ev = &entry.event;
+            if !matches!(ev.kind, EventKind::Signal) {
+                continue;
+            }
+            let Some(t) = ev.signal_type.as_ref() else {
+                continue;
+            };
+            if t.as_str() == "mission_goal" {
+                return ev
+                    .payload
+                    .get("text")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+            }
+        }
+        String::new()
+    }
+
+    /// Compose + inject the lead's launch prompt manually. Same prompt
+    /// the bus's `mission_goal` handler would build, but we call this
+    /// directly when the resume path detects a missing claude-code
+    /// conversation file for a lead slot: the bus can't replay
+    /// `mission_goal` on resume (the `mission_attach` watermark
+    /// suppresses it), so without this call the lead's freshly-spawned
+    /// agent would come up with no system context. Reuses
+    /// `inject_and_submit_delayed`'s 2.5s budget so claude-code's TUI
+    /// has time to boot before the bytes land.
+    pub fn fire_lead_launch_prompt(&self) {
+        // Build the prompt body the same way `handlers::mission_goal`
+        // does — single source of truth lives in
+        // `router::prompt::compose_launch_prompt`, kept in sync via
+        // the shared LaunchInputs view.
+        let goal = self.latest_mission_goal_text();
+        let lead_row = self.launch.lead();
+        let roster_entries: Vec<crate::router::prompt::RosterEntry> = self
+            .launch
+            .roster()
+            .iter()
+            .map(|r| crate::router::prompt::RosterEntry {
+                handle: r.handle(),
+                display_name: r.display_name(),
+                lead: r.is_lead(),
+            })
+            .collect();
+        let prompt = crate::router::prompt::compose_launch_prompt(
+            &crate::router::prompt::LaunchPromptInput {
+                lead: crate::router::prompt::LeadView {
+                    handle: lead_row.handle(),
+                    display_name: lead_row.display_name(),
+                    system_prompt: lead_row.system_prompt(),
+                },
+                crew_name: self.launch.crew_name(),
+                mission_goal: &goal,
+                roster: &roster_entries,
+                allowed_signals: self.launch.allowed_signals(),
+            },
+        );
+        let body = prompt
+            .trim_end_matches(['\n', '\r'])
+            .as_bytes()
+            .to_vec();
+        self.inject_and_submit_delayed(
+            lead_row.handle(),
+            body,
+            std::time::Duration::from_millis(2500),
+        );
     }
 
     pub(crate) fn record_pending_ask(&self, question_id: String, asker: String) {

--- a/src-tauri/src/router/prompt.rs
+++ b/src-tauri/src/router/prompt.rs
@@ -90,9 +90,12 @@ pub fn compose_launch_prompt(input: &LaunchPromptInput<'_>) -> String {
     out.push_str(
         "- Reply to a worker with `runner msg post --to <handle> \"…\"`; broadcasts omit `--to`.\n",
     );
+    out.push_str(
+        "- Reply to the HUMAN with `runner msg post --to human \"…\"`. The human watches the workspace feed, not your TUI — typing answers into the TUI keeps them in your local scrollback only. `human` is a reserved virtual handle for this two-way path.\n",
+    );
     out.push_str("- Read your inbox with `runner msg read` — it's pull-based.\n");
     out.push_str(
-        "- Escalate to the human with `runner signal ask_human --payload '{\"prompt\":\"…\",\"choices\":[\"yes\",\"no\"],\"on_behalf_of\":\"<asker>\"}'`.\n",
+        "- Escalate to the human (with structured choices) via `runner signal ask_human --payload '{\"prompt\":\"…\",\"choices\":[\"yes\",\"no\"],\"on_behalf_of\":\"<asker>\"}'`. Plain replies should use `runner msg post --to human` instead.\n",
     );
     out.push_str("- Report idle with `runner status idle` so the lead view stays accurate.\n");
     if !input.allowed_signals.is_empty() {

--- a/src-tauri/src/router/runtime.rs
+++ b/src-tauri/src/router/runtime.rs
@@ -176,6 +176,46 @@ fn is_uuid(s: &str) -> bool {
     uuid::Uuid::parse_str(s).is_ok()
 }
 
+/// True iff claude-code's conversation file for `(cwd, uuid)` exists on
+/// disk. Used by `SessionManager::resume` to skip `--resume <uuid>` when
+/// the agent never persisted a turn (lead PTYs reset within the
+/// schedule_first_prompt window, fast Stop after spawn) — passing
+/// `--resume` against a missing file makes claude-code print
+/// "No conversation found with session ID …" and leave the TUI sitting
+/// in a half-initialised state. Path scheme:
+/// `$HOME/.claude/projects/<cwd-with-/-as--dashes>/<uuid>.jsonl`. We
+/// resolve `cwd` with the same precedence the spawn used (mission /
+/// runner override) and skip the check when no concrete cwd is known.
+pub fn claude_code_conversation_exists(cwd: Option<&str>, uuid: &str) -> bool {
+    let Some(cwd) = cwd else {
+        // No cwd → claude-code falls back to the parent's, which we
+        // can't reproduce here. Be permissive: let `--resume` try and
+        // surface its own error rather than masking it.
+        return true;
+    };
+    let Some(home) = std::env::var_os("HOME") else {
+        return true;
+    };
+    // claude-code encodes the project dir by replacing both `/` and
+    // `.` with `-`. e.g. `/Users/jason/go/src/github.com/yicheng47`
+    // → `-Users-jason-go-src-github-com-yicheng47`. Confirmed against
+    // `~/.claude/projects/` directory listings. Only swapping `/`
+    // would miss every cwd containing a `.` (most repos), causing
+    // `path.exists()` to return false even when the conversation
+    // file is on disk — every resume would then spuriously fall back
+    // to a fresh spawn.
+    let encoded: String = cwd
+        .chars()
+        .map(|c| if c == '/' || c == '.' { '-' } else { c })
+        .collect();
+    let path = std::path::PathBuf::from(home)
+        .join(".claude")
+        .join("projects")
+        .join(encoded)
+        .join(format!("{uuid}.jsonl"));
+    path.exists()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src-tauri/src/router/runtime.rs
+++ b/src-tauri/src/router/runtime.rs
@@ -187,6 +187,20 @@ fn is_uuid(s: &str) -> bool {
 /// resolve `cwd` with the same precedence the spawn used (mission /
 /// runner override) and skip the check when no concrete cwd is known.
 pub fn claude_code_conversation_exists(cwd: Option<&str>, uuid: &str) -> bool {
+    // `cfg(test)` short-circuits the filesystem check so unit tests
+    // for the resume flow don't have to fake out
+    // `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`. The path
+    // encoding is exercised directly by `claude_code_conversation_*`
+    // tests below; the SessionManager-level resume tests just want
+    // the production semantic of "prior conversation present" to
+    // hold so they can assert key preservation.
+    #[cfg(test)]
+    {
+        let _ = (cwd, uuid);
+        return true;
+    }
+    #[cfg(not(test))]
+    {
     let Some(cwd) = cwd else {
         // No cwd → claude-code falls back to the parent's, which we
         // can't reproduce here. Be permissive: let `--resume` try and
@@ -214,6 +228,7 @@ pub fn claude_code_conversation_exists(cwd: Option<&str>, uuid: &str) -> bool {
         .join(encoded)
         .join(format!("{uuid}.jsonl"));
     path.exists()
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -944,10 +944,19 @@ impl SessionManager {
                 cmd.arg(extra);
             }
         }
-        for extra in crate::router::runtime::system_prompt_args(
-            &runner.runtime,
-            runner.system_prompt.as_deref(),
-        ) {
+        // codex on resume: skip the runner's `system_prompt` argv.
+        // codex's positional prompt argument is treated as a NEW user
+        // turn, so re-passing the brief on every resume would replay
+        // it as another message against the existing conversation.
+        // claude-code's `--append-system-prompt` is system-level and
+        // safe to keep on resume (no-op against an existing
+        // conversation in the TUI). Mirrors the spawn() guard above.
+        let prompt_for_argv = if runner.runtime == "codex" && plan.resuming {
+            None
+        } else {
+            runner.system_prompt.as_deref()
+        };
+        for extra in crate::router::runtime::system_prompt_args(&runner.runtime, prompt_for_argv) {
             cmd.arg(extra);
         }
 
@@ -1658,9 +1667,14 @@ fn emit_runner_activity(pool: &DbPool, runner: &Runner, events: &dyn SessionEven
             |r| r.get(0),
         )
         .unwrap_or(0);
+    // `crew_runners` was replaced by `slots` in migration 0006 — count
+    // distinct crews this runner is wired into via the slots table.
+    // Mirrors the cold-path query in `commands::runner::runner_activity`
+    // so live `runner/activity` events stay consistent with what the
+    // Runners list shows on a refresh.
     let crew_count: i64 = conn
         .query_row(
-            "SELECT COUNT(*) FROM crew_runners WHERE runner_id = ?1",
+            "SELECT COUNT(DISTINCT crew_id) FROM slots WHERE runner_id = ?1",
             params![runner.id],
             |r| r.get(0),
         )

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -143,6 +143,17 @@ pub struct SpawnedSession {
     pub runner_id: String,
     pub handle: String,
     pub pid: Option<u32>,
+    /// True iff this resume detected a missing claude-code
+    /// conversation file for a lead slot and degraded to a fresh
+    /// spawn. Internal signal: `commands::session::session_resume`
+    /// uses it to ask the router to fire the rich launch prompt
+    /// (the bus's `mission_goal` handler can't, since
+    /// `mission_attach`'s watermark suppresses replay on resume).
+    /// Always false on initial spawn / direct chat / non-lead resume
+    /// — kept off the frontend type since it's not actionable from
+    /// the UI.
+    #[serde(skip)]
+    pub fresh_fallback_lead: bool,
 }
 
 struct SessionHandle {
@@ -297,9 +308,16 @@ impl SessionManager {
 
         // Working directory: runner override if set, else mission cwd, else
         // inherit parent's. `CommandBuilder::cwd` requires a concrete path.
-        if let Some(wd) = runner.working_dir.as_deref() {
-            cmd.cwd(wd);
-        } else if let Some(wd) = mission.cwd.as_deref() {
+        // Capture the resolved cwd so we can persist it on the session row
+        // — `resume` reads it back to spawn the same dir on respawn, which
+        // matters for claude-code (its conversation files are keyed under
+        // `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`; resuming with a
+        // different cwd makes `--resume` fail with "No conversation found").
+        let resolved_cwd: Option<String> = runner
+            .working_dir
+            .clone()
+            .or_else(|| mission.cwd.clone());
+        if let Some(wd) = resolved_cwd.as_deref() {
             cmd.cwd(wd);
         }
 
@@ -309,14 +327,35 @@ impl SessionManager {
         for (k, v) in &runner.env {
             cmd.env(k, v);
         }
-        // Prepend the bundled CLI directory to PATH so `runners` on the
-        // child's PATH resolves to our drop (C9 installs it here) before
-        // any system binary with the same name. Inherit the parent PATH
-        // as the tail — if nothing else, agents need `sh`, `git`, `node`.
+        // Per-slot runner shim: hardcodes the RUNNER_* env vars + exec's
+        // the real bundled CLI. claude-code's Bash tool spawns
+        // non-login shells that don't inherit the PTY's env, so a CLI
+        // call like `runner msg post …` would otherwise see the vars
+        // as unset. The shim sits in front of the bundled `runner` on
+        // PATH so `runner` resolves to it regardless of shell context.
+        let shim_dir = crate::cli_install::install_session_runner_shim(
+            app_data_dir,
+            &mission.crew_id,
+            &mission.id,
+            &slot.slot_handle,
+            &events_log_path,
+            mission.cwd.as_deref(),
+        )
+        .ok();
+
+        // Prepend (shim, fallback bundled bin) to PATH so `runner` on the
+        // child's PATH resolves first to our env-baked shim, then to
+        // the raw CLI for verbs (`runner help`) that don't need
+        // env. Inherit the parent PATH as the tail.
         let bin_dir = app_data_dir.join("bin");
         let sep = if cfg!(windows) { ';' } else { ':' };
         let parent_path = std::env::var_os("PATH").unwrap_or_default();
-        let mut new_path = std::ffi::OsString::from(bin_dir.as_os_str());
+        let mut new_path = std::ffi::OsString::new();
+        if let Some(shim) = shim_dir.as_ref() {
+            new_path.push(shim.as_os_str());
+            new_path.push(std::ffi::OsString::from(sep.to_string()));
+        }
+        new_path.push(bin_dir.as_os_str());
         if !parent_path.is_empty() {
             new_path.push(std::ffi::OsString::from(sep.to_string()));
             new_path.push(parent_path);
@@ -369,14 +408,15 @@ impl SessionManager {
             let conn = pool.get()?;
             conn.execute(
                 "INSERT INTO sessions
-                    (id, mission_id, runner_id, slot_id, status, pid, started_at,
+                    (id, mission_id, runner_id, slot_id, cwd, status, pid, started_at,
                      agent_session_key)
-                 VALUES (?1, ?2, ?3, ?4, 'running', ?5, ?6, ?7)",
+                 VALUES (?1, ?2, ?3, ?4, ?5, 'running', ?6, ?7, ?8)",
                 params![
                     session_id,
                     mission.id,
                     runner.id,
                     slot.id,
+                    resolved_cwd,
                     pid,
                     started_at,
                     plan.assigned_key
@@ -457,6 +497,7 @@ impl SessionManager {
             runner_id: runner.id.clone(),
             handle: runner.handle.clone(),
             pid,
+            fresh_fallback_lead: false,
         })
     }
 
@@ -681,6 +722,7 @@ impl SessionManager {
             runner_id: runner.id.clone(),
             handle: runner.handle.clone(),
             pid,
+            fresh_fallback_lead: false,
         })
     }
 
@@ -796,6 +838,7 @@ impl SessionManager {
         struct MissionCtx {
             crew_id: String,
             mission_id: String,
+            mission_cwd: Option<String>,
             slot_handle: String,
             lead: bool,
         }
@@ -818,6 +861,7 @@ impl SessionManager {
                 Some(MissionCtx {
                     crew_id: mission.crew_id,
                     mission_id: mission.id,
+                    mission_cwd: mission.cwd,
                     slot_handle,
                     lead: lead != 0,
                 })
@@ -849,8 +893,44 @@ impl SessionManager {
         // codex (once capture lands) uses `codex resume <uuid>`. If the
         // row's key is NULL (e.g. shell runtime, or codex pre-capture)
         // we just respawn fresh — same agent, no conversation state.
+        //
+        // claude-code only: if the conversation file for this
+        // (cwd, uuid) was never persisted (e.g. the lead PTY was
+        // reset before its first turn landed), `--resume <uuid>`
+        // would print "No conversation found …" and leave the TUI
+        // half-broken. Detect the missing file up front and degrade
+        // to a fresh spawn that *keeps* the same uuid via
+        // `--session-id`, so the row's existing key still binds to
+        // the new conversation.
+        let resolved_cwd_for_check: Option<String> =
+            snap.cwd.clone().or_else(|| runner.working_dir.clone());
+        let is_lead_slot = mission_ctx.as_ref().is_some_and(|c| c.lead);
+        let conversation_missing = matches!(
+            (runner.runtime.as_str(), snap.agent_session_key.as_deref()),
+            ("claude-code", Some(key))
+                if !crate::router::runtime::claude_code_conversation_exists(
+                    resolved_cwd_for_check.as_deref(),
+                    key,
+                )
+        );
+        // Lead-only signal back to the caller: when a lead's prior
+        // conversation file is missing, the resume degrades to a
+        // fresh spawn and the bus's mission_goal handler will NOT
+        // fire (mission_attach's watermark suppresses replay), so
+        // the lead would come up with no system context. The caller
+        // in commands/session.rs uses this flag to ask the router
+        // to fire the launch prompt manually after the resume
+        // returns.
+        let fresh_fallback_lead = conversation_missing && is_lead_slot;
+        let effective_prior_key = match (
+            runner.runtime.as_str(),
+            snap.agent_session_key.as_deref(),
+        ) {
+            ("claude-code", Some(_)) if conversation_missing => None,
+            (_, k) => k,
+        };
         let plan =
-            crate::router::runtime::resume_plan(&runner.runtime, snap.agent_session_key.as_deref());
+            crate::router::runtime::resume_plan(&runner.runtime, effective_prior_key);
 
         let mut cmd = CommandBuilder::new(&runner.command);
         if plan.prepend {
@@ -886,10 +966,36 @@ impl SessionManager {
         for (k, v) in &runner.env {
             cmd.env(k, v);
         }
+        // Refresh the per-slot runner shim before computing PATH so it
+        // picks up any post-spawn env changes (mission cwd edited,
+        // etc.) for THIS resume cycle. Direct chats skip — no
+        // mission_ctx, no shim.
+        let shim_dir = mission_ctx.as_ref().and_then(|ctx| {
+            let event_log_path = runner_core::event_log::path::events_path(
+                app_data_dir,
+                &ctx.crew_id,
+                &ctx.mission_id,
+            );
+            crate::cli_install::install_session_runner_shim(
+                app_data_dir,
+                &ctx.crew_id,
+                &ctx.mission_id,
+                &ctx.slot_handle,
+                &event_log_path,
+                ctx.mission_cwd.as_deref(),
+            )
+            .ok()
+        });
+
         let bin_dir = app_data_dir.join("bin");
         let sep = if cfg!(windows) { ';' } else { ':' };
         let parent_path = std::env::var_os("PATH").unwrap_or_default();
-        let mut new_path = std::ffi::OsString::from(bin_dir.as_os_str());
+        let mut new_path = std::ffi::OsString::new();
+        if let Some(shim) = shim_dir.as_ref() {
+            new_path.push(shim.as_os_str());
+            new_path.push(std::ffi::OsString::from(sep.to_string()));
+        }
+        new_path.push(bin_dir.as_os_str());
         if !parent_path.is_empty() {
             new_path.push(std::ffi::OsString::from(sep.to_string()));
             new_path.push(parent_path);
@@ -899,11 +1005,23 @@ impl SessionManager {
         // bundled `runner` CLI in this PTY attributes events as the
         // slot, not the runner template. Direct chat falls through to
         // the template handle. Crew/mission ids surface for
-        // `runner signal` / `runner msg post` calls inside the PTY.
+        // `runner signal` / `runner msg post` calls inside the PTY,
+        // and RUNNER_EVENT_LOG / MISSION_CWD parity the original
+        // mission spawn so the bundled CLI can find the event log
+        // and tools that read $MISSION_CWD keep working post-resume.
         if let Some(ctx) = mission_ctx.as_ref() {
             cmd.env("RUNNER_CREW_ID", &ctx.crew_id);
             cmd.env("RUNNER_MISSION_ID", &ctx.mission_id);
             cmd.env("RUNNER_HANDLE", &ctx.slot_handle);
+            let event_log_path = runner_core::event_log::path::events_path(
+                app_data_dir,
+                &ctx.crew_id,
+                &ctx.mission_id,
+            );
+            cmd.env("RUNNER_EVENT_LOG", event_log_path.to_string_lossy().to_string());
+            if let Some(wd) = ctx.mission_cwd.as_deref() {
+                cmd.env("MISSION_CWD", wd);
+            }
         } else {
             cmd.env("RUNNER_HANDLE", &runner.handle);
         }
@@ -1016,13 +1134,24 @@ impl SessionManager {
         emit_runner_activity(&pool, &runner, events.as_ref());
 
         // claude-code first-turn injection. `plan.resuming` is true on
-        // any resume that has a real prior_key — those skip naturally.
-        // For mission resumes where the slot is the lead, also skip:
-        // the launch prompt's "Your brief" section already embeds
-        // system_prompt, and a redundant first-turn injection would
-        // race the launch prompt.
-        let is_lead_resume = mission_ctx.as_ref().is_some_and(|c| c.lead);
+        // any resume against a real prior_key — those skip naturally
+        // (the agent already has its system context). The lead always
+        // suppresses the worker preamble: when the lead's conversation
+        // file is missing and the resume degrades to a fresh spawn,
+        // the *launch prompt* (composed by the router with crew /
+        // roster / goal context) is the right thing to inject — the
+        // commands::session::session_resume caller fires that path
+        // when it sees `fresh_fallback_lead = true` on the returned
+        // SpawnedSession.
+        let is_lead_resume = is_lead_slot;
         schedule_first_prompt(self, session_id.to_string(), &runner, &plan, is_lead_resume);
+
+        // On a real resume (not a fresh-with-known-uuid spawn), nudge
+        // the agent with "continue" so it picks up where it left off
+        // without the user having to type. Skipped for fresh spawns
+        // — the first-prompt path covers those — and for non-claude-
+        // code runtimes that don't have a real resume semantic.
+        schedule_continue_on_resume(self, session_id.to_string(), &runner, &plan);
 
         // Return the slot's in-mission identity for mission rows so the
         // frontend (and the router, which keys on slot_handle) sees the
@@ -1037,6 +1166,7 @@ impl SessionManager {
             runner_id: runner.id.clone(),
             handle: resumed_handle,
             pid,
+            fresh_fallback_lead,
         })
     }
 
@@ -1384,20 +1514,28 @@ fn capture_cwd(explicit: Option<String>) -> Option<String> {
 ///
 /// Sleeps a short delay so claude-code's TUI has time to boot and
 /// bind stdin — without it, the input is sometimes echoed before the
-/// editor takes over and gets lost. Skipped on resume (the
-/// conversation already exists), on non-claude-code runtimes (codex
-/// uses positional argv, shell has no prompt concept), and when the
-/// caller flags this slot as the mission lead — the lead's
-/// `mission_goal` handler injects a richer launch prompt with the
-/// system_prompt embedded in its "Your brief" section, so a separate
-/// first-turn injection would race the launch prompt and waste a
-/// turn.
+/// editor takes over and gets lost. Skipped on resume against a real
+/// prior conversation (the agent already has its system context) and
+/// on non-claude-code runtimes (codex uses positional argv, shell has
+/// no prompt concept).
+///
+/// `suppress_lead_preamble` is set by the initial mission_start spawn
+/// path: there, the bus's `mission_goal` handler injects a richer
+/// launch prompt with `system_prompt` embedded in its "Your brief"
+/// section, so a separate first-turn injection would race the launch
+/// prompt and waste a turn. On a resume that degrades to a fresh
+/// spawn (claude-code conversation file went missing — see
+/// `claude_code_conversation_exists`) the bus does NOT replay
+/// `mission_goal`, so the lead would otherwise come up with no
+/// system context; the resume path passes `false` here so the
+/// preamble + system_prompt land via this stdin-injection route
+/// instead.
 fn schedule_first_prompt(
     mgr: &Arc<SessionManager>,
     session_id: String,
     runner: &Runner,
     plan: &router::runtime::ResumePlan,
-    is_lead: bool,
+    suppress_lead_preamble: bool,
 ) {
     if runner.runtime != "claude-code" {
         return;
@@ -1405,29 +1543,101 @@ fn schedule_first_prompt(
     if plan.resuming {
         return;
     }
-    if is_lead {
+    if suppress_lead_preamble {
         return;
     }
-    let prompt = match runner.system_prompt.as_deref() {
-        Some(p) => {
-            let trimmed = p.trim();
-            if trimmed.is_empty() {
-                return;
-            }
-            trimmed.to_string()
-        }
-        None => return,
-    };
+    // Compose the worker's first turn: a platform coordination
+    // preamble (bus mechanics, --to human convention, signal verbs)
+    // followed by the user-authored brief on the runner template.
+    // Keeping bus protocol out of the user's system_prompt means
+    // template authors can focus on persona/role; the runtime adds
+    // the "how to talk to the rest of the crew" layer automatically.
+    let user_brief = runner
+        .system_prompt
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    let mut prompt = String::new();
+    prompt.push_str(WORKER_COORDINATION_PREAMBLE);
+    if let Some(brief) = user_brief {
+        prompt.push_str("\n\n== Your brief ==\n");
+        prompt.push_str(&brief);
+    }
     let mgr = Arc::clone(mgr);
     std::thread::spawn(move || {
-        // 1.5s is empirically enough for claude-code's TUI to bind
-        // stdin without making the user feel the lag.
-        std::thread::sleep(std::time::Duration::from_millis(1500));
-        let mut bytes = prompt.into_bytes();
-        if !bytes.ends_with(b"\n") {
-            bytes.push(b'\n');
-        }
-        let _ = mgr.inject_stdin(&session_id, &bytes);
+        // 2.5s gives claude-code's TUI room to render its welcome
+        // banner, dismiss any "trust this folder" prompt, and bind
+        // its raw-mode keypress reader before our typed text lands.
+        // Anything shorter and the early bytes get swallowed by a
+        // confirmation dialog that's still on screen.
+        std::thread::sleep(std::time::Duration::from_millis(2500));
+        // Strip any embedded `\r` so the prompt body is one piece;
+        // embedded `\n`s render as line breaks inside the input
+        // box. The submit byte goes in a separate write below so
+        // claude-code's editor sees it as Enter rather than
+        // appending it to the input buffer (which is what happens
+        // when text + `\r` arrive in the same chunk).
+        let body: String = prompt.chars().filter(|c| *c != '\r').collect();
+        let _ = mgr.inject_stdin(&session_id, body.as_bytes());
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        let _ = mgr.inject_stdin(&session_id, b"\r");
+    });
+}
+
+/// Platform-injected preamble for non-lead worker spawns. Covers the
+/// bus conventions a worker needs to interact with the crew + the
+/// human, leaving the user-authored `system_prompt` free to focus on
+/// persona / role. Sent as the first user turn (before any task
+/// dispatch from the lead) by `schedule_first_prompt`.
+const WORKER_COORDINATION_PREAMBLE: &str = r#"You are a worker in a crew coordinated by the bundled `runner` CLI. The CLI is on your PATH and talks to the rest of the crew + the human operator via a shared event bus. Use these verbs to participate; do not invent your own conventions.
+
+== Coordination ==
+- `runner msg read` — read your inbox (pull-based: new messages do NOT auto-print). Run this when you see an `[inbox]` notification or any time you suspect new traffic.
+- `runner msg post --to <handle> "<text>"` — direct message to a specific handle. Valid handles: any slot in this crew, plus the reserved virtual handle `human` (the workspace operator).
+- `runner msg post "<text>"` — broadcast to the crew (no `--to`).
+- `runner signal ask_lead --payload '{"question":"…","context":"…"}'` — escalate to the lead when a load-bearing decision is genuinely ambiguous.
+- `runner status idle` — report you've finished the current task. The lead view uses this to dispatch the next slot.
+
+== Replying to the human ==
+The human is watching the workspace feed, NOT your TUI. When the human speaks to you directly (raw input lands in your TUI, often prefixed with `[human_said]`), reply via:
+    runner msg post --to human "<your reply>"
+Plain TUI output (typing into your editor, printing to stdout) stays in your local scrollback only — it never reaches the human. The `--to human` route is the only way your reply lands in the workspace feed."#;
+
+/// Auto-send "continue" as a first user turn after a successful
+/// resume so the agent picks up where it left off without the user
+/// having to manually nudge it. Only fires when the resume actually
+/// reloaded a prior conversation (`plan.resuming == true` AND we
+/// have an `agent_session_key` to point claude-code at). For
+/// runtimes that don't have a real "resume" semantic (shell, or
+/// codex pre-capture), no-op — there's no conversation thread to
+/// continue.
+///
+/// Same split-injection pattern as `schedule_first_prompt`: body
+/// first, then a separate `\r` after a small delay so claude-code's
+/// editor sees the carriage return as Enter rather than appending
+/// it to the input buffer.
+fn schedule_continue_on_resume(
+    mgr: &Arc<SessionManager>,
+    session_id: String,
+    runner: &Runner,
+    plan: &router::runtime::ResumePlan,
+) {
+    if runner.runtime != "claude-code" {
+        return;
+    }
+    if !plan.resuming {
+        return;
+    }
+    let mgr = Arc::clone(mgr);
+    std::thread::spawn(move || {
+        // Same 2.5s budget as `schedule_first_prompt` — claude-code
+        // shows the prior conversation history first, and we want
+        // the editor bound before typing.
+        std::thread::sleep(std::time::Duration::from_millis(2500));
+        let _ = mgr.inject_stdin(&session_id, b"continue");
+        std::thread::sleep(std::time::Duration::from_millis(80));
+        let _ = mgr.inject_stdin(&session_id, b"\r");
     });
 }
 

--- a/src/components/AskHumanCard.tsx
+++ b/src/components/AskHumanCard.tsx
@@ -9,6 +9,7 @@ import { useState } from "react";
 
 import { api } from "../lib/api";
 import type { HumanQuestionPayload } from "../lib/types";
+import { MessageBody } from "./MessageBody";
 
 interface AskHumanCardProps {
   missionId: string;
@@ -81,10 +82,20 @@ export function AskHumanCard({
         </div>
         <span className="text-[11px] text-fg-3">{formatTs(ts)}</span>
       </div>
-      <p className="mt-2 text-[13px] leading-relaxed text-fg">
-        {payload.prompt || "(no prompt)"}
-      </p>
-      <div className="mt-3 flex flex-wrap items-center gap-2">
+      <div className="mt-2 text-[13px] leading-relaxed text-fg">
+        {payload.prompt ? (
+          <MessageBody text={payload.prompt} />
+        ) : (
+          <span className="text-fg-3">(no prompt)</span>
+        )}
+      </div>
+      {/* Choices stack vertically as full-width buttons. Multi-choice
+          asks (3–4 long options) used to wrap across rows in a tight
+          horizontal flex, hard to scan; vertical full-width matches
+          Pencil node `Z7Dbo` and gives each option its own line.
+          Primary action (first choice) is the green-filled CTA;
+          subsequent options are outlined buttons. */}
+      <div className="mt-3 flex flex-col gap-1.5">
         {choices.map((c, idx) => {
           const isPrimary = idx === 0;
           const isPicked = resolved
@@ -98,14 +109,14 @@ export function AskHumanCard({
               disabled={submitting || resolved}
               className={
                 isPrimary
-                  ? `rounded-md px-3.5 py-1.5 text-[12px] font-semibold transition-colors ${
+                  ? `flex w-full cursor-pointer items-center rounded-md px-3.5 py-2.5 text-left text-[12px] font-semibold transition-all ${
                       isPicked
                         ? "bg-accent text-accent-ink"
-                        : "bg-accent text-accent-ink hover:bg-accent/90"
-                    } disabled:cursor-not-allowed disabled:opacity-60`
-                  : `rounded-md border border-line bg-panel px-3.5 py-1.5 text-[12px] font-medium text-fg transition-colors ${
+                        : "bg-accent text-accent-ink hover:bg-accent/90 hover:shadow-[0_0_0_1px_var(--color-accent)] hover:-translate-y-px"
+                    } disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0 disabled:hover:shadow-none`
+                  : `flex w-full cursor-pointer items-center rounded-md border border-line bg-panel px-3.5 py-2.5 text-left text-[12px] font-medium text-fg transition-all ${
                       isPicked ? "border-accent text-accent" : ""
-                    } hover:border-line-strong disabled:cursor-not-allowed disabled:opacity-60`
+                    } hover:border-fg-3 hover:bg-raised hover:text-fg disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-panel disabled:hover:border-line`
               }
             >
               {c}
@@ -113,7 +124,7 @@ export function AskHumanCard({
           );
         })}
         {resolved ? (
-          <span className="ml-1 text-[11px] text-fg-3">
+          <span className="mt-1 text-[11px] text-fg-3">
             answered: <span className="text-fg-2">{resolvedChoice}</span>
           </span>
         ) : null}

--- a/src/components/EventFeed.tsx
+++ b/src/components/EventFeed.tsx
@@ -13,6 +13,7 @@
 import { useEffect, useRef } from "react";
 
 import { AskHumanCard } from "./AskHumanCard";
+import { MessageBody } from "./MessageBody";
 import type { Event, HumanQuestionPayload } from "../lib/types";
 
 interface EventFeedProps {
@@ -130,7 +131,9 @@ function EventRow({
           <span>·</span>
           <span>{formatTs(event.ts)}</span>
         </div>
-        <div className="text-[13px] leading-relaxed text-fg">{text}</div>
+        <div className="text-[13px] leading-relaxed text-fg">
+          <MessageBody text={text} />
+        </div>
       </div>
     );
   }
@@ -173,12 +176,12 @@ function renderPayload(event: Event): React.ReactNode {
     const text = typeof p.text === "string" ? p.text : "";
     const target = typeof p.target === "string" ? p.target : null;
     return (
-      <>
-        <span className="text-fg">{text || "(no text)"}</span>
+      <div className="text-fg">
+        {text ? <MessageBody text={text} /> : <span>(no text)</span>}
         {target ? (
-          <span className="ml-2 text-fg-3">→ @{target}</span>
+          <div className="mt-1 text-fg-3">→ @{target}</div>
         ) : null}
-      </>
+      </div>
     );
   }
   if (event.type === "ask_lead") {

--- a/src/components/MessageBody.tsx
+++ b/src/components/MessageBody.tsx
@@ -1,0 +1,112 @@
+// Renders a message body the way claude-code and codex output —
+// GFM markdown with code blocks, lists, headings, inline code, links.
+// The bundled CLI streams whatever the agent typed, which in claude/
+// codex is markdown by convention. Plain-text rendering loses that
+// structure (lists collapse into one line, code becomes prose, etc.).
+//
+// Styling tuned for a chat-log feel: tight line-height, generous
+// monospace blocks, accent green for inline code so it pops against
+// the carbon background. Lists keep their bullets and indentation.
+
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+export function MessageBody({ text }: { text: string }) {
+  return (
+    <div className="prose-message">
+      <ReactMarkdown
+        remarkPlugins={[remarkGfm]}
+        components={{
+          // Open links in a new window via the Tauri shell. Plain
+          // anchors would crash the webview by trying to navigate
+          // away from the SPA. For now we render as a styled span
+          // that copies the URL on click — a real opener is a
+          // follow-up.
+          a: ({ children, href }) => (
+            <a
+              href={href ?? "#"}
+              onClick={(e) => {
+                e.preventDefault();
+                if (href) navigator.clipboard?.writeText(href).catch(() => {});
+              }}
+              className="text-accent underline decoration-accent/40 underline-offset-2 hover:decoration-accent"
+              title={href ? `Click to copy: ${href}` : undefined}
+            >
+              {children}
+            </a>
+          ),
+          code: ({ className, children }) => {
+            const isBlock = (className ?? "").startsWith("language-");
+            if (isBlock) {
+              return (
+                <code
+                  className={`block whitespace-pre overflow-x-auto rounded-md border border-line bg-bg px-3 py-2 font-mono text-[12px] leading-relaxed text-fg ${className ?? ""}`}
+                >
+                  {children}
+                </code>
+              );
+            }
+            return (
+              <code className="rounded bg-raised px-1 py-px font-mono text-[12px] text-accent">
+                {children}
+              </code>
+            );
+          },
+          pre: ({ children }) => <pre className="my-2">{children}</pre>,
+          ul: ({ children }) => (
+            <ul className="my-1 ml-5 list-disc space-y-0.5">{children}</ul>
+          ),
+          ol: ({ children }) => (
+            <ol className="my-1 ml-5 list-decimal space-y-0.5">{children}</ol>
+          ),
+          li: ({ children }) => <li className="leading-snug">{children}</li>,
+          h1: ({ children }) => (
+            <h1 className="mt-3 mb-1.5 text-[14px] font-semibold text-fg">
+              {children}
+            </h1>
+          ),
+          h2: ({ children }) => (
+            <h2 className="mt-3 mb-1 text-[13px] font-semibold text-fg">
+              {children}
+            </h2>
+          ),
+          h3: ({ children }) => (
+            <h3 className="mt-2 mb-1 text-[13px] font-semibold text-fg-2">
+              {children}
+            </h3>
+          ),
+          p: ({ children }) => (
+            <p className="my-1 leading-relaxed">{children}</p>
+          ),
+          blockquote: ({ children }) => (
+            <blockquote className="my-2 border-l-2 border-line pl-3 text-fg-2">
+              {children}
+            </blockquote>
+          ),
+          hr: () => <hr className="my-3 border-line" />,
+          strong: ({ children }) => (
+            <strong className="font-semibold text-fg">{children}</strong>
+          ),
+          em: ({ children }) => <em className="italic text-fg">{children}</em>,
+          table: ({ children }) => (
+            <div className="my-2 overflow-x-auto">
+              <table className="border-collapse text-[12px]">{children}</table>
+            </div>
+          ),
+          th: ({ children }) => (
+            <th className="border border-line bg-raised px-2 py-1 text-left font-semibold text-fg">
+              {children}
+            </th>
+          ),
+          td: ({ children }) => (
+            <td className="border border-line px-2 py-1 align-top text-fg-2">
+              {children}
+            </td>
+          ),
+        }}
+      >
+        {text}
+      </ReactMarkdown>
+    </div>
+  );
+}

--- a/src/components/MissionInput.tsx
+++ b/src/components/MissionInput.tsx
@@ -4,10 +4,11 @@
 // are pull-based and never trigger router actions.
 //
 // Recipient semantics: default is `@<lead>`. Switching the chip to a
-// non-lead handle scopes `payload.target` to that worker; clearing the
-// chip with the × icon broadcasts (omits payload.target — the router
-// then defaults to the lead anyway, so for v0 the behaviour is the same
-// as the default).
+// non-lead handle scopes `payload.target` to that worker; the router
+// injects into that worker's PTY. Workers reply via
+// `runner msg post --to human "…"` which lands as a `message` event in
+// the feed — the bundled CLI reserves `human` as a virtual roster
+// handle for exactly this two-way path.
 
 import { useEffect, useRef, useState } from "react";
 
@@ -17,8 +18,8 @@ interface MissionInputProps {
   missionId: string;
   /** Stable lead handle — default recipient. */
   leadHandle: string;
-  /** All non-human handles in the roster. The recipient picker offers
-   *  these; the human can also broadcast (clear the chip). */
+  /** All slot handles in the roster. The recipient picker offers
+   *  these alongside the lead. */
   handles: string[];
   /** Set when the mission is no longer running. The input still renders
    *  (so the feed below it stays visible) but submission is disabled. */
@@ -34,15 +35,15 @@ export function MissionInput({
   onError,
 }: MissionInputProps) {
   const [text, setText] = useState("");
-  const [target, setTarget] = useState<string | null>(leadHandle);
+  const [target, setTarget] = useState<string>(leadHandle);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const pickerRef = useRef<HTMLDivElement | null>(null);
 
-  // Sync with new lead if the prop changes (rare — but harmless to keep).
+  // Sync with new lead if the prop changes.
   useEffect(() => {
-    setTarget((cur) => (cur === null ? null : leadHandle));
-  }, [leadHandle]);
+    setTarget((cur) => (handles.includes(cur) ? cur : leadHandle));
+  }, [handles, leadHandle]);
 
   useEffect(() => {
     if (!pickerOpen) return;
@@ -58,11 +59,10 @@ export function MissionInput({
     if (!body || submitting || disabled) return;
     setSubmitting(true);
     try {
-      const payload = target ? { text: body, target } : { text: body };
       await api.mission.postHumanSignal({
         mission_id: missionId,
         signal_type: "human_said",
-        payload,
+        payload: { text: body, target },
       });
       setText("");
     } catch (e) {
@@ -97,28 +97,12 @@ export function MissionInput({
           onClick={() => setPickerOpen((v) => !v)}
           className="inline-flex items-center gap-1.5 rounded border border-line bg-panel px-2.5 py-1 font-mono text-[11px] text-fg hover:border-line-strong"
         >
-          {target ? (
-            <>
-              @{target}
-              {target === leadHandle ? (
-                <span className="text-fg-3">(lead)</span>
-              ) : null}
-            </>
-          ) : (
-            <span className="text-fg-2">broadcast</span>
-          )}
+          @{target}
+          {target === leadHandle ? (
+            <span className="text-fg-3">(lead)</span>
+          ) : null}
           <span className="text-fg-3">▾</span>
         </button>
-        {target ? (
-          <button
-            type="button"
-            onClick={() => setTarget(null)}
-            title="Clear recipient (broadcast)"
-            className="text-fg-3 hover:text-fg"
-          >
-            ×
-          </button>
-        ) : null}
         {pickerOpen ? (
           <div className="relative">
             <div className="absolute left-0 top-1.5 z-20 flex w-44 flex-col overflow-hidden rounded border border-line-strong bg-panel py-1 shadow-xl">
@@ -140,17 +124,6 @@ export function MissionInput({
                   ) : null}
                 </button>
               ))}
-              <div className="border-t border-line my-1" />
-              <button
-                type="button"
-                onClick={() => {
-                  setTarget(null);
-                  setPickerOpen(false);
-                }}
-                className="px-3 py-1.5 text-left text-[11px] text-fg-2 hover:bg-raised"
-              >
-                broadcast
-              </button>
             </div>
           </div>
         ) : null}

--- a/src/components/MissionResetConfirm.tsx
+++ b/src/components/MissionResetConfirm.tsx
@@ -1,0 +1,117 @@
+// Mission reset confirm dialog. Mirrors Pencil node `DzNZe`:
+// destructive-but-recoverable (mission row + crew stay; only the run
+// context is wiped). Amber warning border + triangle-alert icon flag
+// the destructive intent without dropping into hard-red danger
+// territory — that's reserved for archive.
+
+import { useEffect, useRef, useState } from "react";
+import { RotateCcw, TriangleAlert } from "lucide-react";
+
+interface MissionResetConfirmProps {
+  open: boolean;
+  missionTitle: string;
+  onConfirm: () => void | Promise<void>;
+  onClose: () => void;
+}
+
+export function MissionResetConfirm({
+  open,
+  missionTitle,
+  onConfirm,
+  onClose,
+}: MissionResetConfirmProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setSubmitting(false);
+    // Outside-click + Escape close. Cancel button works the same.
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    const onMouseDown = (e: MouseEvent) => {
+      if (!cardRef.current) return;
+      if (!cardRef.current.contains(e.target as Node)) onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    document.addEventListener("mousedown", onMouseDown);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("mousedown", onMouseDown);
+    };
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const handleConfirm = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      await onConfirm();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55">
+      <div
+        ref={cardRef}
+        className="flex w-full max-w-[480px] flex-col gap-4 overflow-hidden rounded-xl border-2 border-warn bg-panel shadow-[0_14px_40px_rgba(0,0,0,0.6)]"
+      >
+        <div className="h-[3px] w-full bg-warn" />
+        <div className="flex flex-col gap-4 px-6 pb-6">
+          <header className="flex items-center gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-warn/15">
+              <TriangleAlert aria-hidden className="h-[18px] w-[18px] text-warn" />
+            </div>
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <h2 className="truncate text-[16px] font-semibold text-fg">
+                Reset mission?
+              </h2>
+              <p className="truncate text-[12px] text-fg-3">
+                This wipes the run and starts the crew over.
+              </p>
+            </div>
+          </header>
+          <div className="flex flex-col gap-1.5 rounded-lg border border-line bg-bg px-3.5 py-3">
+            {[
+              "All slot PTYs are killed and respawned fresh.",
+              "The event log is wiped — feed history is lost.",
+              "Agent conversations are dropped — claude-code starts fresh.",
+            ].map((line) => (
+              <div key={line} className="flex items-start gap-2 text-[12px] leading-snug text-fg-2">
+                <span className="select-none text-fg-3">·</span>
+                <span>{line}</span>
+              </div>
+            ))}
+          </div>
+          <p className="text-[12px] text-fg-3">
+            <span className="font-mono text-fg-2">{missionTitle}</span> will
+            keep its title, crew, and slots — just nothing else.
+          </p>
+          <div className="flex items-center justify-end gap-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={submitting}
+              className="cursor-pointer rounded-md border border-line bg-raised px-3.5 py-2 text-[13px] font-medium text-fg transition-colors hover:border-line-strong disabled:cursor-default disabled:opacity-60"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={() => void handleConfirm()}
+              disabled={submitting}
+              className="flex cursor-pointer items-center gap-2 rounded-md bg-warn px-3.5 py-2 text-[13px] font-semibold text-bg transition-opacity hover:opacity-90 disabled:cursor-default disabled:opacity-60"
+            >
+              <RotateCcw aria-hidden className="h-3.5 w-3.5" />
+              {submitting ? "Resetting…" : "Reset mission"}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/RunnersRail.tsx
+++ b/src/components/RunnersRail.tsx
@@ -30,10 +30,10 @@ export function RunnersRail({
   return (
     <div className="flex flex-1 min-h-0 flex-col gap-3 overflow-y-auto px-5 pb-5">
       <div className="text-[10px] font-semibold uppercase tracking-[0.15em] text-fg-3">
-        Runners
+        Runner sessions
       </div>
       {sessions.length === 0 ? (
-        <p className="text-xs text-fg-3">No runners spawned.</p>
+        <p className="text-xs text-fg-3">No runner sessions yet.</p>
       ) : (
         sessions.map((s) => {
           const isLead = s.handle === leadHandle;

--- a/src/components/SessionEndedOverlay.tsx
+++ b/src/components/SessionEndedOverlay.tsx
@@ -1,0 +1,138 @@
+// Shared "session is closed, here are your options" surface used by
+// both RunnerChat (direct chats) and MissionWorkspace (mission slot
+// PTYs). Mirrors Pencil node `vS5ce`'s bottom card. The two surfaces
+// previously had separate inline implementations that drifted in
+// copy and styling — consolidated here so changes land everywhere.
+
+import { Archive, Loader2, Play, PowerOff } from "lucide-react";
+
+import type { SessionStatus } from "../lib/types";
+
+export interface SessionEndedOverlayProps {
+  status: SessionStatus;
+  /** Process exit code, if known. RunnerChat tracks it from the
+   *  `session/exit` event payload; MissionWorkspace doesn't surface
+   *  it today (the SessionRow shape doesn't carry it), so this is
+   *  optional and the copy adjusts when it's missing. */
+  exitCode?: number | null;
+  /** True iff the row's `agent_session_key` is non-NULL, so resume
+   *  reattaches to the same agent CLI conversation. False for shell
+   *  runtimes and codex chats whose post-spawn rollout capture
+   *  hasn't completed — in those cases Resume just spawns a fresh
+   *  agent with no conversation history, and the copy reflects that. */
+  resumable: boolean;
+  /** Friendly label for the runner / slot ("@architect"). When set,
+   *  the resume button reads "Resume @architect"; falls back to
+   *  generic "Resume chat" / "Restart chat" wording. */
+  handle?: string;
+  onResume: () => void;
+  /** Optional. RunnerChat surfaces an Archive option (calls
+   *  session_archive); MissionWorkspace's slot pane doesn't expose
+   *  one because archiving a mission slot's session row would orphan
+   *  the slot — handled at the mission level instead. */
+  onArchive?: () => void;
+  /** Variant: "card" (default) renders as a centered card overlay
+   *  matching the design; "inline" anchors to the bottom of its
+   *  container, used by RunnerChat where the xterm fills the same
+   *  region. */
+  variant?: "card" | "inline";
+  /** Override the default "Session ended" header. Used by the
+   *  mission feed surface where the right phrase is "Mission paused"
+   *  — same visual card, different semantics. */
+  title?: string;
+  /** Override the default subtitle. The status/resumable/exitCode
+   *  matrix doesn't fit mission-level copy, so callers in that
+   *  context pass their own line. */
+  subtitle?: string;
+  /** Override the resume button label. Defaults derive from
+   *  `handle` + `resumable`. */
+  resumeLabel?: string;
+}
+
+export function SessionEndedOverlay({
+  status,
+  exitCode = null,
+  resumable,
+  handle,
+  onResume,
+  onArchive,
+  variant = "card",
+  title,
+  subtitle,
+  resumeLabel,
+}: SessionEndedOverlayProps) {
+  const computedSubtitle = !resumable
+    ? "The PTY is closed. Resume to start a fresh agent process — there's no saved conversation to pick up from this row."
+    : status === "crashed"
+      ? exitCode != null
+        ? `The PTY exited with code ${exitCode}. Resume to start a fresh process — the prior agent conversation is preserved.`
+        : "The PTY exited unexpectedly. Resume to start a fresh process — the prior agent conversation is preserved."
+      : "The PTY is closed, but the conversation is preserved. Resume to pick up where you left off.";
+  const finalSubtitle = subtitle ?? computedSubtitle;
+  const computedResumeLabel = handle
+    ? `Resume @${handle}`
+    : resumable
+      ? "Resume chat"
+      : "Restart chat";
+  const finalResumeLabel = resumeLabel ?? computedResumeLabel;
+  const finalTitle = title ?? "Session ended";
+
+  const card = (
+    <div className="flex w-full max-w-2xl flex-col gap-3.5 rounded-xl border border-line bg-panel p-5 shadow-[0_8px_30px_rgba(0,0,0,0.67)]">
+      <div className="flex items-center gap-2.5">
+        <PowerOff aria-hidden className="h-4 w-4 text-fg-3" />
+        <span className="text-[15px] font-semibold text-fg">
+          {finalTitle}
+        </span>
+      </div>
+      <p className="text-[13px] leading-snug text-fg-2">{finalSubtitle}</p>
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={onResume}
+          className="flex cursor-pointer items-center gap-2 rounded-md bg-accent px-3.5 py-2 text-[13px] font-semibold text-bg hover:bg-accent/90"
+        >
+          <Play aria-hidden className="h-3.5 w-3.5" />
+          {finalResumeLabel}
+        </button>
+        {onArchive ? (
+          <button
+            type="button"
+            onClick={onArchive}
+            className="flex cursor-pointer items-center gap-2 rounded-md border border-line bg-raised px-3.5 py-2 text-[13px] text-fg hover:border-fg-3"
+          >
+            <Archive aria-hidden className="h-3.5 w-3.5 text-fg-2" />
+            Archive
+          </button>
+        ) : null}
+      </div>
+    </div>
+  );
+
+  if (variant === "inline") {
+    return (
+      <div className="pointer-events-none absolute inset-4 flex items-end justify-center pb-10">
+        <div className="pointer-events-auto">{card}</div>
+      </div>
+    );
+  }
+  return (
+    <div className="flex flex-1 min-h-0 items-center justify-center p-6">
+      {card}
+    </div>
+  );
+}
+
+/// Centered transitional pill while a resume is in flight. Mirrors
+/// Pencil node `GZhHO`. Shown overlaid on a freshly-cleared xterm
+/// canvas while the agent CLI re-attaches.
+export function ResumingOverlay() {
+  return (
+    <div className="pointer-events-none absolute inset-4 flex items-center justify-center">
+      <div className="pointer-events-auto flex items-center gap-2.5 rounded-full border border-[#1F3D4D] bg-[#0F1E26] px-4 py-2 text-[13px] font-medium text-[#39E5FF] shadow-[0_8px_30px_rgba(0,0,0,0.5)]">
+        <Loader2 aria-hidden className="h-4 w-4 animate-spin" />
+        Resuming…
+      </div>
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -120,6 +120,10 @@ export const api = {
     /** Terminal end-of-mission. Drops router + bus, flips status to
      *  `completed`. Cannot be undone. */
     archive: (id: string) => invoke<Mission>("mission_archive", { id }),
+    /** Wipe the run context and respawn every slot. Mostly for
+     *  testing — keeps the mission row, crew, and slots intact;
+     *  drops the event log, agent session keys, and router state. */
+    reset: (id: string) => invoke<Mission>("mission_reset", { id }),
     /** Toggle a mission's pin. Pinned missions float to the top of
      *  the sidebar's MISSION list. */
     pin: (id: string, pinned: boolean) =>

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -22,6 +22,7 @@ import {
   PinOff,
   PanelRightClose,
   PanelRightOpen,
+  RotateCcw,
   Square,
   SquarePen,
   Terminal,
@@ -38,8 +39,13 @@ import type {
 } from "../lib/types";
 import { EventFeed } from "../components/EventFeed";
 import { MissionInput } from "../components/MissionInput";
+import { MissionResetConfirm } from "../components/MissionResetConfirm";
 import { RunnersRail } from "../components/RunnersRail";
 import { RunnerTerminal } from "../components/RunnerTerminal";
+import {
+  ResumingOverlay,
+  SessionEndedOverlay,
+} from "../components/SessionEndedOverlay";
 
 export default function MissionWorkspace() {
   const { id } = useParams<{ id: string }>();
@@ -126,6 +132,10 @@ export default function MissionWorkspace() {
         if (cancelled) return;
         setMission(m);
         setSessions(ss);
+        // Auto-open every slot's PTY tab on mount. The user can close
+        // individual tabs via the × on each tab; if they close them
+        // all and re-mount, the mount path opens them again.
+        setOpenTabs(ss.map((s) => s.id));
         ingest(evs);
       } catch (e) {
         if (!cancelled) setError(String(e));
@@ -261,6 +271,43 @@ export default function MissionWorkspace() {
     }
   }, [mission]);
 
+  // Reset = wipe the run, respawn slots, keep the mission row. Used
+  // for testing — you get the same mission back with a clean event
+  // log and fresh PTYs. Confirmed via a modal (`MissionResetConfirm`)
+  // because event-log loss is hard to undo.
+  const [resetConfirmOpen, setResetConfirmOpen] = useState(false);
+  const resetMission = useCallback(async () => {
+    if (!mission) return;
+    try {
+      const next = await api.mission.reset(mission.id);
+      setMission(next);
+      // Refresh sessions + events. The reset path archives the old
+      // session rows and inserts fresh ones, so session_list returns
+      // the new set of running slots. The event log was wiped + has
+      // only the two opening events; eventsReplay picks them up.
+      const [rows, evs] = await Promise.all([
+        api.session.list(mission.id),
+        api.mission.eventsReplay(mission.id),
+      ]);
+      setSessions(rows);
+      // Clear stale events + ingest fresh — bypassing the seenIds
+      // dedup since the new events have new ULIDs we haven't seen.
+      seenIdsRef.current = new Set();
+      setEvents([]);
+      const fresh = evs.filter((e) => {
+        if (seenIdsRef.current.has(e.id)) return false;
+        seenIdsRef.current.add(e.id);
+        return true;
+      });
+      setEvents(fresh);
+      // Fresh slots = open all PTY tabs.
+      setOpenTabs(rows.map((s) => s.id));
+      setResetConfirmOpen(false);
+    } catch (e) {
+      setError(String(e));
+    }
+  }, [mission]);
+
   // Resume all = iterate stopped/crashed sessions and respawn each.
   // Hits the same `session_resume` path the per-slot Resume button
   // uses; just saves clicks when every slot needs to come back.
@@ -275,6 +322,14 @@ export default function MissionWorkspace() {
       }
       const rows = await api.session.list(mission.id);
       setSessions(rows);
+      // Mission Resume implies the user wants to see the slots come
+      // back to life. Reopen any tabs they'd previously closed —
+      // resume isn't a useful action if the panes are hidden.
+      setOpenTabs((prev) => {
+        const next = new Set(prev);
+        for (const r of rows) next.add(r.id);
+        return Array.from(next);
+      });
     } catch (e) {
       setError(String(e));
     } finally {
@@ -390,11 +445,21 @@ export default function MissionWorkspace() {
           {mission ? (() => {
             // Display status is derived: a `running` mission with no
             // live PTYs reads as "stopped" so the badge matches the
-            // Resume button next to it. Mission row state
-            // (`mission.status`) is still authoritative for backend
-            // gating; only the visual label is derived.
-            const display: "running" | "stopped" | "archived" | "aborted" =
-              mission.status === "running"
+            // Resume button next to it. While `resumingAll` is in
+            // flight (mission-level Resume button clicked, slots are
+            // being respawned), the pill flips to a cyan "resuming…"
+            // matching Pencil node `a3c7p`'s topbar. Mission row
+            // state is still authoritative for backend gating; only
+            // the visual label is derived.
+            type Display =
+              | "running"
+              | "stopped"
+              | "archived"
+              | "aborted"
+              | "resuming";
+            const display: Display = resumingAll
+              ? "resuming"
+              : mission.status === "running"
                 ? allSessionsLive
                   ? "running"
                   : "stopped"
@@ -402,19 +467,24 @@ export default function MissionWorkspace() {
                   ? "archived"
                   : "aborted";
             // Smaller pill matching design `M5Kohk` — tighter padding,
-            // pure rounded ends, slightly subdued bg tints.
+            // pure rounded ends, slightly subdued bg tints. Cyan
+            // tones for resuming match `Y5e0K5` in `a3c7p`.
             const pillClass =
               display === "running"
                 ? "bg-accent/15 text-accent"
                 : display === "aborted"
                   ? "bg-danger/15 text-danger"
-                  : "bg-raised text-fg-2";
+                  : display === "resuming"
+                    ? "bg-[#0F1E26] text-[#39E5FF]"
+                    : "bg-raised text-fg-2";
             const dotClass =
               display === "running"
                 ? "bg-accent"
                 : display === "aborted"
                   ? "bg-danger"
-                  : "bg-fg-3";
+                  : display === "resuming"
+                    ? "bg-[#39E5FF]"
+                    : "bg-fg-3";
             return (
               <span
                 className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium ${pillClass}`}
@@ -422,21 +492,20 @@ export default function MissionWorkspace() {
                 <span
                   className={`inline-flex h-1.5 w-1.5 rounded-full ${dotClass}`}
                 />
-                {display}
+                {display === "resuming" ? "resuming…" : display}
               </span>
             );
           })() : null}
-          {mission?.status === "running" ? (
+          {mission?.status === "running" && !resumingAll ? (
             <>
               {anySessionStopped ? (
                 <button
                   type="button"
                   onClick={() => void resumeMission()}
-                  disabled={resumingAll}
-                  className="inline-flex items-center gap-1.5 rounded-md border border-accent/40 bg-accent/10 px-2.5 py-1 text-[11px] font-semibold text-accent hover:border-accent disabled:cursor-default disabled:opacity-60"
+                  className="inline-flex items-center gap-1.5 rounded-md border border-accent/40 bg-accent/10 px-2.5 py-1 text-[11px] font-semibold text-accent hover:border-accent"
                   title="Respawn every stopped slot in this mission"
                 >
-                  {resumingAll ? "Resuming…" : "Resume"}
+                  Resume
                 </button>
               ) : null}
               {allSessionsLive ? (
@@ -462,6 +531,10 @@ export default function MissionWorkspace() {
                 onRename={() => {
                   setKebabOpen(false);
                   void renameMissionPrompt();
+                }}
+                onReset={() => {
+                  setKebabOpen(false);
+                  setResetConfirmOpen(true);
                 }}
                 onArchive={() => {
                   setKebabOpen(false);
@@ -546,9 +619,26 @@ export default function MissionWorkspace() {
                 missionId={mission.id}
                 leadHandle={leadHandle}
                 handles={handles}
-                disabled={mission.status !== "running"}
+                disabled={mission.status !== "running" || !allSessionsLive}
                 onError={setError}
               />
+              {/* When the mission row is still `running` but every PTY
+                  is dead, float a Resume CTA over the (disabled) input
+                  — same `variant="inline"` placement the slot panes
+                  use, so feed + PTY tabs share one recovery anchor. */}
+              {mission.status === "running" &&
+              !allSessionsLive &&
+              !resumingAll ? (
+                <SessionEndedOverlay
+                  status="stopped"
+                  resumable
+                  title="Mission paused"
+                  subtitle="All slots are stopped. Resume to respawn every slot and pick up the conversation — the event log is preserved."
+                  resumeLabel="Resume mission"
+                  onResume={() => void resumeMission()}
+                  variant="inline"
+                />
+              ) : null}
             </Pane>
 
             {openTabs
@@ -559,6 +649,7 @@ export default function MissionWorkspace() {
                   <SlotPtyPane
                     session={s}
                     active={activeTab === s.id}
+                    forcedResuming={resumingAll}
                     onError={setError}
                     onResumed={async () => {
                       const rows = await api.session.list(mission.id);
@@ -611,74 +702,96 @@ export default function MissionWorkspace() {
           </div>
         </div>
       </aside>
+      <MissionResetConfirm
+        open={resetConfirmOpen && mission !== null}
+        missionTitle={mission?.title ?? ""}
+        onClose={() => setResetConfirmOpen(false)}
+        onConfirm={() => void resetMission()}
+      />
     </div>
   );
 }
 
-/// A slot's PTY pane. Running sessions render an xterm; stopped/crashed
-/// rows show a centered Resume button that calls session_resume (the
-/// backend respawns the same row, preserving agent_session_key so the
-/// agent CLI picks up the same conversation thread).
+/// A slot's PTY pane. Three states map to Pencil nodes:
+///
+///   - running: live xterm (no overlay)
+///   - stopped/crashed: dimmed xterm + bottom-dock card (`vS5ce` →
+///     `jMJmx` for the slot variant). User can Resume.
+///   - resuming: blank xterm + centered cyan pill (`GZhHO` →
+///     `a3c7p`). Set either by the per-slot Resume button OR by the
+///     mission-level Resume button (parent passes `forcedResuming`).
+///
+/// Keeping the xterm mounted across states preserves the scrollback,
+/// so a user reading the prior turn before resuming sees no flash.
 function SlotPtyPane({
   session,
   active,
+  forcedResuming,
   onError,
   onResumed,
 }: {
   session: SessionRow;
   active: boolean;
+  /** True when the parent's "Resume mission" button is iterating
+   *  through every slot. Drives the resuming overlay in this pane
+   *  even though the per-slot button wasn't clicked. */
+  forcedResuming?: boolean;
   onError: (e: string) => void;
   onResumed: () => void | Promise<void>;
 }) {
-  const [resuming, setResuming] = useState(false);
-
-  if (session.status === "running") {
-    return (
-      <div className="flex flex-1 min-h-0 p-3">
-        <RunnerTerminal
-          sessionId={session.id}
-          onError={onError}
-          active={active}
-        />
-      </div>
-    );
-  }
+  const [localResuming, setLocalResuming] = useState(false);
+  const resuming = localResuming || !!forcedResuming;
+  const dead = session.status !== "running";
 
   const onResume = async () => {
     if (resuming) return;
-    setResuming(true);
+    setLocalResuming(true);
     try {
       await api.session.resume(session.id, null, null);
       await onResumed();
     } catch (e) {
       onError(String(e));
     } finally {
-      setResuming(false);
+      setLocalResuming(false);
     }
   };
 
-  const stoppedReason =
-    session.status === "crashed"
-      ? "@" + session.handle + " crashed."
-      : "@" + session.handle + " is stopped.";
-
+  // Mission slot pane omits the Archive option — archiving a slot's
+  // session row would orphan the slot in the workspace. Mission-level
+  // archive lives in the topbar kebab. `resumable` defaults to true:
+  // we don't have agent_session_key on the SessionRow, but mission
+  // sessions almost always carry one (claude-code self-assigns a
+  // UUID on every fresh spawn) and the worst case is friendlier
+  // copy than reality.
+  //
+  // Pane opacity:
+  //   - resuming: 0 (canvas wiped, the pill carries the visual)
+  //   - dead but not resuming: 45% (the user can read scrollback)
+  //   - running: 100%
+  const paneOpacity = resuming ? "opacity-0" : dead ? "opacity-45" : "";
   return (
-    <div className="flex flex-1 min-h-0 items-center justify-center p-6">
-      <div className="flex max-w-sm flex-col items-center gap-3 rounded-lg border border-line bg-panel px-6 py-8 text-center">
-        <span className="text-sm font-medium text-fg">{stoppedReason}</span>
-        <span className="text-xs text-fg-3">
-          Resume respawns the same session — claude-code reattaches via
-          its session UUID; codex reuses the captured rollout.
-        </span>
-        <button
-          type="button"
-          onClick={() => void onResume()}
-          disabled={resuming}
-          className="mt-1 inline-flex items-center justify-center rounded border border-line-strong bg-bg px-3 py-1.5 text-sm font-medium text-fg transition-colors hover:bg-raised disabled:cursor-default disabled:opacity-60"
-        >
-          {resuming ? "Resuming…" : "Resume @" + session.handle}
-        </button>
+    <div className="relative flex flex-1 min-h-0 flex-col">
+      <div
+        className={`flex flex-1 min-h-0 p-3 transition-opacity ${paneOpacity}`}
+      >
+        <RunnerTerminal
+          sessionId={session.id}
+          onError={onError}
+          active={active && !dead && !resuming}
+          disabled={dead || resuming}
+        />
       </div>
+      {resuming ? (
+        <ResumingOverlay />
+      ) : dead ? (
+        <SessionEndedOverlay
+          status={session.status}
+          handle={session.handle}
+          resumable={true}
+          onResume={() => void onResume()}
+          variant="inline"
+        />
+      ) : null}
     </div>
   );
 }
@@ -779,6 +892,7 @@ function MissionKebab({
   onClose,
   onPin,
   onRename,
+  onReset,
   onArchive,
 }: {
   pinned: boolean;
@@ -787,6 +901,7 @@ function MissionKebab({
   onClose: () => void;
   onPin: () => void;
   onRename: () => void;
+  onReset: () => void;
   onArchive: () => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
@@ -830,6 +945,7 @@ function MissionKebab({
             onClick={onPin}
           />
           <KebabItem icon={SquarePen} label="Rename" onClick={onRename} />
+          <KebabItem icon={RotateCcw} label="Reset" onClick={onReset} />
           <KebabItem icon={Archive} label="Archive" onClick={onArchive} danger />
         </div>
       ) : null}

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -341,6 +341,12 @@ export default function MissionWorkspace() {
     sessions.length > 0 && sessions.every((s) => s.status === "running");
   const anySessionStopped =
     sessions.length > 0 && sessions.some((s) => s.status !== "running");
+  // Coordination still works as long as ≥1 slot is alive — the human
+  // can talk to whichever runner is up. Only block input + show the
+  // pause overlay when literally zero PTYs are running. A mid-mission
+  // crash on one worker shouldn't gate human-to-lead messaging.
+  const anySessionLive =
+    sessions.length > 0 && sessions.some((s) => s.status === "running");
 
   // Project ask_human → human_question pairings + human_response
   // resolutions out of the feed. Mirrors the router's reconstruct_from_log
@@ -460,7 +466,7 @@ export default function MissionWorkspace() {
             const display: Display = resumingAll
               ? "resuming"
               : mission.status === "running"
-                ? allSessionsLive
+                ? anySessionLive
                   ? "running"
                   : "stopped"
                 : mission.status === "completed"
@@ -619,15 +625,19 @@ export default function MissionWorkspace() {
                 missionId={mission.id}
                 leadHandle={leadHandle}
                 handles={handles}
-                disabled={mission.status !== "running" || !allSessionsLive}
+                disabled={mission.status !== "running" || !anySessionLive}
                 onError={setError}
               />
-              {/* When the mission row is still `running` but every PTY
-                  is dead, float a Resume CTA over the (disabled) input
-                  — same `variant="inline"` placement the slot panes
-                  use, so feed + PTY tabs share one recovery anchor. */}
+              {/* Pause overlay only when *every* PTY is dead. A
+                  partial crash (one worker stopped, lead still
+                  alive) leaves coordination working — the human can
+                  message the lead and any other live slot — so we
+                  shouldn't gate the feed input. Same
+                  `variant="inline"` placement the slot panes use, so
+                  feed + PTY tabs share one recovery anchor when the
+                  mission really is fully paused. */}
               {mission.status === "running" &&
-              !allSessionsLive &&
+              !anySessionLive &&
               !resumingAll ? (
                 <SessionEndedOverlay
                   status="stopped"

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -14,17 +14,18 @@ import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { listen } from "@tauri-apps/api/event";
 import {
-  Archive,
   Loader2,
   PanelRightClose,
   PanelRightOpen,
-  Play,
-  PowerOff,
   Square,
   Terminal,
 } from "lucide-react";
 
 import { RunnerTerminal } from "../components/RunnerTerminal";
+import {
+  ResumingOverlay,
+  SessionEndedOverlay,
+} from "../components/SessionEndedOverlay";
 import { api, type DirectSessionEntry } from "../lib/api";
 import {
   clearActiveSession,
@@ -770,6 +771,7 @@ export default function RunnerChat() {
             resumable={chatMeta?.resumable ?? true}
             onResume={() => void resumeChat()}
             onArchive={() => void archiveChat()}
+            variant="inline"
           />
         ) : null}
       </div>
@@ -783,80 +785,9 @@ export default function RunnerChat() {
   );
 }
 
-// Centered transitional pill while a resume is in flight. Mirrors
-// Pencil node `GZhHO`: the active xterm has been reset (canvas blank)
-// and this floats in the middle of the now-empty terminal area until
-// chatMeta confirms the row is back to running.
-function ResumingOverlay() {
-  return (
-    <div className="pointer-events-none absolute inset-4 flex items-center justify-center">
-      <div className="pointer-events-auto flex items-center gap-2.5 rounded-full border border-[#1F3D4D] bg-[#0F1E26] px-4 py-2 text-[13px] font-medium text-[#39E5FF] shadow-[0_8px_30px_rgba(0,0,0,0.5)]">
-        <Loader2 aria-hidden className="h-4 w-4 animate-spin" />
-        Resuming…
-      </div>
-    </div>
-  );
-}
-
-// Session-ended overlay matching Pencil node `vS5ce`'s bottom card,
-// promoted to a centered modal-style overlay on top of the dimmed
-// terminal pane. Resume calls session_resume (same row, same agent
-// conversation); Archive calls session_archive and navigates back.
-function SessionEndedOverlay({
-  status,
-  exitCode,
-  resumable,
-  onResume,
-  onArchive,
-}: {
-  status: SessionStatus;
-  exitCode: number | null;
-  resumable: boolean;
-  onResume: () => void;
-  onArchive: () => void;
-}) {
-  // Subtitle wording depends on whether the agent CLI's own session
-  // id is on the row. Without it (shell runtime, codex pre-capture),
-  // Resume spawns a fresh agent without conversation history — don't
-  // promise preservation we can't deliver.
-  const subtitle = !resumable
-    ? "The PTY is closed. Resume to start a fresh agent process — there's no saved conversation to pick up from this row."
-    : status === "crashed"
-      ? `The PTY exited with code ${exitCode ?? "?"}. Resume to start a fresh process — the prior agent conversation is preserved.`
-      : "The PTY is closed, but the conversation is preserved. Resume to pick up where you left off, or archive to remove this chat from the sidebar.";
-  const resumeLabel = resumable ? "Resume chat" : "Restart chat";
-  return (
-    <div className="pointer-events-none absolute inset-4 flex items-end justify-center pb-10">
-      <div className="pointer-events-auto flex w-full max-w-2xl flex-col gap-3.5 rounded-xl border border-line bg-panel p-5 shadow-[0_8px_30px_rgba(0,0,0,0.67)]">
-        <div className="flex items-center gap-2.5">
-          <PowerOff aria-hidden className="h-4 w-4 text-fg-3" />
-          <span className="text-[15px] font-semibold text-fg">
-            Session ended
-          </span>
-        </div>
-        <p className="text-[13px] leading-snug text-fg-2">{subtitle}</p>
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={onResume}
-            className="flex cursor-pointer items-center gap-2 rounded-md bg-accent px-3.5 py-2 text-[13px] font-semibold text-bg hover:bg-accent/90"
-          >
-            <Play aria-hidden className="h-3.5 w-3.5" />
-            {resumeLabel}
-          </button>
-          <button
-            type="button"
-            onClick={onArchive}
-            className="flex cursor-pointer items-center gap-2 rounded-md border border-line bg-raised px-3.5 py-2 text-[13px] text-fg hover:border-fg-3"
-          >
-            <Archive aria-hidden className="h-3.5 w-3.5 text-fg-2" />
-            Archive
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
+// SessionEndedOverlay + ResumingOverlay live in
+// `../components/SessionEndedOverlay` and are shared with
+// MissionWorkspace's slot PTY tabs.
 
 // Right-side panel matching Pencil node `IFS3p` inside `GZhHO`. Spans
 // the full height of the chat surface (the topbar lives in the chat

--- a/tests/fixtures/crews/feature-delivery.seed.sh
+++ b/tests/fixtures/crews/feature-delivery.seed.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+#
+# Seed the runner DB with the feature-delivery crew + architect/impl
+# runners + their slots. Pulls system prompts from the sibling
+# tests/fixtures/system-prompts/*.md files so a single source of truth
+# survives ad-hoc edits.
+#
+# Usage:
+#   ./tests/fixtures/crews/feature-delivery.seed.sh           # default app db
+#   ./tests/fixtures/crews/feature-delivery.seed.sh /tmp/x.db # custom path
+#
+# Safe to re-run: re-seeding overwrites the rows for the fixed IDs
+# below. Drop the runner.db (and crews/) first if you want to start
+# from a truly empty state.
+
+set -euo pipefail
+
+DEFAULT_DB="$HOME/Library/Application Support/com.wycstudios.runner/runner.db"
+DB_PATH="${1:-$DEFAULT_DB}"
+
+if [[ ! -f "$DB_PATH" ]]; then
+  echo "error: db not found at $DB_PATH" >&2
+  echo "       launch the app once to create it, or pass a path" >&2
+  exit 1
+fi
+
+FIXTURES_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROMPTS_DIR="$FIXTURES_DIR/../system-prompts"
+# SQLite single-quote escape: a literal ' inside a string literal is
+# written as ''. sed handles this consistently across bash + zsh; the
+# parameter-expansion equivalent (${var//\'/\'\'}) doubles the escape
+# in zsh and lands `\'\'` in the SQL.
+ARCHITECT_PROMPT="$(sed "s/'/''/g" "$PROMPTS_DIR/architect.md")"
+IMPL_PROMPT="$(sed "s/'/''/g" "$PROMPTS_DIR/impl.md")"
+
+# Fixed ULIDs so the seed is reproducible. These do not collide with
+# real-world IDs (their timestamp prefix `01K000FIXTURE…` is a
+# placeholder; the suffix is random padding to satisfy ULID's 26-char
+# Crockford base32 shape).
+CREW_ID="01K000FIXTURE000FEATUREDLV01"
+ARCHITECT_RUNNER_ID="01K000FIXTURE000RUNNERAR0001"
+IMPL_RUNNER_ID="01K000FIXTURE000RUNNERIMPL01"
+ARCHITECT_SLOT_ID="01K000FIXTURE000SLOTARCH0001"
+IMPL_SLOT_ID="01K000FIXTURE000SLOTIMPL0001"
+
+NOW="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+DEFAULT_CWD="${RUNNER_FIXTURE_CWD:-$HOME/go/src/github.com/yicheng47}"
+
+# Default seeded signal_types — matches db::DEFAULT_SIGNAL_TYPES so
+# the seeded crew behaves like one created via the UI.
+SIGNAL_TYPES_JSON='["mission_goal","human_said","ask_lead","ask_human","human_question","human_response","runner_status","inbox_read"]'
+
+sqlite3 "$DB_PATH" <<SQL
+PRAGMA foreign_keys = ON;
+BEGIN;
+
+INSERT OR REPLACE INTO crews (id, name, purpose, goal, orchestrator_policy, signal_types, created_at, updated_at)
+VALUES (
+  '$CREW_ID',
+  'Feature delivery',
+  'Ship a single, well-scoped feature against an existing codebase. Architect plans, one implementer ships the work.',
+  'Definition of done = code merged behind a green test suite, with a one-paragraph human-readable summary posted as a broadcast.',
+  NULL,
+  '$SIGNAL_TYPES_JSON',
+  '$NOW',
+  '$NOW'
+);
+
+INSERT OR REPLACE INTO runners (id, handle, display_name, runtime, command, args_json, working_dir, system_prompt, env_json, created_at, updated_at)
+VALUES (
+  '$ARCHITECT_RUNNER_ID',
+  'architect',
+  'Architect',
+  'claude-code',
+  'claude',
+  '[]',
+  '$DEFAULT_CWD',
+  '$ARCHITECT_PROMPT',
+  NULL,
+  '$NOW',
+  '$NOW'
+);
+
+INSERT OR REPLACE INTO runners (id, handle, display_name, runtime, command, args_json, working_dir, system_prompt, env_json, created_at, updated_at)
+VALUES (
+  '$IMPL_RUNNER_ID',
+  'impl',
+  'Implementation',
+  'claude-code',
+  'claude',
+  '[]',
+  '$DEFAULT_CWD',
+  '$IMPL_PROMPT',
+  NULL,
+  '$NOW',
+  '$NOW'
+);
+
+INSERT OR REPLACE INTO slots (id, crew_id, runner_id, slot_handle, position, lead, added_at)
+VALUES ('$ARCHITECT_SLOT_ID', '$CREW_ID', '$ARCHITECT_RUNNER_ID', 'architect', 0, 1, '$NOW');
+
+INSERT OR REPLACE INTO slots (id, crew_id, runner_id, slot_handle, position, lead, added_at)
+VALUES ('$IMPL_SLOT_ID', '$CREW_ID', '$IMPL_RUNNER_ID', 'impl', 1, 0, '$NOW');
+
+COMMIT;
+SQL
+
+echo "seeded feature-delivery crew + runners + slots into $DB_PATH"
+echo "  crew:       $CREW_ID"
+echo "  architect:  $ARCHITECT_RUNNER_ID (slot $ARCHITECT_SLOT_ID, lead)"
+echo "  impl:       $IMPL_RUNNER_ID (slot $IMPL_SLOT_ID)"
+echo "  cwd:        $DEFAULT_CWD"
+echo ""
+echo "next: launch the app and click 'Start mission' against the crew."
+echo "      mission rows aren't seeded — going through the real"
+echo "      mission_start path keeps the event log + sidecars in"
+echo "      lockstep with the Rust code's expectations."

--- a/tests/fixtures/system-prompts/architect.md
+++ b/tests/fixtures/system-prompts/architect.md
@@ -33,6 +33,16 @@ While the mission runs:
   on workers and have nothing else to dispatch, so the workspace UI shows
   the crew state accurately.
 
+When the human speaks to you directly (input appears in your TUI
+without a `runner msg post` envelope or a `[ask_lead]` / `[human_said]`
+prefix, or with the `[human_said]` prefix), they are the operator
+typing in the workspace feed. Reply via:
+    runner msg post --to human "<your answer>"
+Do NOT just type your reply into the TUI — that text only ends up in
+your local scrollback; the human is watching the workspace feed and
+sees only events that flow through the bus. `human` is a reserved
+virtual handle for this two-way path.
+
 When the mission goal is satisfied:
 
 - Confirm with the human via `ask_human` before declaring done if there is

--- a/tests/fixtures/system-prompts/impl.md
+++ b/tests/fixtures/system-prompts/impl.md
@@ -37,3 +37,14 @@ Constraints:
 When the lead asks a question via `runner msg post --to <you>`, treat it
 like any other directed message: answer in one return message, then return
 to whatever task you had in flight.
+
+When the **human** speaks to you directly (you'll see input prefixed by
+something like "look at line 42" appearing in your TUI without a
+`runner msg post` envelope), they are the human operator typing in the
+workspace feed. Respond via:
+    runner msg post --to human "<your reply>"
+Do NOT just type your reply into the TUI — the human can't see your TUI
+output by default. The `runner msg post --to human` route lands the
+reply as a row in the workspace feed where they're watching. Treat
+`human` like any other roster handle for reply routing; it's a reserved
+virtual handle in the bus.

--- a/tests/fixtures/system-prompts/reviewer.md
+++ b/tests/fixtures/system-prompts/reviewer.md
@@ -44,3 +44,11 @@ Constraints:
 When the lead escalates a design question to you via `ask_lead`-equivalent
 direction, treat it as a review request on a hypothetical diff: lay out
 the trade-offs and recommend a path, do not just describe the options.
+
+When the **human** speaks to you directly (raw input lands in your TUI
+without a `runner msg post` envelope, often prefixed `[human_said]`),
+reply via:
+    runner msg post --to human "<your reply>"
+The human is watching the workspace feed, not your local TUI output —
+typing your answer into the TUI just leaves it in your scrollback.
+`human` is a reserved virtual handle for this two-way path.


### PR DESCRIPTION
## Summary

- **Workspace input gating** — when a mission row is `running` but every PTY is dead, the feed input is replaced by a bottom-anchored Resume card (`SessionEndedOverlay` `variant=\"inline\"`, mission-level copy). Feed and slot panes share one recovery anchor.
- **Reset cleanup** — `session_list` now filters on `archived_at IS NULL`, so post-reset sidebars no longer stack the old stopped row alongside the freshly-spawned one for every slot.
- **Lead launch prompt deferred** — `Router::inject_and_submit_delayed` lifts the bus's synchronous `mission_goal` injection onto the same 2.5s budget `schedule_first_prompt` uses for workers, so the lead's prompt no longer gets eaten by claude-code's boot / trust-folder screen on warm starts (mission_reset, fast mission_start).
- **Resume fresh-fallback for claude-code** — `claude_code_conversation_exists(cwd, uuid)` checks `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl` (encoding maps both `/` and `.` to `-`). On miss, `SessionManager::resume` swaps `--resume` for `--session-id <existing-uuid>`, keeping the row's UUID bound to the new conversation. `Router::fire_lead_launch_prompt` reads the latest `mission_goal` text from the log and re-fires `compose_launch_prompt` for the lead — `session_resume` calls it when `SpawnedSession.fresh_fallback_lead` is set, so the architect gets the rich launch prompt (system_prompt + mission goal + roster + crew context), not the worker preamble.

## Test plan

- [ ] Start a mission with claude-code lead + impl. Verify the architect tab receives its launch prompt on a fresh start.
- [ ] Stop the mission, then Resume from the topbar. Verify both PTYs come back via `--resume <uuid>` (no fresh spawn) and the prior conversation continues.
- [ ] Reset a mission via the kebab. Verify the sidebar shows exactly one session per slot (no ghosts) and the lead receives the launch prompt 2.5s after spawn.
- [ ] Stop a mission, manually delete the lead's `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`, then Resume. Verify the lead falls back to a fresh spawn keeping its UUID and receives the rich launch prompt (not the worker coordination preamble).
- [ ] With the mission running, click Stop. Verify the feed shows the \"Mission paused\" overlay, the input is non-interactive, and clicking Resume from the overlay restores both PTYs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)