### PR TITLE
docs: clean up first-turn timer references

### DIFF
--- a/src-tauri/src/router/handlers.rs
+++ b/src-tauri/src/router/handlers.rs
@@ -21,12 +21,16 @@ use super::{Router, RunnerStatus};
 
 /// How long to defer the lead's launch-prompt write after spawn so
 /// claude-code's TUI has time to draw before the bytes land. Matches
-/// `SessionManager::schedule_first_prompt`'s 2.5s budget for workers.
+/// `SessionManager::FIRST_PROMPT_DELAY` for workers — same race in
+/// two places. Calibrated against #50's PTY probe research:
+/// claude-code on a trusted folder is ready to receive input at
+/// ~250ms after spawn (2x safety margin here); codex queues input
+/// from spawn time so the wait is irrelevant for that runtime.
 /// `cfg(test)` zeros the delay so unit tests can assert injections
 /// synchronously without sleeping (the injector's `inject_and_submit_
 /// delayed` runs inline when the duration is zero).
 #[cfg(not(test))]
-const LEAD_LAUNCH_PROMPT_DELAY: std::time::Duration = std::time::Duration::from_millis(2500);
+const LEAD_LAUNCH_PROMPT_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
 #[cfg(test)]
 const LEAD_LAUNCH_PROMPT_DELAY: std::time::Duration = std::time::Duration::ZERO;
 
@@ -68,8 +72,8 @@ pub(super) fn mission_goal(router: &Router, event: &Event) {
         roster: &roster_entries,
         allowed_signals: launch.allowed_signals(),
     });
-    // Defer the lead's launch prompt by the same 2.5s budget the
-    // worker preamble uses (`SessionManager::schedule_first_prompt`).
+    // Defer the lead's launch prompt by the same 500ms budget the
+    // worker preamble uses (`SessionManager::FIRST_PROMPT_DELAY`).
     // The bus's initial replay can fire `mission_goal` milliseconds
     // after the lead PTY spawns — on a warm app (mission_reset, fast
     // mission_start) claude-code's TUI hasn't drawn yet and any bytes

--- a/src-tauri/src/router/handlers.rs
+++ b/src-tauri/src/router/handlers.rs
@@ -22,15 +22,14 @@ use super::{Router, RunnerStatus};
 /// How long to defer the lead's launch-prompt write after spawn so
 /// claude-code's TUI has time to draw before the bytes land. Matches
 /// `SessionManager::FIRST_PROMPT_DELAY` for workers — same race in
-/// two places. Calibrated against #50's PTY probe research:
-/// claude-code on a trusted folder is ready to receive input at
-/// ~250ms after spawn (2x safety margin here); codex queues input
-/// from spawn time so the wait is irrelevant for that runtime.
+/// two places. 500ms wasn't enough in practice (the lead came up
+/// without its system prompt on warm boots), so we hold the
+/// 2500ms budget pending a real readback-verification fix (#50).
 /// `cfg(test)` zeros the delay so unit tests can assert injections
 /// synchronously without sleeping (the injector's `inject_and_submit_
 /// delayed` runs inline when the duration is zero).
 #[cfg(not(test))]
-const LEAD_LAUNCH_PROMPT_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
+const LEAD_LAUNCH_PROMPT_DELAY: std::time::Duration = std::time::Duration::from_millis(2500);
 #[cfg(test)]
 const LEAD_LAUNCH_PROMPT_DELAY: std::time::Duration = std::time::Duration::ZERO;
 
@@ -72,7 +71,7 @@ pub(super) fn mission_goal(router: &Router, event: &Event) {
         roster: &roster_entries,
         allowed_signals: launch.allowed_signals(),
     });
-    // Defer the lead's launch prompt by the same 500ms budget the
+    // Defer the lead's launch prompt by the same 2.5s budget the
     // worker preamble uses (`SessionManager::FIRST_PROMPT_DELAY`).
     // The bus's initial replay can fire `mission_goal` milliseconds
     // after the lead PTY spawns — on a warm app (mission_reset, fast

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -415,8 +415,8 @@ impl Router {
     /// a warm app (mission_reset, fast mission_start) claude-code's
     /// TUI hasn't drawn yet, so synchronous bytes get swallowed by
     /// the boot / trust-folder screen and the lead never sees its
-    /// system prompt. The 2.5s budget matches
-    /// `SessionManager::schedule_first_prompt`, which solves the
+    /// system prompt. The 500ms budget matches
+    /// `SessionManager::FIRST_PROMPT_DELAY`, which solves the
     /// same race for non-lead workers.
     ///
     /// Resolves the handle → session_id at schedule time. Mission
@@ -513,7 +513,7 @@ impl Router {
     /// `mission_goal` on resume (the `mission_attach` watermark
     /// suppresses it), so without this call the lead's freshly-spawned
     /// agent would come up with no system context. Reuses
-    /// `inject_and_submit_delayed`'s 2.5s budget so claude-code's TUI
+    /// `inject_and_submit_delayed`'s 500ms budget so claude-code's TUI
     /// has time to boot before the bytes land.
     pub fn fire_lead_launch_prompt(&self) {
         // Build the prompt body the same way `handlers::mission_goal`
@@ -549,7 +549,7 @@ impl Router {
         self.inject_and_submit_delayed(
             lead_row.handle(),
             body,
-            std::time::Duration::from_millis(2500),
+            std::time::Duration::from_millis(500),
         );
     }
 

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -415,7 +415,7 @@ impl Router {
     /// a warm app (mission_reset, fast mission_start) claude-code's
     /// TUI hasn't drawn yet, so synchronous bytes get swallowed by
     /// the boot / trust-folder screen and the lead never sees its
-    /// system prompt. The 500ms budget matches
+    /// system prompt. The 2.5s budget matches
     /// `SessionManager::FIRST_PROMPT_DELAY`, which solves the
     /// same race for non-lead workers.
     ///
@@ -513,7 +513,7 @@ impl Router {
     /// `mission_goal` on resume (the `mission_attach` watermark
     /// suppresses it), so without this call the lead's freshly-spawned
     /// agent would come up with no system context. Reuses
-    /// `inject_and_submit_delayed`'s 500ms budget so claude-code's TUI
+    /// `inject_and_submit_delayed`'s 2.5s budget so claude-code's TUI
     /// has time to boot before the bytes land.
     pub fn fire_lead_launch_prompt(&self) {
         // Build the prompt body the same way `handlers::mission_goal`
@@ -549,7 +549,7 @@ impl Router {
         self.inject_and_submit_delayed(
             lead_row.handle(),
             body,
-            std::time::Duration::from_millis(500),
+            std::time::Duration::from_millis(2500),
         );
     }
 

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1574,18 +1574,15 @@ fn capture_cwd(explicit: Option<String>) -> Option<String> {
 /// to render the welcome banner, dismiss any "trust this folder" /
 /// approval dialog, and bind their raw-mode keypress reader before
 /// typed bytes land — anything shorter and the early bytes get
-/// swallowed by a dialog still on screen. Calibrated against #50's
-/// PTY probe research: claude-code on a trusted folder is ready at
-/// ~250ms after spawn (2x safety margin); codex queues input from
-/// spawn time so the wait is irrelevant for that runtime. The
-/// startup-dialog case is now handled by the bypass-permission
-/// default (#45), not by stretching this timer.
-/// `cfg(test)` zeros it so unit tests don't have to sleep multiple
-/// seconds (we run inline at the call site when zero). Mirrors
-/// `LEAD_LAUNCH_PROMPT_DELAY` in `router/handlers.rs` since they
-/// solve the same race.
+/// swallowed by a dialog still on screen. 500ms wasn't enough in
+/// practice (the worker came up without its preamble on warm
+/// boots), so we hold the 2.5s budget pending a real
+/// readback-verification fix (#50). `cfg(test)` zeros it so unit
+/// tests don't have to sleep multiple seconds (we run inline at the
+/// call site when zero). Mirrors `LEAD_LAUNCH_PROMPT_DELAY` in
+/// `router/handlers.rs` since they solve the same race.
 #[cfg(not(test))]
-const FIRST_PROMPT_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
+const FIRST_PROMPT_DELAY: std::time::Duration = std::time::Duration::from_millis(2500);
 #[cfg(test)]
 const FIRST_PROMPT_DELAY: std::time::Duration = std::time::Duration::ZERO;
 
@@ -1688,7 +1685,7 @@ fn schedule_direct_first_prompt(
 /// submit byte goes in a separate write so the TUI sees it as Enter
 /// rather than appending it to the input buffer (which is what
 /// happens when text + `\r` arrive in the same chunk). Production
-/// runs on a 500ms settle thread; `cfg(test)` zeros the delay and
+/// runs on a 2.5s settle thread; `cfg(test)` zeros the delay and
 /// runs inline so unit tests can assert synchronously.
 fn inject_first_turn(mgr: &Arc<SessionManager>, session_id: String, prompt: String) {
     let body: String = prompt.chars().filter(|c| *c != '\r').collect();
@@ -1757,10 +1754,10 @@ fn schedule_continue_on_resume(
     }
     let mgr = Arc::clone(mgr);
     std::thread::spawn(move || {
-        // Same 500ms budget as `FIRST_PROMPT_DELAY` — claude-code
+        // Same 2.5s budget as `FIRST_PROMPT_DELAY` — claude-code
         // shows the prior conversation history first, and we want
         // the editor bound before typing.
-        std::thread::sleep(std::time::Duration::from_millis(500));
+        std::thread::sleep(std::time::Duration::from_millis(2500));
         let _ = mgr.inject_stdin(&session_id, b"continue");
         std::thread::sleep(std::time::Duration::from_millis(80));
         let _ = mgr.inject_stdin(&session_id, b"\r");

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1574,12 +1574,18 @@ fn capture_cwd(explicit: Option<String>) -> Option<String> {
 /// to render the welcome banner, dismiss any "trust this folder" /
 /// approval dialog, and bind their raw-mode keypress reader before
 /// typed bytes land — anything shorter and the early bytes get
-/// swallowed by a dialog still on screen. `cfg(test)` zeros it so unit
-/// tests don't have to sleep multiple seconds (we run inline at the
-/// call site when zero). Mirrors `LEAD_LAUNCH_PROMPT_DELAY` in
-/// `router/handlers.rs` since they solve the same race.
+/// swallowed by a dialog still on screen. Calibrated against #50's
+/// PTY probe research: claude-code on a trusted folder is ready at
+/// ~250ms after spawn (2x safety margin); codex queues input from
+/// spawn time so the wait is irrelevant for that runtime. The
+/// startup-dialog case is now handled by the bypass-permission
+/// default (#45), not by stretching this timer.
+/// `cfg(test)` zeros it so unit tests don't have to sleep multiple
+/// seconds (we run inline at the call site when zero). Mirrors
+/// `LEAD_LAUNCH_PROMPT_DELAY` in `router/handlers.rs` since they
+/// solve the same race.
 #[cfg(not(test))]
-const FIRST_PROMPT_DELAY: std::time::Duration = std::time::Duration::from_millis(2500);
+const FIRST_PROMPT_DELAY: std::time::Duration = std::time::Duration::from_millis(500);
 #[cfg(test)]
 const FIRST_PROMPT_DELAY: std::time::Duration = std::time::Duration::ZERO;
 
@@ -1682,7 +1688,7 @@ fn schedule_direct_first_prompt(
 /// submit byte goes in a separate write so the TUI sees it as Enter
 /// rather than appending it to the input buffer (which is what
 /// happens when text + `\r` arrive in the same chunk). Production
-/// runs on a 2.5s settle thread; `cfg(test)` zeros the delay and
+/// runs on a 500ms settle thread; `cfg(test)` zeros the delay and
 /// runs inline so unit tests can assert synchronously.
 fn inject_first_turn(mgr: &Arc<SessionManager>, session_id: String, prompt: String) {
     let body: String = prompt.chars().filter(|c| *c != '\r').collect();
@@ -1751,10 +1757,10 @@ fn schedule_continue_on_resume(
     }
     let mgr = Arc::clone(mgr);
     std::thread::spawn(move || {
-        // Same 2.5s budget as `schedule_first_prompt` — claude-code
+        // Same 500ms budget as `FIRST_PROMPT_DELAY` — claude-code
         // shows the prior conversation history first, and we want
         // the editor bound before typing.
-        std::thread::sleep(std::time::Duration::from_millis(2500));
+        std::thread::sleep(std::time::Duration::from_millis(500));
         let _ = mgr.inject_stdin(&session_id, b"continue");
         std::thread::sleep(std::time::Duration::from_millis(80));
         let _ = mgr.inject_stdin(&session_id, b"\r");


### PR DESCRIPTION
## Summary

Doc-only cleanup of the first-turn timer references in the session/router modules. No runtime change — all four timers stay at 2500ms.

## Background

This branch originally shipped a probe-then-inject mechanism for #50, then tried a 500ms recalibration as a simpler alternative. Both were reverted: the probe-echo signal didn't actually verify TUI raw-mode bind (only PTY-chain liveness), and 500ms wasn't enough in practice — workers came up without their preambles on warm boots. The conservative 2500ms timer remains the load-bearing protection until a real readback-verification fix lands.

What's left is the comment cleanup that surfaced while diagnosing the issue:

- Fix stale `SessionManager::schedule_first_prompt` references → the actual constant is `FIRST_PROMPT_DELAY` (the function was renamed long ago).
- Add a note at each timer site recording that 500ms was tried and didn't work, so the next person reading the code knows not to repeat the experiment.
- Reference #50 from each site so the future readback-verification fix has a clean trail.

## Changed sites

- `session::manager::FIRST_PROMPT_DELAY` (worker first-turn / direct-chat first-turn)
- `router::handlers::LEAD_LAUNCH_PROMPT_DELAY` (mission-boot lead launch prompt)
- `Router::inject_and_submit_delayed` (the shared delayed-inject helper)
- `session::manager::schedule_continue_on_resume` (claude-code resume \"continue\" type-ahead)

#50 stays open.

## Test plan

- [x] `cargo test --lib`: 160 passed (no behavioral change to test).
- [x] `cargo clippy --lib --tests -- -D warnings`: clean.
- [x] `cargo fmt --all --check`: clean.
- [x] `pnpm tsc --noEmit`: clean.
- [x] `pnpm lint`: clean except a pre-existing Fast-Refresh warning in `src/contexts/UpdateContext.tsx` (out of scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)