### PR TITLE
dev: isolate dev-build data dir from prod install

### DIFF
--- a/design/runners-design.pen
+++ b/design/runners-design.pen
@@ -24012,10 +24012,10 @@
                         {
                           "type": "text",
                           "id": "M9HaRG",
-                          "fill": "#9A9BA5",
+                          "fill": "#00FF9C",
                           "textGrowth": "fixed-width",
                           "width": "fill_container",
-                          "content": "You're up to date — last checked 12 minutes ago.",
+                          "content": "v0.1.1 is available — released 2 hours ago.",
                           "fontFamily": "Inter",
                           "fontSize": 11,
                           "fontWeight": "normal"
@@ -24026,12 +24026,12 @@
                       "type": "frame",
                       "id": "Z7PvVt",
                       "name": "checkBtn",
-                      "fill": "#16171B",
+                      "fill": "#00FF9C",
                       "cornerRadius": 6,
                       "stroke": {
                         "align": "inside",
                         "thickness": 1,
-                        "fill": "#1F2127"
+                        "fill": "#00FF9C"
                       },
                       "gap": 6,
                       "padding": [
@@ -24045,15 +24045,15 @@
                           "id": "XYBKa",
                           "width": 12,
                           "height": 12,
-                          "iconFontName": "refresh-cw",
+                          "iconFontName": "download",
                           "iconFontFamily": "lucide",
-                          "fill": "#EDEDF0"
+                          "fill": "#0E0E10"
                         },
                         {
                           "type": "text",
                           "id": "I0tPVd",
-                          "fill": "#EDEDF0",
-                          "content": "Check now",
+                          "fill": "#0E0E10",
+                          "content": "Download & install",
                           "fontFamily": "Inter",
                           "fontSize": 12,
                           "fontWeight": "500"
@@ -24504,10 +24504,10 @@
                         {
                           "type": "text",
                           "id": "ybcAp",
-                          "fill": "#9A9BA5",
+                          "fill": "#EDEDF0",
                           "textGrowth": "fixed-width",
                           "width": "fill_container",
-                          "content": "You're up to date — last checked 12 minutes ago.",
+                          "content": "Downloading update… 47%",
                           "fontFamily": "Inter",
                           "fontSize": 11,
                           "fontWeight": "normal"
@@ -24537,15 +24537,15 @@
                           "id": "BOfdM",
                           "width": 12,
                           "height": 12,
-                          "iconFontName": "refresh-cw",
+                          "iconFontName": "loader",
                           "iconFontFamily": "lucide",
-                          "fill": "#EDEDF0"
+                          "fill": "#9A9BA5"
                         },
                         {
                           "type": "text",
                           "id": "C1feD",
                           "fill": "#EDEDF0",
-                          "content": "Check now",
+                          "content": "Cancel",
                           "fontFamily": "Inter",
                           "fontSize": 12,
                           "fontWeight": "500"
@@ -24996,10 +24996,10 @@
                         {
                           "type": "text",
                           "id": "p9Zwyj",
-                          "fill": "#9A9BA5",
+                          "fill": "#00FF9C",
                           "textGrowth": "fixed-width",
                           "width": "fill_container",
-                          "content": "You're up to date — last checked 12 minutes ago.",
+                          "content": "Update ready — restart to apply",
                           "fontFamily": "Inter",
                           "fontSize": 11,
                           "fontWeight": "normal"
@@ -25010,12 +25010,12 @@
                       "type": "frame",
                       "id": "G1ZJk",
                       "name": "checkBtn",
-                      "fill": "#16171B",
+                      "fill": "#00FF9C",
                       "cornerRadius": 6,
                       "stroke": {
                         "align": "inside",
                         "thickness": 1,
-                        "fill": "#1F2127"
+                        "fill": "#00FF9C"
                       },
                       "gap": 6,
                       "padding": [
@@ -25029,15 +25029,15 @@
                           "id": "xgpMK",
                           "width": 12,
                           "height": 12,
-                          "iconFontName": "refresh-cw",
+                          "iconFontName": "rotate-ccw",
                           "iconFontFamily": "lucide",
-                          "fill": "#EDEDF0"
+                          "fill": "#0E0E10"
                         },
                         {
                           "type": "text",
                           "id": "dw7v9",
-                          "fill": "#EDEDF0",
-                          "content": "Check now",
+                          "fill": "#0E0E10",
+                          "content": "Restart to update",
                           "fontFamily": "Inter",
                           "fontSize": 12,
                           "fontWeight": "500"

--- a/docs/tests/v0-mvp-tests.md
+++ b/docs/tests/v0-mvp-tests.md
@@ -57,11 +57,12 @@ Start the app:
 pnpm tauri dev
 ```
 
-Optional clean-state reset on macOS:
+Optional clean-state reset on macOS. `pnpm tauri dev` writes to the
+`-dev` sibling directory so a packaged install's data isn't touched —
+only wipe the dev dir:
 
 ```sh
-rm -rf "$HOME/Library/Application Support/com.wycstudios.runner"
-rm -rf "$HOME/Library/Application Support/com.wycstudios.runner.dev"
+rm -rf "$HOME/Library/Application Support/com.wycstudios.runner-dev"
 ```
 
 Prepare two crews:

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -41,7 +41,23 @@ pub fn run() {
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .setup(|app| {
-            let app_data_dir = app.path().app_data_dir()?;
+            // Dev builds write to a sibling `<identifier>-dev` directory so
+            // local testing can't trample a packaged install's database,
+            // event logs, or bundled CLI. `cfg!(debug_assertions)` is true
+            // for `tauri dev` and false for release bundles, which matches
+            // how Quill separates dev vs prod data.
+            let app_data_dir = {
+                let base = app.path().app_data_dir()?;
+                if cfg!(debug_assertions) {
+                    let dev_name = match base.file_name().and_then(|s| s.to_str()) {
+                        Some(name) => format!("{name}-dev"),
+                        None => "runner-dev".to_string(),
+                    };
+                    base.with_file_name(dev_name)
+                } else {
+                    base
+                }
+            };
             std::fs::create_dir_all(&app_data_dir)?;
             let db_path = app_data_dir.join("runner.db");
             let pool = Arc::new(db::open_pool(&db_path)?);


### PR DESCRIPTION
## Summary
- Dev builds (`cfg!(debug_assertions)`) now write to `~/Library/Application Support/com.wycstudios.runner-dev/` so `make dev` doesn't share state with a packaged v0.1.0 install
- Mirrors Quill's pattern: same identifier in `tauri.conf.json`, swap happens once in Rust `setup` and propagates via `AppState.app_data_dir`
- Affected paths: `runner.db`, bundled CLI at `<dir>/bin/`, mission event logs, session PATH prepend

## Test plan
- [x] `make dev` creates `com.wycstudios.runner-dev/` with a fresh `runner.db`
- [x] Existing `com.wycstudios.runner/` install untouched after dev run
- [ ] Release bundle (next tag) continues to use `com.wycstudios.runner/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)