### PR TITLE
fix: Shift+Enter newline + Cmd+V image paste in embedded xterm

### DIFF
--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -185,6 +185,29 @@ export function RunnerTerminal({
       });
     });
 
+    // Shift+Enter → ESC+CR so claude-code/codex insert a newline in their
+    // input frame instead of submitting. Plain Enter falls through to the
+    // default \r emission via onData above.
+    term.attachCustomKeyEventHandler((e) => {
+      if (e.type !== "keydown") return true;
+      if (
+        e.key === "Enter" &&
+        e.shiftKey &&
+        !e.ctrlKey &&
+        !e.altKey &&
+        !e.metaKey
+      ) {
+        const sid = sessionIdRef.current;
+        if (sid) {
+          void api.session.injectStdin(sid, "\x1b\r").catch((err) => {
+            onErrorRef.current?.(String(err));
+          });
+        }
+        return false;
+      }
+      return true;
+    });
+
     const pushSize = () => {
       const t = termRef.current;
       const sid = sessionIdRef.current;

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -198,7 +198,7 @@ export function RunnerTerminal({
         !e.metaKey
       ) {
         const sid = sessionIdRef.current;
-        if (sid) {
+        if (sid && !disabledRef.current) {
           void api.session.injectStdin(sid, "\x1b\r").catch((err) => {
             onErrorRef.current?.(String(err));
           });
@@ -224,7 +224,7 @@ export function RunnerTerminal({
     // default behavior unchanged.
     const onPaste = (e: ClipboardEvent) => {
       const sid = sessionIdRef.current;
-      if (!sid) return;
+      if (!sid || disabledRef.current) return;
       const items = e.clipboardData?.items;
       if (!items) return;
       let hasImage = false;

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -208,6 +208,43 @@ export function RunnerTerminal({
       return true;
     });
 
+    // Image paste support. claude-code and codex already know how to
+    // attach a clipboard image when they see Ctrl+V (\x16) on stdin —
+    // they shell out to `pbpaste -Prefer png` (or the platform
+    // equivalent) and read the OS clipboard themselves. The bug surface
+    // is that on macOS the user instinctively presses Cmd+V, which the
+    // WebView intercepts as a *text* paste; xterm.js's default handler
+    // then drops the image and pastes whatever placeholder text rep the
+    // OS attached, so the keystroke that would have triggered the CLI's
+    // clipboard read never reaches the PTY.
+    //
+    // Fix: when the paste event carries an image, swallow xterm.js's
+    // text-paste handler and inject \x16 instead. The agent CLI takes
+    // it from there. Pure-text pastes fall through to xterm.js's
+    // default behavior unchanged.
+    const onPaste = (e: ClipboardEvent) => {
+      const sid = sessionIdRef.current;
+      if (!sid) return;
+      const items = e.clipboardData?.items;
+      if (!items) return;
+      let hasImage = false;
+      for (let i = 0; i < items.length; i += 1) {
+        const it = items[i];
+        if (it.kind === "file" && it.type.startsWith("image/")) {
+          hasImage = true;
+          break;
+        }
+      }
+      if (!hasImage) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      void api.session.injectStdin(sid, "\x16").catch((err) => {
+        onErrorRef.current?.(String(err));
+      });
+    };
+    const textarea = term.textarea;
+    textarea?.addEventListener("paste", onPaste, { capture: true });
+
     const pushSize = () => {
       const t = termRef.current;
       const sid = sessionIdRef.current;
@@ -251,6 +288,7 @@ export function RunnerTerminal({
       window.removeEventListener("resize", onResize);
       window.removeEventListener("focus", refreshTerm);
       document.removeEventListener("visibilitychange", onVisibility);
+      textarea?.removeEventListener("paste", onPaste, { capture: true });
       onDataDisposable.dispose();
       term.dispose();
       termRef.current = null;


### PR DESCRIPTION
## Summary

Two related xterm input-config fixes that bring the embedded terminal closer to what users expect from iTerm2/Ghostty/etc when running claude-code or codex.

### 1. Shift+Enter inserts a newline (closes #53)
- Add `attachCustomKeyEventHandler` in `RunnerTerminal` to map Shift+Enter to `\x1b\r` (ESC+CR), which claude-code and codex interpret as "insert newline in input frame".
- Plain Enter still falls through to the default `\r` via `term.onData`, so submission behavior is unchanged.

### 2. Cmd+V forwards clipboard images to the agent CLI
claude-code and codex already attach clipboard images natively when they see Ctrl+V (`\x16`) on stdin — they shell out to `pbpaste -Prefer png` (or the platform equivalent) and read the OS clipboard themselves. On macOS users instinctively press **Cmd+V**, which the WebView grabs as a *text* paste; xterm.js's default handler drops the image and pastes the placeholder text rep, so the keystroke that would have triggered the CLI's clipboard read never reaches the PTY.

- Add a capture-phase `paste` listener on `term.textarea`. When `clipboardData.items` contains an `image/*` file, `preventDefault` xterm.js's text-paste handler and inject `\x16` into the PTY. The CLI does the rest.
- Pure-text pastes fall through to xterm.js's default behavior unchanged.

## Test plan
- [ ] Open a runner session, type "hello", press Shift+Enter — line stays in the input frame with cursor on a new line.
- [ ] Press Enter normally — message submits as before.
- [ ] Confirm Ctrl+Enter / Alt+Enter / Cmd+Enter still pass through unchanged.
- [ ] Take a clipboard screenshot (Cmd+Shift+Ctrl+4), focus the xterm, press **Cmd+V** → claude-code shows `[Image #1]` placeholder in its input.
- [ ] Plain text Cmd+V → unchanged xterm text paste.
- [ ] Ctrl+V with an image still works (xterm forwards `\x16` natively).