### PR TITLE
ci: tag-triggered release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,134 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-macos:
+    strategy:
+      matrix:
+        include:
+          - target: aarch64-apple-darwin
+            arch: aarch64
+          - target: x86_64-apple-darwin
+            arch: x64
+
+    runs-on: macos-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Import Apple Developer Certificate
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 32)
+          echo $APPLE_CERTIFICATE | base64 --decode > certificate.p12
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security default-keychain -s build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -t 3600 -u build.keychain
+          security import certificate.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+
+      - name: Verify Certificate
+        run: |
+          CERT_INFO=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID Application")
+          CERT_ID=$(echo "$CERT_INFO" | awk -F'"' '{print $2}')
+          echo "APPLE_SIGNING_IDENTITY=$CERT_ID" >> $GITHUB_ENV
+          echo "Certificate: $CERT_ID"
+
+      - name: Build Tauri app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_SIGNING_IDENTITY: ${{ env.APPLE_SIGNING_IDENTITY }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: "Runner ${{ github.ref_name }}"
+          releaseBody: "See the [commits](https://github.com/${{ github.repository }}/commits/${{ github.ref_name }}) for details."
+          releaseDraft: true
+          prerelease: false
+          args: --target ${{ matrix.target }}
+
+  build-windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: src-tauri -> target
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Tauri app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        with:
+          tagName: ${{ github.ref_name }}
+          releaseName: "Runner ${{ github.ref_name }}"
+          releaseBody: "See the [commits](https://github.com/${{ github.repository }}/commits/${{ github.ref_name }}) for details."
+          releaseDraft: true
+          prerelease: false

--- a/design/runners-design.pen
+++ b/design/runners-design.pen
@@ -21869,67 +21869,6 @@
                 },
                 {
                   "type": "frame",
-                  "id": "SqRBj",
-                  "name": "row_autostart",
-                  "width": "fill_container",
-                  "gap": 24,
-                  "justifyContent": "space_between",
-                  "alignItems": "center",
-                  "children": [
-                    {
-                      "type": "frame",
-                      "id": "xwuf4",
-                      "width": "fill_container",
-                      "layout": "vertical",
-                      "gap": 2,
-                      "children": [
-                        {
-                          "type": "text",
-                          "id": "BNx7r",
-                          "fill": "#EDEDF0",
-                          "content": "Auto-start last mission",
-                          "fontFamily": "Inter",
-                          "fontSize": 13,
-                          "fontWeight": "500"
-                        },
-                        {
-                          "type": "text",
-                          "id": "xa6bN",
-                          "fill": "#9A9BA5",
-                          "textGrowth": "fixed-width",
-                          "width": "fill_container",
-                          "content": "Resume the most recent mission when the app launches.",
-                          "fontFamily": "Inter",
-                          "fontSize": 11,
-                          "fontWeight": "normal"
-                        }
-                      ]
-                    },
-                    {
-                      "type": "frame",
-                      "id": "h0n2L",
-                      "name": "toggle_on",
-                      "width": 32,
-                      "height": 18,
-                      "fill": "#0F2418",
-                      "cornerRadius": 999,
-                      "padding": 2,
-                      "justifyContent": "end",
-                      "alignItems": "center",
-                      "children": [
-                        {
-                          "type": "ellipse",
-                          "id": "iDzar",
-                          "fill": "#00FF9C",
-                          "width": 14,
-                          "height": 14
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "type": "frame",
                   "id": "foyS8",
                   "name": "row_default_crew",
                   "width": "fill_container",
@@ -22037,7 +21976,7 @@
                           "fill": "#9A9BA5",
                           "textGrowth": "fixed-width",
                           "width": "fill_container",
-                          "content": "Cwd new runner sessions inherit unless overridden.",
+                          "content": "Cwd new chats inherit unless overridden.",
                           "fontFamily": "Inter",
                           "fontSize": 11,
                           "fontWeight": "normal"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` mirroring Quill's tag-triggered Tauri release workflow, adapted for pnpm. Pushing `vX.Y.Z` tag fans out a matrix:

- **macOS** — `aarch64-apple-darwin` and `x86_64-apple-darwin`. Imports the Apple Developer ID cert into a fresh keychain, captures `APPLE_SIGNING_IDENTITY`, hands env vars to `tauri-apps/tauri-action@v0` (notarization via APPLE_ID/PASSWORD/TEAM_ID, Tauri updater signing key).
- **Windows** — single `windows-latest` build with the Tauri updater signing key (no Apple bits).

The existing `ci.yaml` continues to gate PRs (Frontend `pnpm exec tsc --noEmit` + Backend `cargo fmt/clippy/test`). Releases land as **drafts** so we can edit notes before publishing.

Cutting a release once this merges:

```bash
# from main, after a clean tree:
git tag -a v0.1.0 -m "v0.1.0"
git push origin v0.1.0
# wait for the matrix → edit the draft → publish
```

Or via the global `/github release new 0.1.0` skill (which handles version bumping in `package.json`, `Cargo.toml`, `tauri.conf.json` — all already at `0.1.0` in this repo, so the first cut is just the tag).

## Required repo secrets

Same set Quill uses; copy from there if not already configured:

- `APPLE_CERTIFICATE` (base64 .p12)
- `APPLE_CERTIFICATE_PASSWORD`
- `APPLE_ID`
- `APPLE_PASSWORD`
- `APPLE_TEAM_ID`
- `TAURI_SIGNING_PRIVATE_KEY`
- `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`

## Test plan

- [ ] `gh secret list` confirms all seven secrets present.
- [ ] After merge, `git tag v0.1.0 && git push origin v0.1.0` triggers `Release` workflow.
- [ ] macOS jobs produce signed/notarized `Runner_0.1.0_aarch64.dmg` + `_x64.dmg`.
- [ ] Windows job produces `Runner_0.1.0_x64-setup.exe`.
- [ ] Draft GitHub Release surfaces with all three artifacts attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)