### PR TITLE
fix: allow concurrent missions on the same crew (#55)

### DIFF
--- a/docs/arch/v0-arch.md
+++ b/docs/arch/v0-arch.md
@@ -141,7 +141,7 @@ Lifecycle:
 
 This framing matters: when we say "the coordination bus is mission-scoped" or "the fact whiteboard is mission-scoped," we're saying the same thing as "sessions are mission-scoped." They all share one lifecycle because they all belong to the same container.
 
-v0 constraint: a crew can have at most one live mission at a time. A crew can have many historical missions.
+v0: concurrent missions on the same crew are allowed — a crew is a reusable template, and per-mission state (sessions, the coordination bus, the runner-CLI shim path, the roster sidecar) is fully namespaced by `mission_id`. Per-crew throttle / rate-limit is a future consideration.
 
 ### 2.6 Session — *one runner's PTY process*
 
@@ -281,7 +281,7 @@ user clicks End Mission  (or all sessions have exited)
 
 ### 3.3 v0 constraint
 
-One live mission per crew. Starting a new one while one is live is blocked in the UI. (v1: relax to concurrent missions.)
+Concurrent missions on the same crew are allowed. Each mission gets its own session set, coordination bus, event log, and runner-CLI shim path; the crew row's `signal_types` allowlist is shared but immutable mid-mission. Per-crew throttle / rate-limit is a future consideration.
 
 ## 4. PTY runner sessions
 
@@ -773,14 +773,13 @@ Tauri main thread
   └── Webview process (React + xterm.js)
 ```
 
-For v0 scale (one live mission, ≤ ~10 sessions): fine.
+For v0 scale (a handful of concurrent missions, ≤ ~10 sessions in total): fine.
 
 ## 9. Out of scope for v0
 
 - Threads (v0.x)
 - Facts / shared whiteboard (v0.x)
 - Mentions, reactions (v1)
-- Concurrent live missions per crew
 - Cross-mission memory
 - Remote runners / SSH
 - Sandboxing beyond the child's own permissions

--- a/docs/arch/v0-prd.md
+++ b/docs/arch/v0-prd.md
@@ -45,7 +45,6 @@ All four are described in `v0-arch.md` §2.7 with milestone tags, so the vision 
 
 ### Other non-goals for v0
 
-- Multiple concurrent missions per crew
 - Cross-mission memory
 - Session replay, session history browsing
 - LLM-based signal routing
@@ -99,7 +98,7 @@ If v0 doesn't ship this flow working end-to-end, it hasn't shipped.
 ### 6.3 Missions (a crew's runtime activations)
 - One-click **Start Mission** on a crew. Creates a new mission row, spawns a session per runner, opens the mission control screen.
 - **End Mission** stops all sessions and marks status `completed` (or `aborted` if stopped mid-flight).
-- v0: one live mission per crew. Starting a new mission requires ending the current one.
+- v0: concurrent missions on the same crew are allowed; each gets its own session set, coordination bus, and event log. Per-crew throttle is a future consideration.
 - A mission has: `id`, `crew_id`, `status` (running/completed/aborted), `goal_override` (optional per-mission brief overlay), `started_at`, `stopped_at`.
 - Crew page shows mission history: list of past missions with start time, duration, outcome summary.
 

--- a/src-tauri/src/cli_install.rs
+++ b/src-tauri/src/cli_install.rs
@@ -237,4 +237,72 @@ mod tests {
         // Second copy: dest now matches by size+mtime, should skip.
         assert!(up_to_date(&source, &dest).unwrap());
     }
+
+    #[test]
+    fn shim_dir_includes_mission_id_so_concurrent_missions_dont_collide() {
+        // Regression guard for #55: when the per-crew "at most one live
+        // mission" cap was lifted, two missions on the same crew can
+        // run side by side. They share `crew_id` and (when the same
+        // slot template is on both rosters) `slot_handle`, so the
+        // shim's path key MUST also include `mission_id` to keep the
+        // two RUNNER_* env exports separate. Two installs differing
+        // only in `mission_id` must produce different dirs and
+        // different baked env values.
+        let app_data = tempfile::tempdir().unwrap();
+        let event_log_a = app_data.path().join("missions/m-a/events.jsonl");
+        let event_log_b = app_data.path().join("missions/m-b/events.jsonl");
+        // The shim writer needs the source bin (for the `exec` line).
+        // Stage a fake bundled CLI so the install has something to
+        // point at — content is irrelevant; the shim just embeds the
+        // path.
+        let bin_dir = app_data.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        std::fs::write(bin_dir.join(DEST_BIN_NAME), "#!/bin/sh\nexit 0\n").unwrap();
+
+        let dir_a = install_session_runner_shim(
+            app_data.path(),
+            "crew-1",
+            "m-a",
+            "architect",
+            &event_log_a,
+            None,
+        )
+        .unwrap();
+        let dir_b = install_session_runner_shim(
+            app_data.path(),
+            "crew-1",
+            "m-b",
+            "architect",
+            &event_log_b,
+            None,
+        )
+        .unwrap();
+
+        assert_ne!(
+            dir_a, dir_b,
+            "shim dirs for two missions on the same crew + slot must differ",
+        );
+        assert!(
+            dir_a.to_string_lossy().contains("/m-a/"),
+            "dir_a must include mission_id m-a: {dir_a:?}",
+        );
+        assert!(
+            dir_b.to_string_lossy().contains("/m-b/"),
+            "dir_b must include mission_id m-b: {dir_b:?}",
+        );
+
+        // The baked RUNNER_MISSION_ID export must match the dir's
+        // mission_id, not leak across — without this guarantee a slot
+        // running in mission m-a could attribute events to m-b.
+        let script_a = std::fs::read_to_string(dir_a.join("runner")).unwrap();
+        let script_b = std::fs::read_to_string(dir_b.join("runner")).unwrap();
+        assert!(
+            script_a.contains("export RUNNER_MISSION_ID='m-a'"),
+            "shim_a must export the m-a mission id: {script_a}",
+        );
+        assert!(
+            script_b.contains("export RUNNER_MISSION_ID='m-b'"),
+            "shim_b must export the m-b mission id: {script_b}",
+        );
+    }
 }

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -174,22 +174,16 @@ pub fn start(
     // finding #1). The sole piece of state that can linger on failure is
     // an empty mission directory — harmless because the ULID is never
     // reused, and the next `mission_start` gets a fresh ID + dir.
+    //
+    // Per #55 the crew-level "at most one live mission" guard was lifted
+    // — the constraint was conservative, not load-bearing. Per-mission
+    // state is fully namespaced: `sessions.mission_id` is a foreign key,
+    // `kill_all_for_mission` is mission-scoped, the runner-CLI shim path
+    // includes mission_id (`$APPDATA/missions/<mission_id>/shims/...`),
+    // the roster sidecar is per-mission, and the router boots fresh per
+    // mission. The shared crew row's `signal_types` allowlist is
+    // immutable mid-mission and safe to reuse.
     let tx = conn.transaction()?;
-
-    // Arch §2.5: a crew can have at most one live mission at a time
-    // (review finding #2). Enforce here inside the tx to avoid a
-    // race between the check and the insert.
-    let running_count: i64 = tx.query_row(
-        "SELECT COUNT(*) FROM missions WHERE crew_id = ?1 AND status = 'running'",
-        params![crew.id],
-        |row| row.get(0),
-    )?;
-    if running_count > 0 {
-        return Err(Error::msg(format!(
-            "crew {} already has a live mission; stop it before starting another",
-            crew.name
-        )));
-    }
 
     let id = new_id();
     let started_at = now();
@@ -1475,14 +1469,19 @@ mod tests {
     }
 
     #[test]
-    fn start_rejects_second_live_mission_on_same_crew() {
+    fn concurrent_missions_on_same_crew_are_allowed() {
+        // Per #55 the "at most one live mission per crew" guard was
+        // lifted: per-mission state (sessions, kill_all_for_mission,
+        // shim path, roster sidecar, router) is fully namespaced by
+        // mission_id, so a second mission_start on the same crew
+        // produces a distinct live mission rather than rejecting.
         let pool = pool();
         let mut conn = pool.get().unwrap();
         let crew_id = seed_crew(&conn, "A", None);
         add_runner(&mut conn, &crew_id, "lead");
         let tmp = tempfile::tempdir().unwrap();
 
-        start(
+        let first = start(
             &mut conn,
             tmp.path(),
             StartMissionInput {
@@ -1494,21 +1493,49 @@ mod tests {
         )
         .unwrap();
 
-        let err = start(
+        let second = start(
             &mut conn,
             tmp.path(),
             StartMissionInput {
-                crew_id,
+                crew_id: crew_id.clone(),
                 title: "second".into(),
                 goal_override: Some("go".into()),
                 cwd: None,
             },
         )
-        .unwrap_err();
-        assert!(
-            format!("{err}").contains("already has a live mission"),
-            "expected one-live-mission error, got {err}"
+        .unwrap();
+
+        assert_ne!(
+            first.mission.id, second.mission.id,
+            "second mission must get a distinct id",
         );
+
+        // Both rows must show status='running' and reference the same
+        // crew. Order by started_at so the assertion doesn't depend on
+        // ULID stamping order.
+        let mut rows: Vec<(String, String, String)> = conn
+            .prepare(
+                "SELECT id, status, crew_id FROM missions
+                  WHERE crew_id = ?1
+                  ORDER BY started_at ASC",
+            )
+            .unwrap()
+            .query_map(params![crew_id], |r| {
+                Ok((
+                    r.get::<_, String>(0)?,
+                    r.get::<_, String>(1)?,
+                    r.get::<_, String>(2)?,
+                ))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        rows.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(rows.len(), 2, "two mission rows expected: {rows:?}");
+        for (_, status, row_crew) in &rows {
+            assert_eq!(status, "running");
+            assert_eq!(row_crew, &crew_id);
+        }
     }
 
     #[test]

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -2038,6 +2038,167 @@ mod tests {
     }
 
     #[test]
+    fn concurrent_missions_on_same_crew_keep_session_state_isolated() {
+        // Per #55 the per-crew "at most one live mission" guard was
+        // lifted. The contract that makes that safe is mission-id
+        // namespacing: `sessions.mission_id` is a foreign key,
+        // `kill_all_for_mission` filters on `mission_id`, the runner
+        // CLI shim path is keyed by mission_id, etc. This test pins
+        // the session-isolation half of that contract: spawn one
+        // session per mission against the same crew + same runner
+        // template, assert both alive concurrently, then assert
+        // `kill_all_for_mission(A)` reaps A's session and leaves B's
+        // alone.
+        let pool = pool_with_schema();
+        let runner_id = ulid::Ulid::new().to_string();
+        let crew_id = "c-concurrent".to_string();
+        let slot_id = ulid::Ulid::new().to_string();
+        let mission_a = ulid::Ulid::new().to_string();
+        let mission_b = ulid::Ulid::new().to_string();
+        let now = Utc::now().to_rfc3339();
+        {
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "INSERT INTO crews (id, name, created_at, updated_at)
+                 VALUES (?1, 'c', ?2, ?2)",
+                params![crew_id, now],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'concurrent', 'C', 'shell', '/bin/cat',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+                params![runner_id, now],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO slots
+                    (id, crew_id, runner_id, slot_handle, position, lead, added_at)
+                 VALUES (?1, ?2, ?3, 'concurrent', 0, 1, ?4)",
+                params![slot_id, crew_id, runner_id, now],
+            )
+            .unwrap();
+            for mid in [&mission_a, &mission_b] {
+                conn.execute(
+                    "INSERT INTO missions (id, crew_id, title, status, started_at)
+                     VALUES (?1, ?2, 't', 'running', ?3)",
+                    params![mid, crew_id, now],
+                )
+                .unwrap();
+            }
+        }
+
+        let mut runner = runner("/bin/cat", &[]);
+        runner.id = runner_id.clone();
+        runner.handle = "concurrent".into();
+        let mut slot = slot_for(&runner);
+        slot.id = slot_id.clone();
+        slot.crew_id = crew_id.clone();
+
+        let mission_row_a = Mission {
+            id: mission_a.clone(),
+            crew_id: crew_id.clone(),
+            ..mission()
+        };
+        let mission_row_b = Mission {
+            id: mission_b.clone(),
+            crew_id: crew_id.clone(),
+            ..mission()
+        };
+
+        let mgr = SessionManager::new(None);
+        let spawned_a = mgr
+            .spawn(
+                &mission_row_a,
+                &runner,
+                &slot,
+                std::path::Path::new("/tmp"),
+                PathBuf::from("/dev/null"),
+                Arc::clone(&pool),
+                capture(),
+            )
+            .unwrap();
+        let spawned_b = mgr
+            .spawn(
+                &mission_row_b,
+                &runner,
+                &slot,
+                std::path::Path::new("/tmp"),
+                PathBuf::from("/dev/null"),
+                Arc::clone(&pool),
+                capture(),
+            )
+            .unwrap();
+        assert_ne!(
+            spawned_a.id, spawned_b.id,
+            "two missions on the same crew must produce distinct session ids",
+        );
+
+        // Both sessions live in the SessionManager's map at this point
+        // — /bin/cat reads stdin until EOF, so neither has exited yet.
+        {
+            let sessions = mgr.sessions.lock().unwrap();
+            assert!(
+                sessions.contains_key(&spawned_a.id),
+                "session A must be live"
+            );
+            assert!(
+                sessions.contains_key(&spawned_b.id),
+                "session B must be live"
+            );
+        }
+
+        // Reap mission A's sessions only. The filter on mission_id must
+        // leave B untouched.
+        mgr.kill_all_for_mission(&mission_a).unwrap();
+
+        // After kill_all_for_mission, A's reader thread joins via
+        // SessionManager::kill (which awaits the join), so A's row is
+        // already terminal in the DB. B is still running.
+        let status_a: String = pool
+            .get()
+            .unwrap()
+            .query_row(
+                "SELECT status FROM sessions WHERE id = ?1",
+                params![spawned_a.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_ne!(status_a, "running", "mission A's session must be reaped");
+
+        {
+            let sessions = mgr.sessions.lock().unwrap();
+            assert!(
+                !sessions.contains_key(&spawned_a.id),
+                "mission A's session must be removed from the live map",
+            );
+            assert!(
+                sessions.contains_key(&spawned_b.id),
+                "mission B's session must survive kill_all_for_mission(A)",
+            );
+        }
+        let status_b: String = pool
+            .get()
+            .unwrap()
+            .query_row(
+                "SELECT status FROM sessions WHERE id = ?1",
+                params![spawned_b.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            status_b, "running",
+            "mission B's session row must still be running",
+        );
+
+        // Cleanup so the test's PTY child doesn't outlive the test.
+        mgr.kill(&spawned_b.id).unwrap();
+    }
+
+    #[test]
     fn spawn_echo_roundtrip() {
         // Spawn `sh -c "echo hi && exit"`; assert the exit event fires with
         // success=true. We skip output inspection because the Tauri mock app


### PR DESCRIPTION
## Summary

The `running_count > 0` guard in `mission_start` was conservative, not load-bearing. Per-mission state is already fully namespaced — `sessions.mission_id` is a foreign key, `kill_all_for_mission` filters on `mission_id`, the runner-CLI shim path lives at `\$APPDATA/missions/<mission_id>/shims/<handle>/bin`, the roster sidecar is per-mission, and the router boots fresh per mission. The crew row's `signal_types` allowlist is shared but immutable mid-mission, so concurrent missions can safely read from it.

Four coordinated changes:

- **Lifted the guard** in `commands::mission::start` (lines 179-192). `crew_not_found` precondition stays. Replaced the inline rationale with one pointing at the per-mission namespacing and noting the shared `signal_types` carve-out.
- **Flipped the locking test:** `start_rejects_second_live_mission_on_same_crew` → `concurrent_missions_on_same_crew_are_allowed`. Starts two missions on the same crew, asserts distinct mission_ids and both rows `status='running'`.
- **New tests pinning the safety contract:**
  - `cli_install::tests::shim_dir_includes_mission_id_so_concurrent_missions_dont_collide` — two installs differing only in `mission_id` must produce different dirs and embed each install's `RUNNER_MISSION_ID` export verbatim.
  - `session::manager::tests::concurrent_missions_on_same_crew_keep_session_state_isolated` — spawn one `/bin/cat` session per mission, assert both alive in the live map, then `kill_all_for_mission(A)` reaps A's session and leaves B's running. Stress-ran 5/5 green.
- **Docs:** replaced or removed the "at most one live mission per crew" claim in `docs/arch/v0-arch.md` (§2.5, §3.3, capacity sizing, out-of-scope list) and `docs/arch/v0-prd.md` (§6.3, non-goals list). Frontend already keys mission lookups on `mission_id` (Sidebar mission switcher, `/missions/:id` route), so no UI work was needed; verified by walk.

Closes #55.

## Test plan

- [x] `cargo test --lib` (src-tauri): 160 passed (3 new + 1 renamed/flipped).
- [x] 5/5 stress runs of `concurrent_missions_on_same_crew_keep_session_state_isolated`.
- [x] `cargo clippy --lib --tests --manifest-path src-tauri/Cargo.toml -- -D warnings`: clean.
- [x] `cargo fmt --all --check`: clean.
- [x] `npx tsc --noEmit`: clean.
- [x] `npm run lint`: clean except a pre-existing Fast-Refresh warning in `src/contexts/UpdateContext.tsx` (out of scope).

## Caveats

- Workspace-level filesystem collisions when two missions touch the same working directory are user-environment-scoped (e.g. two missions writing to the same `cwd` could race), not new with this fix and not introduced by it. Same agreement / discipline that was already required.
- Per-crew concurrent-mission throttle / rate-limit is deferred as a future consideration; the issue intentionally scopes "lift the cap" only.
- The crew row's `signal_types` allowlist remains immutable mid-mission, so concurrent missions on the same crew share that read-only state by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)