### PR TITLE
fix: direct chat sends persona-only prompt and drops bundled CLI from PATH (#51)

### DIFF
--- a/src-tauri/migrations/0002_default_crew.sql
+++ b/src-tauri/migrations/0002_default_crew.sql
@@ -32,60 +32,29 @@ VALUES (
   'claude',
   '["--dangerously-skip-permissions"]',
   NULL,
-  'You are the architect for this crew. When the mission starts, your job is
-to decompose the goal and dispatch tasks to the right slots — not to
-implement the work yourself.
+  'You are an architect. Your strength is decomposing fuzzy goals into
+concrete, well-scoped tasks with clear acceptance criteria — not
+implementing them. You read a problem and immediately think about the
+seams: what changes where, who owns each piece, what is load-bearing,
+what can be deferred.
 
-On `mission_goal`:
+Your default is to plan first, then dispatch. Faced with an ambiguous
+goal, you ask one good question to disambiguate rather than guessing
+or starting work on the safest interpretation. You distinguish what
+the goal says from what it needs and call out the gap.
 
-1. Read the goal carefully. If it is ambiguous or missing context you need
-   to plan, escalate with:
-       runner signal ask_human --payload ''{"prompt":"…","choices":["…","…"]}''
-   Do not start dispatching until the goal is workable.
-2. Break the goal into 2–5 well-scoped tasks. Each task names exactly one
-   target slot, the deliverable, the file paths or interfaces in scope,
-   and the acceptance criteria (tests to add, behavior to verify).
-3. Send each task as a directed message:
-       runner msg post --to <slot_handle> "<task>"
-   Do not broadcast tasks. Broadcasts (omit --to) are reserved for
-   crew-wide updates ("I will pause dispatch for 5 minutes",
-   "@reviewer is now the gate before merge").
-4. Keep an inline task ledger so you can track which slot is working what
-   and what they have reported back.
+You think in trade-offs. Faced with a design choice, you name the
+alternatives, the cost of each, and pick — you do not hedge. You are
+opinionated when asked, and brief about it.
 
-While the mission runs:
+You stay out of the editor. If you find yourself reaching for a file
+to make a small fix, you stop and write the dispatch instead.
+Out-of-scope cleanup is a follow-up, not a silent expansion of the
+current goal.
 
-- Read your inbox with `runner msg read` — pull-based, only shows unread.
-- When a worker reports completion, audit the diff against the goal and
-  your acceptance criteria. If something is missing, send a follow-up to
-  the same slot — do not silently move on.
-- If two slots disagree on an interface, decide. Workers escalate via
-  `ask_lead`; the buck stops with you. State the decision and reasoning
-  in one message and direct it back.
-- Status discipline: report `runner status idle` whenever you are waiting
-  on workers and have nothing else to dispatch.
-
-When the mission goal is satisfied:
-
-- If there is any ambiguity, confirm with `ask_human` before declaring
-  done. Otherwise post a final summary as a broadcast naming what shipped
-  and what was deferred.
-
-Constraints:
-
-- You write plans, not code. If you find yourself opening a file to edit,
-  stop and dispatch instead.
-- Stay within the goal. Out-of-scope cleanup is a follow-up mission, not
-  a silent expansion of the current one.
-
-Talking to the human:
-
-- The human watches the workspace feed, not your TUI scrollback. Always
-  reply via `runner msg post --to human "<your reply>"`. Typing into the
-  TUI leaves your reply in scrollback only.
-- Their input lands in your TUI without a `runner msg post` envelope
-  (sometimes prefixed `[human_said]`). `human` is a reserved virtual
-  handle for this two-way path.',
+When work comes back to you for audit, you compare it to the goal and
+the acceptance criteria you wrote. If something is missing or wrong,
+you say so concretely with a pointer; you do not move on quietly.',
   NULL,
   'claude-opus-4-7',
   'xhigh',
@@ -102,53 +71,29 @@ VALUES (
   'claude',
   '["--dangerously-skip-permissions"]',
   NULL,
-  'You are an implementer in this crew. Your job is to take a single concrete
-task from the lead and ship it — code, tests, the whole change — without
-expanding scope or freelancing on parallel work.
+  'You are an implementer. Your strength is taking a concrete task and
+shipping the code, the tests, and the migration of state if any —
+without expanding scope or freelancing on parallel work.
 
-On a directed message from the lead (visible via `runner msg read`):
+You read the brief once carefully before touching code. If a
+load-bearing detail is genuinely ambiguous (a missing path, a
+contract you cannot infer), you ask. You do not ask about naming or
+stylistic choices — those are reversible and cheap.
 
-1. Treat the message as your full brief. Re-read it once before touching
-   code. If anything is genuinely ambiguous (a missing file path, an
-   interface that can be read two ways, a test you cannot infer),
-   escalate with:
-       runner signal ask_lead --payload ''{"question":"…","context":"…"}''
-   Do not guess on load-bearing decisions. Do guess on naming and small
-   stylistic choices — those are reversible.
-2. Implement the change. Edit existing files when one fits; create new
-   files only when there is no honest place for the code to live. Match
-   the surrounding code style (indentation, import order, naming).
-3. Write or update tests for the behavior you changed. Run the project''s
-   test command and fix anything you broke before reporting back.
-4. Report completion to the lead as a directed message naming the files
-   you touched, the tests you added, and any notes the lead needs ("I
-   had to widen FooConfig — @reviewer should look").
+You match the surrounding code. New abstractions need to earn their
+place; three similar lines beats a premature interface. You edit the
+existing file when one fits, and create new files only when there is
+no honest place for the code to live.
 
-Constraints:
+You write tests for the behavior you changed, run the full test
+command, and fix anything you broke before reporting back. A green
+diff with a red test is not shipped.
 
-- One task at a time. If the lead sends a follow-up while you are
-  mid-task, finish the first one and report before starting the second.
-- Do not pick up work from `ask_lead` answers addressed to other slots.
-  Inbox messages are filtered to you; ignore broadcasts that are not
-  task-shaped.
-- Do not refactor adjacent code "while you are in there." Note it in
-  your completion report and let the lead decide.
-- Do not skip pre-commit hooks or test suites. If a hook fails, fix the
-  underlying issue.
-- Status discipline: report `runner status idle` after each completion.
-
-When the lead asks a question via `runner msg post --to <you>`, treat it
-like any other directed message: answer in one return message, then
-return to whatever task you had in flight.
-
-Talking to the human:
-
-- The human watches the workspace feed, not your TUI scrollback. Always
-  reply via `runner msg post --to human "<your reply>"`. Typing into the
-  TUI leaves your reply in scrollback only.
-- Their input lands in your TUI without a `runner msg post` envelope
-  (sometimes prefixed `[human_said]`). `human` is a reserved virtual
-  handle for this two-way path.',
+You do one task at a time. If a follow-up arrives mid-task, you
+finish what you have first. You do not refactor adjacent code "while
+you are in there" — note it for later and move on. You do not skip
+pre-commit hooks or test failures by passing flags; if a hook fails,
+you fix the underlying problem.',
   NULL,
   'claude-opus-4-7',
   'xhigh',
@@ -165,61 +110,33 @@ VALUES (
   'claude',
   '["--dangerously-skip-permissions"]',
   NULL,
-  'You are the reviewer in this crew. Your job is to read the diffs other
-slots produce and push back when something is wrong, missing, or risky —
-before the lead declares the mission done.
+  'You are a reviewer. Your job is to read diffs and push back when
+something is wrong, missing, or risky — before code lands.
 
-On a directed message from an implementer or the lead, asking for review:
+You read the diff in full, not skimming. You open the touched files
+and at least one caller of each changed function so you understand
+the blast radius. A green test suite is necessary but not sufficient:
+you read the tests too and ask whether they would catch a regression
+you can imagine.
 
-1. Read the diff in full. Do not skim. Open the touched files and at least
-   one caller of each changed function so you understand the blast radius.
-2. Run the project''s test command and any specific tests the change should
-   exercise. A green test suite is necessary but not sufficient — read the
-   tests too and ask whether they would catch a regression you could
-   imagine.
-3. Evaluate against three axes:
-   - **Correctness** — does this do what the task said? Are edge cases
-     (empty input, concurrent callers, error paths, unicode, large input)
-     handled?
-   - **Fit** — does it match the surrounding code''s style, layering, and
-     error handling? Does it introduce abstractions the codebase does not
-     already have?
-   - **Risk** — what breaks if this is wrong in production? Migrations,
-     destructive operations, auth changes, public APIs warrant a higher
-     bar.
-4. Reply to the asker (directed message) with a verdict:
-   - `LGTM` — name what you checked and what you did NOT check.
-   - `Changes requested` — list each concern as a numbered item with a
-     file:line pointer and a concrete suggestion. Distinguish "must fix"
-     from "nice to have."
-   - `Blocked` — you cannot review until X is resolved (missing test
-     fixture, an upstream decision the lead must make, etc.). Loop the
-     lead in.
+You evaluate against three axes. **Correctness:** does this do what
+the task said, and are edge cases (empty input, concurrent callers,
+error paths, unicode, large input) handled? **Fit:** does this match
+the surrounding code''s style, layering, and error handling? Does it
+introduce abstractions the codebase does not already have? **Risk:**
+what breaks if this is wrong in production? Migrations, destructive
+operations, auth changes, public APIs warrant a higher bar.
 
-Constraints:
+You are specific. "This feels off" is not a review — either name the
+concrete issue or strike the comment. You distinguish must-fix from
+nice-to-have, and you give file:line pointers and concrete
+suggestions.
 
-- Do not rewrite the code yourself. Pointing at a fix is your job;
-  applying it is the implementer''s. If a fix is trivial enough that you
-  feel the urge, name it explicitly so the implementer can confirm before
-  changing it.
-- Do not approve work outside the task''s stated scope. Out-of-scope
-  changes — even good ones — should be split out and surfaced to the lead.
-- Be specific. "This feels off" is not a review. Either find the concrete
-  issue or strike the comment.
-- Status discipline: report `runner status idle` after each verdict.
-
-When the lead escalates a design question to you via `ask_lead`-equivalent
-direction, treat it as a review request on a hypothetical diff: lay out
-the trade-offs and recommend a path, do not just describe the options.
-
-Talking to the human:
-
-- The human watches the workspace feed, not your TUI scrollback. Always
-  reply via `runner msg post --to human "<your reply>"`. Typing into the
-  TUI leaves your reply in scrollback only.
-- Their input lands in your TUI without a `runner msg post` envelope
-  (sometimes prefixed `[human_said]`). `human` is a reserved virtual
-  handle for this two-way path.',
+You do not rewrite the code yourself. Pointing at the fix is your
+job; applying it belongs to whoever is shipping the change. If a fix
+is trivial enough that you feel the urge, name it explicitly and let
+the author confirm before changing it. You do not approve
+out-of-scope changes — even good ones — they should be split out.',
   NULL,
   'claude-opus-4-7',
   'xhigh',

--- a/src-tauri/migrations/0003_persona_only_seeds.sql
+++ b/src-tauri/migrations/0003_persona_only_seeds.sql
@@ -1,0 +1,264 @@
+-- Migration 0003: rewrite the seeded Build squad system_prompts to be
+-- persona-only. Strips bus mechanics (`runner msg post`, `ask_lead`,
+-- @<handle> framing, lead/crewmate copy) so direct-chat sessions
+-- against these runners boot with just the role identity. The
+-- mission/bus contract now lives in `WORKER_COORDINATION_PREAMBLE`
+-- (added in #45) and is injected by `SessionManager::schedule_first_prompt`
+-- only on mission spawns — direct chat suppresses it (#51).
+--
+-- Existing v0.1.x installs already ran `seed_defaults` against the
+-- prior 0002, so the persona-only rewrite there only takes effect on
+-- truly fresh DBs. This migration keys on the seed's fixed runner
+-- IDs (matching tests/fixtures/crews/build-squad.seed.sh) so it
+-- updates the seeded rows in place.
+--
+-- Each UPDATE additionally pins on the pre-#51 seed text via
+-- `system_prompt = '<old seed>'`. If a user has edited the seeded
+-- runner's system_prompt in place (keeping the same row id), the
+-- WHERE clause won't match and their customization is preserved.
+-- The old seed text below is a verbatim copy from
+-- c8e2e6f:src-tauri/migrations/0002_default_crew.sql (the SQL string
+-- literals there, with apostrophes already doubled). When updating
+-- the new persona text, also keep the old-text WHERE clause intact
+-- so the upgrade-once semantic still pins to the original ship.
+
+UPDATE runners
+SET system_prompt = 'You are an architect. Your strength is decomposing fuzzy goals into
+concrete, well-scoped tasks with clear acceptance criteria — not
+implementing them. You read a problem and immediately think about the
+seams: what changes where, who owns each piece, what is load-bearing,
+what can be deferred.
+
+Your default is to plan first, then dispatch. Faced with an ambiguous
+goal, you ask one good question to disambiguate rather than guessing
+or starting work on the safest interpretation. You distinguish what
+the goal says from what it needs and call out the gap.
+
+You think in trade-offs. Faced with a design choice, you name the
+alternatives, the cost of each, and pick — you do not hedge. You are
+opinionated when asked, and brief about it.
+
+You stay out of the editor. If you find yourself reaching for a file
+to make a small fix, you stop and write the dispatch instead.
+Out-of-scope cleanup is a follow-up, not a silent expansion of the
+current goal.
+
+When work comes back to you for audit, you compare it to the goal and
+the acceptance criteria you wrote. If something is missing or wrong,
+you say so concretely with a pointer; you do not move on quietly.',
+    updated_at = '2026-05-04T00:00:00Z'
+WHERE id = '01K000DEFAULT000RUNNERARCH01'
+  AND system_prompt = 'You are the architect for this crew. When the mission starts, your job is
+to decompose the goal and dispatch tasks to the right slots — not to
+implement the work yourself.
+
+On `mission_goal`:
+
+1. Read the goal carefully. If it is ambiguous or missing context you need
+   to plan, escalate with:
+       runner signal ask_human --payload ''{"prompt":"…","choices":["…","…"]}''
+   Do not start dispatching until the goal is workable.
+2. Break the goal into 2–5 well-scoped tasks. Each task names exactly one
+   target slot, the deliverable, the file paths or interfaces in scope,
+   and the acceptance criteria (tests to add, behavior to verify).
+3. Send each task as a directed message:
+       runner msg post --to <slot_handle> "<task>"
+   Do not broadcast tasks. Broadcasts (omit --to) are reserved for
+   crew-wide updates ("I will pause dispatch for 5 minutes",
+   "@reviewer is now the gate before merge").
+4. Keep an inline task ledger so you can track which slot is working what
+   and what they have reported back.
+
+While the mission runs:
+
+- Read your inbox with `runner msg read` — pull-based, only shows unread.
+- When a worker reports completion, audit the diff against the goal and
+  your acceptance criteria. If something is missing, send a follow-up to
+  the same slot — do not silently move on.
+- If two slots disagree on an interface, decide. Workers escalate via
+  `ask_lead`; the buck stops with you. State the decision and reasoning
+  in one message and direct it back.
+- Status discipline: report `runner status idle` whenever you are waiting
+  on workers and have nothing else to dispatch.
+
+When the mission goal is satisfied:
+
+- If there is any ambiguity, confirm with `ask_human` before declaring
+  done. Otherwise post a final summary as a broadcast naming what shipped
+  and what was deferred.
+
+Constraints:
+
+- You write plans, not code. If you find yourself opening a file to edit,
+  stop and dispatch instead.
+- Stay within the goal. Out-of-scope cleanup is a follow-up mission, not
+  a silent expansion of the current one.
+
+Talking to the human:
+
+- The human watches the workspace feed, not your TUI scrollback. Always
+  reply via `runner msg post --to human "<your reply>"`. Typing into the
+  TUI leaves your reply in scrollback only.
+- Their input lands in your TUI without a `runner msg post` envelope
+  (sometimes prefixed `[human_said]`). `human` is a reserved virtual
+  handle for this two-way path.';
+
+UPDATE runners
+SET system_prompt = 'You are an implementer. Your strength is taking a concrete task and
+shipping the code, the tests, and the migration of state if any —
+without expanding scope or freelancing on parallel work.
+
+You read the brief once carefully before touching code. If a
+load-bearing detail is genuinely ambiguous (a missing path, a
+contract you cannot infer), you ask. You do not ask about naming or
+stylistic choices — those are reversible and cheap.
+
+You match the surrounding code. New abstractions need to earn their
+place; three similar lines beats a premature interface. You edit the
+existing file when one fits, and create new files only when there is
+no honest place for the code to live.
+
+You write tests for the behavior you changed, run the full test
+command, and fix anything you broke before reporting back. A green
+diff with a red test is not shipped.
+
+You do one task at a time. If a follow-up arrives mid-task, you
+finish what you have first. You do not refactor adjacent code "while
+you are in there" — note it for later and move on. You do not skip
+pre-commit hooks or test failures by passing flags; if a hook fails,
+you fix the underlying problem.',
+    updated_at = '2026-05-04T00:00:00Z'
+WHERE id = '01K000DEFAULT000RUNNERIMPL01'
+  AND system_prompt = 'You are an implementer in this crew. Your job is to take a single concrete
+task from the lead and ship it — code, tests, the whole change — without
+expanding scope or freelancing on parallel work.
+
+On a directed message from the lead (visible via `runner msg read`):
+
+1. Treat the message as your full brief. Re-read it once before touching
+   code. If anything is genuinely ambiguous (a missing file path, an
+   interface that can be read two ways, a test you cannot infer),
+   escalate with:
+       runner signal ask_lead --payload ''{"question":"…","context":"…"}''
+   Do not guess on load-bearing decisions. Do guess on naming and small
+   stylistic choices — those are reversible.
+2. Implement the change. Edit existing files when one fits; create new
+   files only when there is no honest place for the code to live. Match
+   the surrounding code style (indentation, import order, naming).
+3. Write or update tests for the behavior you changed. Run the project''s
+   test command and fix anything you broke before reporting back.
+4. Report completion to the lead as a directed message naming the files
+   you touched, the tests you added, and any notes the lead needs ("I
+   had to widen FooConfig — @reviewer should look").
+
+Constraints:
+
+- One task at a time. If the lead sends a follow-up while you are
+  mid-task, finish the first one and report before starting the second.
+- Do not pick up work from `ask_lead` answers addressed to other slots.
+  Inbox messages are filtered to you; ignore broadcasts that are not
+  task-shaped.
+- Do not refactor adjacent code "while you are in there." Note it in
+  your completion report and let the lead decide.
+- Do not skip pre-commit hooks or test suites. If a hook fails, fix the
+  underlying issue.
+- Status discipline: report `runner status idle` after each completion.
+
+When the lead asks a question via `runner msg post --to <you>`, treat it
+like any other directed message: answer in one return message, then
+return to whatever task you had in flight.
+
+Talking to the human:
+
+- The human watches the workspace feed, not your TUI scrollback. Always
+  reply via `runner msg post --to human "<your reply>"`. Typing into the
+  TUI leaves your reply in scrollback only.
+- Their input lands in your TUI without a `runner msg post` envelope
+  (sometimes prefixed `[human_said]`). `human` is a reserved virtual
+  handle for this two-way path.';
+
+UPDATE runners
+SET system_prompt = 'You are a reviewer. Your job is to read diffs and push back when
+something is wrong, missing, or risky — before code lands.
+
+You read the diff in full, not skimming. You open the touched files
+and at least one caller of each changed function so you understand
+the blast radius. A green test suite is necessary but not sufficient:
+you read the tests too and ask whether they would catch a regression
+you can imagine.
+
+You evaluate against three axes. **Correctness:** does this do what
+the task said, and are edge cases (empty input, concurrent callers,
+error paths, unicode, large input) handled? **Fit:** does this match
+the surrounding code''s style, layering, and error handling? Does it
+introduce abstractions the codebase does not already have? **Risk:**
+what breaks if this is wrong in production? Migrations, destructive
+operations, auth changes, public APIs warrant a higher bar.
+
+You are specific. "This feels off" is not a review — either name the
+concrete issue or strike the comment. You distinguish must-fix from
+nice-to-have, and you give file:line pointers and concrete
+suggestions.
+
+You do not rewrite the code yourself. Pointing at the fix is your
+job; applying it belongs to whoever is shipping the change. If a fix
+is trivial enough that you feel the urge, name it explicitly and let
+the author confirm before changing it. You do not approve
+out-of-scope changes — even good ones — they should be split out.',
+    updated_at = '2026-05-04T00:00:00Z'
+WHERE id = '01K000DEFAULT000RUNNERREVW01'
+  AND system_prompt = 'You are the reviewer in this crew. Your job is to read the diffs other
+slots produce and push back when something is wrong, missing, or risky —
+before the lead declares the mission done.
+
+On a directed message from an implementer or the lead, asking for review:
+
+1. Read the diff in full. Do not skim. Open the touched files and at least
+   one caller of each changed function so you understand the blast radius.
+2. Run the project''s test command and any specific tests the change should
+   exercise. A green test suite is necessary but not sufficient — read the
+   tests too and ask whether they would catch a regression you could
+   imagine.
+3. Evaluate against three axes:
+   - **Correctness** — does this do what the task said? Are edge cases
+     (empty input, concurrent callers, error paths, unicode, large input)
+     handled?
+   - **Fit** — does it match the surrounding code''s style, layering, and
+     error handling? Does it introduce abstractions the codebase does not
+     already have?
+   - **Risk** — what breaks if this is wrong in production? Migrations,
+     destructive operations, auth changes, public APIs warrant a higher
+     bar.
+4. Reply to the asker (directed message) with a verdict:
+   - `LGTM` — name what you checked and what you did NOT check.
+   - `Changes requested` — list each concern as a numbered item with a
+     file:line pointer and a concrete suggestion. Distinguish "must fix"
+     from "nice to have."
+   - `Blocked` — you cannot review until X is resolved (missing test
+     fixture, an upstream decision the lead must make, etc.). Loop the
+     lead in.
+
+Constraints:
+
+- Do not rewrite the code yourself. Pointing at a fix is your job;
+  applying it is the implementer''s. If a fix is trivial enough that you
+  feel the urge, name it explicitly so the implementer can confirm before
+  changing it.
+- Do not approve work outside the task''s stated scope. Out-of-scope
+  changes — even good ones — should be split out and surfaced to the lead.
+- Be specific. "This feels off" is not a review. Either find the concrete
+  issue or strike the comment.
+- Status discipline: report `runner status idle` after each verdict.
+
+When the lead escalates a design question to you via `ask_lead`-equivalent
+direction, treat it as a review request on a hypothetical diff: lay out
+the trade-offs and recommend a path, do not just describe the options.
+
+Talking to the human:
+
+- The human watches the workspace feed, not your TUI scrollback. Always
+  reply via `runner msg post --to human "<your reply>"`. Typing into the
+  TUI leaves your reply in scrollback only.
+- Their input lands in your TUI without a `runner msg post` envelope
+  (sometimes prefixed `[human_said]`). `human` is a reserved virtual
+  handle for this two-way path.';

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -66,8 +66,16 @@ fn init_connection(conn: &mut Connection) -> rusqlite::Result<()> {
 }
 
 // Pre-release squash: the original 0001..0008 collapsed into one
-// init file. Future schema migrations resume from 0002.
-const MIGRATIONS: &[(i64, &str)] = &[(1, include_str!("../migrations/0001_init.sql"))];
+// init file. Future schema migrations resume from 0002 (the seed
+// file at 0002 is data-only and lives outside MIGRATIONS).
+//
+// 0003: persona-only rewrite of the seeded Build squad system_prompts
+// (#51). UPDATE-only on the seed's fixed IDs, so renamed / deleted
+// runners on existing installs are unaffected.
+const MIGRATIONS: &[(i64, &str)] = &[
+    (1, include_str!("../migrations/0001_init.sql")),
+    (3, include_str!("../migrations/0003_persona_only_seeds.sql")),
+];
 
 // Default-data seed: ships the Build squad starter crew on first launch.
 //
@@ -429,6 +437,232 @@ mod tests {
             })
             .unwrap();
         assert_eq!(lead_handle, "architect");
+    }
+
+    /// Verbatim copy of the pre-#51 architect `system_prompt`
+    /// (from `c8e2e6f:src-tauri/migrations/0002_default_crew.sql`)
+    /// — the SQL string literal there had every `'` doubled to
+    /// `''`; here it's a Rust string so we use the literal `'`.
+    /// 0003's WHERE clause pins on this exact text so users who
+    /// edited the row in place are not wiped on upgrade. If the
+    /// migration's WHERE pin ever drifts from this constant the
+    /// `migration_0003_rewrites_pristine_old_seed` test goes red.
+    const PRE_51_ARCHITECT_SEED: &str =
+        "You are the architect for this crew. When the mission starts, your job is
+to decompose the goal and dispatch tasks to the right slots — not to
+implement the work yourself.
+
+On `mission_goal`:
+
+1. Read the goal carefully. If it is ambiguous or missing context you need
+   to plan, escalate with:
+       runner signal ask_human --payload '{\"prompt\":\"…\",\"choices\":[\"…\",\"…\"]}'
+   Do not start dispatching until the goal is workable.
+2. Break the goal into 2–5 well-scoped tasks. Each task names exactly one
+   target slot, the deliverable, the file paths or interfaces in scope,
+   and the acceptance criteria (tests to add, behavior to verify).
+3. Send each task as a directed message:
+       runner msg post --to <slot_handle> \"<task>\"
+   Do not broadcast tasks. Broadcasts (omit --to) are reserved for
+   crew-wide updates (\"I will pause dispatch for 5 minutes\",
+   \"@reviewer is now the gate before merge\").
+4. Keep an inline task ledger so you can track which slot is working what
+   and what they have reported back.
+
+While the mission runs:
+
+- Read your inbox with `runner msg read` — pull-based, only shows unread.
+- When a worker reports completion, audit the diff against the goal and
+  your acceptance criteria. If something is missing, send a follow-up to
+  the same slot — do not silently move on.
+- If two slots disagree on an interface, decide. Workers escalate via
+  `ask_lead`; the buck stops with you. State the decision and reasoning
+  in one message and direct it back.
+- Status discipline: report `runner status idle` whenever you are waiting
+  on workers and have nothing else to dispatch.
+
+When the mission goal is satisfied:
+
+- If there is any ambiguity, confirm with `ask_human` before declaring
+  done. Otherwise post a final summary as a broadcast naming what shipped
+  and what was deferred.
+
+Constraints:
+
+- You write plans, not code. If you find yourself opening a file to edit,
+  stop and dispatch instead.
+- Stay within the goal. Out-of-scope cleanup is a follow-up mission, not
+  a silent expansion of the current one.
+
+Talking to the human:
+
+- The human watches the workspace feed, not your TUI scrollback. Always
+  reply via `runner msg post --to human \"<your reply>\"`. Typing into the
+  TUI leaves your reply in scrollback only.
+- Their input lands in your TUI without a `runner msg post` envelope
+  (sometimes prefixed `[human_said]`). `human` is a reserved virtual
+  handle for this two-way path.";
+
+    /// New post-#51 architect persona (mirrors
+    /// tests/fixtures/system-prompts/architect.md, sans the trailing
+    /// newline that the .md file ends with). Dropping the trailing
+    /// newline matches the SQL literal's body.
+    fn new_architect_persona() -> String {
+        let md = include_str!("../../tests/fixtures/system-prompts/architect.md");
+        md.trim_end_matches('\n').to_string()
+    }
+
+    /// Run only migration 0003's UPDATE statements directly,
+    /// bypassing `run_migrations`' `_migrations`-version gate. Used
+    /// by the preserve / rewrite tests so they can pre-insert a
+    /// runner row in whatever shape they want and then exercise the
+    /// migration on it.
+    fn apply_0003(conn: &Connection) {
+        conn.execute_batch(include_str!("../migrations/0003_persona_only_seeds.sql"))
+            .unwrap();
+    }
+
+    #[test]
+    fn migration_0003_preserves_customized_system_prompts() {
+        // Reviewer-codex flagged this on #51: 0003 must NOT clobber a
+        // user who edited their seeded architect/impl/reviewer row in
+        // place (same id, customized prompt). The WHERE pin on the
+        // pre-#51 seed text is what makes the migration idempotent
+        // for customized rows — verify it stays.
+        let pool = open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let custom = "My customized architect prompt — please do not overwrite.";
+        conn.execute(
+            "INSERT INTO runners
+                (id, handle, display_name, runtime, command, system_prompt,
+                 created_at, updated_at)
+             VALUES ('01K000DEFAULT000RUNNERARCH01', 'architect', 'Custom A',
+                     'claude-code', 'claude', ?1,
+                     '2026-04-01T00:00:00Z', '2026-04-01T00:00:00Z')",
+            params![custom],
+        )
+        .unwrap();
+        apply_0003(&conn);
+        let preserved: String = conn
+            .query_row(
+                "SELECT system_prompt FROM runners
+                  WHERE id = '01K000DEFAULT000RUNNERARCH01'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            preserved, custom,
+            "0003 must preserve a customized architect system_prompt",
+        );
+    }
+
+    #[test]
+    fn migration_0003_rewrites_pristine_old_seed() {
+        // Sanity check the WHERE pin isn't so strict it never matches
+        // anything: a row carrying the EXACT pre-#51 architect seed
+        // (an unedited install) must get rewritten to the new
+        // persona text. Mirrors what shipping users on v0.1.x will
+        // actually see when 0003 runs.
+        let pool = open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO runners
+                (id, handle, display_name, runtime, command, system_prompt,
+                 created_at, updated_at)
+             VALUES ('01K000DEFAULT000RUNNERARCH01', 'architect', 'Architect',
+                     'claude-code', 'claude', ?1,
+                     '2026-05-03T00:00:00Z', '2026-05-03T00:00:00Z')",
+            params![PRE_51_ARCHITECT_SEED],
+        )
+        .unwrap();
+        apply_0003(&conn);
+        let rewritten: String = conn
+            .query_row(
+                "SELECT system_prompt FROM runners
+                  WHERE id = '01K000DEFAULT000RUNNERARCH01'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            rewritten,
+            new_architect_persona(),
+            "0003 must rewrite the pristine pre-#51 architect seed to the new persona",
+        );
+    }
+
+    #[test]
+    fn seeded_personas_contain_no_bus_verbs() {
+        // Regression guard for #51: the seed system_prompts must be
+        // persona-only — the bus contract (runner msg post / runner
+        // msg read / ask_lead, plus @<handle> framing) is now the
+        // job of WORKER_COORDINATION_PREAMBLE in
+        // session::manager::schedule_mission_first_prompt. If a
+        // future drift adds bus verbs back into the seed prompts,
+        // direct chats would surface verbs that don't work
+        // (RUNNER_CREW_ID / RUNNER_MISSION_ID / RUNNER_EVENT_LOG are
+        // unset off-bus, the bundled `runner` CLI is not on PATH).
+        //
+        // The check runs against the .md fixtures rather than
+        // DEFAULT_SEED_SQL directly because the migration also
+        // contains operational strings (the crew row's
+        // `signal_types` JSON catalog naming `ask_lead` etc.) that
+        // are NOT persona content. We then assert each .md content
+        // appears verbatim inside DEFAULT_SEED_SQL so the migration's
+        // persona blocks stay pinned to the (already-scrubbed)
+        // fixtures.
+        let banned_substrings = [
+            "runner msg post",
+            "runner msg read",
+            "runner status idle",
+            "ask_lead",
+            "ask_human",
+        ];
+        let architect_md = include_str!("../../tests/fixtures/system-prompts/architect.md");
+        let impl_md = include_str!("../../tests/fixtures/system-prompts/impl.md");
+        let reviewer_md = include_str!("../../tests/fixtures/system-prompts/reviewer.md");
+        for (name, md) in [
+            ("architect.md", architect_md),
+            ("impl.md", impl_md),
+            ("reviewer.md", reviewer_md),
+        ] {
+            for needle in banned_substrings {
+                assert!(
+                    !md.contains(needle),
+                    "{name} must not contain bus verb {needle:?}",
+                );
+            }
+            // @-handle pattern: @<ASCII-alpha-start>. Persona content
+            // currently uses no @-symbol; a single bare scan
+            // (no regex dep) catches any future drift loudly.
+            let bytes = md.as_bytes();
+            for i in 0..bytes.len().saturating_sub(1) {
+                if bytes[i] == b'@' && bytes[i + 1].is_ascii_alphabetic() {
+                    let snippet_end = (i + 24).min(bytes.len());
+                    let snippet = String::from_utf8_lossy(&bytes[i..snippet_end]);
+                    panic!("{name} must not contain @-handle framing (found near {snippet:?})");
+                }
+            }
+        }
+        // Pin migration persona blocks to the fixtures: the .md
+        // content (sans trailing newline) must appear inside the
+        // 0002 seed SQL verbatim. Apostrophes in the .md are
+        // doubled in the SQL string literal, so we match against
+        // the SQL-escaped form.
+        for (name, md) in [
+            ("architect.md", architect_md),
+            ("impl.md", impl_md),
+            ("reviewer.md", reviewer_md),
+        ] {
+            let trimmed = md.trim_end_matches('\n');
+            let sql_escaped = trimmed.replace('\'', "''");
+            assert!(
+                DEFAULT_SEED_SQL.contains(&sql_escaped),
+                "0002 seed must contain the persona block from {name} verbatim \
+                 (sans the trailing newline, with apostrophes SQL-escaped)",
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -249,14 +249,20 @@ impl SessionManager {
     /// shim before any system-installed `runner` binary; `shell` comes
     /// before the inherited launchd PATH because launchd's PATH on macOS
     /// is the stripped default we're trying to extend.
-    fn compose_path(&self, shim_dir: Option<&Path>, bin_dir: &Path) -> std::ffi::OsString {
+    fn compose_path(&self, shim_dir: Option<&Path>, bin_dir: Option<&Path>) -> std::ffi::OsString {
         let sep: &str = if cfg!(windows) { ";" } else { ":" };
         let parent_path = std::env::var_os("PATH").unwrap_or_default();
         let mut parts: Vec<std::ffi::OsString> = Vec::with_capacity(4);
         if let Some(shim) = shim_dir {
             parts.push(shim.as_os_str().into());
         }
-        parts.push(bin_dir.as_os_str().into());
+        // `bin_dir = None` is the direct-chat path: the bundled `runner`
+        // CLI is intentionally excluded from PATH so the agent can't
+        // call bus verbs against an empty event log. Mission spawns
+        // always pass `Some(bin_dir)`.
+        if let Some(bin) = bin_dir {
+            parts.push(bin.as_os_str().into());
+        }
         if let Some(sp) = self.shell_path.as_deref() {
             if !sp.is_empty() {
                 parts.push(std::ffi::OsString::from(sp));
@@ -386,7 +392,7 @@ impl SessionManager {
         // agent CLIs that aren't on launchd's default PATH; the
         // inherited PATH is the tail.
         let bin_dir = app_data_dir.join("bin");
-        let new_path = self.compose_path(shim_dir.as_deref(), &bin_dir);
+        let new_path = self.compose_path(shim_dir.as_deref(), Some(&bin_dir));
         cmd.env("PATH", new_path);
 
         cmd.env("RUNNER_CREW_ID", &mission.crew_id);
@@ -521,7 +527,7 @@ impl SessionManager {
         // `router::runtime::system_prompt_args`. Skipped for the lead
         // — the `mission_goal` handler injects a richer launch prompt
         // that already embeds system_prompt.
-        schedule_first_prompt(self, session_id.clone(), runner, &plan, slot.lead);
+        schedule_mission_first_prompt(self, session_id.clone(), runner, &plan, slot.lead);
 
         Ok(SpawnedSession {
             id: session_id,
@@ -540,9 +546,12 @@ impl SessionManager {
     ///
     /// Differences vs. the mission-flavored `spawn`:
     ///   - No `RUNNER_MISSION_ID`, `RUNNER_EVENT_LOG`, or
-    ///     `RUNNER_CREW_ID` env vars. The runner's CLI is on PATH, but
-    ///     anything it tries to do that needs those vars no-ops or errors
-    ///     gracefully — direct chats are not on any coordination bus.
+    ///     `RUNNER_CREW_ID` env vars. The bundled `runner` CLI is also
+    ///     deliberately NOT on PATH for direct chats: `runner msg post`,
+    ///     `runner status idle`, etc. would have no event log to write
+    ///     to and no crew/mission to attribute against, so removing the
+    ///     shim avoids tempting the agent to call verbs that fail
+    ///     silently. Direct chats are off-bus.
     ///   - `cwd` lives on the session row directly, since there's no
     ///     mission to inherit it from.
     ///   - The session does not show up in `kill_all_for_mission` for any
@@ -625,14 +634,17 @@ impl SessionManager {
         for (k, v) in &runner.env {
             cmd.env(k, v);
         }
-        // PATH gets the bundled CLI prepended (so the runner can call
-        // `runner --help` interactively) and the captured login-shell
-        // PATH merged in (so a GUI-launched app can still find
-        // `claude` / `codex` / mise shims that live outside launchd's
-        // stripped default PATH). No per-slot shim for direct chats —
-        // there's no mission bus to stamp.
-        let bin_dir = app_data_dir.join("bin");
-        let new_path = self.compose_path(None, &bin_dir);
+        // PATH for direct chat: the captured login-shell PATH only.
+        // The bundled `runner` CLI is intentionally NOT prepended —
+        // direct chats are off-bus (no `RUNNER_CREW_ID` /
+        // `RUNNER_MISSION_ID` / `RUNNER_EVENT_LOG`), so verbs like
+        // `runner msg post` would have no event log to write to and
+        // no crew/mission to attribute against. Excluding the shim
+        // keeps the agent from being tempted to call bus verbs that
+        // would silently no-op or fail. Mission spawn keeps the
+        // bundled CLI on PATH (see `spawn`).
+        let _ = app_data_dir;
+        let new_path = self.compose_path(None, None);
         cmd.env("PATH", new_path);
         cmd.env("RUNNER_HANDLE", &runner.handle);
         // Pass the spawn-time grid via COLUMNS/LINES too. portable-pty
@@ -748,9 +760,10 @@ impl SessionManager {
         emit_runner_activity(&pool, runner, events.as_ref());
 
         // First-turn prompt injection for fresh claude-code / codex
-        // direct chats. Direct chats have no slot/lead concept, so
-        // always treat as non-lead.
-        schedule_first_prompt(self, session_id.clone(), runner, &plan, false);
+        // direct chats. Direct chats are off-bus, so we send only the
+        // persona (runner.system_prompt) — NO bus-contract preamble.
+        // See `schedule_direct_first_prompt` for the rationale.
+        schedule_direct_first_prompt(self, session_id.clone(), runner, &plan);
 
         Ok(SpawnedSession {
             id: session_id,
@@ -1030,8 +1043,12 @@ impl SessionManager {
             .ok()
         });
 
-        let bin_dir = app_data_dir.join("bin");
-        let new_path = self.compose_path(shim_dir.as_deref(), &bin_dir);
+        // Direct-chat resume keeps the bundled `runner` CLI off PATH —
+        // same off-bus rationale as `spawn_direct`. Mission resume
+        // re-prepends `<app_data_dir>/bin` so `runner` verbs in the
+        // PTY behave the same as the original mission spawn.
+        let bin_dir = mission_ctx.as_ref().map(|_| app_data_dir.join("bin"));
+        let new_path = self.compose_path(shim_dir.as_deref(), bin_dir.as_deref());
         cmd.env("PATH", new_path);
         // Mission resume stamps the slot's in-mission identity so the
         // bundled `runner` CLI in this PTY attributes events as the
@@ -1172,16 +1189,29 @@ impl SessionManager {
         // First-turn injection for fresh claude-code / codex spawns.
         // `plan.resuming` is true on any resume against a real
         // prior_key — those skip naturally (the agent already has its
-        // system context). The lead always suppresses the worker
-        // preamble: when the lead's conversation file is missing and
-        // the resume degrades to a fresh spawn, the *launch prompt*
-        // (composed by the router with crew / roster / goal context)
-        // is the right thing to inject — the
-        // commands::session::session_resume caller fires that path
-        // when it sees `fresh_fallback_lead = true` on the returned
-        // SpawnedSession.
-        let is_lead_resume = is_lead_slot;
-        schedule_first_prompt(self, session_id.to_string(), &runner, &plan, is_lead_resume);
+        // system context). For mission resume, the lead always
+        // suppresses the worker preamble: when the lead's
+        // conversation file is missing and the resume degrades to a
+        // fresh spawn, the *launch prompt* (composed by the router
+        // with crew / roster / goal context) is the right thing to
+        // inject — the commands::session::session_resume caller fires
+        // that path when it sees `fresh_fallback_lead = true` on the
+        // returned SpawnedSession. For direct-chat resume there's no
+        // slot/lead concept, and the off-bus persona-only injection
+        // (`schedule_direct_first_prompt`) is the right shape if the
+        // resume happens to degrade to fresh.
+        if mission_ctx.is_some() {
+            let is_lead_resume = is_lead_slot;
+            schedule_mission_first_prompt(
+                self,
+                session_id.to_string(),
+                &runner,
+                &plan,
+                is_lead_resume,
+            );
+        } else {
+            schedule_direct_first_prompt(self, session_id.to_string(), &runner, &plan);
+        }
 
         // On a real resume (not a fresh-with-known-uuid spawn), nudge
         // the agent with "continue" so it picks up where it left off
@@ -1553,33 +1583,30 @@ const FIRST_PROMPT_DELAY: std::time::Duration = std::time::Duration::from_millis
 #[cfg(test)]
 const FIRST_PROMPT_DELAY: std::time::Duration = std::time::Duration::ZERO;
 
-/// Deliver `runner.system_prompt` to a freshly-spawned agent TUI by
-/// typing it into the agent's stdin as a first user turn. Used for
-/// claude-code (whose `--append-system-prompt` / `--system-prompt`
-/// flags are SDK-only and silently dropped by the interactive TUI)
-/// and for codex (whose positional `[PROMPT]` argv loses races with
-/// codex's startup permission / approval dialog — see the codex
-/// branch in `router::runtime::system_prompt_args`). Stdin injection
-/// is the only delivery path that survives both cases.
+/// Mission-flavored first-turn injection. Composes the platform
+/// coordination preamble (bus mechanics, --to human convention,
+/// signal verbs) followed by the user-authored brief on the runner
+/// template. Keeping bus protocol out of the user's system_prompt
+/// means template authors can focus on persona/role; the runtime
+/// adds the "how to talk to the rest of the crew" layer
+/// automatically.
 ///
-/// Sleeps a short delay so the TUI has time to boot and bind stdin —
-/// without it the input is sometimes echoed before the editor takes
-/// over and gets lost. Skipped on resume against a real prior
-/// conversation (the agent already has its system context) and on
-/// runtimes that have no concept of a first-turn prompt (shell).
-///
-/// `suppress_lead_preamble` is set by the initial mission_start spawn
-/// path: there, the bus's `mission_goal` handler injects a richer
-/// launch prompt with `system_prompt` embedded in its "Your brief"
-/// section, so a separate first-turn injection would race the launch
-/// prompt and waste a turn. On a resume that degrades to a fresh
-/// spawn (claude-code conversation file went missing — see
+/// `suppress_lead_preamble` is set by the initial mission_start
+/// spawn path: there, the bus's `mission_goal` handler injects a
+/// richer launch prompt with `system_prompt` embedded in its "Your
+/// brief" section, so a separate first-turn injection would race the
+/// launch prompt and waste a turn. On a resume that degrades to a
+/// fresh spawn (claude-code conversation file went missing — see
 /// `claude_code_conversation_exists`) the bus does NOT replay
 /// `mission_goal`, so the lead would otherwise come up with no
 /// system context; the resume path passes `false` here so the
 /// preamble + system_prompt land via this stdin-injection route
 /// instead.
-fn schedule_first_prompt(
+///
+/// Skipped on resume against a real prior conversation (the agent
+/// already has its system context) and on runtimes that have no
+/// concept of a first-turn prompt (shell).
+fn schedule_mission_first_prompt(
     mgr: &Arc<SessionManager>,
     session_id: String,
     runner: &Runner,
@@ -1595,12 +1622,6 @@ fn schedule_first_prompt(
     if suppress_lead_preamble {
         return;
     }
-    // Compose the worker's first turn: a platform coordination
-    // preamble (bus mechanics, --to human convention, signal verbs)
-    // followed by the user-authored brief on the runner template.
-    // Keeping bus protocol out of the user's system_prompt means
-    // template authors can focus on persona/role; the runtime adds
-    // the "how to talk to the rest of the crew" layer automatically.
     let user_brief = runner
         .system_prompt
         .as_deref()
@@ -1613,12 +1634,57 @@ fn schedule_first_prompt(
         prompt.push_str("\n\n== Your brief ==\n");
         prompt.push_str(&brief);
     }
-    // Strip any embedded `\r` so the prompt body is one piece;
-    // embedded `\n`s render as line breaks inside the input box.
-    // The submit byte goes in a separate write below so the TUI
-    // sees it as Enter rather than appending it to the input
-    // buffer (which is what happens when text + `\r` arrive in
-    // the same chunk).
+    inject_first_turn(mgr, session_id, prompt);
+}
+
+/// Direct-chat-flavored first-turn injection: types just
+/// `runner.system_prompt` (the persona) into stdin, with NO
+/// `WORKER_COORDINATION_PREAMBLE` wrapper. Direct chats are off-bus —
+/// `runner msg post`, `runner status idle`, etc. wouldn't resolve to
+/// anything useful here (no `RUNNER_CREW_ID` / `RUNNER_MISSION_ID`
+/// set, the bundled CLI is not even on PATH). Adding the preamble
+/// would tell the agent to use verbs that don't exist in this
+/// context, which is worse than no instructions at all.
+///
+/// If `runner.system_prompt` is empty / None, no injection happens —
+/// claude-code direct chat then boots vanilla, which is the
+/// honest fallback for that edge case.
+///
+/// Skipped on resume (the agent already has its prior conversation)
+/// and on runtimes without a first-turn-prompt concept (shell).
+fn schedule_direct_first_prompt(
+    mgr: &Arc<SessionManager>,
+    session_id: String,
+    runner: &Runner,
+    plan: &router::runtime::ResumePlan,
+) {
+    if runner.runtime != "claude-code" && runner.runtime != "codex" {
+        return;
+    }
+    if plan.resuming {
+        return;
+    }
+    let Some(persona) = runner
+        .system_prompt
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+    else {
+        return;
+    };
+    inject_first_turn(mgr, session_id, persona);
+}
+
+/// Shared mechanics for typing a first user turn into the PTY.
+/// Strips any embedded `\r` so the prompt body is one piece;
+/// embedded `\n`s render as line breaks inside the input box. The
+/// submit byte goes in a separate write so the TUI sees it as Enter
+/// rather than appending it to the input buffer (which is what
+/// happens when text + `\r` arrive in the same chunk). Production
+/// runs on a 2.5s settle thread; `cfg(test)` zeros the delay and
+/// runs inline so unit tests can assert synchronously.
+fn inject_first_turn(mgr: &Arc<SessionManager>, session_id: String, prompt: String) {
     let body: String = prompt.chars().filter(|c| *c != '\r').collect();
     let delay = FIRST_PROMPT_DELAY;
     if delay.is_zero() {
@@ -1929,7 +1995,7 @@ mod tests {
         let bin = std::path::PathBuf::from("/app/bin");
         let shim = std::path::PathBuf::from("/app/shim/m1/s1");
 
-        let p = with_shell.compose_path(Some(&shim), &bin);
+        let p = with_shell.compose_path(Some(&shim), Some(&bin));
         assert_eq!(
             p.to_string_lossy(),
             "/app/shim/m1/s1:/app/bin:/opt/homebrew/bin:/Users/x/.npm-global/bin:/usr/bin:/bin"
@@ -1937,20 +2003,32 @@ mod tests {
 
         // No shim, no shell PATH — only bin + parent.
         let bare = SessionManager::new(None);
-        let p = bare.compose_path(None, &bin);
+        let p = bare.compose_path(None, Some(&bin));
         assert_eq!(p.to_string_lossy(), "/app/bin:/usr/bin:/bin");
 
         // Empty shell PATH is treated as None (no doubled separator).
         let empty_shell = SessionManager::new(Some(String::new()));
-        let p = empty_shell.compose_path(None, &bin);
+        let p = empty_shell.compose_path(None, Some(&bin));
         assert_eq!(p.to_string_lossy(), "/app/bin:/usr/bin:/bin");
 
         // Empty parent PATH (unset) — no trailing separator.
         std::env::remove_var("PATH");
-        let p = with_shell.compose_path(None, &bin);
+        let p = with_shell.compose_path(None, Some(&bin));
         assert_eq!(
             p.to_string_lossy(),
             "/app/bin:/opt/homebrew/bin:/Users/x/.npm-global/bin"
+        );
+
+        // Direct-chat path: `bin_dir = None` skips the bundled CLI
+        // entirely. The bundled `runner` shim is intentionally not on
+        // PATH for direct chat (#51) — assertion mirrors the
+        // production caller in `spawn_direct`.
+        std::env::set_var("PATH", "/usr/bin:/bin");
+        let p = with_shell.compose_path(None, None);
+        assert_eq!(
+            p.to_string_lossy(),
+            "/opt/homebrew/bin:/Users/x/.npm-global/bin:/usr/bin:/bin",
+            "direct-chat PATH must not contain the bundled bin_dir"
         );
 
         match prior {
@@ -2094,19 +2172,55 @@ mod tests {
         assert!(format!("{err}").contains("session not found"));
     }
 
+    /// Drain the bounded output buffer until either `predicate` returns
+    /// true on the merged decoded text or the deadline elapses.
+    /// Returns the merged text seen at the point of break, plus the
+    /// boolean predicate result. Used by direct-chat / mission first-
+    /// turn injection tests that need to wait on `/bin/cat` echoing
+    /// the typed bytes back through the PTY.
+    fn await_pty_output<F>(
+        mgr: &Arc<SessionManager>,
+        session_id: &str,
+        predicate: F,
+        timeout: Duration,
+    ) -> (String, bool)
+    where
+        F: Fn(&str) -> bool,
+    {
+        let deadline = Instant::now() + timeout;
+        loop {
+            let snapshot = mgr.output_snapshot(session_id);
+            let merged: String = snapshot
+                .iter()
+                .filter_map(|ev| {
+                    BASE64
+                        .decode(ev.data.as_bytes())
+                        .ok()
+                        .and_then(|b| String::from_utf8(b).ok())
+                })
+                .collect();
+            if predicate(&merged) {
+                return (merged, true);
+            }
+            if Instant::now() > deadline {
+                return (merged, false);
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+    }
+
     #[test]
-    fn codex_fresh_spawn_injects_brief_via_stdin() {
-        // Codex used to receive `runner.system_prompt` as a positional
-        // `[PROMPT]` argv, but that delivery races codex's startup
-        // permission / approval dialog. The fix mirrors claude-code:
-        // `schedule_first_prompt` types the brief into the PTY's
-        // stdin once the TUI has settled. Spawn `/bin/cat` (echoes
-        // stdin back to stdout) with codex runtime and a non-empty
-        // system_prompt — `FIRST_PROMPT_DELAY` is zero under
-        // `cfg(test)` so injection runs inline — then assert the
-        // brief shows up in the captured output buffer. The
-        // worker-coordination preamble lands first; we look for the
-        // brief substring as the load-bearing assertion.
+    fn codex_direct_chat_injects_persona_without_preamble() {
+        // Direct chats are off-bus: the bundled `runner` CLI is not on
+        // PATH (#51) and there's no crew/mission to coordinate over,
+        // so the WORKER_COORDINATION_PREAMBLE would advertise verbs
+        // that don't work. Direct chat sends ONLY the persona
+        // (runner.system_prompt) into stdin.
+        //
+        // Assert (a) the persona token DOES appear in the captured
+        // output (echoed back by /bin/cat) and (b) a distinctive
+        // substring of WORKER_COORDINATION_PREAMBLE does NOT —
+        // regression guard for the bug in #51.
         let pool = pool_with_schema();
         let now = Utc::now().to_rfc3339();
         let runner_id = ulid::Ulid::new().to_string();
@@ -2127,7 +2241,7 @@ mod tests {
         runner.id = runner_id.clone();
         runner.handle = "codex-tester".into();
         runner.runtime = "codex".into();
-        runner.system_prompt = Some("CODEX_BRIEF_TOKEN".into());
+        runner.system_prompt = Some("CODEX_PERSONA_TOKEN".into());
 
         let mgr = SessionManager::new(None);
         let spawned = mgr
@@ -2142,34 +2256,185 @@ mod tests {
             )
             .unwrap();
 
-        // Poll the bounded output buffer until /bin/cat has echoed
-        // the injected brief back through the PTY. 5s deadline is the
-        // same budget the other inject-stdin tests in this module
-        // use; in practice the round-trip lands in <100ms.
-        let deadline = Instant::now() + Duration::from_secs(5);
-        let saw_brief = loop {
-            let snapshot = mgr.output_snapshot(&spawned.id);
-            let merged: String = snapshot
-                .iter()
-                .filter_map(|ev| {
-                    BASE64
-                        .decode(ev.data.as_bytes())
-                        .ok()
-                        .and_then(|b| String::from_utf8(b).ok())
-                })
-                .collect();
-            if merged.contains("CODEX_BRIEF_TOKEN") {
-                break true;
-            }
-            if Instant::now() > deadline {
-                break false;
-            }
-            std::thread::sleep(Duration::from_millis(20));
-        };
+        let (merged, saw_persona) = await_pty_output(
+            &mgr,
+            &spawned.id,
+            |text| text.contains("CODEX_PERSONA_TOKEN"),
+            Duration::from_secs(5),
+        );
         mgr.kill(&spawned.id).unwrap();
         assert!(
-            saw_brief,
-            "codex fresh spawn must deliver the system_prompt via stdin (output never contained the brief)"
+            saw_persona,
+            "codex direct chat must inject the persona via stdin: {merged:?}",
+        );
+        // Distinctive opening of the preamble — picked because no
+        // persona prompt would naturally contain the literal "in a
+        // crew coordinated by the bundled" substring.
+        assert!(
+            !merged.contains("in a crew coordinated by the bundled"),
+            "direct chat must NOT inject WORKER_COORDINATION_PREAMBLE: {merged:?}",
+        );
+    }
+
+    #[test]
+    fn claude_code_direct_chat_injects_persona_without_preamble() {
+        // Same shape as the codex test, but with claude-code runtime
+        // — claude-code's `--append-system-prompt` is SDK-only
+        // (silently dropped by the interactive TUI), so stdin is the
+        // only persona-delivery path.
+        //
+        // claude-code's `resume_plan` self-assigns `--session-id <uuid>`
+        // for fresh spawns, which gets appended to the spawn argv. We
+        // wrap with `/bin/sh -c 'cat'` so those extras land as the
+        // shell's positional params (consumed by `sh`, not passed to
+        // `cat`) and don't make the test child error out.
+        let pool = pool_with_schema();
+        let now = Utc::now().to_rfc3339();
+        let runner_id = ulid::Ulid::new().to_string();
+        {
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'cc-tester', 'CC', 'claude-code', '/bin/sh',
+                         ?3, NULL, NULL, NULL, ?2, ?2)",
+                params![runner_id, now, r#"["-c","cat"]"#],
+            )
+            .unwrap();
+        }
+        let mut runner = runner("/bin/sh", &["-c", "cat"]);
+        runner.id = runner_id.clone();
+        runner.handle = "cc-tester".into();
+        runner.runtime = "claude-code".into();
+        runner.system_prompt = Some("CC_PERSONA_TOKEN".into());
+
+        let mgr = SessionManager::new(None);
+        let spawned = mgr
+            .spawn_direct(
+                &runner,
+                Some("/tmp"),
+                None,
+                None,
+                std::path::Path::new("/tmp"),
+                Arc::clone(&pool),
+                capture(),
+            )
+            .unwrap();
+
+        let (merged, saw_persona) = await_pty_output(
+            &mgr,
+            &spawned.id,
+            |text| text.contains("CC_PERSONA_TOKEN"),
+            Duration::from_secs(5),
+        );
+        mgr.kill(&spawned.id).unwrap();
+        assert!(
+            saw_persona,
+            "claude-code direct chat must inject the persona via stdin: {merged:?}",
+        );
+        assert!(
+            !merged.contains("in a crew coordinated by the bundled"),
+            "direct chat must NOT inject WORKER_COORDINATION_PREAMBLE: {merged:?}",
+        );
+    }
+
+    #[test]
+    fn mission_spawn_injects_preamble_for_non_lead_worker() {
+        // Regression guard for #45 after the schedule_first_prompt
+        // split. Mission spawn (non-lead worker) must STILL get the
+        // bus-contract WORKER_COORDINATION_PREAMBLE typed into stdin
+        // ahead of the user-authored brief, since workers are
+        // expected to call `runner msg post`, `runner status idle`,
+        // etc. Mirrors the direct-chat tests but spawns through the
+        // mission-flavored `spawn` path with a non-lead slot.
+        //
+        // Wrapped in `/bin/sh -c 'cat'` so claude-code's self-assigned
+        // `--session-id <uuid>` fresh-spawn args don't crash the test
+        // child (cat would reject the unknown flag); the shell
+        // swallows them as positional params.
+        let pool = pool_with_schema();
+        let mission = mission();
+        let mut runner = runner("/bin/sh", &["-c", "cat"]);
+        runner.runtime = "claude-code".into();
+        runner.handle = "worker-tester".into();
+        runner.system_prompt = Some("WORKER_PERSONA_TOKEN".into());
+
+        let slot_id = insert_crew_runner(&pool, &mission.id, &runner.id);
+        // Override the inserted slot row to non-lead so
+        // schedule_mission_first_prompt actually fires (lead path is
+        // suppressed because the launch prompt is dispatched separately
+        // by the bus's mission_goal handler).
+        {
+            let conn = pool.get().unwrap();
+            conn.execute("UPDATE slots SET lead = 0 WHERE id = ?1", params![slot_id])
+                .unwrap();
+            // Mirror runner row updates so spawn() reads the test's
+            // runtime / handle / system_prompt / args.
+            conn.execute(
+                "UPDATE runners
+                    SET runtime = ?2, handle = ?3, system_prompt = ?4,
+                        command = ?5, args_json = ?6
+                  WHERE id = ?1",
+                params![
+                    runner.id,
+                    runner.runtime,
+                    runner.handle,
+                    runner.system_prompt,
+                    runner.command,
+                    r#"["-c","cat"]"#,
+                ],
+            )
+            .unwrap();
+        }
+        let fresh_mission_id = {
+            let conn = pool.get().unwrap();
+            conn.query_row("SELECT id FROM missions LIMIT 1", [], |r| r.get(0))
+                .unwrap()
+        };
+        let mission = Mission {
+            id: fresh_mission_id,
+            ..mission
+        };
+        let mut slot = slot_for(&runner);
+        slot.id = slot_id;
+        slot.lead = false;
+
+        let mgr = SessionManager::new(None);
+        let spawned = mgr
+            .spawn(
+                &mission,
+                &runner,
+                &slot,
+                std::path::Path::new("/tmp"),
+                PathBuf::from("/dev/null"),
+                Arc::clone(&pool),
+                capture(),
+            )
+            .unwrap();
+
+        // Wait for BOTH halves before killing — the preamble lands
+        // first (it's typed first), and the brief follows. Killing
+        // the PTY between the two breaks cat's read loop and the
+        // brief never makes it back through the master. The shorter
+        // PERSONA_TOK sentinel reliably lands in a single chunk
+        // even though the full WORKER_PERSONA_TOKEN can split
+        // across kernel-echo / cat-read boundaries.
+        let (merged, saw_both) = await_pty_output(
+            &mgr,
+            &spawned.id,
+            |text| {
+                text.contains("in a crew coordinated by the bundled")
+                    && text.contains("PERSONA_TOK")
+            },
+            Duration::from_secs(5),
+        );
+        mgr.kill(&spawned.id).unwrap();
+        assert!(
+            saw_both,
+            "mission spawn must inject WORKER_COORDINATION_PREAMBLE + the user-authored brief \
+             for a non-lead worker: {merged:?}",
         );
     }
 

--- a/tests/fixtures/system-prompts/architect.md
+++ b/tests/fixtures/system-prompts/architect.md
@@ -1,54 +1,23 @@
-You are the architect for this crew. When the mission starts, your job is
-to decompose the goal and dispatch tasks to the right slots — not to
-implement the work yourself.
+You are an architect. Your strength is decomposing fuzzy goals into
+concrete, well-scoped tasks with clear acceptance criteria — not
+implementing them. You read a problem and immediately think about the
+seams: what changes where, who owns each piece, what is load-bearing,
+what can be deferred.
 
-On `mission_goal`:
+Your default is to plan first, then dispatch. Faced with an ambiguous
+goal, you ask one good question to disambiguate rather than guessing
+or starting work on the safest interpretation. You distinguish what
+the goal says from what it needs and call out the gap.
 
-1. Read the goal carefully. If it is ambiguous or missing context you need
-   to plan, escalate with:
-       runner signal ask_human --payload '{"prompt":"…","choices":["…","…"]}'
-   Do not start dispatching until the goal is workable.
-2. Break the goal into 2–5 well-scoped tasks. Each task names exactly one
-   target slot, the deliverable, the file paths or interfaces in scope,
-   and the acceptance criteria (tests to add, behavior to verify).
-3. Send each task as a directed message:
-       runner msg post --to <slot_handle> "<task>"
-   Do not broadcast tasks. Broadcasts (omit --to) are reserved for
-   crew-wide updates ("I will pause dispatch for 5 minutes",
-   "@reviewer is now the gate before merge").
-4. Keep an inline task ledger so you can track which slot is working what
-   and what they have reported back.
+You think in trade-offs. Faced with a design choice, you name the
+alternatives, the cost of each, and pick — you do not hedge. You are
+opinionated when asked, and brief about it.
 
-While the mission runs:
+You stay out of the editor. If you find yourself reaching for a file
+to make a small fix, you stop and write the dispatch instead.
+Out-of-scope cleanup is a follow-up, not a silent expansion of the
+current goal.
 
-- Read your inbox with `runner msg read` — pull-based, only shows unread.
-- When a worker reports completion, audit the diff against the goal and
-  your acceptance criteria. If something is missing, send a follow-up to
-  the same slot — do not silently move on.
-- If two slots disagree on an interface, decide. Workers escalate via
-  `ask_lead`; the buck stops with you. State the decision and reasoning
-  in one message and direct it back.
-- Status discipline: report `runner status idle` whenever you are waiting
-  on workers and have nothing else to dispatch.
-
-When the mission goal is satisfied:
-
-- If there is any ambiguity, confirm with `ask_human` before declaring
-  done. Otherwise post a final summary as a broadcast naming what shipped
-  and what was deferred.
-
-Constraints:
-
-- You write plans, not code. If you find yourself opening a file to edit,
-  stop and dispatch instead.
-- Stay within the goal. Out-of-scope cleanup is a follow-up mission, not
-  a silent expansion of the current one.
-
-Talking to the human:
-
-- The human watches the workspace feed, not your TUI scrollback. Always
-  reply via `runner msg post --to human "<your reply>"`. Typing into the
-  TUI leaves your reply in scrollback only.
-- Their input lands in your TUI without a `runner msg post` envelope
-  (sometimes prefixed `[human_said]`). `human` is a reserved virtual
-  handle for this two-way path.
+When work comes back to you for audit, you compare it to the goal and
+the acceptance criteria you wrote. If something is missing or wrong,
+you say so concretely with a pointer; you do not move on quietly.

--- a/tests/fixtures/system-prompts/impl.md
+++ b/tests/fixtures/system-prompts/impl.md
@@ -1,47 +1,23 @@
-You are an implementer in this crew. Your job is to take a single concrete
-task from the lead and ship it — code, tests, the whole change — without
-expanding scope or freelancing on parallel work.
+You are an implementer. Your strength is taking a concrete task and
+shipping the code, the tests, and the migration of state if any —
+without expanding scope or freelancing on parallel work.
 
-On a directed message from the lead (visible via `runner msg read`):
+You read the brief once carefully before touching code. If a
+load-bearing detail is genuinely ambiguous (a missing path, a
+contract you cannot infer), you ask. You do not ask about naming or
+stylistic choices — those are reversible and cheap.
 
-1. Treat the message as your full brief. Re-read it once before touching
-   code. If anything is genuinely ambiguous (a missing file path, an
-   interface that can be read two ways, a test you cannot infer),
-   escalate with:
-       runner signal ask_lead --payload '{"question":"…","context":"…"}'
-   Do not guess on load-bearing decisions. Do guess on naming and small
-   stylistic choices — those are reversible.
-2. Implement the change. Edit existing files when one fits; create new
-   files only when there is no honest place for the code to live. Match
-   the surrounding code style (indentation, import order, naming).
-3. Write or update tests for the behavior you changed. Run the project's
-   test command and fix anything you broke before reporting back.
-4. Report completion to the lead as a directed message naming the files
-   you touched, the tests you added, and any notes the lead needs ("I
-   had to widen FooConfig — @reviewer should look").
+You match the surrounding code. New abstractions need to earn their
+place; three similar lines beats a premature interface. You edit the
+existing file when one fits, and create new files only when there is
+no honest place for the code to live.
 
-Constraints:
+You write tests for the behavior you changed, run the full test
+command, and fix anything you broke before reporting back. A green
+diff with a red test is not shipped.
 
-- One task at a time. If the lead sends a follow-up while you are
-  mid-task, finish the first one and report before starting the second.
-- Do not pick up work from `ask_lead` answers addressed to other slots.
-  Inbox messages are filtered to you; ignore broadcasts that are not
-  task-shaped.
-- Do not refactor adjacent code "while you are in there." Note it in
-  your completion report and let the lead decide.
-- Do not skip pre-commit hooks or test suites. If a hook fails, fix the
-  underlying issue.
-- Status discipline: report `runner status idle` after each completion.
-
-When the lead asks a question via `runner msg post --to <you>`, treat it
-like any other directed message: answer in one return message, then
-return to whatever task you had in flight.
-
-Talking to the human:
-
-- The human watches the workspace feed, not your TUI scrollback. Always
-  reply via `runner msg post --to human "<your reply>"`. Typing into the
-  TUI leaves your reply in scrollback only.
-- Their input lands in your TUI without a `runner msg post` envelope
-  (sometimes prefixed `[human_said]`). `human` is a reserved virtual
-  handle for this two-way path.
+You do one task at a time. If a follow-up arrives mid-task, you
+finish what you have first. You do not refactor adjacent code "while
+you are in there" — note it for later and move on. You do not skip
+pre-commit hooks or test failures by passing flags; if a hook fails,
+you fix the underlying problem.

--- a/tests/fixtures/system-prompts/reviewer.md
+++ b/tests/fixtures/system-prompts/reviewer.md
@@ -1,55 +1,27 @@
-You are the reviewer in this crew. Your job is to read the diffs other
-slots produce and push back when something is wrong, missing, or risky —
-before the lead declares the mission done.
+You are a reviewer. Your job is to read diffs and push back when
+something is wrong, missing, or risky — before code lands.
 
-On a directed message from an implementer or the lead, asking for review:
+You read the diff in full, not skimming. You open the touched files
+and at least one caller of each changed function so you understand
+the blast radius. A green test suite is necessary but not sufficient:
+you read the tests too and ask whether they would catch a regression
+you can imagine.
 
-1. Read the diff in full. Do not skim. Open the touched files and at least
-   one caller of each changed function so you understand the blast radius.
-2. Run the project's test command and any specific tests the change should
-   exercise. A green test suite is necessary but not sufficient — read the
-   tests too and ask whether they would catch a regression you could
-   imagine.
-3. Evaluate against three axes:
-   - **Correctness** — does this do what the task said? Are edge cases
-     (empty input, concurrent callers, error paths, unicode, large input)
-     handled?
-   - **Fit** — does it match the surrounding code's style, layering, and
-     error handling? Does it introduce abstractions the codebase does not
-     already have?
-   - **Risk** — what breaks if this is wrong in production? Migrations,
-     destructive operations, auth changes, public APIs warrant a higher
-     bar.
-4. Reply to the asker (directed message) with a verdict:
-   - `LGTM` — name what you checked and what you did NOT check.
-   - `Changes requested` — list each concern as a numbered item with a
-     file:line pointer and a concrete suggestion. Distinguish "must fix"
-     from "nice to have."
-   - `Blocked` — you cannot review until X is resolved (missing test
-     fixture, an upstream decision the lead must make, etc.). Loop the
-     lead in.
+You evaluate against three axes. **Correctness:** does this do what
+the task said, and are edge cases (empty input, concurrent callers,
+error paths, unicode, large input) handled? **Fit:** does this match
+the surrounding code's style, layering, and error handling? Does it
+introduce abstractions the codebase does not already have? **Risk:**
+what breaks if this is wrong in production? Migrations, destructive
+operations, auth changes, public APIs warrant a higher bar.
 
-Constraints:
+You are specific. "This feels off" is not a review — either name the
+concrete issue or strike the comment. You distinguish must-fix from
+nice-to-have, and you give file:line pointers and concrete
+suggestions.
 
-- Do not rewrite the code yourself. Pointing at a fix is your job;
-  applying it is the implementer's. If a fix is trivial enough that you
-  feel the urge, name it explicitly so the implementer can confirm before
-  changing it.
-- Do not approve work outside the task's stated scope. Out-of-scope
-  changes — even good ones — should be split out and surfaced to the lead.
-- Be specific. "This feels off" is not a review. Either find the concrete
-  issue or strike the comment.
-- Status discipline: report `runner status idle` after each verdict.
-
-When the lead escalates a design question to you via `ask_lead`-equivalent
-direction, treat it as a review request on a hypothetical diff: lay out
-the trade-offs and recommend a path, do not just describe the options.
-
-Talking to the human:
-
-- The human watches the workspace feed, not your TUI scrollback. Always
-  reply via `runner msg post --to human "<your reply>"`. Typing into the
-  TUI leaves your reply in scrollback only.
-- Their input lands in your TUI without a `runner msg post` envelope
-  (sometimes prefixed `[human_said]`). `human` is a reserved virtual
-  handle for this two-way path.
+You do not rewrite the code yourself. Pointing at the fix is your
+job; applying it belongs to whoever is shipping the change. If a fix
+is trivial enough that you feel the urge, name it explicitly and let
+the author confirm before changing it. You do not approve
+out-of-scope changes — even good ones — they should be split out.


### PR DESCRIPTION
## Summary

Direct chats are off-bus (no `RUNNER_CREW_ID` / `RUNNER_MISSION_ID` / `RUNNER_EVENT_LOG`), but `spawn_direct` was reusing the mission spawn path: it prepended the bundled `runner` CLI to PATH and typed the mission-shaped `WORKER_COORDINATION_PREAMBLE` ahead of the seed brief into stdin. The seeded architect/impl/reviewer system_prompts were also mission-shaped (`runner msg post`, `@<handle>`, lead/crewmate framing) — so a direct chat with the architect surfaced bus verbs that have no event log to write to. (#51)

Four coordinated changes:

- **Split `schedule_first_prompt`** into `schedule_mission_first_prompt` (preamble + persona) and `schedule_direct_first_prompt` (persona only; skips entirely if `runner.system_prompt` is empty/None). Both share a private `inject_first_turn` helper for the body+Enter mechanics, keep the `cfg(test)` zero-delay inline path, and skip on `plan.resuming` / non-{claude-code,codex} runtimes. `spawn` / `spawn_direct` / `resume` route to the right variant; resume picks based on `mission_ctx.is_some()` (NULL `mission_id` = direct-chat row).
- **`compose_path` widened to `bin_dir: Option<&Path>`.** `spawn_direct` passes `None` (bundled CLI is intentionally not on PATH for off-bus chats); `spawn` passes `Some(&bin_dir)`; `resume` conditionally passes `Some` only when `mission_ctx` is set, so direct-chat resume matches `spawn_direct`.
- **Seed system_prompts re-shaped persona-only** in `0002_default_crew.sql` and the mirrored `tests/fixtures/system-prompts/*.md`. Stripped: `runner msg post`, `runner msg read`, `runner status idle`, `ask_lead`, `ask_human`, `@<handle>` framing, lead / crewmate copy. Mission/bus contract now flows through `WORKER_COORDINATION_PREAMBLE` (mission spawns only); direct chat boots with just the persona.
- **New migration `0003_persona_only_seeds.sql`** UPDATEs the seeded architect/impl/reviewer rows for upgraders. Each UPDATE pins on the seeded id AND on the exact pre-#51 seed text, so users who edited a seeded row's `system_prompt` in place are not wiped on upgrade — the WHERE clause misses for them.

Closes #51.

## Test plan

- [x] `cargo test --lib` (src-tauri): 158 passed (includes 2 new migration tests + 3 new PTY-injection tests).
  - `db::tests::migration_0003_preserves_customized_system_prompts` — custom system_prompt survives 0003.
  - `db::tests::migration_0003_rewrites_pristine_old_seed` — exact pre-#51 seed gets rewritten to new persona.
  - `db::tests::seeded_personas_contain_no_bus_verbs` — .md fixtures + verbatim presence in 0002.
  - `session::manager::tests::codex_direct_chat_injects_persona_without_preamble` — persona present, preamble absent.
  - `session::manager::tests::claude_code_direct_chat_injects_persona_without_preamble` — same shape, claude-code runtime.
  - `session::manager::tests::mission_spawn_injects_preamble_for_non_lead_worker` — preamble + brief still injected for mission worker.
- [x] 10/10 stress runs of `mission_spawn_injects_preamble_for_non_lead_worker` pass (combined-predicate fix, no kill-before-second-substring).
- [x] `cargo clippy --lib --tests --manifest-path src-tauri/Cargo.toml -- -D warnings`: clean.
- [x] `cargo fmt --all --check`: clean.
- [x] `npx tsc --noEmit`: clean.
- [x] `npm run lint`: clean except a pre-existing Fast-Refresh warning in `src/contexts/UpdateContext.tsx` (out of scope).

## Caveats

- The 0003 WHERE-pin protects in-place customizations BUT users who modified the seed through other means — different runner id, deleted-and-recreated runner — are unaffected and the migration is a no-op for them. That matches the migration's intent (only rewrite pristine v0.1.x seeds).
- The PTY-injection tests use `cfg(test)` `FIRST_PROMPT_DELAY = Duration::ZERO` so the injection runs inline. Slow-machine timing (the 2.5s production settle + dialog races) is not exercised here; same caveat as #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)