### PR TITLE
fix(ui): hide main window until first frame paints (#63)

### DIFF
--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -1,0 +1,16 @@
+use tauri::{AppHandle, Manager};
+
+use crate::error::Error;
+
+/// Called by the frontend after React has mounted and painted its first frame.
+/// Shows the main window — the window starts hidden so the user sees the dock
+/// bounce → fully-rendered window instead of a blank webview.
+#[tauri::command]
+pub fn app_ready(app: AppHandle) -> crate::error::Result<()> {
+    let window = app
+        .get_webview_window("main")
+        .ok_or_else(|| Error::msg("main window not found"))?;
+    window.show().map_err(|e| Error::msg(e.to_string()))?;
+    window.set_focus().map_err(|e| Error::msg(e.to_string()))?;
+    Ok(())
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -4,6 +4,7 @@
 // in-memory pool) plus thin `#[tauri::command]` wrappers that pull a
 // connection from the r2d2 pool and delegate. See docs/impls/0001-v0-mvp.md §C2.
 
+pub mod app;
 pub mod crew;
 pub mod mission;
 pub mod runner;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -138,6 +138,7 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            commands::app::app_ready,
             commands::crew::crew_list,
             commands::crew::crew_get,
             commands::crew::crew_create,

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,9 +17,8 @@
         "height": 900,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "visible": true,
-        "acceptFirstMouse": true,
-        "focus": true
+        "visible": false,
+        "acceptFirstMouse": true
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { invoke } from "@tauri-apps/api/core";
 import { AppShell } from "./components/AppShell";
 import { UpdateProvider } from "./contexts/UpdateContext";
 import Crews from "./pages/Crews";
@@ -9,6 +11,15 @@ import RunnerDetail from "./pages/RunnerDetail";
 import RunnerChat from "./pages/RunnerChat";
 
 export default function App() {
+  // Tell the backend the first frame has painted so it can show + focus the
+  // main window. Don't wrap this in requestAnimationFrame — macOS pauses rAF
+  // for hidden windows, so the rAF callback would never fire and the window
+  // would stay hidden forever. useEffect runs after React commits, which is
+  // enough to guarantee a non-blank webview before show.
+  useEffect(() => {
+    invoke("app_ready").catch(console.error);
+  }, []);
+
   return (
     <UpdateProvider>
       <BrowserRouter>


### PR DESCRIPTION
## Summary
- Window starts hidden (`tauri.conf.json`: `visible: false`); frontend invokes new `app_ready` command after React commits its first frame.
- Backend `app_ready` shows + focuses the `main` webview window.
- Cold launch now does dock bounce → fully-rendered window, no blank-webview flash. Pattern ported from Quill (`com.wycstudios.quill`); iCloud/sync logic intentionally not carried over.

Closes #63.

## Test plan
- [x] `cd src-tauri && cargo check` clean
- [x] `npx tsc --noEmit` clean
- [ ] Manual: `npm run tauri dev` cold launch — dock bounces, window appears focused with no blank flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)