### PR TITLE
fix(router): synthesize busy status when waking a runner

### DIFF
--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -337,6 +337,45 @@ impl Router {
         self.injector.inject(&session_id, bytes)
     }
 
+    /// Mark a runner as busy when the router is about to wake them via
+    /// stdin injection (issue #32). Appends a synthetic `runner_status`
+    /// busy event with `from = handle` so the workspace rail projection
+    /// (MissionWorkspace.tsx:397-411) keys the badge against the
+    /// recipient, and updates router state so back-to-back nudges within
+    /// the same task don't churn the log. Skips for the virtual `human`
+    /// handle and skips if the recipient is already marked busy.
+    ///
+    /// Centralized here so the policy applies uniformly to every wake
+    /// source: directed/broadcast `message_nudge`, `ask_lead` relay,
+    /// `human_said`, `human_response`, the lead's `mission_goal`
+    /// bootstrap, and the `runner_status idle` notice to the lead.
+    fn synthesize_wake_busy(&self, handle: &str) {
+        if handle == "human" {
+            return;
+        }
+        {
+            let state = self.state.lock().unwrap();
+            if matches!(state.status.get(handle), Some(RunnerStatus::Busy)) {
+                return;
+            }
+        }
+        let draft = runner_core::model::EventDraft::signal(
+            self.crew_id.clone(),
+            self.mission_id.clone(),
+            handle,
+            SignalType::new("runner_status"),
+            serde_json::json!({ "state": "busy" }),
+        );
+        if let Err(e) = self.log.append(draft) {
+            eprintln!(
+                "router[{}]: failed to append synthetic runner_status busy for @{handle}: {e}",
+                self.mission_id,
+            );
+            return;
+        }
+        self.set_status(handle.to_string(), RunnerStatus::Busy);
+    }
+
     /// Inject `body` to the handle's stdin, then send a separate
     /// carriage-return (`\r`) on a brief delay. claude-code's TUI
     /// editor treats `\r` as Enter, but bytes arriving in the same
@@ -356,6 +395,7 @@ impl Router {
                 "router: no live session for handle @{handle}"
             )));
         };
+        self.synthesize_wake_busy(handle);
         if !body.is_empty() {
             self.injector.inject(&session_id, body)?;
         }
@@ -398,6 +438,7 @@ impl Router {
             ));
             return;
         };
+        self.synthesize_wake_busy(handle);
         // Zero-delay path: run inline, body only — no separate `\r`
         // chord. Used by unit tests
         // (`LEAD_LAUNCH_PROMPT_DELAY = ZERO` under `cfg(test)`) so

--- a/src-tauri/src/router/tests.rs
+++ b/src-tauri/src/router/tests.rs
@@ -901,6 +901,147 @@ fn reconstruct_tolerates_malformed_lines_like_the_bus() {
 }
 
 #[test]
+fn directed_wake_synthesizes_busy_and_idle_clears_it() {
+    // Issue #32: the rail badge stayed `idle` because nothing flipped
+    // a worker to `busy` on dispatch — only the worker's own end-of-task
+    // `idle` was emitted. The router now synthesizes `runner_status busy`
+    // (with `from = recipient`) for any wake nudge, and the existing
+    // worker-emitted `idle` clears it.
+    let (router, _injector, log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+
+    let busy_for_impl = |log: &EventLog| -> usize {
+        read_signals(log)
+            .into_iter()
+            .filter(|s| {
+                s.signal_type
+                    .as_ref()
+                    .map(|t| t.as_str() == "runner_status")
+                    .unwrap_or(false)
+                    && s.from == "impl"
+                    && s.payload.get("state").and_then(|v| v.as_str()) == Some("busy")
+            })
+            .count()
+    };
+
+    // (a) directed `runner msg post --to impl` → recipient flips to busy
+    // and a synthetic runner_status busy event lands in the log.
+    let direct = log.append(message("lead", Some("impl"), "go")).unwrap();
+    router.handle_event(&direct);
+    assert_eq!(busy_for_impl(&log), 1, "wake nudge must append one busy event");
+    assert!(matches!(
+        router.state.lock().unwrap().status.get("impl"),
+        Some(super::RunnerStatus::Busy),
+    ));
+
+    // A second directed wake while still busy must not churn another
+    // busy event into the log — the dedupe guard suppresses it.
+    let direct_again = log
+        .append(message("lead", Some("impl"), "still going"))
+        .unwrap();
+    router.handle_event(&direct_again);
+    assert_eq!(
+        busy_for_impl(&log),
+        1,
+        "back-to-back wake while busy must not append a second busy event",
+    );
+
+    // (b) worker emits runner_status idle → state flips back to Idle.
+    let idle = log
+        .append(signal(
+            "impl",
+            "runner_status",
+            serde_json::json!({ "state": "idle" }),
+        ))
+        .unwrap();
+    router.handle_event(&idle);
+    assert!(matches!(
+        router.state.lock().unwrap().status.get("impl"),
+        Some(super::RunnerStatus::Idle),
+    ));
+
+    // (c) follow-up directed message → flips back to busy. This is the
+    // exact regression issue #32 calls out.
+    let direct_followup = log.append(message("lead", Some("impl"), "next")).unwrap();
+    router.handle_event(&direct_followup);
+    assert_eq!(
+        busy_for_impl(&log),
+        2,
+        "wake after idle must re-synthesize busy",
+    );
+    assert!(matches!(
+        router.state.lock().unwrap().status.get("impl"),
+        Some(super::RunnerStatus::Busy),
+    ));
+}
+
+#[test]
+fn synthetic_busy_replays_through_existing_runner_status_projection() {
+    // The reconstruct_from_log path at router/mod.rs handles
+    // runner_status events generically — synthetic ones written by
+    // inject_and_submit must replay correctly without any special
+    // handling. This pins that contract: a busy event from a prior
+    // session is recovered into router state on reopen.
+    let dir = tempfile::tempdir().unwrap();
+    let log = Arc::new(EventLog::open(dir.path()).unwrap());
+    let roster = vec![
+        slot_with_runner("lead", true),
+        slot_with_runner("impl", false),
+    ];
+
+    // First mount: drive a directed message to synthesize busy.
+    {
+        let injector = Arc::new(RecordingInjector::default());
+        let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
+        let router = Router::new(
+            "mission-1".into(),
+            "crew-1".into(),
+            "Crew One".into(),
+            &roster,
+            vec![],
+            log.clone(),
+            injector_dyn,
+        )
+        .unwrap();
+        router.register_sessions(&[
+            ("lead".into(), "S-LEAD".into()),
+            ("impl".into(), "S-IMPL".into()),
+        ]);
+        let direct = log.append(message("lead", Some("impl"), "go")).unwrap();
+        router.handle_event(&direct);
+    }
+
+    // Reopen + reconstruct.
+    let injector = Arc::new(RecordingInjector::default());
+    let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
+    let router2 = Router::new(
+        "mission-1".into(),
+        "crew-1".into(),
+        "Crew One".into(),
+        &roster,
+        vec![],
+        log.clone(),
+        injector_dyn,
+    )
+    .unwrap();
+    router2.register_sessions(&[
+        ("lead".into(), "S-LEAD".into()),
+        ("impl".into(), "S-IMPL".into()),
+    ]);
+    router2.reconstruct_from_log().unwrap();
+
+    assert!(matches!(
+        router2.state.lock().unwrap().status.get("impl"),
+        Some(super::RunnerStatus::Busy),
+    ));
+}
+
+#[test]
 fn registry_register_get_unregister() {
     let (router, _i, _l, _d) = fixture(vec![slot_with_runner("lead", true)], &[("lead", "S-LEAD")]);
     let reg = RouterRegistry::new();

--- a/src-tauri/src/router/tests.rs
+++ b/src-tauri/src/router/tests.rs
@@ -933,7 +933,11 @@ fn directed_wake_synthesizes_busy_and_idle_clears_it() {
     // and a synthetic runner_status busy event lands in the log.
     let direct = log.append(message("lead", Some("impl"), "go")).unwrap();
     router.handle_event(&direct);
-    assert_eq!(busy_for_impl(&log), 1, "wake nudge must append one busy event");
+    assert_eq!(
+        busy_for_impl(&log),
+        1,
+        "wake nudge must append one busy event"
+    );
     assert!(matches!(
         router.state.lock().unwrap().status.get("impl"),
         Some(super::RunnerStatus::Busy),


### PR DESCRIPTION
## Summary
- The runner status badge stayed `idle` while a worker was clearly working — status was purely agent-self-reported, and the prompt only asked agents to emit `idle`. The rail never flipped to `busy` between tasks.
- Synthesize a `runner_status busy` event for the recipient inside `Router::inject_and_submit` (+ delayed variant). One central injection point covers every wake call site: directed and broadcast `message_nudge`, `ask_lead`, `human_said`, `human_response`, `mission_goal` bootstrap, and the idle-notice-to-lead.
- Worker-emitted `runner_status idle` continues to clear the badge. Skips the virtual `human` handle and dedupes when already `Busy` so the log gets one busy event per task arc.
- No frontend change — the existing projection at `src/pages/MissionWorkspace.tsx:397-411` consumes synthetic events natively. Replay through `reconstruct_from_log` is unchanged.

Closes #32.

## Test plan
- [x] `make test-rust` (workspace green, including the two new router tests)
- [x] `cargo clippy --workspace --all-targets` clean
- [x] New test `directed_wake_synthesizes_busy_and_idle_clears_it` pins the exact #32 regression: directed msg → busy → worker idle → next msg → busy, plus dedupe assertion
- [x] New test `synthetic_busy_replays_through_existing_runner_status_projection` pins replay safety on a freshly-mounted Router
- [ ] Manual smoke: start a Build-squad mission, watch the impl badge during a follow-up dispatch — should flip to `busy` immediately, then `idle` when impl reports done

## Notes
- Pre-existing edge (out of scope): an aborted prior mission ending on synthetic `Busy` with no following `Idle` will project as `Busy` on reopen until the next agent-emitted idle. File a follow-up if cleanup is wanted.