### PR TITLE
docs: plan 0005 — first-prompt readback verification

### DIFF
--- a/docs/impls/0005-first-prompt-readback.md
+++ b/docs/impls/0005-first-prompt-readback.md
@@ -92,33 +92,59 @@ exposed. The plan covers all three.
 A new manager-side method `inject_paste_with_verify` runs the loop:
 
 ```text
-sleep(initial_wait)          // first-cut readiness wait, smaller than today
+sleep(initial_wait)              // first-cut readiness wait, smaller than today
+before = runtime.capture_visible(session)
+marker = paste_marker(body)
+before_marker_count = count_substr(strip_ansi(before), marker)
+before_placeholder_count = count_placeholders(before)
 loop attempt = 0..max_attempts:
     if session no longer in self.sessions: bail (user killed it)
     runtime.paste(session, body)
-    sleep(render_wait)        // give tmux + agent TUI time to render
-    snapshot = runtime.capture_visible(session)
-    if pane_acknowledged_paste(snapshot, marker(body)):
+    sleep(render_wait)           // give tmux + agent TUI time to render
+    after = runtime.capture_visible(session)
+    after_stripped = strip_ansi(after)
+    if count_substr(after_stripped, marker) > before_marker_count:
+        runtime.send_key(session, "Enter")
+        return Ok
+    if body.len() >= PLACEHOLDER_MIN_BODY_LEN
+       && count_placeholders_stripped(after_stripped) > before_placeholder_count:
         runtime.send_key(session, "Enter")
         return Ok
     sleep(between_attempts)
-return Err("persona not visible after N attempts")
+return Err("paste not visible after N attempts")
 ```
 
-`pane_acknowledged_paste` matches **either** of:
+Both acceptance signals use a **count delta** between `before` (one
+capture, taken once before the loop) and `after` (one capture per
+attempt). Either delta increasing by ≥ 1 means our paste landed:
 
-1. The body marker (first ≤32 chars of trimmed body, line-bounded)
-   appears verbatim in the pane after CSI escapes are stripped. Covers
-   short personas (Claude Code shows the paste verbatim under its
-   wrap threshold) and the codex TUI (always verbatim).
-2. The literal substring `Pasted text` appears in the pane. Covers
-   long personas where Claude Code substitutes a `[Pasted text #N
-   +M lines]` placeholder for the actual content.
+1. **Body-marker count delta.** The first ≤32 chars of trimmed body
+   (line-bounded; stop at first `\n`) — `paste_marker(body)` —
+   counted as a substring in the CSI-stripped snapshot. Covers
+   short pastes (Claude Code shows them verbatim) and the codex
+   TUI (always verbatim regardless of length). For 8-byte bodies
+   like `"continue"` this is the only signal that fires; using the
+   delta (rather than just "marker is now visible") handles the
+   resume case where the prior conversation already contains the
+   marker text — a `continue` resume against a transcript
+   mentioning the word "continue" still verifies correctly,
+   because the paste pushes the count from N to N+1.
+2. **Placeholder count delta.** `count_placeholders` is occurrences
+   of the literal `Pasted text` substring in the CSI-stripped
+   snapshot. Only consulted when `body.len() >=
+   PLACEHOLDER_MIN_BODY_LEN` (64 bytes — well below Claude Code's
+   actual wrap threshold of ~200, but above any reasonable
+   short-prompt zone where the placeholder shouldn't fire). Skipping
+   for short bodies plus using a delta both defend against the
+   resume false-ack case the reviewer flagged: a resumed pane that
+   already shows `[Pasted text #5 ...]` from prior turns has
+   `before_placeholder_count = 1`; a failed `continue` paste leaves
+   `after_placeholder_count = 1`; delta = 0 → reject and retry.
 
-Either match means the paste landed in the input box. The placeholder
-match is Claude-Code-specific by design — codex is the other
-production runtime and it always shows verbatim, so the body-marker
-match covers it.
+The capture-before is taken **once**, before the retry loop. Each
+retry compares against that fixed baseline, so duplicate pastes that
+actually do land (a paste-then-render race resulting in two
+placeholders) still verify on the first delta-positive attempt.
 
 ### Timing budget
 
@@ -228,18 +254,24 @@ impl StdinInjector for SessionManager {
 }
 ```
 
-Update `Router::inject_and_submit_delayed` to drop the
-keystroke-then-`\r` chord on the non-zero-delay path and use
-`injector.inject_paste_with_verify(session_id, &body)` instead. The
-verified path delivers the body as a bracketed paste (so multi-line
-launch prompts render correctly inside the input box, not as
-character-by-character keystrokes that wrap differently) and
-internally handles the Enter once it's confirmed the body landed.
+Update `Router::inject_and_submit_delayed` so **both** branches route
+through `injector.inject_paste_with_verify(session_id, &body)`,
+regardless of whether the `delay` parameter is zero or non-zero. The
+delay parameter now controls only "spawn a thread vs run inline";
+the *routing* decision is settled by the method name (the
+`_delayed` suffix means launch-prompt-class injection, which always
+needs the verified path):
 
-The zero-delay path (used by router unit tests with
-`LEAD_LAUNCH_PROMPT_DELAY = ZERO`) keeps the existing inline-`inject`
-behavior — those tests assert byte-write counts against a fake
-injector and shouldn't see a different call shape.
+- **Non-zero delay** (production): spawn a thread, immediately call
+  `inject_paste_with_verify` (no outer `sleep(delay)` — see Risks /
+  budget below).
+- **Zero delay** (tests): call `inject_paste_with_verify` inline.
+  Under `cfg(test)` the verified path's own durations are all zero,
+  so this stays a synchronous millisecond no-op.
+
+Drop the trailing `\r` chord entirely from the delayed path — the
+verified primitive sends Enter internally once it confirms the body
+landed.
 
 `inject_and_submit` (the synchronous, non-delayed path used by
 `human_said` and `ask_lead`) stays on raw byte injection. Those
@@ -247,21 +279,75 @@ target *running* agents that already have their TUI bound, so the
 readback isn't needed; using a paste there would just add latency
 and double-encode user-typed text.
 
+#### Readiness budget — verified path owns it
+
+The lead launch prompt today wraps the legacy raw-byte path in an
+outer `LEAD_LAUNCH_PROMPT_DELAY` (2500ms). The verified path has
+its own `initial_wait` (1500ms) plus per-attempt `render_wait`
+(600ms). **Stacking both would mean ~4600ms before the first
+verify, which is worse UX than today's blind 2500ms.** To avoid the
+stack:
+
+- The verified path is the sole owner of pre-paste readiness
+  waiting. `inject_paste_with_verify` does its own `initial_wait`
+  internally; callers must not sleep before calling it.
+- `inject_and_submit_delayed`'s thread *immediately* calls
+  `inject_paste_with_verify` — no outer `sleep`. The `delay`
+  parameter is preserved as a no-op argument for API stability with
+  the existing call sites (`handlers::mission_goal` and
+  `Router::fire_lead_launch_prompt`); the constant
+  `LEAD_LAUNCH_PROMPT_DELAY` itself can be removed once the
+  legacy raw-byte branch is gone, but keeping it as a documented
+  vestigial argument for one release simplifies the diff.
+  Optionally we delete it in the same commit — judgment call at
+  implementation time, plan accepts either.
+- Net production cost on lead path: 1500ms initial + 600ms render =
+  ~2100ms best case (faster than today's 2500ms blind), 7100ms
+  worst case (vs today's 2500ms-then-fail).
+
 ### Test stubs
 
 - `InertRuntime` (in-test stand-in for tests that never reach the
   runtime): return `Err` from `capture_visible`, matching its other
   methods. The verify loop treats capture errors as "not seen" and
   retries — the eventual give-up path is exercised this way.
-- `FakeRuntime`: add `pane_content: Mutex<Vec<u8>>` (canned snapshot
-  body) and `acknowledge_after: Mutex<usize>` (number of pastes
-  before `capture_visible` reveals the canned content). Default
-  `acknowledge_after = 0` so existing tests are unaffected.
-- The router's test-side fake `StdinInjector` (in `router/tests.rs`)
-  needs the new `inject_paste_with_verify` method too. For
-  zero-delay router unit tests this routes through the same
-  recording shape as `inject` (one byte-write captured), so existing
-  push-count assertions stay valid.
+- `FakeRuntime`: capture the new "before-then-after" probe shape
+  with three fields: `pane_pre_paste: Mutex<Vec<u8>>` (what
+  `capture_visible` returns before the canned acknowledge
+  threshold), `pane_post_paste: Mutex<Vec<u8>>` (what it returns
+  after), and `acknowledge_after: Mutex<usize>` (paste count
+  threshold). Defaults: pre-paste empty, post-paste = persona body,
+  threshold 0 — so any paste is acknowledged on first capture-after,
+  matching existing test expectations. Tests that exercise
+  retry/give-up override the threshold; the false-ack-on-resume test
+  sets `pane_pre_paste = pane_post_paste = stale-placeholder` and
+  asserts the delta check rejects.
+- `RecordingInjector` in `router/tests.rs`: implements the new
+  `StdinInjector::inject_paste_with_verify` method. To preserve
+  existing push-count assertions (e.g. `lead_pushes.len() == 1`
+  in `tests.rs:230`), tag each recorded entry with an `InjectKind`
+  enum (`Raw` / `PasteVerified`) and have the existing
+  `pushes_for` / `all_pushes` helpers continue projecting the kind
+  away — so existing assertions on body content stay valid as-is.
+  Add `paste_pushes_for(session_id)` filter so the new
+  lead-routing test can assert which path was used.
+
+### Existing test impact
+
+- Router tests that currently assert on lead-launch-prompt body
+  content via `pushes_for("S-LEAD")` (e.g. `tests.rs:230-232`,
+  `tests.rs:273-275`, `tests.rs:296`) keep their content
+  assertions unchanged — the body still goes through the recorder,
+  just tagged `PasteVerified` now. The trailing `\r` push that
+  exists in the *non-zero-delay production* path doesn't appear in
+  these tests today (they run under `cfg(test)` zero-delay which
+  skips the `\r` chord), so the chord removal is a no-op for the
+  test suite.
+- Manager-level first-prompt tests (the existing ones, pre-this-PR)
+  stay green because the default `acknowledge_after = 0` +
+  non-empty `pane_post_paste` means the verified loop terminates
+  on attempt 1 with the same paste + Enter call shape — plus one
+  capture_visible-pre and one capture_visible-post per spawn.
 
 ### Tests
 
@@ -279,39 +365,46 @@ Three new manager-level unit tests against `FakeRuntime`:
 
 Plus one router-level unit test:
 
-4. **`lead_launch_prompt_routes_through_verified_paste`** —
-   configure `LEAD_LAUNCH_PROMPT_DELAY` non-zero, fire
-   `mission_goal`, assert the fake injector's
+4. **`lead_launch_prompt_routes_through_verified_paste`** — fire
+   `mission_goal` against the router with the existing
+   `cfg(test)` zero-delay constant; assert the fake injector's
    `inject_paste_with_verify` was called once with the composed
-   launch-prompt body (and that the legacy `inject` path was *not*
-   called for that body). Guards against future churn re-introducing
-   the keystroke path.
-
-Existing first-prompt tests stay green because they don't configure
-`acknowledge_after` — the default-zero value means
-`capture_visible` returns the canned `pane_content` immediately, and
-the loop terminates on attempt 1 with the same call shape as today
-plus one `capture_visible` invocation per spawn.
+   launch-prompt body, **and** that the legacy `inject` path was
+   *not* called for that body (no leftover keystroke-then-`\r`
+   chord). The test works under `cfg(test)`'s zero-delay shape
+   because the new routing decision (verified path for *all*
+   delay values, not just non-zero) is no longer keyed on the
+   `LEAD_LAUNCH_PROMPT_DELAY` constant — guards against future
+   churn re-introducing the keystroke path.
 
 ## Risks
 
 - **`Pasted text` match is Claude-Code-specific.** If a future
   Claude Code version renames the placeholder, large pastes start
-  failing the body-marker path AND failing the placeholder path —
-  retry loop exhausts attempts, persona doesn't land. Mitigation:
-  the substring check is a single literal in `pane_acknowledged_paste`,
-  trivial to update. Worst case we revert to the blind wait — same
-  failure mode as today, no regression.
-- **Body marker false-positive on agent prior output.** The first 32
-  chars of a persona could coincidentally match unrelated pane
-  content (e.g. agent's own banner). For "You are an…" personas this
-  is unlikely; for very generic openings it could fire. Mitigation:
-  the marker comes from the *first non-whitespace line* of the body,
-  capped at 32 chars — distinctive enough in practice. If it
-  becomes a real issue we'd extend the match to require the marker
-  appear *after* a known input-box delimiter.
-- **Capture-pane cost.** ~1ms per call on macOS in benchmarks; 4
-  calls per spawn worst case. Negligible.
+  failing the body-marker path AND failing the placeholder-delta
+  path — retry loop exhausts attempts, persona doesn't land.
+  Mitigation: the substring check is a single literal in
+  `count_placeholders`, trivial to update. Worst case we revert to
+  the blind wait — same failure mode as today, no regression.
+- **Body marker false-positive on agent prior output.** The first
+  ≤32 chars of a persona could coincidentally match unrelated pane
+  content (e.g. agent's own banner). The count-delta-vs-before
+  scheme defends against the *static* version of this (resume into
+  a pane that already contains the marker — `before` and `after`
+  both count it once, delta = 0, reject) but not the *dynamic*
+  version: if the agent's banner produces the marker substring
+  between our `before` capture and our `after` capture, the count
+  goes 0 → 1 even though our paste hadn't landed yet. Concretely
+  this would require the agent's TUI to render text matching the
+  first 32 chars of the persona during the 600ms render-wait;
+  vanishingly rare for "You are a/an…" personas, and impossible
+  for codex (its banner is a fixed string with no persona-shaped
+  text). If it bites we'd extend the marker to require it appear
+  inside the input box specifically (e.g. only count occurrences
+  in the bottom N rows of the visible region).
+- **Capture-pane cost.** ~1ms per call on macOS in benchmarks; 1
+  pre-paste capture + up to 4 post-paste captures per spawn worst
+  case. Negligible.
 
 ## Out of scope follow-ups
 

--- a/docs/impls/0005-first-prompt-readback.md
+++ b/docs/impls/0005-first-prompt-readback.md
@@ -84,8 +84,10 @@ exposed. The plan covers all three.
   `continue` injection, which has the same race) gets the new path.
 - **Not implementing this on `InertRuntime` / non-tmux runtimes.**
   `InertRuntime` returns an error from `capture_visible`; the verify
-  loop treats capture errors the same as "needle not visible" and
-  retries. Non-tmux runtimes don't exist yet in production.
+  loop's capture-error policy (zero baselines on `before` failure,
+  skip-the-attempt on `after` failure — see "Capture error
+  handling" under Approach) covers it. Non-tmux runtimes don't
+  exist yet in production.
 
 ## Approach
 
@@ -93,58 +95,99 @@ A new manager-side method `inject_paste_with_verify` runs the loop:
 
 ```text
 sleep(initial_wait)              // first-cut readiness wait, smaller than today
-before = runtime.capture_visible(session)
-marker = paste_marker(body)
-before_marker_count = count_substr(strip_ansi(before), marker)
-before_placeholder_count = count_placeholders(before)
+before = runtime.capture_visible(session).unwrap_or_default()  // see error policy
+(head_marker, tail_marker) = paste_markers(body)
+before_stripped = strip_ansi(before)
+before_head_count = count_substr(before_stripped, head_marker)
+before_tail_count = count_substr(before_stripped, tail_marker)
+before_placeholder_count = count_substr(before_stripped, b"Pasted text")
 loop attempt = 0..max_attempts:
     if session no longer in self.sessions: bail (user killed it)
     runtime.paste(session, body)
     sleep(render_wait)           // give tmux + agent TUI time to render
-    after = runtime.capture_visible(session)
+    after = match runtime.capture_visible(session) {
+        Ok(b) => b,
+        Err(_) => { sleep(between_attempts); continue }   // skip this attempt's check
+    };
     after_stripped = strip_ansi(after)
-    if count_substr(after_stripped, marker) > before_marker_count:
-        runtime.send_key(session, "Enter")
-        return Ok
-    if body.len() >= PLACEHOLDER_MIN_BODY_LEN
-       && count_placeholders_stripped(after_stripped) > before_placeholder_count:
+    accept = count_substr(after_stripped, head_marker) > before_head_count
+          || count_substr(after_stripped, tail_marker) > before_tail_count
+          || (body.len() >= PLACEHOLDER_MIN_BODY_LEN
+              && count_substr(after_stripped, b"Pasted text") > before_placeholder_count)
+    if accept:
         runtime.send_key(session, "Enter")
         return Ok
     sleep(between_attempts)
 return Err("paste not visible after N attempts")
 ```
 
-Both acceptance signals use a **count delta** between `before` (one
-capture, taken once before the loop) and `after` (one capture per
-attempt). Either delta increasing by ≥ 1 means our paste landed:
+All three acceptance signals use a **count delta** between `before`
+(one capture, taken once before the loop) and `after` (one capture
+per attempt). Any one delta increasing by ≥ 1 means our paste
+landed:
 
-1. **Body-marker count delta.** The first ≤32 chars of trimmed body
-   (line-bounded; stop at first `\n`) — `paste_marker(body)` —
-   counted as a substring in the CSI-stripped snapshot. Covers
-   short pastes (Claude Code shows them verbatim) and the codex
-   TUI (always verbatim regardless of length). For 8-byte bodies
-   like `"continue"` this is the only signal that fires; using the
-   delta (rather than just "marker is now visible") handles the
-   resume case where the prior conversation already contains the
-   marker text — a `continue` resume against a transcript
-   mentioning the word "continue" still verifies correctly,
-   because the paste pushes the count from N to N+1.
-2. **Placeholder count delta.** `count_placeholders` is occurrences
-   of the literal `Pasted text` substring in the CSI-stripped
-   snapshot. Only consulted when `body.len() >=
-   PLACEHOLDER_MIN_BODY_LEN` (64 bytes — well below Claude Code's
-   actual wrap threshold of ~200, but above any reasonable
-   short-prompt zone where the placeholder shouldn't fire). Skipping
-   for short bodies plus using a delta both defend against the
-   resume false-ack case the reviewer flagged: a resumed pane that
-   already shows `[Pasted text #5 ...]` from prior turns has
-   `before_placeholder_count = 1`; a failed `continue` paste leaves
-   `after_placeholder_count = 1`; delta = 0 → reject and retry.
+1. **Head-marker count delta.** The first ≤32 chars of the trimmed
+   body's first non-empty line — `head_marker` — counted as a
+   substring in the CSI-stripped snapshot. Covers short pastes
+   (Claude Code shows them verbatim) and any TUI where the input
+   editor scrolls to keep the *start* of the paste visible. For
+   8-byte bodies like `"continue"` this is the only signal that
+   fires; using the delta (rather than just "marker is now
+   visible") handles the resume case where the prior conversation
+   already contains the marker text — a `continue` resume against
+   a transcript mentioning the word "continue" still verifies
+   correctly, because the paste pushes the count from N to N+1.
+2. **Tail-marker count delta.** The last ≤32 chars of trimmed body's
+   last non-empty line — `tail_marker`. Covers TUIs that scroll the
+   input editor to keep the *cursor* (and therefore the *end* of the
+   paste) visible — codex's chat composer is the known case. A long
+   codex mission prompt (preamble + roster + brief, often >2KB)
+   will not show its first line in the visible region; the
+   editor's bottom rows show the trailing lines instead. Tail-marker
+   delta picks that up. For short bodies where head and tail
+   overlap, both signals fire on the same paste — equivalent to
+   "either marker matched" with no double-count concern.
+3. **Placeholder count delta.** Occurrences of the literal
+   `Pasted text` substring in the CSI-stripped snapshot. Consulted
+   only when `body.len() >= PLACEHOLDER_MIN_BODY_LEN` (64 bytes —
+   well below Claude Code's actual wrap threshold of ~200, but
+   above any reasonable short-prompt zone where the placeholder
+   shouldn't fire). Skipping for short bodies plus using a delta
+   both defend against the resume false-ack case: a resumed pane
+   that already shows `[Pasted text #5 ...]` from prior turns has
+   `before_placeholder_count = 1`; a failed `continue` paste
+   leaves `after_placeholder_count = 1`; delta = 0 → reject and
+   retry.
 
 The capture-before is taken **once**, before the retry loop. Each
 retry compares against that fixed baseline, so duplicate pastes that
 actually do land (a paste-then-render race resulting in two
 placeholders) still verify on the first delta-positive attempt.
+
+#### Capture error handling
+
+The `capture_visible` call can fail (tmux daemon flaked, pane id no
+longer valid, runtime returns `Err` — `InertRuntime` always errors
+this way for unit-test paths that never reach a real runtime). Two
+distinct cases:
+
+- **Baseline (`before`) capture fails.** Treat as zero counts and
+  proceed. Concretely: `unwrap_or_default()` returns an empty
+  `Vec<u8>`, and `count_substr(b"", _) == 0` — so the baselines
+  become 0 across the board. The first post-paste capture will
+  count whatever appears in the pane against zero; if that pane
+  contains the marker text from prior content, we'd false-ack on
+  attempt 1. The alternative (abort the verify and fall back to
+  raw send-keys) regresses every baseline-capture failure to the
+  pre-fix state, which is worse than a rare false-ack. We log the
+  failure to stderr so operators can correlate. In practice
+  baseline-capture failures are transient — tmux is alive enough
+  to spawn but momentarily unresponsive — and resolve by the next
+  attempt.
+- **Per-attempt (`after`) capture fails.** Skip the check for
+  *this* attempt and continue the loop after the
+  `between_attempts` sleep. Don't retry the capture inline; the
+  loop's natural cadence already rate-limits.
 
 ### Timing budget
 
@@ -351,22 +394,30 @@ stack:
 
 ### Tests
 
-Three new manager-level unit tests against `FakeRuntime`:
+Five new unit tests:
 
-1. **`first_prompt_landed_first_try`** —
-   `acknowledge_after = 0`, `pane_content = persona`. Inject. Assert
-   1 paste captured, 1 `Key("Enter")` captured, no `Err` log.
-2. **`first_prompt_landed_after_retry`** —
-   `acknowledge_after = 2`, `pane_content = persona`. Inject. Assert
-   2 pastes captured (the loop retried once), 1 Enter captured.
-3. **`first_prompt_gives_up_after_max_attempts`** —
+1. **`first_prompt_landed_first_try`** (manager) —
+   `acknowledge_after = 0`, `pane_post_paste` contains the persona
+   body. Inject. Assert 1 paste captured, 1 `Key("Enter")` captured,
+   no `Err` log.
+2. **`first_prompt_landed_after_retry`** (manager) —
+   `acknowledge_after = 2`, `pane_post_paste` contains the persona
+   body, `pane_pre_paste` empty. Inject. Assert 2 pastes captured
+   (loop retried once), 1 Enter captured.
+3. **`first_prompt_gives_up_after_max_attempts`** (manager) —
    `acknowledge_after = 999`. Inject. Assert `max_attempts` pastes
    captured, **zero** Enters captured.
-
-Plus one router-level unit test:
-
-4. **`lead_launch_prompt_routes_through_verified_paste`** — fire
-   `mission_goal` against the router with the existing
+4. **`continue_resume_rejects_stale_placeholder`** (manager) —
+   `body = b"continue"`, `pane_pre_paste = pane_post_paste =
+   "[Pasted text #5 +20 lines]"` (resume showing prior placeholder),
+   `acknowledge_after = 0`. Inject. Assert `max_attempts` pastes,
+   zero Enters — the placeholder count delta is 0 (both before and
+   after see one placeholder), `body.len() = 8 < 64` so the
+   placeholder check wouldn't fire anyway, and the body marker
+   "continue" is not in the canned content. Guards the
+   round-2 false-ack regression directly.
+5. **`lead_launch_prompt_routes_through_verified_paste`** (router) —
+   fire `mission_goal` against the router with the existing
    `cfg(test)` zero-delay constant; assert the fake injector's
    `inject_paste_with_verify` was called once with the composed
    launch-prompt body, **and** that the legacy `inject` path was
@@ -424,7 +475,9 @@ Plus one router-level unit test:
 ## Rollout
 
 Single PR off `fix/first-prompt-readback`, target v0.1.4. CI runs
-the full unit suite (so the three new tests + 197 existing pass);
-manual smoke is "spawn three direct chats with a persona in
-parallel, confirm all three show the persona as the first user turn
-in each agent".
+the full unit suite (5 new tests + 197 existing pass); manual smoke:
+(a) spawn three claude-code direct chats with personas in parallel,
+confirm all three show the persona as the first user turn; (b) start
+a fresh codex-lead mission with a long preamble+brief (≥2KB), confirm
+the lead receives the launch prompt and submits it (covers the
+tail-marker path).

--- a/docs/impls/0005-first-prompt-readback.md
+++ b/docs/impls/0005-first-prompt-readback.md
@@ -38,6 +38,31 @@ substring matching, but with much weaker guarantees (frontend-coupled
 buffer, no alternate-screen awareness). Now that we own the pane via
 tmux, the readback loop is straightforward.
 
+### Three injection paths share the race
+
+`SessionManager::inject_first_turn` is one of three places where Runner
+hands a first user turn to a freshly-spawned agent on the same 2500ms
+budget. All three race the agent's TUI bind, all three need the fix:
+
+| Path | Caller | Today's primitive | Used for |
+|---|---|---|---|
+| `inject_first_turn` (manager.rs:1897) | `schedule_direct_first_prompt`, `schedule_mission_first_prompt` (non-lead workers) | `inject_paste` — `tmux paste-buffer -p -r -d` + 120ms + `send_key("Enter")` | Direct-chat persona; non-lead mission worker preamble |
+| `Router::inject_and_submit_delayed` (router/mod.rs:425) | `handlers::mission_goal` (mission boot), `Router::fire_lead_launch_prompt` (resume-fresh-fallback) | `StdinInjector::inject` — raw bytes via `tmux send-keys -l`; trailing `b"\r"` after 80ms | Mission lead launch prompt (system_prompt + bus protocol + mission goal) |
+| `schedule_continue_on_resume` (manager.rs:1953) | claude-code resume path | `inject_paste` of `b"continue"` | Auto-`continue` after a successful resume |
+
+The lead-launch-prompt path is the most fragile of the three: it
+delivers a multi-line prompt (preamble + roster + brief) as
+*keystrokes* (`send-keys -l`, character-by-character) rather than as a
+bracketed paste, so even when the readiness window does hold,
+embedded `\n`s can render as line breaks the TUI never wraps the same
+way a real paste would. Plus the readiness race itself.
+
+A v0.1.4 fix that only patched `inject_first_turn` would leave Codex
+mission leads (always on this path because their argv `[PROMPT]`
+positional gets swallowed by the approval dialog —
+`router/runtime.rs:13-16`) and Claude Code mission leads still
+exposed. The plan covers all three.
+
 ## What we're not doing
 
 - **Not bumping the timer.** 4000ms or 5000ms would mask the bug for
@@ -172,6 +197,56 @@ Five changes:
    just the literal string "continue" (covered by the body-marker
    path; `Pasted text` doesn't fire for an 8-char paste).
 
+### `src-tauri/src/router/mod.rs`
+
+Extend the `StdinInjector` trait so the router can route lead launch
+prompts through the verified path without bypassing the seam the
+test-side fake injector relies on:
+
+```rust
+pub trait StdinInjector: Send + Sync + 'static {
+    fn inject(&self, session_id: &str, bytes: &[u8]) -> Result<()>;
+    /// Verified paste-and-submit. Used by `inject_and_submit_delayed`
+    /// for mission lead launch prompts. Performs the readback retry
+    /// loop internally; on success the agent has the body in its
+    /// input buffer AND has received Enter.
+    fn inject_paste_with_verify(&self, session_id: &str, body: &[u8]) -> Result<()>;
+}
+
+impl StdinInjector for SessionManager {
+    fn inject(&self, session_id: &str, bytes: &[u8]) -> Result<()> {
+        SessionManager::inject_stdin(self, session_id, bytes)
+    }
+    fn inject_paste_with_verify(&self, session_id: &str, body: &[u8]) -> Result<()> {
+        SessionManager::inject_paste_with_verify(
+            self,
+            session_id,
+            body,
+            FIRST_PROMPT_CONFIG, // exposed pub(crate) from session::manager
+        )
+    }
+}
+```
+
+Update `Router::inject_and_submit_delayed` to drop the
+keystroke-then-`\r` chord on the non-zero-delay path and use
+`injector.inject_paste_with_verify(session_id, &body)` instead. The
+verified path delivers the body as a bracketed paste (so multi-line
+launch prompts render correctly inside the input box, not as
+character-by-character keystrokes that wrap differently) and
+internally handles the Enter once it's confirmed the body landed.
+
+The zero-delay path (used by router unit tests with
+`LEAD_LAUNCH_PROMPT_DELAY = ZERO`) keeps the existing inline-`inject`
+behavior — those tests assert byte-write counts against a fake
+injector and shouldn't see a different call shape.
+
+`inject_and_submit` (the synchronous, non-delayed path used by
+`human_said` and `ask_lead`) stays on raw byte injection. Those
+target *running* agents that already have their TUI bound, so the
+readback isn't needed; using a paste there would just add latency
+and double-encode user-typed text.
+
 ### Test stubs
 
 - `InertRuntime` (in-test stand-in for tests that never reach the
@@ -182,10 +257,15 @@ Five changes:
   body) and `acknowledge_after: Mutex<usize>` (number of pastes
   before `capture_visible` reveals the canned content). Default
   `acknowledge_after = 0` so existing tests are unaffected.
+- The router's test-side fake `StdinInjector` (in `router/tests.rs`)
+  needs the new `inject_paste_with_verify` method too. For
+  zero-delay router unit tests this routes through the same
+  recording shape as `inject` (one byte-write captured), so existing
+  push-count assertions stay valid.
 
 ### Tests
 
-Three new unit tests against `FakeRuntime`:
+Three new manager-level unit tests against `FakeRuntime`:
 
 1. **`first_prompt_landed_first_try`** —
    `acknowledge_after = 0`, `pane_content = persona`. Inject. Assert
@@ -196,6 +276,16 @@ Three new unit tests against `FakeRuntime`:
 3. **`first_prompt_gives_up_after_max_attempts`** —
    `acknowledge_after = 999`. Inject. Assert `max_attempts` pastes
    captured, **zero** Enters captured.
+
+Plus one router-level unit test:
+
+4. **`lead_launch_prompt_routes_through_verified_paste`** —
+   configure `LEAD_LAUNCH_PROMPT_DELAY` non-zero, fire
+   `mission_goal`, assert the fake injector's
+   `inject_paste_with_verify` was called once with the composed
+   launch-prompt body (and that the legacy `inject` path was *not*
+   called for that body). Guards against future churn re-introducing
+   the keystroke path.
 
 Existing first-prompt tests stay green because they don't configure
 `acknowledge_after` — the default-zero value means

--- a/docs/impls/0005-first-prompt-readback.md
+++ b/docs/impls/0005-first-prompt-readback.md
@@ -1,0 +1,247 @@
+# First-prompt readback verification
+
+> Post-tmux-cutover bugfix. Replaces the `FIRST_PROMPT_DELAY = 2500ms`
+> blind-wait heuristic in `inject_first_turn` with a paste → capture-pane →
+> verify → retry → Enter loop, so persona injection lands deterministically
+> regardless of how long the agent's TUI takes to bind raw-mode input.
+>
+> Companion to `0004-tmux-session-runtime.md` (the runtime that makes this
+> feasible — `capture-pane` is what unlocks readback). Targets the v0.1.4
+> release.
+
+## Why
+
+Issue #50 (also reported live by the user post v0.1.3): after a fresh
+chat spawn, the system_prompt sometimes fails to land in the agent's
+input box. The 2500ms `FIRST_PROMPT_DELAY` is supposed to cover the
+window between `tmux new-session` and the agent's TUI binding raw-mode
+keypress reading; in practice that window varies with CPU contention
+(parallel spawns, cold disk, mid-update Node startup) and 2500ms isn't
+always enough.
+
+When the paste lands too early it gets eaten by whichever pre-input
+handler is on screen — Claude Code's "trust this folder" dialog, the
+banner animation phase, or just an unbound stdin during Node init.
+Once eaten, no recovery: we send Enter on a 120ms timer regardless,
+and the agent boots vanilla with no persona context. The user has to
+notice and re-inject manually.
+
+`claude-squad` (cs#266) ships with the same bug — their `SendPrompt`
+has a 100ms gap between body and Enter and no readiness wait at all.
+We're already doing better with 2500ms; the goal here is to do better
+than "better".
+
+The tmux runtime is a hard prerequisite: `capture-pane -p -e` is the
+primitive that makes "did our paste actually land" answerable. The
+prior `portable-pty` path could have stitched together output-buffer
+substring matching, but with much weaker guarantees (frontend-coupled
+buffer, no alternate-screen awareness). Now that we own the pane via
+tmux, the readback loop is straightforward.
+
+## What we're not doing
+
+- **Not bumping the timer.** 4000ms or 5000ms would mask the bug for
+  most cases but adds wasted UX latency for fast spawns and still
+  fails under contention. The retry loop is deterministic — fast
+  agents return on attempt 1 (faster than today, since the initial
+  wait drops to 1500ms); slow agents get retried.
+- **Not changing the paste primitive.** `tmux paste-buffer -p -r -d`
+  stays the bracketed-paste delivery mechanism. Only the
+  *verification* layer changes.
+- **Not surfacing failures to the UI.** A first-prompt give-up after
+  the max retry budget logs to stderr; the user can re-paste from the
+  composer manually. UI surfacing is a follow-up if it turns out to
+  matter.
+- **Not refactoring `inject_paste`.** The general-purpose paste path
+  (composer submits, mission `--to` deliveries) still uses the
+  blind-wait shape — those land into a known-ready agent and don't
+  need readback. Only the *first-turn* injection (and the post-resume
+  `continue` injection, which has the same race) gets the new path.
+- **Not implementing this on `InertRuntime` / non-tmux runtimes.**
+  `InertRuntime` returns an error from `capture_visible`; the verify
+  loop treats capture errors the same as "needle not visible" and
+  retries. Non-tmux runtimes don't exist yet in production.
+
+## Approach
+
+A new manager-side method `inject_paste_with_verify` runs the loop:
+
+```text
+sleep(initial_wait)          // first-cut readiness wait, smaller than today
+loop attempt = 0..max_attempts:
+    if session no longer in self.sessions: bail (user killed it)
+    runtime.paste(session, body)
+    sleep(render_wait)        // give tmux + agent TUI time to render
+    snapshot = runtime.capture_visible(session)
+    if pane_acknowledged_paste(snapshot, marker(body)):
+        runtime.send_key(session, "Enter")
+        return Ok
+    sleep(between_attempts)
+return Err("persona not visible after N attempts")
+```
+
+`pane_acknowledged_paste` matches **either** of:
+
+1. The body marker (first ≤32 chars of trimmed body, line-bounded)
+   appears verbatim in the pane after CSI escapes are stripped. Covers
+   short personas (Claude Code shows the paste verbatim under its
+   wrap threshold) and the codex TUI (always verbatim).
+2. The literal substring `Pasted text` appears in the pane. Covers
+   long personas where Claude Code substitutes a `[Pasted text #N
+   +M lines]` placeholder for the actual content.
+
+Either match means the paste landed in the input box. The placeholder
+match is Claude-Code-specific by design — codex is the other
+production runtime and it always shows verbatim, so the body-marker
+match covers it.
+
+### Timing budget
+
+| Phase | Production | Test (`cfg(test)`) |
+|---|---|---|
+| `initial_wait` | 1500ms | 0 |
+| `render_wait` (per attempt) | 600ms | 0 |
+| `between_attempts` | 800ms | 0 |
+| `max_attempts` | 4 | 4 |
+
+- **Best case** (fast spawn, paste landed first try): 1500 + 600 ≈
+  2100ms — *faster* than today's 2500ms blind wait.
+- **Worst case** (4 retries before giving up): 1500 + 4×(600+800) =
+  7100ms. Worse than today only if today would also have failed; in
+  exchange the persona actually lands.
+
+Test mode collapses every duration to zero so unit tests stay
+synchronous (matches the existing `FIRST_PROMPT_DELAY = ZERO` shape).
+
+### Idempotency under retry
+
+The retry loop accepts a small risk of duplicate paste: if the agent
+*just* started rendering when we capture-pane and our marker isn't
+visible yet, we paste again, the agent now has the body twice. In
+practice Claude Code merges the two into a single
+`[Pasted text #1 +N lines] [Pasted text #2 +M lines]` — the user
+sees both segments delivered as one prompt. Mildly weird, not
+broken, and rare in the timing budgets above (600ms render wait is
+generous).
+
+The alternative (capture *before* paste, paste only when pane
+"looks ready") would need a runtime-specific readiness signal.
+`Pasted text` indicates a successful paste; there's no symmetric
+"agent is now ready" indicator across runtimes. Post-paste
+verification is the simpler primitive.
+
+## Touch surface
+
+### `src-tauri/src/session/runtime.rs`
+
+Add one method to `SessionRuntime`:
+
+```rust
+/// Snapshot of the pane's currently-rendered visible region with
+/// SGR escapes preserved (`tmux capture-pane -p -e`). Used by the
+/// manager's first-prompt readback loop to verify a paste actually
+/// landed in the agent's input box before sending Enter.
+fn capture_visible(&self, session: &RuntimeSession) -> RuntimeResult<Vec<u8>>;
+```
+
+### `src-tauri/src/session/tmux_runtime.rs`
+
+Implement `capture_visible` by promoting the existing private
+`capture_visible_region` helper to a public trait method (it's
+already called by `attach_streaming` for fresh-spawn snapshots, so
+the shape is exactly what we need).
+
+### `src-tauri/src/session/manager.rs`
+
+Five changes:
+
+1. Replace the `FIRST_PROMPT_DELAY` constant with a `FirstPromptConfig`
+   struct holding all four durations + max_attempts. Production /
+   test variants gated on `cfg(test)`.
+2. Add `inject_paste_with_verify(session_id, body, config)` method on
+   `SessionManager`. Pure orchestration — runtime calls only.
+3. Add the helpers `paste_marker(body)` and
+   `pane_acknowledged_paste(snapshot, marker)` (the latter strips
+   CSI escapes from the snapshot before substring matching, reusing
+   the strip logic shape from `is_visually_blank`).
+4. Switch `inject_first_turn` from `inject_paste` blind-wait to
+   `inject_paste_with_verify`. Same `cfg(test)` inline-vs-thread
+   split as today.
+5. Switch `schedule_continue_on_resume` to `inject_paste_with_verify`
+   too — same race, same fix. The marker for the `continue` body is
+   just the literal string "continue" (covered by the body-marker
+   path; `Pasted text` doesn't fire for an 8-char paste).
+
+### Test stubs
+
+- `InertRuntime` (in-test stand-in for tests that never reach the
+  runtime): return `Err` from `capture_visible`, matching its other
+  methods. The verify loop treats capture errors as "not seen" and
+  retries — the eventual give-up path is exercised this way.
+- `FakeRuntime`: add `pane_content: Mutex<Vec<u8>>` (canned snapshot
+  body) and `acknowledge_after: Mutex<usize>` (number of pastes
+  before `capture_visible` reveals the canned content). Default
+  `acknowledge_after = 0` so existing tests are unaffected.
+
+### Tests
+
+Three new unit tests against `FakeRuntime`:
+
+1. **`first_prompt_landed_first_try`** —
+   `acknowledge_after = 0`, `pane_content = persona`. Inject. Assert
+   1 paste captured, 1 `Key("Enter")` captured, no `Err` log.
+2. **`first_prompt_landed_after_retry`** —
+   `acknowledge_after = 2`, `pane_content = persona`. Inject. Assert
+   2 pastes captured (the loop retried once), 1 Enter captured.
+3. **`first_prompt_gives_up_after_max_attempts`** —
+   `acknowledge_after = 999`. Inject. Assert `max_attempts` pastes
+   captured, **zero** Enters captured.
+
+Existing first-prompt tests stay green because they don't configure
+`acknowledge_after` — the default-zero value means
+`capture_visible` returns the canned `pane_content` immediately, and
+the loop terminates on attempt 1 with the same call shape as today
+plus one `capture_visible` invocation per spawn.
+
+## Risks
+
+- **`Pasted text` match is Claude-Code-specific.** If a future
+  Claude Code version renames the placeholder, large pastes start
+  failing the body-marker path AND failing the placeholder path —
+  retry loop exhausts attempts, persona doesn't land. Mitigation:
+  the substring check is a single literal in `pane_acknowledged_paste`,
+  trivial to update. Worst case we revert to the blind wait — same
+  failure mode as today, no regression.
+- **Body marker false-positive on agent prior output.** The first 32
+  chars of a persona could coincidentally match unrelated pane
+  content (e.g. agent's own banner). For "You are an…" personas this
+  is unlikely; for very generic openings it could fire. Mitigation:
+  the marker comes from the *first non-whitespace line* of the body,
+  capped at 32 chars — distinctive enough in practice. If it
+  becomes a real issue we'd extend the match to require the marker
+  appear *after* a known input-box delimiter.
+- **Capture-pane cost.** ~1ms per call on macOS in benchmarks; 4
+  calls per spawn worst case. Negligible.
+
+## Out of scope follow-ups
+
+- Surfacing a "persona not delivered" toast to the UI when
+  `inject_paste_with_verify` exhausts its budget. Today this only
+  hits stderr; if it turns out to fire often enough that users
+  notice silently, we'd add a UI signal. Punted until we have signal.
+- Generalizing the readback to mission `--to` deliveries. Those
+  paste into a known-ready agent (the spawn already settled), so
+  the race we're fixing here doesn't apply. Could still be
+  defensive armor against the next class of stuck-paste bugs;
+  punted for now.
+- Extracting `paste_marker` / `pane_acknowledged_paste` into a
+  shared helper module if a third caller appears. Currently they're
+  internal to the first-prompt path.
+
+## Rollout
+
+Single PR off `fix/first-prompt-readback`, target v0.1.4. CI runs
+the full unit suite (so the three new tests + 197 existing pass);
+manual smoke is "spawn three direct chats with a persona in
+parallel, confirm all three show the persona as the first user turn
+in each agent".

--- a/src-tauri/src/router/handlers.rs
+++ b/src-tauri/src/router/handlers.rs
@@ -19,17 +19,20 @@ use runner_core::model::Event;
 use super::prompt::{compose_launch_prompt, LaunchPromptInput, RosterEntry};
 use super::{Router, RunnerStatus};
 
-/// How long to defer the lead's launch-prompt write after spawn so
-/// claude-code's TUI has time to draw before the bytes land. Matches
-/// `SessionManager::FIRST_PROMPT_DELAY` for workers — same race in
-/// two places. 500ms wasn't enough in practice (the lead came up
-/// without its system prompt on warm boots), so we hold the
-/// 2500ms budget pending a real readback-verification fix (#50).
-/// `cfg(test)` zeros the delay so unit tests can assert injections
-/// synchronously without sleeping (the injector's `inject_and_submit_
-/// delayed` runs inline when the duration is zero).
+/// Vestigial post 0005-first-prompt-readback. Used to be the
+/// blind-wait budget before the lead's launch prompt landed via raw
+/// keystrokes; that role is now owned by the verified primitive
+/// (`SessionManager::inject_paste_with_verify` via the
+/// `StdinInjector::inject_paste_with_verify` trait method), which
+/// has its own initial_wait + render_wait. This constant now
+/// controls **only** thread-vs-inline execution inside
+/// `Router::inject_and_submit_delayed`: a non-zero duration spawns
+/// a thread, ZERO under `cfg(test)` runs the verified primitive
+/// inline so unit tests can read the recording injector
+/// synchronously. The exact production value is not load-bearing —
+/// any non-zero duration triggers the threaded branch.
 #[cfg(not(test))]
-const LEAD_LAUNCH_PROMPT_DELAY: std::time::Duration = std::time::Duration::from_millis(2500);
+const LEAD_LAUNCH_PROMPT_DELAY: std::time::Duration = std::time::Duration::from_millis(1);
 #[cfg(test)]
 const LEAD_LAUNCH_PROMPT_DELAY: std::time::Duration = std::time::Duration::ZERO;
 
@@ -71,13 +74,13 @@ pub(super) fn mission_goal(router: &Router, event: &Event) {
         roster: &roster_entries,
         allowed_signals: launch.allowed_signals(),
     });
-    // Defer the lead's launch prompt by the same 2.5s budget the
-    // worker preamble uses (`SessionManager::FIRST_PROMPT_DELAY`).
-    // The bus's initial replay can fire `mission_goal` milliseconds
-    // after the lead PTY spawns — on a warm app (mission_reset, fast
-    // mission_start) claude-code's TUI hasn't drawn yet and any bytes
-    // we write get swallowed by its boot / trust-folder screen,
-    // leaving the architect with no system prompt.
+    // Route through the verified paste-and-submit primitive: the
+    // bus's initial replay can fire `mission_goal` milliseconds after
+    // the lead PTY spawns, before claude-code's / codex's TUI has
+    // bound raw input. The primitive captures the pane after each
+    // attempt and only sends Enter once it confirms the paste landed.
+    // Owns its own readiness waiting — `LEAD_LAUNCH_PROMPT_DELAY`
+    // here just selects thread (production) vs inline (cfg(test)).
     router.inject_and_submit_delayed(
         lead_row.handle(),
         submit_body(&prompt),

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -37,12 +37,36 @@ use crate::session::manager::SessionManager;
 /// `SessionManager` impls it; tests use a recording fake. Lives behind a
 /// trait so the router doesn't pull a PTY runtime into unit tests.
 pub trait StdinInjector: Send + Sync + 'static {
+    /// Raw stdin bytes — used by `inject_and_submit` for the
+    /// already-running-agent paths (`human_said`, `ask_lead`).
+    /// `\r` becomes Enter, anything else is a literal byte stream.
     fn inject(&self, session_id: &str, bytes: &[u8]) -> Result<()>;
+
+    /// Verified paste-and-submit. Used by
+    /// `inject_and_submit_delayed` for mission lead launch prompts:
+    /// the agent's TUI may not be bound for raw input yet, and
+    /// blind keystrokes get eaten by whatever pre-input handler is
+    /// on screen (trust dialog, banner animation). The verified
+    /// primitive pastes via tmux paste-buffer, captures the pane,
+    /// confirms the paste rendered (head/tail-marker or
+    /// `Pasted text` placeholder count delta), and only then sends
+    /// Enter. Owns its own readiness budget — callers MUST NOT
+    /// sleep before calling it.
+    fn inject_paste_with_verify(&self, session_id: &str, body: &[u8]) -> Result<()>;
 }
 
 impl StdinInjector for SessionManager {
     fn inject(&self, session_id: &str, bytes: &[u8]) -> Result<()> {
         SessionManager::inject_stdin(self, session_id, bytes)
+    }
+
+    fn inject_paste_with_verify(&self, session_id: &str, body: &[u8]) -> Result<()> {
+        SessionManager::inject_paste_with_verify(
+            self,
+            session_id,
+            body,
+            crate::session::manager::FIRST_PROMPT_CONFIG,
+        )
     }
 }
 
@@ -408,16 +432,23 @@ impl Router {
         Ok(())
     }
 
-    /// Same contract as `inject_and_submit`, but the whole sequence
-    /// (body + delayed `\r`) is deferred by `delay`. Used for the
-    /// lead's launch prompt: the bus's initial replay fires
-    /// `mission_goal` immediately after the lead PTY spawns, but on
-    /// a warm app (mission_reset, fast mission_start) claude-code's
-    /// TUI hasn't drawn yet, so synchronous bytes get swallowed by
-    /// the boot / trust-folder screen and the lead never sees its
-    /// system prompt. The 2.5s budget matches
-    /// `SessionManager::FIRST_PROMPT_DELAY`, which solves the
-    /// same race for non-lead workers.
+    /// Lead launch-prompt injection: routes through the verified
+    /// paste-and-submit primitive (`inject_paste_with_verify`) so
+    /// the body lands as one bracketed paste and Enter only fires
+    /// once the pane confirms the paste rendered. Used for the
+    /// lead's `mission_goal`-driven launch prompt and the
+    /// resume-fresh-fallback path; both spawn a fresh agent that
+    /// races us to bind raw-mode input.
+    ///
+    /// `delay` controls only thread-vs-inline execution:
+    /// non-zero spawns a thread; zero (cfg(test)) runs inline.
+    /// **The verified primitive owns pre-paste readiness waiting**
+    /// — this method does NOT sleep before calling it, otherwise
+    /// the lead path would stack `delay` on top of the verify
+    /// loop's own initial_wait. The legacy outer-sleep budget
+    /// (`LEAD_LAUNCH_PROMPT_DELAY`) is therefore vestigial post
+    /// 0005-first-prompt-readback and should be removed once the
+    /// constant has no other readers.
     ///
     /// Resolves the handle → session_id at schedule time. Mission
     /// boot is the only caller and the lead's session is fully
@@ -439,34 +470,30 @@ impl Router {
             return;
         };
         self.synthesize_wake_busy(handle);
-        // Zero-delay path: run inline, body only — no separate `\r`
-        // chord. Used by unit tests
-        // (`LEAD_LAUNCH_PROMPT_DELAY = ZERO` under `cfg(test)`) so
-        // synchronous push-count assertions match the prior single-
-        // push behavior of `inject_and_submit` (where the `\r` was
-        // always deferred to a background thread and never observed
-        // by sync test code). Production never hits this branch —
-        // claude-code is the only consumer that needs the
-        // body-then-`\r` chord, and it's always on a non-zero delay.
+        if body.is_empty() {
+            return;
+        }
+
+        // Zero-delay path: run inline. Under `cfg(test)`
+        // (LEAD_LAUNCH_PROMPT_DELAY = ZERO) the verified primitive's
+        // own durations are also zero, so this stays a synchronous
+        // millisecond no-op and existing `pushes_for(...)`
+        // assertions still observe one body push.
         if delay.is_zero() {
-            if !body.is_empty() {
-                if let Err(e) = self.injector.inject(&session_id, &body) {
-                    eprintln!("router: inline inject to {session_id} failed: {e}");
-                }
+            if let Err(e) = self.injector.inject_paste_with_verify(&session_id, &body) {
+                eprintln!("router: inline verified-paste to {session_id} failed: {e}");
             }
             return;
         }
         let injector = Arc::clone(&self.injector);
         std::thread::spawn(move || {
-            std::thread::sleep(delay);
-            if !body.is_empty() {
-                if let Err(e) = injector.inject(&session_id, &body) {
-                    eprintln!("router: delayed inject to {session_id} failed: {e}");
-                    return;
-                }
+            // No outer sleep — the verified primitive owns the
+            // readiness budget (initial_wait + render_wait). Stacking
+            // `delay` here would push the lead launch prompt past
+            // 4s before the first paste even tries.
+            if let Err(e) = injector.inject_paste_with_verify(&session_id, &body) {
+                eprintln!("router: delayed verified-paste to {session_id} failed: {e}");
             }
-            std::thread::sleep(std::time::Duration::from_millis(80));
-            let _ = injector.inject(&session_id, b"\r");
         });
     }
 

--- a/src-tauri/src/router/tests.rs
+++ b/src-tauri/src/router/tests.rs
@@ -16,10 +16,23 @@ use super::{Router, RouterRegistry, StdinInjector};
 use crate::error::Result;
 use crate::model::{Runner, Slot, SlotWithRunner};
 
-/// Records every `inject` call so handler outputs can be asserted.
+/// Discriminator on each recorded push so tests can assert which
+/// primitive the router used: raw byte injection (`inject`) for
+/// already-running-agent paths, vs verified paste-and-submit
+/// (`inject_paste_with_verify`) for fresh-spawn launch prompts.
+/// Existing `pushes_for` / `all_pushes` helpers project the kind
+/// away, so existing body-content assertions stay valid.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InjectKind {
+    Raw,
+    PasteVerified,
+}
+
+/// Records every `inject` / `inject_paste_with_verify` call so
+/// handler outputs can be asserted.
 #[derive(Default)]
 struct RecordingInjector {
-    pushes: Mutex<Vec<(String, Vec<u8>)>>,
+    pushes: Mutex<Vec<(String, InjectKind, Vec<u8>)>>,
     /// Optional `dead_session` set — `inject` errors when called with one
     /// of these ids, simulating a crashed PTY for `mission_warning` tests.
     dead: Mutex<Vec<String>>,
@@ -31,8 +44,8 @@ impl RecordingInjector {
             .lock()
             .unwrap()
             .iter()
-            .filter(|(s, _)| s == session_id)
-            .map(|(_, bytes)| String::from_utf8_lossy(bytes).into_owned())
+            .filter(|(s, _, _)| s == session_id)
+            .map(|(_, _, bytes)| String::from_utf8_lossy(bytes).into_owned())
             .collect()
     }
 
@@ -41,7 +54,35 @@ impl RecordingInjector {
             .lock()
             .unwrap()
             .iter()
-            .map(|(s, b)| (s.clone(), String::from_utf8_lossy(b).into_owned()))
+            .map(|(s, _, b)| (s.clone(), String::from_utf8_lossy(b).into_owned()))
+            .collect()
+    }
+
+    /// Pushes for `session_id` recorded specifically via the
+    /// verified-paste primitive. Used by the lead-launch-prompt test
+    /// to confirm the routing didn't fall back to raw stdin.
+    #[allow(dead_code)]
+    fn paste_pushes_for(&self, session_id: &str) -> Vec<String> {
+        self.pushes
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(s, k, _)| s == session_id && *k == InjectKind::PasteVerified)
+            .map(|(_, _, bytes)| String::from_utf8_lossy(bytes).into_owned())
+            .collect()
+    }
+
+    /// Pushes for `session_id` recorded specifically via the raw
+    /// primitive. Used to confirm the verified path didn't *also*
+    /// fall through to raw stdin.
+    #[allow(dead_code)]
+    fn raw_pushes_for(&self, session_id: &str) -> Vec<String> {
+        self.pushes
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(s, k, _)| s == session_id && *k == InjectKind::Raw)
+            .map(|(_, _, bytes)| String::from_utf8_lossy(bytes).into_owned())
             .collect()
     }
 
@@ -60,7 +101,21 @@ impl StdinInjector for RecordingInjector {
         self.pushes
             .lock()
             .unwrap()
-            .push((session_id.to_string(), bytes.to_vec()));
+            .push((session_id.to_string(), InjectKind::Raw, bytes.to_vec()));
+        Ok(())
+    }
+
+    fn inject_paste_with_verify(&self, session_id: &str, body: &[u8]) -> Result<()> {
+        if self.dead.lock().unwrap().iter().any(|d| d == session_id) {
+            return Err(crate::error::Error::msg(format!(
+                "test: session {session_id} is dead"
+            )));
+        }
+        self.pushes.lock().unwrap().push((
+            session_id.to_string(),
+            InjectKind::PasteVerified,
+            body.to_vec(),
+        ));
         Ok(())
     }
 }
@@ -235,6 +290,53 @@ fn mission_goal_injects_composed_prompt_to_lead() {
     assert!(prompt.contains("Allowed signal types"));
     // Workers do not receive the launch prompt.
     assert!(injector.pushes_for("S-IMPL").is_empty());
+}
+
+#[test]
+fn lead_launch_prompt_routes_through_verified_paste() {
+    // Round-2 review regression guard (impl plan 0005): the lead's
+    // launch prompt must land via `inject_paste_with_verify`, NOT
+    // raw stdin. The verified primitive captures the pane post-paste
+    // and only sends Enter once it confirms the body landed —
+    // critical for fresh-spawn agents whose TUI hasn't bound raw
+    // input yet (Codex argv `[PROMPT]` gets eaten by the approval
+    // dialog; claude-code body keystrokes get eaten by the
+    // trust-folder screen).
+    let (router, injector, log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    let ev = log
+        .append(signal(
+            "human",
+            "mission_goal",
+            serde_json::json!({ "text": "ship v0" }),
+        ))
+        .unwrap();
+    router.handle_event(&ev);
+
+    // Body landed via the verified-paste primitive exactly once.
+    let lead_paste_pushes = injector.paste_pushes_for("S-LEAD");
+    assert_eq!(
+        lead_paste_pushes.len(),
+        1,
+        "lead launch prompt must route through inject_paste_with_verify; got {lead_paste_pushes:?}"
+    );
+    assert!(lead_paste_pushes[0].contains("Goal: ship v0"));
+
+    // Body did NOT also land via the legacy raw `inject` path —
+    // guards against future churn re-introducing the keystroke
+    // chord. Worker-inbox nudges (which DO use raw `inject`) only
+    // fire on directed messages, not on `mission_goal`, so S-LEAD
+    // shouldn't have any raw pushes in this test.
+    let lead_raw_pushes = injector.raw_pushes_for("S-LEAD");
+    assert!(
+        lead_raw_pushes.is_empty(),
+        "lead must not also receive a raw stdin push for the launch prompt; got {lead_raw_pushes:?}"
+    );
 }
 
 #[test]

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1283,6 +1283,111 @@ impl SessionManager {
             .map_err(Into::into)
     }
 
+    /// Paste a first-turn body and submit it once we've verified the
+    /// pane actually rendered the paste — covers the agent-readiness
+    /// race that the bare `inject_paste` path leaves open
+    /// (FIRST_PROMPT_DELAY blind wait isn't enough under contention).
+    ///
+    /// Loop shape: sleep `initial_wait`, take a baseline capture, then
+    /// up to `max_attempts` rounds of paste → sleep `render_wait` →
+    /// capture → if any of head/tail-marker delta or (body ≥
+    /// `PLACEHOLDER_MIN_BODY_LEN`) placeholder delta ≥ 1 vs the
+    /// baseline, send Enter and return. Otherwise sleep
+    /// `between_attempts` and retry. If no attempt verifies, return
+    /// Err — caller logs.
+    ///
+    /// `before` capture failures fall through with zero baselines
+    /// (alternative is to abort, which regresses every transient
+    /// tmux flake to the pre-fix shape). Per-attempt capture
+    /// failures skip THAT attempt's check and continue.
+    pub(crate) fn inject_paste_with_verify(
+        &self,
+        session_id: &str,
+        body: &[u8],
+        config: FirstPromptConfig,
+    ) -> Result<()> {
+        if !config.initial_wait.is_zero() {
+            std::thread::sleep(config.initial_wait);
+        }
+
+        let rt_session = self
+            .sessions
+            .lock()
+            .unwrap()
+            .get(session_id)
+            .map(|h| h.runtime_session.clone())
+            .ok_or_else(|| Error::msg(format!("session not found: {session_id}")))?;
+
+        let (head_marker, tail_marker) = paste_markers(body);
+        let before_bytes = self
+            .runtime
+            .capture_visible(&rt_session)
+            .unwrap_or_else(|e| {
+                eprintln!(
+                    "runner: first-prompt baseline capture for {session_id} failed: {e} \
+                     (proceeding with zero baselines)"
+                );
+                Vec::new()
+            });
+        let before_stripped = strip_ansi(&before_bytes);
+        let before_head_count = count_substr(&before_stripped, &head_marker);
+        let before_tail_count = count_substr(&before_stripped, &tail_marker);
+        let before_placeholder_count = count_substr(&before_stripped, b"Pasted text");
+
+        for attempt in 0..config.max_attempts {
+            // Re-confirm the session is still live before each
+            // attempt — a kill while the loop is sleeping shouldn't
+            // trigger more pastes.
+            let still_live = self.sessions.lock().unwrap().contains_key(session_id);
+            if !still_live {
+                return Err(Error::msg(format!(
+                    "session {session_id} gone before first-prompt verified"
+                )));
+            }
+
+            self.runtime.paste(&rt_session, body)?;
+
+            if !config.render_wait.is_zero() {
+                std::thread::sleep(config.render_wait);
+            }
+
+            let after = match self.runtime.capture_visible(&rt_session) {
+                Ok(b) => b,
+                Err(e) => {
+                    eprintln!(
+                        "runner: first-prompt capture for {session_id} attempt {attempt} failed: {e}"
+                    );
+                    if !config.between_attempts.is_zero() {
+                        std::thread::sleep(config.between_attempts);
+                    }
+                    continue;
+                }
+            };
+            let after_stripped = strip_ansi(&after);
+
+            let head_delta_pos = count_substr(&after_stripped, &head_marker) > before_head_count;
+            let tail_delta_pos = count_substr(&after_stripped, &tail_marker) > before_tail_count;
+            let placeholder_delta_pos = body.len() >= PLACEHOLDER_MIN_BODY_LEN
+                && count_substr(&after_stripped, b"Pasted text") > before_placeholder_count;
+
+            if head_delta_pos || tail_delta_pos || placeholder_delta_pos {
+                return self
+                    .runtime
+                    .send_key(&rt_session, "Enter")
+                    .map_err(Into::into);
+            }
+
+            if !config.between_attempts.is_zero() {
+                std::thread::sleep(config.between_attempts);
+            }
+        }
+
+        Err(Error::msg(format!(
+            "first-prompt for {session_id}: paste not visible after {} attempts",
+            config.max_attempts
+        )))
+    }
+
     /// Resize the session's pane. The frontend calls this after
     /// xterm fits its container — without it, claude-code stays at
     /// the spawn-time grid regardless of how big the visible grid
@@ -1776,22 +1881,49 @@ fn capture_cwd(explicit: Option<String>) -> Option<String> {
         .and_then(|p| p.into_os_string().into_string().ok())
 }
 
-/// How long to wait after spawn before typing the worker's first
-/// user turn into the PTY. claude-code and codex both need their TUIs
-/// to render the welcome banner, dismiss any "trust this folder" /
-/// approval dialog, and bind their raw-mode keypress reader before
-/// typed bytes land — anything shorter and the early bytes get
-/// swallowed by a dialog still on screen. 500ms wasn't enough in
-/// practice (the worker came up without its preamble on warm
-/// boots), so we hold the 2.5s budget pending a real
-/// readback-verification fix (#50). `cfg(test)` zeros it so unit
-/// tests don't have to sleep multiple seconds (we run inline at the
-/// call site when zero). Mirrors `LEAD_LAUNCH_PROMPT_DELAY` in
-/// `router/handlers.rs` since they solve the same race.
+/// Tunables for the first-prompt readback loop. Production uses a
+/// short initial wait (so a fast spawn doesn't sit idle), modest
+/// per-attempt render wait (let tmux + the agent TUI commit the
+/// paste before we capture-pane), and a small max_attempts. `cfg(test)`
+/// zeros every duration so unit tests stay synchronous; the count
+/// stays at 4 so retry/give-up paths still exercise their branches.
+///
+/// See `docs/impls/0005-first-prompt-readback.md` for the rationale
+/// behind the specific numbers (best case 2100ms, worst case 7100ms).
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct FirstPromptConfig {
+    pub initial_wait: std::time::Duration,
+    pub render_wait: std::time::Duration,
+    pub between_attempts: std::time::Duration,
+    pub max_attempts: usize,
+}
+
 #[cfg(not(test))]
-const FIRST_PROMPT_DELAY: std::time::Duration = std::time::Duration::from_millis(2500);
+pub(crate) const FIRST_PROMPT_CONFIG: FirstPromptConfig = FirstPromptConfig {
+    initial_wait: std::time::Duration::from_millis(1500),
+    render_wait: std::time::Duration::from_millis(600),
+    between_attempts: std::time::Duration::from_millis(800),
+    max_attempts: 4,
+};
+
 #[cfg(test)]
-const FIRST_PROMPT_DELAY: std::time::Duration = std::time::Duration::ZERO;
+pub(crate) const FIRST_PROMPT_CONFIG: FirstPromptConfig = FirstPromptConfig {
+    initial_wait: std::time::Duration::ZERO,
+    render_wait: std::time::Duration::ZERO,
+    between_attempts: std::time::Duration::ZERO,
+    max_attempts: 4,
+};
+
+/// Bodies shorter than this skip the `Pasted text` placeholder
+/// check entirely. Below this threshold Claude Code shows the paste
+/// verbatim (head/tail markers cover it), and matching the
+/// placeholder substring on a short body risks false-acking against
+/// stale resume content (e.g. a resumed pane already showing
+/// `[Pasted text #5 +20 lines]` from a prior turn). 64 bytes is well
+/// below Claude Code's actual wrap threshold (~200 bytes in
+/// practice) and above any reasonable short-prompt zone where the
+/// placeholder shouldn't fire.
+const PLACEHOLDER_MIN_BODY_LEN: usize = 64;
 
 /// Mission-flavored first-turn injection. Composes the platform
 /// coordination preamble (bus mechanics, --to human convention,
@@ -1887,34 +2019,29 @@ fn schedule_direct_first_prompt(
 }
 
 /// Shared mechanics for typing a first user turn into the PTY.
-/// Strips any embedded `\r` so the prompt body is one piece;
-/// embedded `\n`s render as line breaks inside the input box. The
-/// submit byte goes in a separate write so the TUI sees it as Enter
-/// rather than appending it to the input buffer (which is what
-/// happens when text + `\r` arrive in the same chunk). Production
-/// runs on a 2.5s settle thread; `cfg(test)` zeros the delay and
-/// runs inline so unit tests can assert synchronously.
+/// Strips any embedded `\r` so the prompt body is one piece; embedded
+/// `\n`s render as line breaks inside the input box.
+/// `inject_paste_with_verify` handles the readback-and-retry loop +
+/// emits Enter once the paste lands. Production runs on a settle
+/// thread; `cfg(test)` zeros every duration in `FIRST_PROMPT_CONFIG`
+/// so the loop completes inline within one synchronous call.
 fn inject_first_turn(mgr: &Arc<SessionManager>, session_id: String, prompt: String) {
-    // Strip embedded \r so the prompt body is one piece of text;
-    // embedded \n inside the body renders as a line break inside
-    // the agent's input box. `inject_paste` handles the LF→CR
-    // semantics correctly (paste-buffer -p -r -d preserves LF and
-    // emits a separate Enter for submit), so we don't need the
-    // old two-write split-pattern here.
     let body: String = prompt.chars().filter(|c| *c != '\r').collect();
-    let delay = FIRST_PROMPT_DELAY;
-    if delay.is_zero() {
-        // Inline path used by unit tests (`FIRST_PROMPT_DELAY = ZERO`
-        // under `cfg(test)`) so synchronous output assertions can
-        // observe the injection without waiting on a background
-        // thread. Production never hits this branch.
-        let _ = mgr.inject_paste(&session_id, body.as_bytes());
+    let config = FIRST_PROMPT_CONFIG;
+
+    if config.initial_wait.is_zero() && config.between_attempts.is_zero() {
+        // Inline path under `cfg(test)`: every duration in
+        // `FIRST_PROMPT_CONFIG` is zero, so the verify loop completes
+        // synchronously and tests can read the FakeRuntime
+        // immediately. Production never hits this branch.
+        let _ = mgr.inject_paste_with_verify(&session_id, body.as_bytes(), config);
         return;
     }
     let mgr = Arc::clone(mgr);
     std::thread::spawn(move || {
-        std::thread::sleep(delay);
-        let _ = mgr.inject_paste(&session_id, body.as_bytes());
+        if let Err(e) = mgr.inject_paste_with_verify(&session_id, body.as_bytes(), config) {
+            eprintln!("runner: first-prompt for {session_id} failed: {e}");
+        }
     });
 }
 
@@ -1946,10 +2073,16 @@ Plain TUI output (typing into your editor, printing to stdout) stays in your loc
 /// codex pre-capture), no-op — there's no conversation thread to
 /// continue.
 ///
-/// Same split-injection pattern as `schedule_first_prompt`: body
-/// first, then a separate `\r` after a small delay so claude-code's
-/// editor sees the carriage return as Enter rather than appending
-/// it to the input buffer.
+/// Same readback-verified primitive as `inject_first_turn`. The
+/// resume case carries an extra subtlety: a resumed pane may
+/// already display old `[Pasted text #N ...]` placeholders from
+/// prior turns, which a naive "Pasted text appears" check would
+/// false-ack. `inject_paste_with_verify`'s count-delta check
+/// handles this — `before_placeholder_count` and
+/// `after_placeholder_count` see the same stale placeholder, delta
+/// is 0, and the body length (`continue` is 8 bytes < 64) skips
+/// the placeholder gate entirely; only the head/tail-marker delta
+/// for "continue" can accept.
 fn schedule_continue_on_resume(
     mgr: &Arc<SessionManager>,
     session_id: String,
@@ -1962,14 +2095,119 @@ fn schedule_continue_on_resume(
     if !plan.resuming {
         return;
     }
+    let config = FIRST_PROMPT_CONFIG;
+    if config.initial_wait.is_zero() && config.between_attempts.is_zero() {
+        // Inline path under `cfg(test)` so synchronous output
+        // assertions can observe the injection.
+        let _ = mgr.inject_paste_with_verify(&session_id, b"continue", config);
+        return;
+    }
     let mgr = Arc::clone(mgr);
     std::thread::spawn(move || {
-        // Same 2.5s budget as `FIRST_PROMPT_DELAY` — claude-code
-        // shows the prior conversation history first, and we want
-        // the editor bound before typing.
-        std::thread::sleep(std::time::Duration::from_millis(2500));
-        let _ = mgr.inject_paste(&session_id, b"continue");
+        if let Err(e) = mgr.inject_paste_with_verify(&session_id, b"continue", config) {
+            eprintln!("runner: continue-on-resume for {session_id} failed: {e}");
+        }
     });
+}
+
+/// Pick `(head_marker, tail_marker)` from the body to look for in
+/// the post-paste pane snapshot. Head = first ≤32 chars of the
+/// trimmed body's first non-empty line (covers TUIs that scroll to
+/// keep the start of the paste visible — claude-code, codex short
+/// pastes). Tail = last ≤32 chars of the trimmed body's last
+/// non-empty line (covers TUIs that scroll to keep the cursor /
+/// end of the paste visible — codex multi-KB lead launch prompts).
+/// For short bodies the two markers can overlap; both signals fire
+/// on the same paste with no double-count concern (we only check
+/// "delta > 0", not the magnitude).
+///
+/// Boundaries are line-bounded (stop at `\n` / `\r`) because a
+/// pasted multi-line block gets line-wrapped by the agent's input
+/// editor, and a marker straddling a soft-wrap boundary won't match
+/// verbatim in the rendered pane.
+fn paste_markers(body: &[u8]) -> (Vec<u8>, Vec<u8>) {
+    fn first_line(body: &[u8]) -> &[u8] {
+        let start = body
+            .iter()
+            .position(|&b| !b.is_ascii_whitespace())
+            .unwrap_or(body.len());
+        let mut end = start;
+        while end < body.len() && end - start < 32 && body[end] != b'\n' && body[end] != b'\r' {
+            end += 1;
+        }
+        &body[start..end]
+    }
+    fn last_line(body: &[u8]) -> &[u8] {
+        // Trim trailing whitespace.
+        let mut end = body.len();
+        while end > 0 && body[end - 1].is_ascii_whitespace() {
+            end -= 1;
+        }
+        // Walk back to start of last line OR until we've covered 32 chars.
+        let mut start = end;
+        while start > 0 && end - start < 32 && body[start - 1] != b'\n' && body[start - 1] != b'\r'
+        {
+            start -= 1;
+        }
+        &body[start..end]
+    }
+    (first_line(body).to_vec(), last_line(body).to_vec())
+}
+
+/// Strip CSI escape sequences (ESC `[` … final byte 0x40-0x7e)
+/// from a captured pane snapshot. Tmux's `capture-pane -e` emits
+/// SGR + cursor-positioning escapes around colored content; the
+/// readback substring search needs those out of the way so a
+/// marker that spans a color boundary still matches. Non-CSI ESC
+/// sequences are dropped too (rare in practice; defensive).
+fn strip_ansi(input: &[u8]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(input.len());
+    let mut i = 0;
+    while i < input.len() {
+        let b = input[i];
+        if b == 0x1b {
+            i += 1;
+            if i < input.len() && input[i] == b'[' {
+                // CSI: skip params then final byte.
+                i += 1;
+                while i < input.len() && !(0x40..=0x7e).contains(&input[i]) {
+                    i += 1;
+                }
+                if i < input.len() {
+                    i += 1;
+                }
+            } else if i < input.len() {
+                // Other escape (e.g. OSC, single-char). Drop the
+                // byte after ESC; good enough for our substring
+                // search.
+                i += 1;
+            }
+            continue;
+        }
+        out.push(b);
+        i += 1;
+    }
+    out
+}
+
+/// Count non-overlapping occurrences of `needle` in `haystack`. An
+/// empty needle returns 0 — empty markers can happen when the body
+/// is all whitespace, and counting "every position" isn't useful.
+fn count_substr(haystack: &[u8], needle: &[u8]) -> usize {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return 0;
+    }
+    let mut count = 0;
+    let mut i = 0;
+    while i + needle.len() <= haystack.len() {
+        if &haystack[i..i + needle.len()] == needle {
+            count += 1;
+            i += needle.len();
+        } else {
+            i += 1;
+        }
+    }
+    count
 }
 
 fn emit_runner_activity(pool: &DbPool, runner: &Runner, events: &dyn SessionEvents) {
@@ -2084,6 +2322,11 @@ mod tests {
         fn status(&self, _: &RuntimeSession) -> RuntimeResult<Option<SessionStatus>> {
             Err(RuntimeError::Msg("InertRuntime: status unsupported".into()))
         }
+        fn capture_visible(&self, _: &RuntimeSession) -> RuntimeResult<Vec<u8>> {
+            Err(RuntimeError::Msg(
+                "InertRuntime: capture_visible unsupported".into(),
+            ))
+        }
     }
 
     fn inert_runtime() -> Arc<dyn SessionRuntime> {
@@ -2109,6 +2352,22 @@ mod tests {
         /// wants exit_code=143 (SIGTERM) to verify the
         /// stop-vs-crash discrimination still flips correctly.
         status_response: std::sync::Mutex<SessionStatus>,
+        /// What `capture_visible` returns BEFORE the paste-count
+        /// crosses `acknowledge_after`. Empty by default — fresh
+        /// spawns have a blank pane, and the count-delta check
+        /// reduces to "any non-zero count in `after` accepts".
+        pane_pre_paste: std::sync::Mutex<Vec<u8>>,
+        /// What `capture_visible` returns AFTER the paste-count
+        /// has reached `acknowledge_after`. Default mirrors the
+        /// expected paste body so tests that don't override it
+        /// observe acknowledgement on attempt 1.
+        pane_post_paste: std::sync::Mutex<Vec<u8>>,
+        /// Number of `paste` calls before `capture_visible` flips
+        /// from `pane_pre_paste` to `pane_post_paste`. Default 0 ⇒
+        /// even the FIRST capture (`before`, taken before any paste)
+        /// returns `pane_post_paste`. Most tests rely on this and
+        /// don't touch it; retry/give-up tests bump it.
+        acknowledge_after: std::sync::Mutex<usize>,
     }
 
     /// One spawn/resume capture. `tx` is the live channel the
@@ -2136,8 +2395,67 @@ mod tests {
                     pid: Some(99999),
                     command: Some("/bin/sh".into()),
                 }),
+                // Default `pane_post_paste` is intentionally empty —
+                // empty acts as a sentinel that triggers
+                // `capture_visible` to synthesize a snapshot
+                // containing the most recent paste body, which means
+                // any test that doesn't configure post-paste content
+                // sees the verify loop accept on attempt 1 (the
+                // marker the verifier extracts from the body is
+                // present in the pasted body verbatim). Tests that
+                // need stale-content scenarios call
+                // `set_pane_post_paste` directly.
                 ..Default::default()
             }
+        }
+
+        /// Override what `capture_visible` returns once
+        /// `acknowledge_after` pastes have happened. Tests use this
+        /// to set the canned post-paste pane content (typically
+        /// containing the marker the verify loop expects to find).
+        #[allow(dead_code)]
+        fn set_pane_post_paste(&self, bytes: &[u8]) {
+            *self.pane_post_paste.lock().unwrap() = bytes.to_vec();
+        }
+
+        /// Override what `capture_visible` returns BEFORE
+        /// `acknowledge_after` pastes have happened. Stale-content
+        /// resume scenarios use this to seed the baseline capture
+        /// with old `[Pasted text #N]` placeholders.
+        #[allow(dead_code)]
+        fn set_pane_pre_paste(&self, bytes: &[u8]) {
+            *self.pane_pre_paste.lock().unwrap() = bytes.to_vec();
+        }
+
+        /// Number of paste calls that must elapse before
+        /// `capture_visible` switches from pre- to post-paste
+        /// content. Use to simulate "agent didn't see paste #1, did
+        /// see paste #2" retry scenarios, or "agent never sees
+        /// paste" give-up scenarios (set to a large value).
+        #[allow(dead_code)]
+        fn set_acknowledge_after(&self, n: usize) {
+            *self.acknowledge_after.lock().unwrap() = n;
+        }
+
+        fn paste_count(&self) -> usize {
+            self.inputs
+                .lock()
+                .unwrap()
+                .iter()
+                .filter(|i| matches!(i, FakeInput::Paste { .. }))
+                .count()
+        }
+
+        fn last_paste_body(&self) -> Option<Vec<u8>> {
+            self.inputs
+                .lock()
+                .unwrap()
+                .iter()
+                .rev()
+                .find_map(|i| match i {
+                    FakeInput::Paste { payload, .. } => Some(payload.clone()),
+                    _ => None,
+                })
         }
 
         /// Push a `Stream` event through the forwarder channel for
@@ -2302,6 +2620,25 @@ mod tests {
 
         fn status(&self, _: &RuntimeSession) -> RuntimeResult<Option<SessionStatus>> {
             Ok(Some(self.status_response.lock().unwrap().clone()))
+        }
+
+        fn capture_visible(&self, _: &RuntimeSession) -> RuntimeResult<Vec<u8>> {
+            let pasted = self.paste_count();
+            let threshold = *self.acknowledge_after.lock().unwrap();
+            if pasted >= threshold {
+                let canned = self.pane_post_paste.lock().unwrap().clone();
+                if canned.is_empty() {
+                    // Sentinel: synthesize a snapshot containing the
+                    // last pasted body so the verifier's marker
+                    // extraction matches whatever the test pasted.
+                    // Lets ~any test that doesn't care about pane
+                    // state pass without per-test setup.
+                    return Ok(self.last_paste_body().unwrap_or_default());
+                }
+                Ok(canned)
+            } else {
+                Ok(self.pane_pre_paste.lock().unwrap().clone())
+            }
         }
     }
 
@@ -3888,5 +4225,170 @@ mod tests {
             )
             .unwrap();
         assert_eq!(status, "stopped");
+    }
+
+    // ──────────────────────────────────────────────────────────
+    // First-prompt readback verification (impl plan 0005).
+    //
+    // These exercise `inject_paste_with_verify` directly against
+    // a registered FakeRuntime session. They bypass the
+    // `inject_first_turn` wrapper so test setup stays minimal —
+    // the wrapper itself just selects between inline and threaded
+    // dispatch and is exercised via the existing
+    // `*_direct_chat_injects_persona_*` tests.
+    // ──────────────────────────────────────────────────────────
+
+    /// Register a FakeRuntime spawn under `session_id` so
+    /// `inject_paste_with_verify` can resolve the runtime session
+    /// without going through the full `spawn_direct` machinery.
+    /// Uses the FakeRuntime's own `spawn` to populate the
+    /// `spawns` Vec and synthesizes a SessionHandle entry on the
+    /// manager so `self.sessions.get(session_id)` returns Some.
+    fn register_fake_session(mgr: &Arc<SessionManager>, fake: &Arc<FakeRuntime>, session_id: &str) {
+        let spec = SpawnSpec {
+            session_id: session_id.into(),
+            command: "/bin/true".into(),
+            ..Default::default()
+        };
+        let (rt_session, stream) = SessionRuntime::spawn(fake.as_ref(), spec).unwrap();
+        // We don't need a forwarder thread for these tests — the
+        // verify loop only touches
+        // `self.runtime.{paste,capture_visible,send_key}`, all of
+        // which the FakeRuntime services without needing the
+        // OutputStream. Just drop the stream so its Sender goes
+        // away cleanly.
+        drop(stream);
+        let handle = SessionHandle {
+            id: session_id.to_string(),
+            mission_id: None,
+            runner_id: format!("rid-{session_id}"),
+            runtime_session: rt_session,
+            forwarder: None,
+            stop: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        };
+        mgr.sessions
+            .lock()
+            .unwrap()
+            .insert(session_id.to_string(), handle);
+    }
+
+    #[test]
+    fn first_prompt_landed_first_try() {
+        let fake = fake_runtime();
+        let mgr = mgr_with_fake(None, Arc::clone(&fake));
+        register_fake_session(&mgr, &fake, "S-FIRST");
+        // Default FakeRuntime: pane_post_paste empty (sentinel) ⇒
+        // capture_visible mirrors the last pasted body, so the
+        // verifier's head-marker delta hits ≥ 1 on attempt 1.
+        let body = b"You are an architect persona.";
+        mgr.inject_paste_with_verify("S-FIRST", body, FIRST_PROMPT_CONFIG)
+            .expect("verify should accept on attempt 1");
+        let pastes = fake.pastes();
+        assert_eq!(pastes.len(), 1, "exactly one paste; got {pastes:?}");
+        assert_eq!(pastes[0].1, body);
+        let keys = fake.keys();
+        let enters: Vec<_> = keys.iter().filter(|(_, k)| k == "Enter").collect();
+        assert_eq!(enters.len(), 1, "exactly one Enter; got {keys:?}");
+    }
+
+    #[test]
+    fn first_prompt_landed_after_retry() {
+        let fake = fake_runtime();
+        let mgr = mgr_with_fake(None, Arc::clone(&fake));
+        register_fake_session(&mgr, &fake, "S-RETRY");
+        // First paste invisible, second paste visible. With the
+        // sentinel-empty default, the synthesized "after" content
+        // mirrors the last pasted body — but only after
+        // `acknowledge_after = 2` pastes. Until then,
+        // `pane_pre_paste` (empty by default) is returned.
+        fake.set_acknowledge_after(2);
+        let body = b"You are an architect persona.";
+        mgr.inject_paste_with_verify("S-RETRY", body, FIRST_PROMPT_CONFIG)
+            .expect("verify should accept on attempt 2");
+        let pastes = fake.pastes();
+        assert_eq!(pastes.len(), 2, "expected two pastes; got {pastes:?}");
+        let keys = fake.keys();
+        let enters: Vec<_> = keys.iter().filter(|(_, k)| k == "Enter").collect();
+        assert_eq!(enters.len(), 1, "expected one Enter; got {keys:?}");
+    }
+
+    #[test]
+    fn first_prompt_gives_up_after_max_attempts() {
+        let fake = fake_runtime();
+        let mgr = mgr_with_fake(None, Arc::clone(&fake));
+        register_fake_session(&mgr, &fake, "S-GIVEUP");
+        // acknowledge_after = 999 ⇒ post-paste content is never
+        // observed; the pre-paste content (empty default) is what
+        // capture_visible returns. No marker delta possible. The
+        // loop must give up after `max_attempts` and NOT send Enter.
+        fake.set_acknowledge_after(999);
+        let body = b"You are an architect persona.";
+        let err = mgr
+            .inject_paste_with_verify("S-GIVEUP", body, FIRST_PROMPT_CONFIG)
+            .expect_err("verify should give up");
+        assert!(
+            err.to_string().contains("not visible"),
+            "expected give-up error; got {err}"
+        );
+        let pastes = fake.pastes();
+        assert_eq!(
+            pastes.len(),
+            FIRST_PROMPT_CONFIG.max_attempts,
+            "expected exactly max_attempts pastes; got {pastes:?}",
+        );
+        let enters: Vec<_> = fake
+            .keys()
+            .into_iter()
+            .filter(|(_, k)| k == "Enter")
+            .collect();
+        assert!(
+            enters.is_empty(),
+            "no Enter must be sent on give-up; got {enters:?}",
+        );
+    }
+
+    #[test]
+    fn continue_resume_rejects_stale_placeholder() {
+        // Round-2 review regression guard: a resumed pane that
+        // already shows `[Pasted text #5 +20 lines]` from prior
+        // turns must NOT false-ack a failed `continue` paste.
+        // - body = b"continue" (8 bytes < PLACEHOLDER_MIN_BODY_LEN)
+        //   so the placeholder gate is closed regardless.
+        // - pane_pre_paste == pane_post_paste contains the stale
+        //   placeholder string. Both head/tail-marker count of
+        //   "continue" is 0 in both before and after. Delta = 0
+        //   on every attempt ⇒ reject ⇒ no Enter.
+        let fake = fake_runtime();
+        let mgr = mgr_with_fake(None, Arc::clone(&fake));
+        register_fake_session(&mgr, &fake, "S-CONT");
+        let stale = b"...prior conversation...\n[Pasted text #5 +20 lines]\n>";
+        fake.set_pane_pre_paste(stale);
+        fake.set_pane_post_paste(stale);
+        // acknowledge_after = 0 so capture_visible returns the
+        // canned post-paste content from the start (no sentinel
+        // synthesis); both before and after see the same stale
+        // pane content.
+        let err = mgr
+            .inject_paste_with_verify("S-CONT", b"continue", FIRST_PROMPT_CONFIG)
+            .expect_err("verify must reject stale-placeholder false-ack");
+        assert!(
+            err.to_string().contains("not visible"),
+            "expected give-up error; got {err}"
+        );
+        let pastes = fake.pastes();
+        assert_eq!(
+            pastes.len(),
+            FIRST_PROMPT_CONFIG.max_attempts,
+            "expected max_attempts pastes; got {pastes:?}",
+        );
+        let enters: Vec<_> = fake
+            .keys()
+            .into_iter()
+            .filter(|(_, k)| k == "Enter")
+            .collect();
+        assert!(
+            enters.is_empty(),
+            "stale placeholder must not trigger Enter; got {enters:?}",
+        );
     }
 }

--- a/src-tauri/src/session/runtime.rs
+++ b/src-tauri/src/session/runtime.rs
@@ -328,4 +328,15 @@ pub trait SessionRuntime: Send + Sync {
     /// `SessionStatus.alive` and `exit_code`. Errors are reserved
     /// for transport failures (tmux daemon gone, etc.).
     fn status(&self, session: &RuntimeSession) -> RuntimeResult<Option<SessionStatus>>;
+
+    /// Snapshot of the pane's currently-rendered visible region with
+    /// SGR escapes preserved (`tmux capture-pane -p -e` for the tmux
+    /// runtime). Used by the manager's first-prompt readback loop
+    /// (`inject_paste_with_verify`) to verify a paste actually landed
+    /// in the agent's input box before sending Enter — the agent
+    /// readiness window is variable across boot phases (Node init,
+    /// trust dialog, banner animation), and a verbatim post-paste
+    /// readback is the only reliable signal absent a runtime-level
+    /// "input bound" event.
+    fn capture_visible(&self, session: &RuntimeSession) -> RuntimeResult<Vec<u8>>;
 }

--- a/src-tauri/src/session/tmux_runtime.rs
+++ b/src-tauri/src/session/tmux_runtime.rs
@@ -669,6 +669,10 @@ impl SessionRuntime for TmuxRuntime {
         Ok(())
     }
 
+    fn capture_visible(&self, session: &RuntimeSession) -> RuntimeResult<Vec<u8>> {
+        capture_visible_region(&self.cmd(), session)
+    }
+
     fn status(&self, session: &RuntimeSession) -> RuntimeResult<Option<SessionStatus>> {
         // First gate: has-session. tmux exits non-zero if the
         // target session is gone — that's our terminal-unavailable


### PR DESCRIPTION
## Summary
- Plan-only PR. Implementation lands in a follow-up commit on the same branch.
- Replaces the `FIRST_PROMPT_DELAY = 2500ms` blind-wait in `inject_first_turn` with a paste → `capture-pane` → verify → retry → Enter loop. Targets v0.1.4 release.
- Fixes the post-v0.1.3 race where the persona occasionally fails to land in the agent's input box on fresh chat spawn (issue #50, also reported live).

## What's in the plan

- **Why**: 2500ms blind wait isn't enough under contention — paste lands during Claude Code's pre-input handler (trust dialog / Node init / banner phase) and gets eaten. `claude-squad` (cs#266) ships with the same bug; we already do better, goal is to do better than "better".
- **Approach**: post-paste readback via tmux `capture-pane -p -e`. Match either the body marker (first ≤32 chars of trimmed body, line-bounded, codex + short claude-code paths) OR the literal `Pasted text` placeholder (Claude Code's long-paste placeholder). Either match → send Enter. Retry on miss.
- **Timing budget**: initial 1500ms / render 600ms / between 800ms / max 4 attempts. Best case 2100ms (faster than today). Worst case 7100ms (only worse if today would have failed anyway, in which case persona actually lands).
- **Touch surface**: 1 new trait method (`SessionRuntime::capture_visible`), 1 new manager method (`inject_paste_with_verify`), 2 helpers, 3 new unit tests. `cfg(test)` zeros all durations so unit tests stay synchronous.

## Test plan

- [ ] Implementation commit lands on this branch
- [ ] `cargo fmt` / `cargo clippy --lib --tests -- -D warnings` clean
- [ ] `cargo test` — 197 existing + 3 new pass
- [ ] Manual smoke: spawn 3 direct chats with personas in parallel, confirm all 3 show persona as first user turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)