### PR TITLE
chore: release v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "runner",
   "private": true,
-  "version": "0.1.2",
+  "version": "0.1.3",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runner"
-version = "0.1.2"
+version = "0.1.3"
 description = "An editor for teams of local coding agents (Claude Code, Codex, and friends)"
 edition.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Runner",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "identifier": "com.wycstudios.runner",
   "build": {
     "beforeDevCommand": "npm run tauri:before:dev",


### PR DESCRIPTION
## Summary
- v0.1.3 — first release on the tmux session runtime (PR #67).
- Sessions now survive Runner restart by design; portable-pty is gone.
- macOS / Linux only — Windows users get a clear startup error pointing at the tmux requirement (issue #68 will ship a bundled tmux binary so the dependency disappears).

## Highlights since v0.1.2
- **tmux session runtime** (full cutover, PR #67): direct chats survive Cmd-Q + reopen; explicit cancellation flag eliminates kill-flow hangs; mission sessions deliberately reset on restart so the bus + router mount cleanly via `mission_attach`; FIFO + pipe-pane streaming with poll-based forwarder.
- **Schema**: nullable `runtime_*` columns added to `sessions` (migration 0003).
- **Inputs**: `paste-buffer -p -r -d` for prompt blocks, `send-keys -l --` for keystrokes, `send-keys Enter` for submit. Bracketed paste lands as one event in the agent's TUI.
- **Reattach reconciliation**: app start queries each running row's pane; alive direct chats reattach, dead panes reconcile to stopped/crashed by exit code, missions get cleanly killed and marked stopped.
- **Cleanup robustness**: failed `runtime.stop` no longer leaves an orphan pane while marking the row stopped — the row stays running until kill actually succeeds.

## Test plan
- [ ] CI green
- [ ] Verify `brew install tmux` is documented as a prerequisite for now (until issue #68 lands)
- [ ] Manual smoke on a fresh macOS install: spawn direct chat, quit Runner, reopen → chat resumes attached