### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "runner",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.1.1",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runner"
-version = "0.1.0"
+version = "0.1.1"
 description = "An editor for teams of local coding agents (Claude Code, Codex, and friends)"
 edition.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Runner",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "identifier": "com.wycstudios.runner",
   "build": {
     "beforeDevCommand": "npm run tauri:before:dev",


### PR DESCRIPTION
## Summary

Bump version to **0.1.1** and ship the post-0.1.0 fix wave.

### Bug fixes
- **#43 / #47** — repair archive flows and surface an Archiving… state
- **#41 / #44** — codex model + effort args reach the spawned CLI
- **#38 / #42** — set `COLORTERM=truecolor` so packaged app renders colored TUI output
- **#39** — synthesize busy status when waking a runner
- bypass approval prompts for default Build squad runners (codex permission disruption)

### Docs
- MCP server feature spec (#40)

## Test plan
- [x] `cargo check` clean
- [ ] CI green
- [ ] Tag + release workflow succeeds