### PR TITLE
fix(codex): bypass approval prompts and inject system prompt via stdin

### DIFF
--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -1212,6 +1212,7 @@ mod tests {
                 env: std::collections::HashMap::new(),
                 model: None,
                 effort: None,
+                skip_approval_prompts: true,
             },
         )
         .unwrap();

--- a/src-tauri/src/commands/runner.rs
+++ b/src-tauri/src/commands/runner.rs
@@ -41,6 +41,25 @@ pub struct CreateRunnerInput {
     pub model: Option<String>,
     #[serde(default)]
     pub effort: Option<String>,
+    /// Whether to apply the runtime's "skip approval prompts" flags
+    /// (claude-code: `--dangerously-skip-permissions`; codex:
+    /// `--ask-for-approval never --sandbox workspace-write`) on the
+    /// stored args column. Defaults to `true` — runner's premise is
+    /// that the user already trusts the crew they configured, so
+    /// click-through-every-permission inside the embedded TUI is
+    /// unhelpful by default. Hidden in the form for runtimes without
+    /// a bypass concept (shell / unknown). See
+    /// `router::runtime::apply_bypass_permissions`.
+    #[serde(default = "default_skip_approval_prompts")]
+    pub skip_approval_prompts: bool,
+}
+
+/// Default-on for the form's "Skip approval prompts" toggle: matches
+/// the seed runners' baked-in flags and keeps API-only callers
+/// (CLI / test fixtures) on the same default the form ships. Pulled
+/// out so serde's `#[serde(default = "...")]` can name it.
+fn default_skip_approval_prompts() -> bool {
+    true
 }
 
 // `handle` is intentionally excluded from updates: per arch §2.2 and §5.2
@@ -61,6 +80,14 @@ pub struct UpdateRunnerInput {
     pub env: Option<HashMap<String, String>>,
     pub model: Option<Option<String>>,
     pub effort: Option<Option<String>>,
+    /// Form's "Skip approval prompts" toggle. `Some(true)` ensures
+    /// the runtime's bypass flags are present in the stored args
+    /// (replacing any prior occurrence so duplicates can't accumulate).
+    /// `Some(false)` strips them. `None` preserves the args as-is —
+    /// callers that don't surface the toggle (CLI patches, programmatic
+    /// updates) shouldn't have to reason about it. See
+    /// `router::runtime::apply_bypass_permissions`.
+    pub skip_approval_prompts: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -222,7 +249,18 @@ pub fn create(conn: &Connection, input: CreateRunnerInput) -> Result<Runner> {
 
     let id = new_id();
     let ts = now().to_rfc3339();
-    let args_json = serde_json::to_string(&input.args)?;
+    // Apply the form's "Skip approval prompts" toggle to the args
+    // column at create time so the canonical bypass flags (or their
+    // absence) are persisted on the row, not derived at spawn time.
+    // See `router::runtime::apply_bypass_permissions`. No-op for
+    // runtimes without a bypass concept (the helper returns input
+    // unchanged for shell/unknown).
+    let args = crate::router::runtime::apply_bypass_permissions(
+        &input.runtime,
+        &input.args,
+        input.skip_approval_prompts,
+    );
+    let args_json = serde_json::to_string(&args)?;
     let env_json = serde_json::to_string(&input.env)?;
 
     conn.execute(
@@ -267,9 +305,33 @@ pub fn update(conn: &Connection, id: &str, input: UpdateRunnerInput) -> Result<R
     }
 
     let display_name = input.display_name.unwrap_or(existing.display_name);
+    // Snapshot the prior runtime *before* unwrap_or moves it, so
+    // we can strip the old runtime's bypass flags when the patch
+    // changes runtime alongside the toggle.
+    let prior_runtime = existing.runtime.clone();
     let runtime = input.runtime.unwrap_or(existing.runtime);
     let command = input.command.unwrap_or(existing.command);
-    let args = input.args.unwrap_or(existing.args);
+    // Compose the new args from the user-provided list (or the
+    // existing one when the patch omits `args`) and the form's
+    // "Skip approval prompts" toggle. `None` toggle = leave args
+    // alone so non-form callers don't have to think about bypass
+    // flags. When the toggle is provided AND the runtime is being
+    // changed in the same patch, we also strip the *prior* runtime's
+    // bypass flags so a switch doesn't leave orphans (the toggle
+    // owns these flags per-runtime). See
+    // `router::runtime::apply_bypass_permissions`.
+    let args = match input.skip_approval_prompts {
+        Some(skip) => {
+            let base = input.args.unwrap_or(existing.args);
+            let cleared = if prior_runtime != runtime {
+                crate::router::runtime::strip_bypass_flags(&prior_runtime, &base)
+            } else {
+                base
+            };
+            crate::router::runtime::apply_bypass_permissions(&runtime, &cleared, skip)
+        }
+        None => input.args.unwrap_or(existing.args),
+    };
     let working_dir = input.working_dir.unwrap_or(existing.working_dir);
     let system_prompt = input.system_prompt.unwrap_or(existing.system_prompt);
     let env = input.env.unwrap_or(existing.env);
@@ -550,6 +612,10 @@ mod tests {
                 env: HashMap::new(),
                 model: None,
                 effort: None,
+                // Default-on per the form, but a no-op for shell — the
+                // runtime adapter has no bypass concept here, so existing
+                // tests that expect `args == []` keep passing.
+                skip_approval_prompts: true,
             },
         )
         .unwrap()
@@ -593,6 +659,7 @@ mod tests {
                 env: HashMap::new(),
                 model: None,
                 effort: None,
+                skip_approval_prompts: true,
             },
         )
         .unwrap_err();
@@ -651,6 +718,368 @@ mod tests {
         assert!(validate_handle("lead!").is_err());
         assert!(validate_handle("-lead").is_err());
         assert!(validate_handle(&"x".repeat(33)).is_err());
+    }
+
+    #[test]
+    fn create_applies_codex_bypass_flags_by_default() {
+        // Form's "Skip approval prompts" toggle defaults to on.
+        // For codex, that means the canonical
+        // `--ask-for-approval never --sandbox workspace-write` pair
+        // lands on the `args` column at create time — keeping the
+        // runner template stable if the recommended default ever
+        // shifts (per #45 task 2).
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let r = create(
+            &conn,
+            CreateRunnerInput {
+                handle: "codex-tester".into(),
+                display_name: "C".into(),
+                runtime: "codex".into(),
+                command: "codex".into(),
+                args: vec!["--debug".into()],
+                working_dir: None,
+                system_prompt: None,
+                env: HashMap::new(),
+                model: None,
+                effort: None,
+                skip_approval_prompts: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            r.args,
+            vec![
+                "--debug".to_string(),
+                "--ask-for-approval".to_string(),
+                "never".to_string(),
+                "--sandbox".to_string(),
+                "workspace-write".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn create_applies_claude_code_bypass_flag_by_default() {
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let r = create(
+            &conn,
+            CreateRunnerInput {
+                handle: "claude-tester".into(),
+                display_name: "Claude".into(),
+                runtime: "claude-code".into(),
+                command: "claude".into(),
+                args: vec![],
+                working_dir: None,
+                system_prompt: None,
+                env: HashMap::new(),
+                model: None,
+                effort: None,
+                skip_approval_prompts: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(r.args, vec!["--dangerously-skip-permissions".to_string()]);
+    }
+
+    #[test]
+    fn create_omits_bypass_flags_when_toggle_off() {
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let r = create(
+            &conn,
+            CreateRunnerInput {
+                handle: "paranoid".into(),
+                display_name: "P".into(),
+                runtime: "codex".into(),
+                command: "codex".into(),
+                args: vec!["--debug".into()],
+                working_dir: None,
+                system_prompt: None,
+                env: HashMap::new(),
+                model: None,
+                effort: None,
+                skip_approval_prompts: false,
+            },
+        )
+        .unwrap();
+        assert_eq!(r.args, vec!["--debug".to_string()]);
+    }
+
+    #[test]
+    fn create_does_not_duplicate_existing_bypass_flags() {
+        // CLI / API users who pass the flags themselves AND leave the
+        // toggle on shouldn't end up with two copies on the row.
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let r = create(
+            &conn,
+            CreateRunnerInput {
+                handle: "explicit".into(),
+                display_name: "E".into(),
+                runtime: "claude-code".into(),
+                command: "claude".into(),
+                args: vec!["--dangerously-skip-permissions".into()],
+                working_dir: None,
+                system_prompt: None,
+                env: HashMap::new(),
+                model: None,
+                effort: None,
+                skip_approval_prompts: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(r.args, vec!["--dangerously-skip-permissions".to_string()]);
+    }
+
+    #[test]
+    fn create_no_op_for_runtime_without_bypass_concept() {
+        // shell has no bypass flags. Toggle on is a no-op — the args
+        // column matches what the caller passed verbatim.
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let r = create(
+            &conn,
+            CreateRunnerInput {
+                handle: "shell-tester".into(),
+                display_name: "Sh".into(),
+                runtime: "shell".into(),
+                command: "/bin/sh".into(),
+                args: vec!["-c".into(), "echo hi".into()],
+                working_dir: None,
+                system_prompt: None,
+                env: HashMap::new(),
+                model: None,
+                effort: None,
+                skip_approval_prompts: true,
+            },
+        )
+        .unwrap();
+        assert_eq!(r.args, vec!["-c".to_string(), "echo hi".to_string()]);
+    }
+
+    #[test]
+    fn update_skip_approval_toggle_round_trips_for_codex() {
+        // Off → strips both halves of the codex bypass pair without
+        // touching the unrelated user arg. On → re-adds them.
+        // No duplicates accumulate across multiple round-trips.
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let r = create(
+            &conn,
+            CreateRunnerInput {
+                handle: "codex-rt".into(),
+                display_name: "C".into(),
+                runtime: "codex".into(),
+                command: "codex".into(),
+                args: vec!["--debug".into()],
+                working_dir: None,
+                system_prompt: None,
+                env: HashMap::new(),
+                model: None,
+                effort: None,
+                skip_approval_prompts: true,
+            },
+        )
+        .unwrap();
+        assert!(r.args.contains(&"--ask-for-approval".to_string()));
+
+        // Toggle off.
+        let r = update(
+            &conn,
+            &r.id,
+            UpdateRunnerInput {
+                skip_approval_prompts: Some(false),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            r.args,
+            vec!["--debug".to_string()],
+            "toggle off must strip both --ask-for-approval and --sandbox cleanly",
+        );
+
+        // Toggle back on.
+        let r = update(
+            &conn,
+            &r.id,
+            UpdateRunnerInput {
+                skip_approval_prompts: Some(true),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            r.args,
+            vec![
+                "--debug".to_string(),
+                "--ask-for-approval".to_string(),
+                "never".to_string(),
+                "--sandbox".to_string(),
+                "workspace-write".to_string(),
+            ],
+        );
+
+        // Re-toggling on a second time must not double up.
+        let r = update(
+            &conn,
+            &r.id,
+            UpdateRunnerInput {
+                skip_approval_prompts: Some(true),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            r.args.iter().filter(|a| a.as_str() == "--ask-for-approval").count(),
+            1,
+            "re-toggling on must not duplicate flags: {:?}",
+            r.args,
+        );
+    }
+
+    #[test]
+    fn update_skip_approval_toggle_round_trips_for_claude_code() {
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let r = create(
+            &conn,
+            CreateRunnerInput {
+                handle: "claude-rt".into(),
+                display_name: "C".into(),
+                runtime: "claude-code".into(),
+                command: "claude".into(),
+                args: vec!["--mcp-debug".into()],
+                working_dir: None,
+                system_prompt: None,
+                env: HashMap::new(),
+                model: None,
+                effort: None,
+                skip_approval_prompts: true,
+            },
+        )
+        .unwrap();
+        assert!(r.args.contains(&"--dangerously-skip-permissions".to_string()));
+
+        let r = update(
+            &conn,
+            &r.id,
+            UpdateRunnerInput {
+                skip_approval_prompts: Some(false),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(r.args, vec!["--mcp-debug".to_string()]);
+
+        let r = update(
+            &conn,
+            &r.id,
+            UpdateRunnerInput {
+                skip_approval_prompts: Some(true),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            r.args,
+            vec![
+                "--mcp-debug".to_string(),
+                "--dangerously-skip-permissions".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn update_without_toggle_field_preserves_args_verbatim() {
+        // Programmatic patches that don't surface the toggle (e.g. a
+        // CLI patch that only updates `display_name`) must not
+        // accidentally rewrite the args column. `None` toggle = no-op.
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let r = create(
+            &conn,
+            CreateRunnerInput {
+                handle: "preserve".into(),
+                display_name: "P".into(),
+                runtime: "codex".into(),
+                command: "codex".into(),
+                args: vec!["--debug".into()],
+                working_dir: None,
+                system_prompt: None,
+                env: HashMap::new(),
+                model: None,
+                effort: None,
+                skip_approval_prompts: true,
+            },
+        )
+        .unwrap();
+        let before = r.args.clone();
+
+        let r = update(
+            &conn,
+            &r.id,
+            UpdateRunnerInput {
+                display_name: Some("renamed".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(r.args, before, "args must be untouched when no toggle is sent");
+        assert_eq!(r.display_name, "renamed");
+    }
+
+    #[test]
+    fn update_runtime_switch_strips_prior_bypass_flags() {
+        // Switching runtime alongside the toggle must also clean up
+        // the old runtime's bypass flags so they don't survive as
+        // orphans on the new runtime.
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let r = create(
+            &conn,
+            CreateRunnerInput {
+                handle: "switcher".into(),
+                display_name: "S".into(),
+                runtime: "claude-code".into(),
+                command: "claude".into(),
+                args: vec![],
+                working_dir: None,
+                system_prompt: None,
+                env: HashMap::new(),
+                model: None,
+                effort: None,
+                skip_approval_prompts: true,
+            },
+        )
+        .unwrap();
+        assert!(r.args.contains(&"--dangerously-skip-permissions".to_string()));
+
+        // Switch to codex with toggle still on. Old flag must be
+        // stripped, new (codex) flags must be applied.
+        let r = update(
+            &conn,
+            &r.id,
+            UpdateRunnerInput {
+                runtime: Some("codex".into()),
+                command: Some("codex".into()),
+                skip_approval_prompts: Some(true),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(
+            !r.args.contains(&"--dangerously-skip-permissions".to_string()),
+            "claude-code's flag must be stripped on runtime switch: {:?}",
+            r.args,
+        );
+        assert!(
+            r.args.contains(&"--ask-for-approval".to_string()),
+            "codex bypass pair must be applied on runtime switch: {:?}",
+            r.args,
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/slot.rs
+++ b/src-tauri/src/commands/slot.rs
@@ -530,6 +530,7 @@ mod tests {
                 env: HashMap::new(),
                 model: None,
                 effort: None,
+                skip_approval_prompts: true,
             },
         )
         .unwrap()

--- a/src-tauri/src/router/runtime.rs
+++ b/src-tauri/src/router/runtime.rs
@@ -10,7 +10,10 @@
 //      ignores them. So claude-code returns no argv from this
 //      function — the prompt is delivered via stdin as a first user
 //      turn instead, by `SessionManager::schedule_first_prompt`.
-//      Codex still uses its positional `[PROMPT]` arg.
+//      Codex follows the same stdin path: a startup permission /
+//      approval dialog can swallow or misorder the positional
+//      `[PROMPT]` argv, so codex also returns empty here and the
+//      brief lands via stdin once the TUI has settled.
 //      arch §4.2 / §4.3.
 //
 //   2. `resume_plan` — pass the agent CLI's *own* resumable
@@ -103,6 +106,174 @@ pub fn model_effort_args(runtime: &str, model: Option<&str>, effort: Option<&str
     }
 }
 
+/// Canonical argv that puts the runtime's interactive TUI into a
+/// "skip approval prompts" mode — used by `commands::runner::create`
+/// (and `update`) to apply the runner-edit-form's "Skip approval
+/// prompts" toggle as concrete flags on the runner row's `args`
+/// column at *create* time, not at spawn time. Storing the flags on
+/// the row keeps existing runners stable if our recommended default
+/// ever shifts.
+///
+/// Returns an empty Vec for runtimes with no equivalent (shell /
+/// unknown), which the caller treats as "toggle does not apply" — the
+/// form hides the toggle row in those cases (see
+/// `RUNTIME_OPTIONS` / `RunnerEditDrawer.tsx`).
+///
+/// claude-code → `--dangerously-skip-permissions` (the SDK & TUI flag,
+/// already baked into the seeded Build squad runners — see
+/// migrations/0002_default_crew.sql).
+///
+/// codex → `--ask-for-approval never --sandbox workspace-write` (codex
+/// 0.x's two-axis approval model: ask cadence + filesystem
+/// sandbox). `workspace-write` keeps writes scoped to the runner's
+/// cwd while removing the per-action prompt; pairing them is what
+/// lets a crew worker run unattended.
+pub fn bypass_permission_args(runtime: &str) -> Vec<String> {
+    match runtime {
+        "claude-code" => vec!["--dangerously-skip-permissions".into()],
+        "codex" => vec![
+            "--ask-for-approval".into(),
+            "never".into(),
+            "--sandbox".into(),
+            "workspace-write".into(),
+        ],
+        _ => Vec::new(),
+    }
+}
+
+/// Strip every prior occurrence of the runtime's bypass-permission
+/// flags (and their values, where applicable) from `args`, preserving
+/// order of the surviving args. Used by `commands::runner::create`
+/// and `update` so toggling the form's "Skip approval prompts"
+/// switch round-trips without leaving duplicate or orphan flags.
+///
+/// Match shape per runtime:
+///   - codex: `--ask-for-approval <value>` and `--sandbox <value>`
+///     (the next token is consumed as the value, regardless of what
+///     it is — toggling the switch is opinionated about owning these
+///     flags). `--flag=value` form is also stripped.
+///   - claude-code: `--dangerously-skip-permissions` (standalone).
+pub fn strip_bypass_flags(runtime: &str, args: &[String]) -> Vec<String> {
+    // (flag_name, takes_value)
+    let keys: &[(&str, bool)] = match runtime {
+        "codex" => &[("--ask-for-approval", true), ("--sandbox", true)],
+        "claude-code" => &[("--dangerously-skip-permissions", false)],
+        _ => &[],
+    };
+    if keys.is_empty() {
+        return args.to_vec();
+    }
+    let mut out = Vec::with_capacity(args.len());
+    let mut i = 0;
+    while i < args.len() {
+        let arg = &args[i];
+        // Exact-match `--flag` form. For takes_value flags we also
+        // skip the next token if present (it's the value).
+        if let Some(&(_, takes_value)) = keys.iter().find(|(name, _)| name == arg) {
+            i += if takes_value && i + 1 < args.len() {
+                2
+            } else {
+                1
+            };
+            continue;
+        }
+        // `--flag=value` form: strip the whole token in one go.
+        if keys
+            .iter()
+            .any(|(name, takes_value)| *takes_value && arg.starts_with(&format!("{name}=")))
+        {
+            i += 1;
+            continue;
+        }
+        out.push(arg.clone());
+        i += 1;
+    }
+    out
+}
+
+/// Compose the runner row's stored `args` from the user-provided
+/// `args` and the runner-edit-form's "Skip approval prompts" toggle.
+/// Strips any prior occurrence of the runtime's bypass flags, then
+/// appends the canonical pair if the toggle is on. No-op for
+/// runtimes without a bypass concept (shell / unknown).
+pub fn apply_bypass_permissions(runtime: &str, args: &[String], skip: bool) -> Vec<String> {
+    let mut out = strip_bypass_flags(runtime, args);
+    if skip {
+        out.extend(bypass_permission_args(runtime));
+    }
+    out
+}
+
+/// Frontend-mirror helper: inspect a runner's stored `args` and
+/// decide whether the "Skip approval prompts" toggle on the
+/// runner-edit form should render as on. True iff every canonical
+/// (flag, expected_value) pair for the runtime is present in `args`,
+/// in either separated form (`--flag value`) or equals form
+/// (`--flag=value`); claude-code's `--dangerously-skip-permissions`
+/// is a value-less flag, just check presence.
+///
+/// Conflicting values (e.g. `--ask-for-approval=on-failure` for
+/// codex) read as toggle-off, since the user clearly didn't choose
+/// the "skip" semantic. Mirrors `inferSkipApprovalPrompts` in
+/// `src/components/ui/runtimes.ts` — the frontend hand-port is
+/// constrained by this function's tests.
+///
+/// `#[allow(dead_code)]` because the only direct consumer is the
+/// test suite: the function exists to *pin the algorithm* the
+/// frontend hand-ports, not to be called from Rust spawn paths
+/// (those use `apply_bypass_permissions` for write-side flag
+/// management). Keep it `pub` so it's discoverable from a
+/// `runtime::` module search.
+#[allow(dead_code)]
+pub fn infer_skip_approval_prompts(runtime: &str, args: &[String]) -> bool {
+    // (flag, Some(expected_value)) pairs for codex; (flag, None) for
+    // claude-code's value-less flag. Hand-synced with
+    // `bypass_permission_args` and the frontend's
+    // `BYPASS_FLAGS_BY_RUNTIME`.
+    let pairs: &[(&str, Option<&str>)] = match runtime {
+        "claude-code" => &[("--dangerously-skip-permissions", None)],
+        "codex" => &[
+            ("--ask-for-approval", Some("never")),
+            ("--sandbox", Some("workspace-write")),
+        ],
+        _ => &[],
+    };
+    if pairs.is_empty() {
+        return false;
+    }
+    pairs
+        .iter()
+        .all(|&(flag, expected)| flag_value_matches(args, flag, expected))
+}
+
+/// `--flag <expected>` (separated) OR `--flag=<expected>` (equals)
+/// for value-bearing flags; bare-token presence for value-less
+/// flags. A wrong value at one site doesn't invalidate a later
+/// canonical site (we keep scanning), so duplicate entries with
+/// mixed values resolve toward "match found".
+///
+/// Helper for `infer_skip_approval_prompts`; same dead-code caveat.
+#[allow(dead_code)]
+fn flag_value_matches(args: &[String], flag: &str, expected: Option<&str>) -> bool {
+    let Some(expected) = expected else {
+        return args.iter().any(|a| a == flag);
+    };
+    let equals_token = format!("{flag}={expected}");
+    for (i, arg) in args.iter().enumerate() {
+        if arg == &equals_token {
+            return true;
+        }
+        if arg == flag {
+            if let Some(next) = args.get(i + 1) {
+                if next == expected {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
 /// Compute the extra args (in declaration order) to append after the
 /// runner's configured `args` so the child receives `system_prompt` via the
 /// runtime's native flag. Returns an empty Vec when no prompt is set or
@@ -112,6 +283,7 @@ pub fn system_prompt_args(runtime: &str, system_prompt: Option<&str>) -> Vec<Str
         Some(p) if !p.trim().is_empty() => p,
         _ => return Vec::new(),
     };
+    let _ = prompt;
     match runtime {
         // claude-code's --append-system-prompt and --system-prompt
         // are documented as SDK-only — they require `-p` (print
@@ -123,36 +295,35 @@ pub fn system_prompt_args(runtime: &str, system_prompt: Option<&str>) -> Vec<Str
         "claude-code" => Vec::new(),
         // codex has no system-prompt flag (we tried `--instructions` and
         // it's rejected; `~/.codex/config.toml` doesn't expose one
-        // either). Codex's CLI does accept a positional `[PROMPT]` arg
-        // that becomes the first user turn of the session — passing
-        // `system_prompt` there is the closest available hook. The
-        // trade-off is visibility: codex's chat history will show the
-        // prompt as the first user message, not a hidden system
-        // instruction. For *resume* paths we deliberately skip this at
-        // the call site so the prompt isn't replayed onto an existing
-        // conversation — see the spawn glue in
-        // `SessionManager::{spawn,spawn_direct,resume}`.
-        "codex" => vec![prompt.to_string()],
+        // either). Codex's positional `[PROMPT]` argv was the closest
+        // available hook, but it loses races with codex's startup
+        // permission / approval dialog: when the TUI shows that
+        // dialog before hitting its main loop, the positional prompt
+        // is swallowed, replayed stale, or misordered. So we fall
+        // through to the same stdin-injection path claude-code uses —
+        // see `SessionManager::schedule_first_prompt`, which waits
+        // for the TUI to settle and then types the brief + Enter.
+        "codex" => Vec::new(),
         // shell / unknown — no prompt mechanism.
         _ => Vec::new(),
     }
 }
 
-/// Compose the runtime-specific trailing args (model/effort flags + the
+/// Compose the runtime-specific trailing args (model/effort flags + any
 /// `system_prompt` argv) in the order the runtime's CLI expects.
 ///
-/// Codex's clap parser requires every flag to appear *before* the positional
-/// `[PROMPT]` argument; passing `--model` (or `-c …`) after the prompt
-/// either gets swallowed into the prompt or errors out (issue #41). So
-/// model/effort flags MUST come before the prompt argv. claude-code's
-/// `system_prompt_args` returns empty (its prompt is delivered via stdin),
-/// so the same ordering is a no-op there. Centralising the splice keeps
-/// `spawn`, `spawn_direct`, and `resume` from drifting.
+/// Both supported runtimes now deliver the system prompt via stdin
+/// (`SessionManager::schedule_first_prompt`) so `system_prompt_args`
+/// returns empty for both — the helper still composes via that path so
+/// a future runtime that wants positional argv can opt back in without
+/// rewriting the call sites. Centralising the splice keeps `spawn`,
+/// `spawn_direct`, and `resume` from drifting.
 ///
-/// `plan_resuming` carries the codex-specific guard from `resume_plan`: on
-/// a codex resume we deliberately drop the `system_prompt` argv so the
-/// brief isn't replayed as a fresh user turn against an existing
-/// conversation. Mirrors the prior behavior at all three spawn sites.
+/// `plan_resuming` is retained for symmetry with the resume guard in
+/// `resume_plan`: callers that add a positional argv via
+/// `system_prompt_args` should not replay it onto an existing
+/// conversation. With both supported runtimes returning empty argv it
+/// is a no-op today, but kept so the contract stays self-describing.
 pub fn trailing_runtime_args(
     runtime: &str,
     plan_resuming: bool,
@@ -161,11 +332,7 @@ pub fn trailing_runtime_args(
     system_prompt: Option<&str>,
 ) -> Vec<String> {
     let mut out = model_effort_args(runtime, model, effort);
-    let prompt_for_argv = if runtime == "codex" && plan_resuming {
-        None
-    } else {
-        system_prompt
-    };
+    let prompt_for_argv = if plan_resuming { None } else { system_prompt };
     out.extend(system_prompt_args(runtime, prompt_for_argv));
     out
 }
@@ -355,14 +522,19 @@ mod tests {
     }
 
     #[test]
-    fn codex_runtime_passes_prompt_as_positional_argv() {
-        // Codex has no system-prompt flag. The closest mechanism it
-        // ships is a positional `[PROMPT]` arg that seeds the session
-        // with a first user turn. We pass `system_prompt` there so
-        // the agent at least sees the brief, even though the trade-
-        // off is the prompt becoming visible as a user message.
+    fn codex_runtime_returns_no_argv_for_system_prompt() {
+        // Codex's positional `[PROMPT]` argv races codex's startup
+        // permission / approval dialog (the prompt gets swallowed,
+        // replayed stale, or misordered when the TUI shows the dialog
+        // before hitting its main loop). The brief is now delivered via
+        // stdin once the TUI has settled — see
+        // `SessionManager::schedule_first_prompt` — so the argv path
+        // returns empty for codex too.
         let args = system_prompt_args("codex", Some("be helpful"));
-        assert_eq!(args, vec!["be helpful".to_string()]);
+        assert!(
+            args.is_empty(),
+            "codex system_prompt is delivered via stdin, not positional argv: {args:?}",
+        );
     }
 
     #[test]
@@ -529,62 +701,272 @@ mod tests {
     }
 
     #[test]
-    fn codex_trailing_args_put_flags_before_positional_prompt() {
-        // Regression test for issue #41 (argv ordering bug). Codex's
-        // clap parser requires every flag to appear *before* the
-        // positional `[PROMPT]` arg. Prior to the fix the prompt argv
-        // was spliced ahead of `--model` / `-c …`, which either
-        // swallowed the flags into the prompt text or hard-errored.
-        let args = trailing_runtime_args(
-            "codex",
-            false,
-            Some("gpt-5-codex"),
-            Some("high"),
-            Some("be helpful"),
+    fn codex_trailing_args_omit_positional_prompt() {
+        // Codex's positional `[PROMPT]` argv races codex's startup
+        // permission / approval dialog, so we deliver the brief via
+        // stdin instead (see `SessionManager::schedule_first_prompt`).
+        // The trailing args MUST NOT include the brief as positional
+        // argv on either fresh or resume spawns. Model/effort flags
+        // still ride along so the runner row's pinned settings reach
+        // the spawned CLI.
+        for plan_resuming in [false, true] {
+            let args = trailing_runtime_args(
+                "codex",
+                plan_resuming,
+                Some("gpt-5-codex"),
+                Some("high"),
+                Some("be helpful"),
+            );
+            assert!(
+                !args.iter().any(|a| a == "be helpful"),
+                "codex trailing args must not contain the brief as positional argv \
+                 (plan_resuming={plan_resuming}): {args:?}",
+            );
+            assert!(
+                args.windows(2)
+                    .any(|w| w[0] == "--model" && w[1] == "gpt-5-codex"),
+                "expected --model flag to survive (plan_resuming={plan_resuming}): {args:?}",
+            );
+            assert!(
+                args.windows(2)
+                    .any(|w| w[0] == "-c" && w[1] == "model_reasoning_effort=high"),
+                "expected reasoning-effort override to survive \
+                 (plan_resuming={plan_resuming}): {args:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn bypass_permission_args_per_runtime() {
+        assert_eq!(
+            bypass_permission_args("claude-code"),
+            vec!["--dangerously-skip-permissions".to_string()],
         );
-        let prompt_pos = args
-            .iter()
-            .position(|a| a == "be helpful")
-            .expect("prompt argv present");
-        let model_pos = args
-            .iter()
-            .position(|a| a == "--model")
-            .expect("--model flag present");
-        let effort_pos = args
-            .iter()
-            .position(|a| a == "model_reasoning_effort=high")
-            .expect("reasoning-effort override emitted");
-        assert!(
-            model_pos < prompt_pos,
-            "--model must precede the positional prompt: {args:?}",
+        assert_eq!(
+            bypass_permission_args("codex"),
+            vec![
+                "--ask-for-approval".to_string(),
+                "never".to_string(),
+                "--sandbox".to_string(),
+                "workspace-write".to_string(),
+            ],
         );
-        assert!(
-            effort_pos < prompt_pos,
-            "reasoning-effort override must precede the positional prompt: {args:?}",
+        assert!(bypass_permission_args("shell").is_empty());
+        assert!(bypass_permission_args("aider-future").is_empty());
+    }
+
+    #[test]
+    fn apply_bypass_permissions_appends_codex_canonical_pair() {
+        let user = vec!["--debug".to_string(), "-v".to_string()];
+        let out = apply_bypass_permissions("codex", &user, true);
+        assert_eq!(
+            out,
+            vec![
+                "--debug".to_string(),
+                "-v".to_string(),
+                "--ask-for-approval".to_string(),
+                "never".to_string(),
+                "--sandbox".to_string(),
+                "workspace-write".to_string(),
+            ],
+            "user-provided args come first; canonical bypass pair appended",
         );
     }
 
     #[test]
-    fn codex_trailing_args_drop_prompt_on_resume() {
-        // On a codex resume the positional `[PROMPT]` would otherwise
-        // be replayed as a fresh user turn against the existing
-        // conversation. The helper drops the prompt argv when
-        // plan_resuming=true, but keeps the model/effort flags so the
-        // resumed session still honors the runner row's pinned
-        // settings.
-        let args = trailing_runtime_args(
-            "codex",
-            true,
-            Some("gpt-5-codex"),
-            Some("high"),
-            Some("be helpful"),
+    fn apply_bypass_permissions_dedupes_existing_codex_flags() {
+        // Toggling on with stale/conflicting bypass flags already in
+        // args must replace them with the canonical pair, not stack
+        // duplicates. Covers both `--flag value` and `--flag=value`
+        // shapes plus an unrelated user arg in the middle.
+        let user = vec![
+            "--ask-for-approval".to_string(),
+            "untrusted".to_string(),
+            "--debug".to_string(),
+            "--sandbox=read-only".to_string(),
+        ];
+        let out = apply_bypass_permissions("codex", &user, true);
+        assert_eq!(
+            out,
+            vec![
+                "--debug".to_string(),
+                "--ask-for-approval".to_string(),
+                "never".to_string(),
+                "--sandbox".to_string(),
+                "workspace-write".to_string(),
+            ],
         );
-        assert!(
-            !args.iter().any(|a| a == "be helpful"),
-            "prompt argv must be dropped on codex resume: {args:?}",
+    }
+
+    #[test]
+    fn apply_bypass_permissions_off_strips_codex_flags() {
+        let user = vec![
+            "--debug".to_string(),
+            "--ask-for-approval".to_string(),
+            "never".to_string(),
+            "--sandbox".to_string(),
+            "workspace-write".to_string(),
+        ];
+        let out = apply_bypass_permissions("codex", &user, false);
+        assert_eq!(out, vec!["--debug".to_string()]);
+    }
+
+    #[test]
+    fn apply_bypass_permissions_appends_claude_code_flag() {
+        let user = vec!["--mcp-debug".to_string()];
+        let out = apply_bypass_permissions("claude-code", &user, true);
+        assert_eq!(
+            out,
+            vec![
+                "--mcp-debug".to_string(),
+                "--dangerously-skip-permissions".to_string(),
+            ],
         );
-        assert!(args.iter().any(|a| a == "--model"));
-        assert!(args.iter().any(|a| a == "model_reasoning_effort=high"));
+    }
+
+    #[test]
+    fn apply_bypass_permissions_dedupes_claude_code_flag() {
+        let user = vec![
+            "--dangerously-skip-permissions".to_string(),
+            "--mcp-debug".to_string(),
+        ];
+        let out = apply_bypass_permissions("claude-code", &user, true);
+        // Single occurrence, appended at the end after the strip pass.
+        assert_eq!(
+            out,
+            vec![
+                "--mcp-debug".to_string(),
+                "--dangerously-skip-permissions".to_string(),
+            ],
+        );
+    }
+
+    #[test]
+    fn apply_bypass_permissions_off_strips_claude_code_flag() {
+        let user = vec![
+            "--dangerously-skip-permissions".to_string(),
+            "--mcp-debug".to_string(),
+        ];
+        let out = apply_bypass_permissions("claude-code", &user, false);
+        assert_eq!(out, vec!["--mcp-debug".to_string()]);
+    }
+
+    #[test]
+    fn apply_bypass_permissions_no_op_for_unsupported_runtime() {
+        let user = vec!["--whatever".to_string()];
+        // toggle on or off — shell has no bypass concept, args pass
+        // through unchanged.
+        for skip in [true, false] {
+            assert_eq!(
+                apply_bypass_permissions("shell", &user, skip),
+                user,
+                "shell must be a no-op (skip={skip})",
+            );
+        }
+    }
+
+    #[test]
+    fn infer_skip_approval_codex_separated_form() {
+        // Bare-token / separated form: `--flag value`.
+        let args = vec![
+            "--ask-for-approval".to_string(),
+            "never".to_string(),
+            "--sandbox".to_string(),
+            "workspace-write".to_string(),
+        ];
+        assert!(infer_skip_approval_prompts("codex", &args));
+    }
+
+    #[test]
+    fn infer_skip_approval_codex_equals_form() {
+        // Equals form — the bug the reviewer reproduced. The frontend
+        // used to return false here; this case locks in the fix.
+        let args = vec![
+            "--ask-for-approval=never".to_string(),
+            "--sandbox=workspace-write".to_string(),
+        ];
+        assert!(infer_skip_approval_prompts("codex", &args));
+    }
+
+    #[test]
+    fn infer_skip_approval_codex_mixed_forms() {
+        let args = vec![
+            "--debug".to_string(),
+            "--ask-for-approval".to_string(),
+            "never".to_string(),
+            "--sandbox=workspace-write".to_string(),
+        ];
+        assert!(infer_skip_approval_prompts("codex", &args));
+    }
+
+    #[test]
+    fn infer_skip_approval_codex_missing_one_flag_false() {
+        let args = vec![
+            // --sandbox is present, --ask-for-approval is not.
+            "--sandbox=workspace-write".to_string(),
+        ];
+        assert!(!infer_skip_approval_prompts("codex", &args));
+    }
+
+    #[test]
+    fn infer_skip_approval_codex_conflicting_value_false() {
+        // Reviewer's reproducer focus: a non-canonical value on one
+        // of the two flags must read as toggle-off so we don't
+        // accidentally tell the user "bypass is on" when it isn't.
+        let args = vec![
+            "--ask-for-approval=on-failure".to_string(),
+            "--sandbox=workspace-write".to_string(),
+        ];
+        assert!(!infer_skip_approval_prompts("codex", &args));
+
+        // Same in separated form.
+        let args = vec![
+            "--ask-for-approval".to_string(),
+            "on-failure".to_string(),
+            "--sandbox".to_string(),
+            "workspace-write".to_string(),
+        ];
+        assert!(!infer_skip_approval_prompts("codex", &args));
+    }
+
+    #[test]
+    fn infer_skip_approval_codex_dangling_flag_false() {
+        // `--ask-for-approval` with no value following — toggle is
+        // not in a confirmed-on state.
+        let args = vec![
+            "--ask-for-approval".to_string(),
+            "--sandbox=workspace-write".to_string(),
+        ];
+        assert!(!infer_skip_approval_prompts("codex", &args));
+    }
+
+    #[test]
+    fn infer_skip_approval_claude_code_present() {
+        let args = vec!["--dangerously-skip-permissions".to_string()];
+        assert!(infer_skip_approval_prompts("claude-code", &args));
+    }
+
+    #[test]
+    fn infer_skip_approval_claude_code_absent() {
+        let args = vec!["--mcp-debug".to_string()];
+        assert!(!infer_skip_approval_prompts("claude-code", &args));
+    }
+
+    #[test]
+    fn infer_skip_approval_unsupported_runtime_false() {
+        let args = vec!["--whatever".to_string()];
+        assert!(!infer_skip_approval_prompts("shell", &args));
+        assert!(!infer_skip_approval_prompts("aider-future", &args));
+    }
+
+    #[test]
+    fn strip_bypass_flags_handles_dangling_value() {
+        // If `--ask-for-approval` is the last token (no value follows
+        // — the user mid-typed), strip just the flag and don't panic
+        // on the missing pair.
+        let user = vec!["--debug".to_string(), "--ask-for-approval".to_string()];
+        let out = strip_bypass_flags("codex", &user);
+        assert_eq!(out, vec!["--debug".to_string()]);
     }
 
     #[test]

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -514,10 +514,13 @@ impl SessionManager {
         // succeeded; activity badges will reconcile on the next event.
         emit_runner_activity(&pool, runner, events.as_ref());
 
+        // Deliver the runner's brief as a first user turn via stdin.
         // claude-code's interactive TUI ignores `--append-system-prompt`,
-        // so deliver the runner's brief as a first user turn via stdin.
-        // Skipped for the lead — the mission_goal handler injects a
-        // richer launch prompt that already embeds system_prompt.
+        // and codex's positional `[PROMPT]` argv loses races with its
+        // startup permission / approval dialog — see
+        // `router::runtime::system_prompt_args`. Skipped for the lead
+        // — the `mission_goal` handler injects a richer launch prompt
+        // that already embeds system_prompt.
         schedule_first_prompt(self, session_id.clone(), runner, &plan, slot.lead);
 
         Ok(SpawnedSession {
@@ -744,9 +747,9 @@ impl SessionManager {
 
         emit_runner_activity(&pool, runner, events.as_ref());
 
-        // First-turn prompt injection for fresh claude-code direct
-        // chats. Direct chats have no slot/lead concept, so always
-        // treat as non-lead.
+        // First-turn prompt injection for fresh claude-code / codex
+        // direct chats. Direct chats have no slot/lead concept, so
+        // always treat as non-lead.
         schedule_first_prompt(self, session_id.clone(), runner, &plan, false);
 
         Ok(SpawnedSession {
@@ -975,11 +978,12 @@ impl SessionManager {
                 cmd.arg(extra);
             }
         }
-        // codex on resume: the helper drops the `system_prompt` argv when
-        // `plan.resuming` is true so codex's positional `[PROMPT]` isn't
-        // replayed as a fresh user turn against the existing conversation.
-        // claude-code is unaffected (its `system_prompt_args` is empty
-        // and its prompt is delivered via stdin instead).
+        // Both supported runtimes deliver the system prompt via stdin
+        // (`schedule_first_prompt`), so `system_prompt_args` is empty
+        // for both and the helper's `plan_resuming` carve-out is a
+        // no-op today — kept on the call so the contract stays
+        // self-describing for any future runtime that opts back into
+        // positional argv.
         for extra in crate::router::runtime::trailing_runtime_args(
             &runner.runtime,
             plan.resuming,
@@ -1165,13 +1169,14 @@ impl SessionManager {
 
         emit_runner_activity(&pool, &runner, events.as_ref());
 
-        // claude-code first-turn injection. `plan.resuming` is true on
-        // any resume against a real prior_key — those skip naturally
-        // (the agent already has its system context). The lead always
-        // suppresses the worker preamble: when the lead's conversation
-        // file is missing and the resume degrades to a fresh spawn,
-        // the *launch prompt* (composed by the router with crew /
-        // roster / goal context) is the right thing to inject — the
+        // First-turn injection for fresh claude-code / codex spawns.
+        // `plan.resuming` is true on any resume against a real
+        // prior_key — those skip naturally (the agent already has its
+        // system context). The lead always suppresses the worker
+        // preamble: when the lead's conversation file is missing and
+        // the resume degrades to a fresh spawn, the *launch prompt*
+        // (composed by the router with crew / roster / goal context)
+        // is the right thing to inject — the
         // commands::session::session_resume caller fires that path
         // when it sees `fresh_fallback_lead = true` on the returned
         // SpawnedSession.
@@ -1534,18 +1539,34 @@ fn capture_cwd(explicit: Option<String>) -> Option<String> {
         .and_then(|p| p.into_os_string().into_string().ok())
 }
 
-/// Deliver `runner.system_prompt` to a freshly-spawned claude-code TUI
-/// by typing it into the agent's stdin as a first user turn. claude-
-/// code's `--append-system-prompt` / `--system-prompt` flags are
-/// SDK-only (they require `-p` / print mode); the interactive TUI
-/// silently drops them. Stdin injection is the only path that lands.
+/// How long to wait after spawn before typing the worker's first
+/// user turn into the PTY. claude-code and codex both need their TUIs
+/// to render the welcome banner, dismiss any "trust this folder" /
+/// approval dialog, and bind their raw-mode keypress reader before
+/// typed bytes land — anything shorter and the early bytes get
+/// swallowed by a dialog still on screen. `cfg(test)` zeros it so unit
+/// tests don't have to sleep multiple seconds (we run inline at the
+/// call site when zero). Mirrors `LEAD_LAUNCH_PROMPT_DELAY` in
+/// `router/handlers.rs` since they solve the same race.
+#[cfg(not(test))]
+const FIRST_PROMPT_DELAY: std::time::Duration = std::time::Duration::from_millis(2500);
+#[cfg(test)]
+const FIRST_PROMPT_DELAY: std::time::Duration = std::time::Duration::ZERO;
+
+/// Deliver `runner.system_prompt` to a freshly-spawned agent TUI by
+/// typing it into the agent's stdin as a first user turn. Used for
+/// claude-code (whose `--append-system-prompt` / `--system-prompt`
+/// flags are SDK-only and silently dropped by the interactive TUI)
+/// and for codex (whose positional `[PROMPT]` argv loses races with
+/// codex's startup permission / approval dialog — see the codex
+/// branch in `router::runtime::system_prompt_args`). Stdin injection
+/// is the only delivery path that survives both cases.
 ///
-/// Sleeps a short delay so claude-code's TUI has time to boot and
-/// bind stdin — without it, the input is sometimes echoed before the
-/// editor takes over and gets lost. Skipped on resume against a real
-/// prior conversation (the agent already has its system context) and
-/// on non-claude-code runtimes (codex uses positional argv, shell has
-/// no prompt concept).
+/// Sleeps a short delay so the TUI has time to boot and bind stdin —
+/// without it the input is sometimes echoed before the editor takes
+/// over and gets lost. Skipped on resume against a real prior
+/// conversation (the agent already has its system context) and on
+/// runtimes that have no concept of a first-turn prompt (shell).
 ///
 /// `suppress_lead_preamble` is set by the initial mission_start spawn
 /// path: there, the bus's `mission_goal` handler injects a richer
@@ -1565,7 +1586,7 @@ fn schedule_first_prompt(
     plan: &router::runtime::ResumePlan,
     suppress_lead_preamble: bool,
 ) {
-    if runner.runtime != "claude-code" {
+    if runner.runtime != "claude-code" && runner.runtime != "codex" {
         return;
     }
     if plan.resuming {
@@ -1592,21 +1613,26 @@ fn schedule_first_prompt(
         prompt.push_str("\n\n== Your brief ==\n");
         prompt.push_str(&brief);
     }
+    // Strip any embedded `\r` so the prompt body is one piece;
+    // embedded `\n`s render as line breaks inside the input box.
+    // The submit byte goes in a separate write below so the TUI
+    // sees it as Enter rather than appending it to the input
+    // buffer (which is what happens when text + `\r` arrive in
+    // the same chunk).
+    let body: String = prompt.chars().filter(|c| *c != '\r').collect();
+    let delay = FIRST_PROMPT_DELAY;
+    if delay.is_zero() {
+        // Inline path used by unit tests (`FIRST_PROMPT_DELAY = ZERO`
+        // under `cfg(test)`) so synchronous output assertions can
+        // observe the injection without waiting on a background
+        // thread. Production never hits this branch.
+        let _ = mgr.inject_stdin(&session_id, body.as_bytes());
+        let _ = mgr.inject_stdin(&session_id, b"\r");
+        return;
+    }
     let mgr = Arc::clone(mgr);
     std::thread::spawn(move || {
-        // 2.5s gives claude-code's TUI room to render its welcome
-        // banner, dismiss any "trust this folder" prompt, and bind
-        // its raw-mode keypress reader before our typed text lands.
-        // Anything shorter and the early bytes get swallowed by a
-        // confirmation dialog that's still on screen.
-        std::thread::sleep(std::time::Duration::from_millis(2500));
-        // Strip any embedded `\r` so the prompt body is one piece;
-        // embedded `\n`s render as line breaks inside the input
-        // box. The submit byte goes in a separate write below so
-        // claude-code's editor sees it as Enter rather than
-        // appending it to the input buffer (which is what happens
-        // when text + `\r` arrive in the same chunk).
-        let body: String = prompt.chars().filter(|c| *c != '\r').collect();
+        std::thread::sleep(delay);
         let _ = mgr.inject_stdin(&session_id, body.as_bytes());
         std::thread::sleep(std::time::Duration::from_millis(80));
         let _ = mgr.inject_stdin(&session_id, b"\r");
@@ -2066,6 +2092,165 @@ mod tests {
         let mgr = SessionManager::new(None);
         let err = mgr.inject_stdin("nope", b"x").unwrap_err();
         assert!(format!("{err}").contains("session not found"));
+    }
+
+    #[test]
+    fn codex_fresh_spawn_injects_brief_via_stdin() {
+        // Codex used to receive `runner.system_prompt` as a positional
+        // `[PROMPT]` argv, but that delivery races codex's startup
+        // permission / approval dialog. The fix mirrors claude-code:
+        // `schedule_first_prompt` types the brief into the PTY's
+        // stdin once the TUI has settled. Spawn `/bin/cat` (echoes
+        // stdin back to stdout) with codex runtime and a non-empty
+        // system_prompt — `FIRST_PROMPT_DELAY` is zero under
+        // `cfg(test)` so injection runs inline — then assert the
+        // brief shows up in the captured output buffer. The
+        // worker-coordination preamble lands first; we look for the
+        // brief substring as the load-bearing assertion.
+        let pool = pool_with_schema();
+        let now = Utc::now().to_rfc3339();
+        let runner_id = ulid::Ulid::new().to_string();
+        {
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'codex-tester', 'CT', 'codex', '/bin/cat',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+                params![runner_id, now],
+            )
+            .unwrap();
+        }
+        let mut runner = runner("/bin/cat", &[]);
+        runner.id = runner_id.clone();
+        runner.handle = "codex-tester".into();
+        runner.runtime = "codex".into();
+        runner.system_prompt = Some("CODEX_BRIEF_TOKEN".into());
+
+        let mgr = SessionManager::new(None);
+        let spawned = mgr
+            .spawn_direct(
+                &runner,
+                Some("/tmp"),
+                None,
+                None,
+                std::path::Path::new("/tmp"),
+                Arc::clone(&pool),
+                capture(),
+            )
+            .unwrap();
+
+        // Poll the bounded output buffer until /bin/cat has echoed
+        // the injected brief back through the PTY. 5s deadline is the
+        // same budget the other inject-stdin tests in this module
+        // use; in practice the round-trip lands in <100ms.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let saw_brief = loop {
+            let snapshot = mgr.output_snapshot(&spawned.id);
+            let merged: String = snapshot
+                .iter()
+                .filter_map(|ev| {
+                    BASE64
+                        .decode(ev.data.as_bytes())
+                        .ok()
+                        .and_then(|b| String::from_utf8(b).ok())
+                })
+                .collect();
+            if merged.contains("CODEX_BRIEF_TOKEN") {
+                break true;
+            }
+            if Instant::now() > deadline {
+                break false;
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        };
+        mgr.kill(&spawned.id).unwrap();
+        assert!(
+            saw_brief,
+            "codex fresh spawn must deliver the system_prompt via stdin (output never contained the brief)"
+        );
+    }
+
+    #[test]
+    fn codex_resume_skips_first_prompt_injection() {
+        // On a codex resume the agent already has its system context
+        // — replaying the brief would either be a no-op (codex
+        // resume doesn't replay first turns) or, worse, push a fresh
+        // user turn against the existing conversation. Verify the
+        // resume path leaves stdin untouched: spawn /bin/cat with
+        // codex runtime + a populated `agent_session_key` (so
+        // `resume_plan` chooses the resuming branch), wait briefly,
+        // and assert no echo arrived. Pairs with
+        // `codex_fresh_spawn_injects_brief_via_stdin` — same setup,
+        // opposite expectation, locking in the resume guard.
+        let pool = pool_with_schema();
+        let now = Utc::now().to_rfc3339();
+        let runner_id = ulid::Ulid::new().to_string();
+        let session_id = ulid::Ulid::new().to_string();
+        let prior_key = uuid::Uuid::new_v4().to_string();
+        {
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'codex-resumer', 'CR', 'codex', '/bin/cat',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+                params![runner_id, now],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO sessions
+                    (id, mission_id, runner_id, cwd, status, started_at,
+                     agent_session_key)
+                 VALUES (?1, NULL, ?2, '/tmp', 'stopped', ?3, ?4)",
+                params![session_id, runner_id, now, prior_key],
+            )
+            .unwrap();
+        }
+        // Update the in-memory runner row to mirror the DB so resume()
+        // reads what we just inserted.
+        {
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "UPDATE runners SET system_prompt = ?2 WHERE id = ?1",
+                params![runner_id, "CODEX_BRIEF_TOKEN_RESUME"],
+            )
+            .unwrap();
+        }
+
+        let mgr = SessionManager::new(None);
+        let resumed = mgr
+            .resume(
+                &session_id,
+                None,
+                None,
+                std::path::Path::new("/tmp"),
+                Arc::clone(&pool),
+                capture(),
+            )
+            .unwrap();
+
+        // Give the (would-be) injection thread a chance to fire.
+        std::thread::sleep(Duration::from_millis(100));
+        let snapshot = mgr.output_snapshot(&resumed.id);
+        let merged: String = snapshot
+            .iter()
+            .filter_map(|ev| {
+                BASE64
+                    .decode(ev.data.as_bytes())
+                    .ok()
+                    .and_then(|b| String::from_utf8(b).ok())
+            })
+            .collect();
+        mgr.kill(&resumed.id).unwrap();
+        assert!(
+            !merged.contains("CODEX_BRIEF_TOKEN_RESUME"),
+            "codex resume must NOT replay the brief over stdin: {merged:?}"
+        );
     }
 
     #[test]

--- a/src/components/CreateRunnerModal.tsx
+++ b/src/components/CreateRunnerModal.tsx
@@ -12,7 +12,8 @@ import { Button } from "./ui/Button";
 import { Modal } from "./ui/Overlay";
 import { Field, Input, Textarea } from "./ui/Field";
 import { RuntimeSelect } from "./ui/RuntimeSelect";
-import { RUNTIME_OPTIONS } from "./ui/runtimes";
+import { RUNTIME_OPTIONS, runtimeSupportsBypassToggle } from "./ui/runtimes";
+import { Toggle } from "./ui/Toggle";
 
 // Mirrors src-tauri/src/commands/runner.rs::validate_handle.
 const HANDLE_RE = /^[a-z0-9][a-z0-9_-]{0,31}$/;
@@ -33,6 +34,11 @@ export function CreateRunnerModal({
   const [argsText, setArgsText] = useState("");
   const [workingDir, setWorkingDir] = useState("");
   const [systemPrompt, setSystemPrompt] = useState("");
+  // "Skip approval prompts" toggle — defaults checked. The backend
+  // applies the runtime's bypass flags to the stored args column at
+  // create time (see commands::runner::create), so the user never
+  // has to type the flags themselves.
+  const [skipApprovalPrompts, setSkipApprovalPrompts] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -45,6 +51,7 @@ export function CreateRunnerModal({
       setArgsText("");
       setWorkingDir("");
       setSystemPrompt("");
+      setSkipApprovalPrompts(true);
       setError(null);
     }
   }, [open]);
@@ -75,6 +82,7 @@ export function CreateRunnerModal({
       args: argsText.trim() ? argsText.trim().split(/\s+/) : [],
       working_dir: workingDir.trim() || null,
       system_prompt: systemPrompt.trim() || null,
+      skip_approval_prompts: skipApprovalPrompts,
     };
     try {
       const runner = await api.runner.create(input);
@@ -183,10 +191,31 @@ export function CreateRunnerModal({
           <Input
             id="new-runner-args"
             value={argsText}
-            placeholder="--dangerously-skip-permissions"
+            placeholder="--mcp-debug"
             onChange={(e) => setArgsText(e.target.value)}
           />
         </Field>
+
+        {runtimeSupportsBypassToggle(runtime) ? (
+          <div className="flex items-start justify-between gap-6">
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <span className="text-[13px] font-medium text-fg">
+                Skip approval prompts
+              </span>
+              <span className="text-[11px] text-fg-2">
+                Skip approval prompts inside the TUI — recommended for crew
+                workflows
+              </span>
+            </div>
+            <div className="shrink-0 pt-0.5">
+              <Toggle
+                ariaLabel="Skip approval prompts"
+                on={skipApprovalPrompts}
+                onChange={setSkipApprovalPrompts}
+              />
+            </div>
+          </div>
+        ) : null}
 
         <Field
           id="new-runner-working-dir"

--- a/src/components/RunnerEditDrawer.tsx
+++ b/src/components/RunnerEditDrawer.tsx
@@ -13,7 +13,12 @@ import { Button } from "./ui/Button";
 import { Drawer } from "./ui/Overlay";
 import { Field, Input, Textarea } from "./ui/Field";
 import { RuntimeSelect } from "./ui/RuntimeSelect";
-import { RUNTIME_OPTIONS } from "./ui/runtimes";
+import {
+  RUNTIME_OPTIONS,
+  inferSkipApprovalPrompts,
+  runtimeSupportsBypassToggle,
+} from "./ui/runtimes";
+import { Toggle } from "./ui/Toggle";
 
 export function RunnerEditDrawer({
   open,
@@ -34,6 +39,15 @@ export function RunnerEditDrawer({
   const [systemPrompt, setSystemPrompt] = useState("");
   const [model, setModel] = useState("");
   const [effort, setEffort] = useState("");
+  // "Skip approval prompts" toggle — initial state derived from
+  // whether the row's stored args already contain the runtime's
+  // bypass flags. The form's args input is intentionally
+  // toggle-aware: the field shows ALL args (including the bypass
+  // pair when the toggle is on) so users see what gets persisted.
+  // Toggling here updates the args text inline so the visible state
+  // matches what we'd submit, and the backend strips/re-applies
+  // canonically on save (see commands::runner::update).
+  const [skipApprovalPrompts, setSkipApprovalPrompts] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -47,6 +61,9 @@ export function RunnerEditDrawer({
       setSystemPrompt(runner.system_prompt ?? "");
       setModel(runner.model ?? "");
       setEffort(runner.effort ?? "");
+      setSkipApprovalPrompts(
+        inferSkipApprovalPrompts(runner.runtime, runner.args),
+      );
       setError(null);
     }
   }, [open, runner]);
@@ -71,6 +88,14 @@ export function RunnerEditDrawer({
         system_prompt: systemPrompt.trim() || null,
         model: model.trim() || null,
         effort: effort.trim() || null,
+        // Send the toggle state only for runtimes that support it —
+        // otherwise the backend's bypass-flag helper is a no-op
+        // anyway, but keeping the field undefined for shell/unknown
+        // makes the contract explicit (`None` toggle on the Rust
+        // side preserves args verbatim).
+        ...(runtimeSupportsBypassToggle(runtime)
+          ? { skip_approval_prompts: skipApprovalPrompts }
+          : {}),
       };
       await api.runner.update(runner.id, input);
       await onSaved();
@@ -151,6 +176,27 @@ export function RunnerEditDrawer({
             onChange={(e) => setArgsText(e.target.value)}
           />
         </Field>
+
+        {runtimeSupportsBypassToggle(runtime) ? (
+          <div className="flex items-start justify-between gap-6">
+            <div className="flex min-w-0 flex-col gap-0.5">
+              <span className="text-[13px] font-medium text-fg">
+                Skip approval prompts
+              </span>
+              <span className="text-[11px] text-fg-2">
+                Skip approval prompts inside the TUI — recommended for crew
+                workflows
+              </span>
+            </div>
+            <div className="shrink-0 pt-0.5">
+              <Toggle
+                ariaLabel="Skip approval prompts"
+                on={skipApprovalPrompts}
+                onChange={setSkipApprovalPrompts}
+              />
+            </div>
+          </div>
+        ) : null}
 
         <Field
           id="edit-working-dir"

--- a/src/components/ui/Toggle.tsx
+++ b/src/components/ui/Toggle.tsx
@@ -1,0 +1,33 @@
+// Pill-style on/off switch. Matches the private Toggle inside
+// SettingsModal.tsx — split out here so the runner-edit forms
+// (CreateRunnerModal, RunnerEditDrawer) can reuse it without
+// cross-component imports.
+
+export function Toggle({
+  on,
+  onChange,
+  ariaLabel,
+}: {
+  on: boolean;
+  onChange: (next: boolean) => void;
+  ariaLabel?: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={on}
+      aria-label={ariaLabel}
+      onClick={() => onChange(!on)}
+      className={`flex h-[18px] w-8 cursor-pointer items-center rounded-full p-0.5 transition-colors ${
+        on ? "justify-end bg-accent/15" : "justify-start bg-raised"
+      }`}
+    >
+      <span
+        className={`block h-3.5 w-3.5 rounded-full ${
+          on ? "bg-accent" : "bg-fg-3"
+        }`}
+      />
+    </button>
+  );
+}

--- a/src/components/ui/runtimes.ts
+++ b/src/components/ui/runtimes.ts
@@ -28,3 +28,73 @@ export const RUNTIME_OPTIONS: RuntimeOption[] = [
     description: "OpenAI Codex CLI",
   },
 ];
+
+// Runtimes that surface a "Skip approval prompts" toggle on the
+// runner edit form. Source of truth: the backend's
+// `router::runtime::bypass_permission_args` knows the canonical
+// flags per runtime — if it returns a non-empty Vec, the toggle
+// applies. Hand-synced; if a future runtime opts in, add it here
+// AND in `bypass_permission_args` (in lockstep).
+const RUNTIMES_WITH_BYPASS_TOGGLE = new Set(["claude-code", "codex"]);
+
+export function runtimeSupportsBypassToggle(runtime: string): boolean {
+  return RUNTIMES_WITH_BYPASS_TOGGLE.has(runtime);
+}
+
+// Hand-synced with the backend's `router::runtime::infer_skip_approval_prompts`.
+// Each entry is a (flag, expected_value | null) pair; `null` means the
+// flag is value-less (just check presence). For value-bearing flags
+// the user's args may use either separated form (`--flag value`) or
+// equals form (`--flag=value`). Conflicting values read as toggle-off.
+const BYPASS_PAIRS_BY_RUNTIME: Record<
+  string,
+  ReadonlyArray<readonly [string, string | null]>
+> = {
+  "claude-code": [["--dangerously-skip-permissions", null]],
+  codex: [
+    ["--ask-for-approval", "never"],
+    ["--sandbox", "workspace-write"],
+  ],
+};
+
+function flagValueMatches(
+  args: string[],
+  flag: string,
+  expected: string | null,
+): boolean {
+  if (expected === null) {
+    return args.includes(flag);
+  }
+  const equalsToken = `${flag}=${expected}`;
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === equalsToken) return true;
+    if (arg === flag && i + 1 < args.length && args[i + 1] === expected) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/// Derive the toggle's initial state from existing args: true iff
+/// every canonical (flag, expected_value) pair for the runtime is
+/// present in `args`, in either separated form (`--flag value`) or
+/// equals form (`--flag=value`). Conflicting values (e.g. codex's
+/// `--ask-for-approval=on-failure`) read as toggle-off — the user
+/// clearly didn't choose the "skip" semantic, and silently flipping
+/// the toggle on would let the backend's strip helper wipe their
+/// custom value.
+///
+/// Mirror of `router::runtime::infer_skip_approval_prompts` (Rust).
+/// Algorithm and edge cases are pinned by tests on the Rust side
+/// since the project has no frontend test runner today.
+export function inferSkipApprovalPrompts(
+  runtime: string,
+  args: string[],
+): boolean {
+  const pairs = BYPASS_PAIRS_BY_RUNTIME[runtime];
+  if (!pairs || pairs.length === 0) return false;
+  return pairs.every(([flag, expected]) =>
+    flagValueMatches(args, flag, expected),
+  );
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -217,6 +217,11 @@ export interface CreateRunnerInput {
   env?: Record<string, string>;
   model?: string | null;
   effort?: string | null;
+  /** Form's "Skip approval prompts" toggle — defaults to true on the
+   *  backend when omitted. The runner-edit-form sends this explicitly
+   *  for codex / claude-code; for runtimes without a bypass concept
+   *  (shell / unknown) the toggle is hidden and this is a no-op. */
+  skip_approval_prompts?: boolean;
 }
 
 // `handle` is intentionally excluded: it's the runner template's identity
@@ -231,6 +236,11 @@ export interface UpdateRunnerInput {
   env?: Record<string, string>;
   model?: string | null;
   effort?: string | null;
+  /** `true` ensures the runtime's bypass-permission flags are present
+   *  on the stored args; `false` strips them. Omit (or `undefined`)
+   *  to leave args alone — non-form callers shouldn't have to think
+   *  about bypass flags. */
+  skip_approval_prompts?: boolean;
 }
 
 export interface CreateSlotInput {


### PR DESCRIPTION
## Summary

Three coordinated fixes from #45 so codex runners come up clean inside the embedded TUI:

- **System prompt over stdin instead of positional argv.** Codex's `[PROMPT]` argv races codex's startup permission/approval dialog (swallowed, replayed stale, or misordered). `router::runtime::system_prompt_args` now returns empty for codex; `SessionManager::schedule_first_prompt` fires for codex on fresh spawns (mission + direct), waits for the TUI to settle (2.5s in prod, ZERO under `cfg(test)` to keep unit tests fast), and types the brief + Enter over the PTY's stdin — parallel to claude-code. Resume still skips: codex resume already has the conversation context.
- **Runtime-aware bypass-permission defaults.** New `router::runtime::bypass_permission_args` returns the canonical flags per runtime (claude-code: `--dangerously-skip-permissions`; codex: `--ask-for-approval never --sandbox workspace-write`). `commands::runner::create` and `update` apply or strip them on the stored args column based on the form's toggle, so recommended defaults land on the row at create time rather than drifting at spawn time. Round-trips without dupes/orphans, and a runtime switch on update strips the prior runtime's flags too.
- **\"Skip approval prompts\" toggle on the runner forms.** Default-on in `CreateRunnerModal`; initial state on `RunnerEditDrawer` derived from the row's args via `inferSkipApprovalPrompts`, which now accepts both `--flag value` and `--flag=value` shapes (the earlier bare-token check missed equals form and would silently disable the bypass on save). Visible only for runtimes with a bypass concept (codex + claude-code today). New shared `ui/Toggle.tsx` lifts SettingsModal's pill switch so both forms reuse it. Caption: \"Skip approval prompts inside the TUI — recommended for crew workflows\".

The frontend's inference algorithm is pinned by Rust tests on `router::runtime::infer_skip_approval_prompts` — no frontend test runner is configured today, so the hand-port in `src/components/ui/runtimes.ts` mirrors the backend.

Closes #45.

## Test plan

- [x] `cargo test --lib` (src-tauri): 153 passed, 0 failed.
- [x] `cargo clippy --lib --tests --manifest-path src-tauri/Cargo.toml -- -D warnings`: clean.
- [x] `npx tsc --noEmit`: clean.
- [x] `npm run lint`: clean except a pre-existing Fast-Refresh warning in `src/contexts/UpdateContext.tsx` (out of scope per architect direction).

Backend tests added (router::runtime + commands::runner):

- `codex_runtime_returns_no_argv_for_system_prompt`
- `codex_trailing_args_omit_positional_prompt`
- `codex_fresh_spawn_injects_brief_via_stdin` (real PTY + /bin/cat round-trip)
- `codex_resume_skips_first_prompt_injection`
- `bypass_permission_args_per_runtime`
- `apply_bypass_permissions_*` (codex/claude-code, on/off, dedupe, equals form, dangling-value, no-op for unsupported runtime)
- `create_applies_codex_bypass_flags_by_default`
- `create_applies_claude_code_bypass_flag_by_default`
- `create_omits_bypass_flags_when_toggle_off`
- `create_does_not_duplicate_existing_bypass_flags`
- `create_no_op_for_runtime_without_bypass_concept`
- `update_skip_approval_toggle_round_trips_for_codex` (off → on → on dedupe)
- `update_skip_approval_toggle_round_trips_for_claude_code`
- `update_without_toggle_field_preserves_args_verbatim`
- `update_runtime_switch_strips_prior_bypass_flags`
- `infer_skip_approval_*` (separated, equals, mixed, missing, conflicting value, dangling, claude-code present/absent, unsupported runtime)

## Caveats

- `FIRST_PROMPT_DELAY` is `Duration::ZERO` under `cfg(test)` so unit tests can assert injections inline without the production 2.5s settle. Production behavior is unchanged.
- No slow-machine TUI smoke verification was performed — both codex and claude-code TUIs need to draw before the injection lands. The 2.5s budget matches the existing `LEAD_LAUNCH_PROMPT_DELAY` for the lead's launch prompt; happy to add real-machine verification before merge if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)