### PR TITLE
chore: cargo fmt

### DIFF
--- a/src-tauri/src/commands/runner.rs
+++ b/src-tauri/src/commands/runner.rs
@@ -933,7 +933,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            r.args.iter().filter(|a| a.as_str() == "--ask-for-approval").count(),
+            r.args
+                .iter()
+                .filter(|a| a.as_str() == "--ask-for-approval")
+                .count(),
             1,
             "re-toggling on must not duplicate flags: {:?}",
             r.args,
@@ -961,7 +964,9 @@ mod tests {
             },
         )
         .unwrap();
-        assert!(r.args.contains(&"--dangerously-skip-permissions".to_string()));
+        assert!(r
+            .args
+            .contains(&"--dangerously-skip-permissions".to_string()));
 
         let r = update(
             &conn,
@@ -1027,7 +1032,10 @@ mod tests {
             },
         )
         .unwrap();
-        assert_eq!(r.args, before, "args must be untouched when no toggle is sent");
+        assert_eq!(
+            r.args, before,
+            "args must be untouched when no toggle is sent"
+        );
         assert_eq!(r.display_name, "renamed");
     }
 
@@ -1055,7 +1063,9 @@ mod tests {
             },
         )
         .unwrap();
-        assert!(r.args.contains(&"--dangerously-skip-permissions".to_string()));
+        assert!(r
+            .args
+            .contains(&"--dangerously-skip-permissions".to_string()));
 
         // Switch to codex with toggle still on. Old flag must be
         // stripped, new (codex) flags must be applied.
@@ -1071,7 +1081,8 @@ mod tests {
         )
         .unwrap();
         assert!(
-            !r.args.contains(&"--dangerously-skip-permissions".to_string()),
+            !r.args
+                .contains(&"--dangerously-skip-permissions".to_string()),
             "claude-code's flag must be stripped on runtime switch: {:?}",
             r.args,
         );


### PR DESCRIPTION
## Summary

Follow-up to PR #49 / #45. The fmt fix on the original branch (1c0b293) didn't land before the squash-merge, so `main` is currently failing `cargo fmt --all --check` on a few `assert!` / `assert_eq!` test bodies in `src-tauri/src/commands/runner.rs` that need their arguments split. This re-applies the same `cargo fmt --all` output against main. No logic changes.

## Test plan

- [x] `cargo fmt --all --check` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)