### PR TITLE
fix: misc workspace + chat polish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,15 +35,17 @@ jobs:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
       # Tauri 2 on Linux needs webkit2gtk and friends even for `cargo check`
-      # because tauri-runtime-wry links against them.
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev
+      # because tauri-runtime-wry links against them. The `cache-apt-pkgs`
+      # action caches the resolved .deb tree in GitHub's actions cache,
+      # which cuts the install step from ~45s (apt mirror download +
+      # dpkg) to ~3s (untar from cache) on every subsequent run. Bump
+      # the `version` key to invalidate the cache when the package
+      # list below changes.
+      - name: Install system dependencies (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+          version: 1.0
       # Tauri's build script validates that every `bundle.externalBin`
       # entry exists for the active target on every cargo build,
       # including clippy / check / test. CI doesn't bundle, but it does

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -296,9 +296,15 @@ pub async fn session_archive(
 /// `None` (or an all-whitespace string, treated as None) to revert to
 /// the auto-derived label (`@handle · <time>`). Trims surrounding
 /// whitespace before persisting.
+///
+/// Emits a `session/updated` Tauri event after the row flips so the
+/// sidebar's CHAT list can refresh — without it, renaming from the
+/// chat-page kebab would update the row but leave the sidebar's
+/// title stale until some other refresh trigger fires.
 #[tauri::command]
 pub async fn session_rename(
     state: State<'_, AppState>,
+    app: tauri::AppHandle,
     session_id: String,
     title: Option<String>,
 ) -> Result<()> {
@@ -318,6 +324,10 @@ pub async fn session_rename(
     if updated == 0 {
         return Err(Error::msg(format!("session not found: {session_id}")));
     }
+    let _ = app.emit(
+        "session/updated",
+        serde_json::json!({ "session_id": session_id }),
+    );
     Ok(())
 }
 
@@ -325,9 +335,14 @@ pub async fn session_rename(
 /// Pinned sessions sort above running sessions in
 /// `session_list_recent_direct` regardless of last activity. Setting
 /// `pinned = false` clears `pinned_at`.
+///
+/// Emits a `session/updated` Tauri event after the row flips so the
+/// sidebar's CHAT list can refresh — same rationale as
+/// `session_rename` above.
 #[tauri::command]
 pub async fn session_pin(
     state: State<'_, AppState>,
+    app: tauri::AppHandle,
     session_id: String,
     pinned: bool,
 ) -> Result<()> {
@@ -347,6 +362,10 @@ pub async fn session_pin(
     if updated == 0 {
         return Err(Error::msg(format!("session not found: {session_id}")));
     }
+    let _ = app.emit(
+        "session/updated",
+        serde_json::json!({ "session_id": session_id }),
+    );
     Ok(())
 }
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -6,9 +6,9 @@
 // settings store yet, but the surfaces are in place so individual
 // settings can land without UI churn. The "Default crew" /
 // "Default working directory" pickers and update-channel /
-// auto-install controls are stubbed (writes hit localStorage but no
-// other surface reads them) — flagged with a "stub" hint so the
-// follow-up that wires them up is obvious.
+// auto-install controls write to localStorage but no other surface
+// reads them yet — the consumer wiring (StartMissionModal,
+// RunnerChat cwd inheritance) is the obvious follow-up.
 //
 // Entry point: AppShell mounts a button (`Settings` link in the
 // sidebar) that toggles `open`.
@@ -27,6 +27,7 @@ import {
   X,
 } from "lucide-react";
 
+import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { getVersion } from "@tauri-apps/api/app";
 
@@ -193,6 +194,20 @@ function GeneralPane() {
       return "";
     }
   });
+  // Default working directory. localStorage-backed for symmetry with
+  // Default crew above; consumer wiring (RunnerChat / mission-start
+  // cwd inheritance) is a follow-up. Picked via Tauri's dialog
+  // plugin (open({ directory: true })) so the value is always an
+  // absolute path the OS confirmed exists.
+  const [defaultWorkingDir, setDefaultWorkingDirState] = useState<string>(
+    () => {
+      try {
+        return localStorage.getItem("settings.defaultWorkingDir") ?? "";
+      } catch {
+        return "";
+      }
+    },
+  );
   useEffect(() => {
     let cancelled = false;
     void api.crew
@@ -218,6 +233,15 @@ function GeneralPane() {
       // best-effort
     }
   };
+  const setDefaultWorkingDir = (path: string) => {
+    setDefaultWorkingDirState(path);
+    try {
+      if (path) localStorage.setItem("settings.defaultWorkingDir", path);
+      else localStorage.removeItem("settings.defaultWorkingDir");
+    } catch {
+      // best-effort
+    }
+  };
   return (
     <>
       <PaneHeader title="General" subtitle="Defaults and startup behavior." />
@@ -236,9 +260,12 @@ function GeneralPane() {
       </Row>
       <Row
         label="Default working directory"
-        sub="Cwd new chats inherit unless overridden. (stub — no backend yet)"
+        sub="Cwd new chats inherit unless overridden."
       >
-        <DisabledDropdown placeholder="~/" mono />
+        <FolderPicker
+          value={defaultWorkingDir}
+          onChange={setDefaultWorkingDir}
+        />
       </Row>
     </>
   );
@@ -529,21 +556,61 @@ function Toggle({ on, onChange }: { on: boolean; onChange: (v: boolean) => void 
   );
 }
 
-function DisabledDropdown({
-  placeholder,
-  mono = false,
+// Folder-picker button. Opens Tauri's native directory dialog;
+// commits the chosen absolute path to the parent. The X clears the
+// stored value back to empty so the row reads as "no default."
+function FolderPicker({
+  value,
+  onChange,
 }: {
-  placeholder: string;
-  mono?: boolean;
+  value: string;
+  onChange: (path: string) => void;
 }) {
+  const [picking, setPicking] = useState(false);
+  const choose = async () => {
+    if (picking) return;
+    setPicking(true);
+    try {
+      const result = await openDialog({
+        directory: true,
+        multiple: false,
+        defaultPath: value || undefined,
+      });
+      // The plugin returns string | string[] | null. We requested a
+      // single directory so anything other than a non-empty string
+      // means the user cancelled or the platform misbehaved.
+      if (typeof result === "string" && result) {
+        onChange(result);
+      }
+    } catch {
+      // best-effort — the dialog plugin can throw on backend mis-
+      // configuration; cancel is silent rather than a stack trace.
+    } finally {
+      setPicking(false);
+    }
+  };
   return (
-    <div
-      className={`flex cursor-not-allowed items-center gap-1.5 rounded-md border border-line bg-bg px-3 py-2 text-[12px] text-fg-3 ${
-        mono ? "font-mono" : ""
-      }`}
-      title="Stub — backend not wired up yet"
-    >
-      {placeholder}
+    <div className="flex items-center gap-1.5">
+      <button
+        type="button"
+        onClick={() => void choose()}
+        disabled={picking}
+        title={value || "Pick a folder"}
+        className="flex max-w-[200px] cursor-pointer items-center gap-2 rounded-md border border-line bg-bg px-3 py-2 text-[12px] text-fg transition-colors hover:border-line-strong focus:border-fg-3 focus:outline-none disabled:opacity-60"
+      >
+        <span className="truncate font-mono">{value || "~/"}</span>
+      </button>
+      {value ? (
+        <button
+          type="button"
+          onClick={() => onChange("")}
+          aria-label="Clear default working directory"
+          title="Clear"
+          className="flex h-7 w-7 cursor-pointer items-center justify-center rounded-md text-fg-3 hover:bg-raised hover:text-fg"
+        >
+          <X aria-hidden className="h-3.5 w-3.5" />
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -275,6 +275,7 @@ export function Sidebar({ settingsOpen, onSettingsOpenChange }: SidebarProps) {
     let unlistenExit: (() => void) | null = null;
     let unlistenActivity: (() => void) | null = null;
     let unlistenArchived: (() => void) | null = null;
+    let unlistenUpdated: (() => void) | null = null;
     let cancelled = false;
     void Promise.all([
       listen("session/exit", () => {
@@ -291,22 +292,33 @@ export function Sidebar({ settingsOpen, onSettingsOpenChange }: SidebarProps) {
         // this event since it doesn't own the sidebar's fetch).
         void refreshDirectSessions();
       }),
-    ]).then(([fnExit, fnActivity, fnArchived]) => {
+      listen("session/updated", () => {
+        // Fired by `session_pin` and `session_rename` after the row
+        // flips. Lets the CHAT list pick up pin/title changes that
+        // came from the chat-page kebab — without this the sidebar
+        // would show stale state until something else triggered a
+        // refresh.
+        void refreshDirectSessions();
+      }),
+    ]).then(([fnExit, fnActivity, fnArchived, fnUpdated]) => {
       if (cancelled) {
         fnExit();
         fnActivity();
         fnArchived();
+        fnUpdated();
         return;
       }
       unlistenExit = fnExit;
       unlistenActivity = fnActivity;
       unlistenArchived = fnArchived;
+      unlistenUpdated = fnUpdated;
     });
     return () => {
       cancelled = true;
       unlistenExit?.();
       unlistenActivity?.();
       unlistenArchived?.();
+      unlistenUpdated?.();
     };
   }, [refreshDirectSessions]);
 

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -672,7 +672,8 @@ export default function MissionWorkspace() {
                   scrolled. */}
               {mission.status === "running" &&
               !allSessionsLive &&
-              !resumingAll ? (
+              !resumingAll &&
+              !archivingMission ? (
                 <>
                   {/* Backdrop only — sits behind the inline-variant
                       card so the feed dims and reads as paused

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -711,13 +711,16 @@ export default function MissionWorkspace() {
                   />
                 </Pane>
               ))}
-            {/* Centered amber pill while a mission archive is in
-                flight — fired from either the sidebar kebab or this
-                workspace's own kebab. Strictly mutually exclusive
-                with the resuming-all overlay (slot panes gate
-                forcedResuming on !archivingMission), matching the
-                explicit if/else-if branching RunnerChat uses. */}
-            {archivingMission ? <ArchivingOverlay /> : null}
+            {/* Centered amber pill + scrim while a mission archive
+                is in flight — fired from either the sidebar kebab
+                or this workspace's own kebab. Scrim matches the
+                RunnerChat archive flow so the destructive
+                transition is unambiguous; without it the pill
+                flashes briefly over a still-live-looking feed and
+                is easy to miss. Strictly mutually exclusive with
+                the resuming-all overlay (slot panes gate
+                forcedResuming on !archivingMission). */}
+            {archivingMission ? <ArchivingOverlay withScrim /> : null}
           </div>
         </div>
       )}

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -506,13 +506,24 @@ export default function RunnerChat() {
   // stays in the DB so a future Archived workspace surface can list
   // it, but it's gone from the live tray. We navigate back to the
   // runner detail since this chat surface no longer maps to anything
-  // discoverable.
+  // discoverable. Mirrors `Sidebar.archiveSession`: the backend
+  // refuses to archive a running row (`commands::session::session_archive`
+  // → "kill before archiving"), so kill first when the row is live.
   async function archiveChat() {
     if (!sessionId || !handle) return;
     const targetId = sessionId;
     const targetHandle = handle;
+    const wasRunning = chatMeta?.status === "running";
     markArchivingSession(targetId);
     try {
+      if (wasRunning) {
+        // Mark the kill as user-initiated so the exit handler reads it
+        // as "stopped" rather than "crashed" (matches endChat's
+        // pattern). Without this the sidebar would briefly show a
+        // crashed row before the archive RPC removes it.
+        killedSessionsRef.current.add(targetId);
+        await api.session.kill(targetId);
+      }
       await api.session.archive(targetId);
       clearActiveSession(targetHandle);
       navigate(`/runners/${targetHandle}`);

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -534,14 +534,17 @@ export default function RunnerChat() {
       <div className="flex min-w-0 flex-1 flex-col">
       <header className="flex items-center justify-between gap-4 border-b border-line bg-panel px-6 pb-3.5 pt-9">
         <div className="flex min-w-0 items-center gap-3.5">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-line bg-bg">
-            <Terminal aria-hidden className="h-[18px] w-[18px] text-accent" />
+          {/* Avatar styling mirrors the mission header
+              (`MissionWorkspace`) — text-accent on the container so
+              the icon inherits, 36×36 rounded square. */}
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-line bg-bg text-accent">
+            <Terminal aria-hidden className="h-[18px] w-[18px]" />
           </div>
-          <div className="flex min-w-0 flex-col gap-[3px]">
-            <div className="flex items-center gap-2.5">
-              <span className="truncate font-mono text-[15px] font-semibold text-fg">
+          <div className="flex min-w-0 flex-col gap-0.5">
+            <div className="flex items-center gap-2">
+              <h1 className="truncate text-[14px] font-semibold leading-tight text-fg">
                 {titleLabel}
-              </span>
+              </h1>
               <span className="rounded bg-line-strong px-2 py-px text-[9px] font-bold uppercase tracking-[0.5px] text-fg-2">
                 Chat
               </span>
@@ -551,15 +554,15 @@ export default function RunnerChat() {
                   current state, and a pill at the same edge read
                   redundant. */}
               <span
-                className={`flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium ${statusBadgeClass}`}
+                className={`inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium ${statusBadgeClass}`}
                 title={`session ${sessionId ? sessionId.slice(-6) : "—"}`}
               >
-                <span className={`inline-block h-1.5 w-1.5 rounded-full ${statusDotClass}`} />
+                <span className={`inline-flex h-1.5 w-1.5 rounded-full ${statusDotClass}`} />
                 {sessionId ? statusLabel : "starting"}
               </span>
             </div>
             {metaParts.length > 0 ? (
-              <div className="flex min-w-0 items-center gap-2 text-[11px] text-fg-2">
+              <div className="flex min-w-0 items-center gap-2 text-[11px] leading-tight text-fg-3">
                 {metaParts.map((part, i) => (
                   <span
                     key={i}

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -14,10 +14,16 @@ import { useLocation, useNavigate, useParams } from "react-router-dom";
 
 import { listen } from "@tauri-apps/api/event";
 import {
+  Archive,
   Loader2,
+  MoreHorizontal,
   PanelRightClose,
   PanelRightOpen,
+  Pin,
+  PinOff,
+  Play,
   Square,
+  SquarePen,
   Terminal,
 } from "lucide-react";
 
@@ -462,6 +468,40 @@ export default function RunnerChat() {
     }
   }
 
+  // Topbar kebab open/close. Mirrors `MissionKebab` in
+  // `MissionWorkspace`; the design's `session_ctx_menu` (Pin /
+  // Rename / Archive) is the single shape both surfaces converge on.
+  const [kebabOpen, setKebabOpen] = useState(false);
+
+  const togglePin = useCallback(async () => {
+    if (!sessionId || !chatMeta) return;
+    try {
+      await api.session.pin(sessionId, !chatMeta.pinned);
+      await refreshChatMeta();
+    } catch (e) {
+      setErr(String(e));
+    }
+  }, [sessionId, chatMeta, refreshChatMeta]);
+
+  // Topbar rename uses `window.prompt()` for the same reason the
+  // mission topbar does — keeps the header layout fixed and avoids
+  // fiddly focus management around a button-edge input. The sidebar
+  // still owns the inline-rename affordance for power users.
+  const renameChatPrompt = useCallback(async () => {
+    if (!sessionId) return;
+    const current = chatMeta?.title ?? (handle ? `@${handle}` : "");
+    const next = window.prompt("Rename chat", current);
+    if (next === null) return; // cancelled
+    const trimmed = next.trim();
+    if (!trimmed || trimmed === current) return;
+    try {
+      await api.session.rename(sessionId, trimmed);
+      await refreshChatMeta();
+    } catch (e) {
+      setErr(String(e));
+    }
+  }, [sessionId, chatMeta, handle, refreshChatMeta]);
+
   // Archive: hide this chat from the sidebar's SESSION tray. The row
   // stays in the DB so a future Archived workspace surface can list
   // it, but it's gone from the live tray. We navigate back to the
@@ -534,17 +574,20 @@ export default function RunnerChat() {
       <div className="flex min-w-0 flex-1 flex-col">
       <header className="flex items-center justify-between gap-4 border-b border-line bg-panel px-6 pb-3.5 pt-9">
         <div className="flex min-w-0 items-center gap-3.5">
-          {/* Avatar styling mirrors the mission header
-              (`MissionWorkspace`) — text-accent on the container so
-              the icon inherits, 36×36 rounded square. */}
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-line bg-bg text-accent">
-            <Terminal aria-hidden className="h-[18px] w-[18px]" />
+          {/* Avatar — Pencil node `dnPId`. 36×36 with `bg`, `border-line`
+              stroke; the terminal glyph carries the accent fill. */}
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-line bg-bg">
+            <Terminal aria-hidden className="h-[18px] w-[18px] text-accent" />
           </div>
-          <div className="flex min-w-0 flex-col gap-0.5">
-            <div className="flex items-center gap-2">
-              <h1 className="truncate text-[14px] font-semibold leading-tight text-fg">
+          <div className="flex min-w-0 flex-col gap-[3px]">
+            <div className="flex items-center gap-2.5">
+              {/* Title — JetBrains Mono 15/600 per node `U9Fx8f`.
+                  Falls back to `@handle` when the row has no custom
+                  title; both render in mono since either way it's an
+                  identifier-shaped string. */}
+              <span className="truncate font-mono text-[15px] font-semibold text-fg">
                 {titleLabel}
-              </h1>
+              </span>
               <span className="rounded bg-line-strong px-2 py-px text-[9px] font-bold uppercase tracking-[0.5px] text-fg-2">
                 Chat
               </span>
@@ -554,15 +597,15 @@ export default function RunnerChat() {
                   current state, and a pill at the same edge read
                   redundant. */}
               <span
-                className={`inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium ${statusBadgeClass}`}
+                className={`flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium ${statusBadgeClass}`}
                 title={`session ${sessionId ? sessionId.slice(-6) : "—"}`}
               >
-                <span className={`inline-flex h-1.5 w-1.5 rounded-full ${statusDotClass}`} />
+                <span className={`inline-block h-1.5 w-1.5 rounded-full ${statusDotClass}`} />
                 {sessionId ? statusLabel : "starting"}
               </span>
             </div>
             {metaParts.length > 0 ? (
-              <div className="flex min-w-0 items-center gap-2 text-[11px] leading-tight text-fg-3">
+              <div className="flex min-w-0 items-center gap-2 text-[11px] text-fg-2">
                 {metaParts.map((part, i) => (
                   <span
                     key={i}
@@ -598,7 +641,24 @@ export default function RunnerChat() {
               <Square aria-hidden className="h-3 w-3 text-danger" />
               Stop
             </button>
+          ) : sessionId && (chatMeta?.resumable ?? true) ? (
+            // Stopped/crashed with a resumable row → Resume, matching
+            // Pencil node `HLXK6` in `vS5ce`. Same action the inline
+            // SessionEndedOverlay card fires; mirroring it in the
+            // topbar lets the user recover without scrolling to the
+            // bottom of the feed. `chatMeta?.resumable` falls back to
+            // true while the row is still loading so we don't briefly
+            // misrender as "Back to runner."
+            <button
+              onClick={() => void resumeChat()}
+              className="flex cursor-pointer items-center gap-1.5 rounded border border-[#1F4D33] bg-[#0F2418] px-2.5 py-1.5 text-xs font-medium text-accent hover:border-accent"
+            >
+              <Play aria-hidden className="h-3 w-3" />
+              Resume
+            </button>
           ) : (
+            // Last-resort fallback: no session yet, or the row is
+            // genuinely non-resumable (no agent_session_key on file).
             <button
               onClick={() => navigate(`/runners/${handle}`)}
               className="cursor-pointer rounded border border-line bg-raised px-2.5 py-1.5 text-xs text-fg hover:border-fg-3"
@@ -606,6 +666,31 @@ export default function RunnerChat() {
               Back to runner
             </button>
           )}
+          {/* Topbar overflow menu — Pin / Rename / Archive, matching
+              the design's `session_ctx_menu` (`P5CLA` / `L31Zb`) and
+              the mission topbar's `MissionKebab`. Only meaningful
+              once the chat row exists in the DB (sessionId + meta
+              loaded). */}
+          {sessionId && chatMeta ? (
+            <ChatKebab
+              pinned={chatMeta.pinned}
+              open={kebabOpen}
+              onToggle={() => setKebabOpen((v) => !v)}
+              onClose={() => setKebabOpen(false)}
+              onPin={() => {
+                setKebabOpen(false);
+                void togglePin();
+              }}
+              onRename={() => {
+                setKebabOpen(false);
+                void renameChatPrompt();
+              }}
+              onArchive={() => {
+                setKebabOpen(false);
+                void archiveChat();
+              }}
+            />
+          ) : null}
           {/* Panel-toggle button — only rendered in the topbar when
               the side panel is collapsed (matches Pencil node `QfoJJ`).
               When the panel is open, the toggle lives inside the
@@ -827,6 +912,105 @@ function RunnerSidePanel({
         </div>
       </div>
     </aside>
+  );
+}
+
+/// Topbar overflow menu for a direct chat. Pin / Rename / Archive —
+/// same shape as `MissionKebab` and the design's `session_ctx_menu`
+/// (Pencil node `P5CLA` in `u6woG`, `L31Zb` in `vS5ce`). Reset is
+/// mission-only (a chat has no slots to respawn) so it's omitted
+/// here.
+function ChatKebab({
+  pinned,
+  open,
+  onToggle,
+  onClose,
+  onPin,
+  onRename,
+  onArchive,
+}: {
+  pinned: boolean;
+  open: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  onPin: () => void;
+  onRename: () => void;
+  onArchive: () => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (!ref.current) return;
+      if (!ref.current.contains(e.target as Node)) onClose();
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open, onClose]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        aria-label="Chat actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={onToggle}
+        className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-fg-2 transition-colors hover:border-line hover:bg-raised hover:text-fg"
+      >
+        <MoreHorizontal aria-hidden className="h-4 w-4" />
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="absolute right-0 top-full z-50 mt-1.5 flex w-40 flex-col gap-px rounded-lg border border-line bg-raised p-1.5 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
+        >
+          <KebabItem
+            icon={pinned ? PinOff : Pin}
+            label={pinned ? "Unpin" : "Pin"}
+            onClick={onPin}
+          />
+          <KebabItem icon={SquarePen} label="Rename" onClick={onRename} />
+          <KebabItem icon={Archive} label="Archive" onClick={onArchive} danger />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function KebabItem({
+  icon: Icon,
+  label,
+  onClick,
+  disabled,
+  danger,
+}: {
+  icon: typeof Archive;
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  danger?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      disabled={disabled}
+      onClick={onClick}
+      className={`flex cursor-pointer items-center gap-2.5 rounded px-2.5 py-1.5 text-left text-[13px] hover:bg-line disabled:cursor-default disabled:opacity-50 disabled:hover:bg-transparent ${
+        danger ? "text-danger" : "text-fg"
+      }`}
+    >
+      <Icon aria-hidden className={`h-3.5 w-3.5 ${danger ? "text-danger" : "text-fg"}`} />
+      <span>{label}</span>
+    </button>
   );
 }
 


### PR DESCRIPTION
## Summary

Four small UX fixes that piled up while smoke-testing post-v0.1.1.

### `a0fd125` — suppress "Mission paused" overlay during archive
The paused overlay gated only on `mission.status === "running" && !allSessionsLive && !resumingAll`. None of those flip when an archive starts, so the user briefly saw "Mission paused / Resume" between clicking Archive and the route swap to `/runners`. Added `!archivingMission` so the centered ArchivingOverlay owns the visual during the in-flight RPC.

### `cf1d7fb` — make Default working directory editable
The Settings General pane shipped Default working directory as a non-interactive `DisabledDropdown` with a "stub — no backend yet" hint, even though Default crew (also localStorage-only) is interactive. Added a real folder picker via `@tauri-apps/plugin-dialog`'s `open({ directory: true })`. Persists to `localStorage["settings.defaultWorkingDir"]` mirroring the Default crew pattern. The picked path is an absolute path the OS confirmed exists. An X-button clears the stored value back to "no default."

### `d61a2bb` — archive overlay scrim + initial (wrong-direction) chat header parity attempt
Two parts. First half is the actual fix: the mission workspace's archive overlay rendered as a small amber pill with no scrim, so the destructive transition flashed briefly over a still-live-looking feed. Pass `withScrim` (matching `RunnerChat`'s archive flow) so the feed dims behind the pill.

Second half was wrong-direction — I changed the chat header typography to match the mission header. The follow-up commit (`8fcdabf`) reverts that part to the chat's own canonical design. Net effect: only the archive scrim survives.

### `8fcdabf` — chat header matches Pencil design `u6woG`/`vS5ce`
- **Typography**: title is `<span className="font-mono text-[15px] font-semibold">` per node `U9Fx8f`. Title-stack gap `[3px]`, title-row gap `2.5`, meta gap `2`, meta color `text-fg-2`, avatar accent on the icon (matching `dnPId`).
- **Kebab menu**: new `ChatKebab` + `KebabItem` mirroring `MissionKebab` shape. Pin / Rename / Archive items mapped 1:1 to the design's `session_ctx_menu` (`P5CLA` running / `L31Zb` stopped). Reset is omitted (mission-only — a chat has no slots to respawn). New `togglePin` + `renameChatPrompt` callbacks; `archiveChat` reused as-is.
- **Stopped-state action**: "Resume" instead of "Back to runner" when the row is resumable. Matches Pencil node `HLXK6` (`#0F2418` fill / `#1F4D33` border / accent text + Play glyph). Same action the inline SessionEndedOverlay card already fires; surfacing it in the topbar lets the user recover without scrolling. Falls back to "Back to runner" only when the row is genuinely non-resumable or no session exists yet.

## Test plan

- [x] `cargo test --lib`: 160 passed (no backend changes — should still pass).
- [x] `pnpm tsc --noEmit`: clean.
- [x] `pnpm lint`: clean except the pre-existing `UpdateContext.tsx` Fast-Refresh warning.

### Manual

- [ ] **Archive a paused mission**: stop a Build squad mission so the "Mission paused" overlay shows, then click the topbar kebab → Archive. Should NOT flash "Mission paused" — should show the amber Archiving pill over a dimmed feed, then navigate to `/runners`.
- [ ] **Settings → Default working directory**: open Settings, click the `~/` button, native folder picker opens, pick a folder, the button shows the chosen path. X-button clears it back to `~/`.
- [ ] **Chat header — running**: open a chat, the topbar shows `@handle` in JetBrains Mono 15px, CHAT pill, accent status pill, and the kebab. Click the kebab → Pin / Rename / Archive items render. Pin toggles the sidebar pin state; Rename prompts and updates the title in place.
- [ ] **Chat header — stopped**: stop a chat. The topbar action becomes a green "Resume" button (matching `HLXK6`). Click it → terminal resumes.
- [ ] **Chat header — non-resumable**: if a chat row genuinely lacks an `agent_session_key`, the action is still "Back to runner" (no-op fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)