### PR TITLE
chore: release v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "runner",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runner"
-version = "0.1.3"
+version = "0.1.4"
 description = "An editor for teams of local coding agents (Claude Code, Codex, and friends)"
 edition.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Runner",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "identifier": "com.wycstudios.runner",
   "build": {
     "beforeDevCommand": "npm run tauri:before:dev",


### PR DESCRIPTION
## Summary
- First-prompt readback verification (PR #72, closes #50). Replaces FIRST_PROMPT_DELAY = 2500ms blind wait with a paste → capture-pane → verify → retry → Enter loop. Persona and lead launch-prompt injection now lands deterministically regardless of agent TUI startup timing.
- Version bumps to 0.1.4 across package.json, src-tauri/tauri.conf.json, src-tauri/Cargo.toml, Cargo.lock.

## Test plan
- [x] cargo fmt / cargo clippy --lib --tests -- -D warnings clean
- [x] cargo test — 211 passed, 0 failed
- [ ] CI green
- [ ] Tag v0.1.4 + release workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)