### PR TITLE
fix: bundle runner-cli into the Tauri app via externalBin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,18 @@ jobs:
             libgtk-3-dev \
             libayatana-appindicator3-dev \
             librsvg2-dev
+      # Tauri's build script validates that every `bundle.externalBin`
+      # entry exists for the active target on every cargo build,
+      # including clippy / check / test. CI doesn't bundle, but it does
+      # build the runner crate, so we stage a placeholder file at the
+      # path the externalBin declaration resolves to. The release
+      # workflow stages a real binary via `scripts/stage-runner-cli.mjs`.
+      - name: Stage runner-cli placeholder for externalBin existence check
+        run: |
+          triple=$(rustc -vV | sed -n 's/^host: //p')
+          mkdir -p src-tauri/binaries
+          touch "src-tauri/binaries/runner-cli-${triple}"
+          chmod +x "src-tauri/binaries/runner-cli-${triple}"
       - run: cargo fmt --all --check
       - run: cargo clippy --workspace --all-targets -- -D warnings
       - run: cargo check --workspace

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ dist-ssr
 src-tauri/target
 /target
 .claude/scheduled_tasks.lock
+
+# Tauri externalBin staging — populated by scripts/stage-runner-cli.mjs
+# at build time, never committed.
+src-tauri/binaries/

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "package": "tauri build",
     "lint": "eslint src/",
     "tauri:before:dev": "cargo build -p runner-cli && npm run dev",
-    "tauri:before:build": "cargo build -p runner-cli --release && npm run build"
+    "tauri:before:build": "node scripts/stage-runner-cli.mjs && npm run build"
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",

--- a/scripts/stage-runner-cli.mjs
+++ b/scripts/stage-runner-cli.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Build `runner-cli` for the active Tauri target triple and stage the
+// artifact at `src-tauri/binaries/runner-cli-<triple>` — the path
+// `tauri.conf.json`'s `bundle.externalBin: ["binaries/runner-cli"]`
+// resolves at bundle time. Tauri's bundler then drops it into
+// `Runner.app/Contents/MacOS/runner-cli` (renamed without the suffix),
+// where `cli_install::install_runner_cli` finds it next to
+// `current_exe` on first launch and copies it into
+// `<app_data>/bin/runner` for child PTYs to spawn.
+//
+// Why a build-time stage instead of a runtime fetch:
+//   - Single bundle ships everything; no first-launch download.
+//   - The CLI version always matches the app version on disk.
+//   - Works offline, works in CI for tagged releases.
+//
+// Triple resolution:
+//   1. `TAURI_ENV_TARGET_TRIPLE` — set by Tauri 2 when running this as a
+//      `beforeBuildCommand` (this is the canonical source during a
+//      `tauri build --target <triple>` invocation).
+//   2. `--target=<triple>` CLI arg — manual override for local
+//      cross-compile testing.
+//   3. `rustc -vV` "host:" line — fallback for plain `tauri build`
+//      with no target specified (host build).
+
+import { execSync, spawnSync } from "node:child_process";
+import { copyFileSync, chmodSync, mkdirSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+
+function resolveTargetTriple() {
+  if (process.env.TAURI_ENV_TARGET_TRIPLE) {
+    return process.env.TAURI_ENV_TARGET_TRIPLE;
+  }
+  const cliArg = process.argv.find((a) => a.startsWith("--target="));
+  if (cliArg) {
+    return cliArg.slice("--target=".length);
+  }
+  // `rustc -vV` prints multiple lines; the `host:` line is the active
+  // toolchain's default triple. Trim and split robustly.
+  const out = execSync("rustc -vV", { encoding: "utf8" });
+  const hostLine = out.split("\n").find((l) => l.startsWith("host:"));
+  if (!hostLine) {
+    throw new Error(
+      `stage-runner-cli: rustc -vV output had no "host:" line:\n${out}`,
+    );
+  }
+  return hostLine.slice("host:".length).trim();
+}
+
+function buildCli(triple) {
+  console.log(`stage-runner-cli: building runner-cli for ${triple}…`);
+  const args = [
+    "build",
+    "-p",
+    "runner-cli",
+    "--release",
+    "--target",
+    triple,
+  ];
+  const result = spawnSync("cargo", args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+  });
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+function stageArtifact(triple) {
+  // Workspace `Cargo.toml` sets `target/` at the repo root, so the
+  // artifact lives there regardless of which crate triggered the build.
+  const ext = process.platform === "win32" ? ".exe" : "";
+  const source = path.join(
+    repoRoot,
+    "target",
+    triple,
+    "release",
+    `runner-cli${ext}`,
+  );
+  if (!existsSync(source)) {
+    throw new Error(
+      `stage-runner-cli: built artifact missing at ${source}. Did the cargo build silently emit elsewhere?`,
+    );
+  }
+  // Tauri's externalBin convention: `<declared-path>-<triple>[.exe]`.
+  // Declared path is `binaries/runner-cli` (relative to `src-tauri/`).
+  const destDir = path.join(repoRoot, "src-tauri", "binaries");
+  mkdirSync(destDir, { recursive: true });
+  const dest = path.join(destDir, `runner-cli-${triple}${ext}`);
+  copyFileSync(source, dest);
+  if (process.platform !== "win32") {
+    chmodSync(dest, 0o755);
+  }
+  console.log(`stage-runner-cli: staged ${dest}`);
+}
+
+function main() {
+  const triple = resolveTargetTriple();
+  buildCli(triple);
+  stageArtifact(triple);
+}
+
+main();

--- a/src-tauri/src/cli_install.rs
+++ b/src-tauri/src/cli_install.rs
@@ -11,12 +11,14 @@
 //
 // Source resolution. In dev (`cargo run`), the CLI lives next to the
 // Tauri exe under `target/{debug,release}/runner-cli`. In production,
-// the Tauri bundler is expected to ship the same artifact alongside
-// the app's main executable. Production-bundle wiring (tauri.conf.json
-// `bundle.externalBin` declaration + a beforeBuildCommand step that
-// stages the binary at the target-triple-suffixed path the bundler
-// expects) is tracked as a follow-up; the dev path is what the v0
-// demo runs.
+// the Tauri bundler ships the same artifact alongside the app's main
+// executable via `bundle.externalBin: ["binaries/runner-cli"]` in
+// `tauri.conf.json` — `scripts/stage-runner-cli.mjs` (run from
+// `tauri:before:build`) cross-builds the CLI for the active triple
+// and stages it at `src-tauri/binaries/runner-cli-<triple>` where the
+// bundler picks it up and drops it into `Runner.app/Contents/MacOS/
+// runner-cli`. Either path leaves a `runner-cli` sibling next to
+// `current_exe`, which is what `locate_source` looks for.
 //
 // Skip-if-current optimization. Compare (size, mtime) — if the source
 // file's mtime is `<=` the destination's AND sizes match, skip the

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -38,6 +38,7 @@
     "active": true,
     "createUpdaterArtifacts": true,
     "targets": ["dmg", "app"],
+    "externalBin": ["binaries/runner-cli"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary

The shipped v0.1.0 .app contained only the Tauri exe — `runner-cli` was never staged into the bundle. `cli_install::install_runner_cli` looked for the artifact next to `current_exe`, didn't find it, and silently logged a warning. `<app_data>/bin/runner` therefore never existed, so per-slot runner shims tried to exec a non-existent binary the moment any agent ran `runner msg post`.

Symptoms in the wild:
- Agents reporting `runner: command not found` / "shim is pointing to a missing binary" errors inside their TUI scrollback.
- A second Runner.app icon appearing in the Dock when an agent symlinked the Tauri exe (`target/debug/runner`) as a workaround — every later `runner …` call launched a second copy of the app instead of the CLI.

This was tracked as a deferred follow-up in `cli_install.rs:15-19`. Wiring it for real now.

## Changes

- **`scripts/stage-runner-cli.mjs`** (new) — resolves the active Tauri target triple (`TAURI_ENV_TARGET_TRIPLE` → `--target=` arg → `rustc -vV` host fallback), cross-builds `runner-cli`, and stages the artifact at `src-tauri/binaries/runner-cli-<triple>` (Tauri's externalBin convention).
- **`src-tauri/tauri.conf.json`** — declares `bundle.externalBin: ["binaries/runner-cli"]` so the bundler picks the staged artifact up and drops it into `Runner.app/Contents/MacOS/runner-cli` (renamed without the suffix).
- **`package.json`** — `tauri:before:build` now invokes the stage script in place of the bare `cargo build`. `tauri:before:dev` is unchanged — dev's current_exe sibling lookup still resolves `target/debug/runner-cli` without externalBin staging.
- **`src-tauri/src/cli_install.rs`** — header comment updated to reflect that the prod-bundle wiring is no longer a TODO.
- **`.gitignore`** — `src-tauri/binaries/` is build-time staging; never committed.

## Test plan

- [x] `pnpm tauri build --target aarch64-apple-darwin` produces `Runner.app/Contents/MacOS/{runner, runner-cli}` (Tauri exe 19MB + CLI 1.2MB)
- [x] Bundled `runner-cli --help` runs cleanly
- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (158 passing)
- [ ] Manual: install the resulting .dmg via Finder, launch from Dock, start a Build squad mission, confirm agents can `runner msg post --to <handle>` without ENOENT and no phantom second Runner.app appears in the Dock
- [ ] CI release build (will run automatically once tagged) cross-builds the CLI for both `aarch64-apple-darwin` and `x86_64-apple-darwin` matrix targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)