### PR TITLE
chore: release v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "runner",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runner"
-version = "0.1.1"
+version = "0.1.2"
 description = "An editor for teams of local coding agents (Claude Code, Codex, and friends)"
 edition.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Runner",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "identifier": "com.wycstudios.runner",
   "build": {
     "beforeDevCommand": "npm run tauri:before:dev",


### PR DESCRIPTION
## Summary

Cuts v0.1.2. Highlights since v0.1.1:

- **Permission mode redesign** (#61): per-runtime dropdown replaces the binary "Skip approval prompts" toggle. claude-code surfaces 4 modes (default / accept_edits / auto / bypass) and codex surfaces 3 (default / auto / bypass). Default seeded mode is `acceptEdits` so first-mission boot doesn't trip claude-code's bypass-permissions consent dialog.
- **Mission + chat workspace polish** (#60): paused-overlay suppression during archive, archive scrim, chat-header parity with the design (font-mono title, kebab with Pin/Rename/Archive, Resume action on stopped state), kill-then-archive on running chats, sidebar refresh on session pin/rename, Default-working-directory folder picker in Settings.
- **CI**: apt packages cached via `awalsh128/cache-apt-pkgs-action` (~45s → ~3s on cache hit).
- **Comment cleanup** in the first-turn timer references (#59).

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm lint` clean (modulo the pre-existing `UpdateContext.tsx` Fast-Refresh warning)
- [x] `cargo test --lib` 163 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)