### PR TITLE
fix(pty): set COLORTERM=truecolor so packaged app renders colored TUI output (#38)

### DIFF
--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -414,6 +414,8 @@ impl SessionManager {
         if let Some(wd) = mission.cwd.as_deref() {
             cmd.env("MISSION_CWD", wd);
         }
+        cmd.env("TERM", "xterm-256color");
+        cmd.env("COLORTERM", "truecolor");
 
         let mut child = pair
             .slave
@@ -653,6 +655,7 @@ impl SessionManager {
         cmd.env("COLUMNS", opened.cols.to_string());
         cmd.env("LINES", opened.rows.to_string());
         cmd.env("TERM", "xterm-256color");
+        cmd.env("COLORTERM", "truecolor");
         // Deliberately NOT setting RUNNER_CREW_ID, RUNNER_MISSION_ID,
         // RUNNER_EVENT_LOG, MISSION_CWD — direct chats are off-bus.
 
@@ -1077,6 +1080,7 @@ impl SessionManager {
         cmd.env("COLUMNS", opened.cols.to_string());
         cmd.env("LINES", opened.rows.to_string());
         cmd.env("TERM", "xterm-256color");
+        cmd.env("COLORTERM", "truecolor");
 
         let mut child = pair
             .slave


### PR DESCRIPTION
## Summary

Fixes #38.

GUI-launched `Runner.app` inherits a stripped env from launchd, so `COLORTERM` is never set in the parent process. claude-code and other ink/chalk TUIs gate their truecolor palette on `COLORTERM` via `supports-color`, so the packaged `.dmg` rendered monochrome xterm.js output. `pnpm tauri dev` worked only because it inherits `COLORTERM=truecolor` from the launching terminal.

The fix is to hardcode `COLORTERM=truecolor` (and `TERM=xterm-256color` where missing) on every PTY spawn in `src-tauri/src/session/manager.rs`:

- **mission `spawn`** — was missing both `TERM` and `COLORTERM`. Added both.
- **`spawn_direct`** — already set `TERM`. Added `COLORTERM` next to it.
- **`resume`** — already set `TERM`. Added `COLORTERM` next to it.

This is a sibling to the launchd-env class of fixes started in #35 / #36 (login-shell `PATH` resolution for GUI-launched apps).

Out of scope (deliberately not done):
- No `FORCE_COLOR` — only set `COLORTERM` per the issue.
- No changes to `shell_path.rs` — hardcoding `truecolor` is the chosen approach.
- No frontend/xterm.js changes — already configured for truecolor.

## Test plan

- [x] `grep -n COLORTERM src-tauri/src/session/manager.rs` returns three hits, one per spawn path
- [x] `cargo check` from `src-tauri/` passes cleanly
- [ ] Packaged `.dmg` renders truecolor in xterm.js (manual verification by reviewer / on next release build)