### PR TITLE
feat(ui): collapsable sidebar with full ↔ icon rail (#34)

### DIFF
--- a/design/README.md
+++ b/design/README.md
@@ -5,3 +5,6 @@ Pencil (`.pen`) source files for the Runners UI. Open these in the Pencil app; t
 Conventions:
 - One `.pen` file per major surface (e.g. `home.pen`, `crew-editor.pen`, `runner-card.pen`).
 - Exports land in `/assets/design/` once we need them in-app.
+
+Follow-ups parked in design (no issue yet):
+- Tooltip primitive (kebab-menu language): `runners-design.pen` node `sE5dM`. Spec'd during issue #34 Phase 4 but deferred — v1 ships with native `title`. Pick this up when a sidebar/rail tooltip primitive is genuinely needed.

--- a/design/runners-design.pen
+++ b/design/runners-design.pen
@@ -27876,6 +27876,1014 @@
           ]
         }
       ]
+    },
+    {
+      "type": "text",
+      "id": "pg0Ap",
+      "x": 50,
+      "y": 7029,
+      "fill": "#9A9BA5",
+      "content": "PHASE 4 · Sidebar collapse — open vs hidden",
+      "fontFamily": "JetBrains Mono",
+      "fontSize": 13,
+      "fontWeight": "600",
+      "letterSpacing": 1
+    },
+    {
+      "type": "frame",
+      "id": "s31wik",
+      "x": 50,
+      "y": 7064,
+      "name": "Window · Sidebar open",
+      "clip": true,
+      "width": 1440,
+      "height": 860,
+      "fill": "#0E0E10",
+      "cornerRadius": 12,
+      "children": [
+        {
+          "type": "frame",
+          "id": "jlQDX",
+          "name": "Sidebar · Full (240px) — collapsable",
+          "width": 240,
+          "height": "fill_container",
+          "fill": "#1F2127",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "#1F2127"
+          },
+          "layout": "vertical",
+          "gap": 4,
+          "padding": [
+            36,
+            20,
+            20,
+            20
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "p0P98j",
+              "name": "brand",
+              "gap": 8,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "C3RNvL",
+                  "name": "brandChevron",
+                  "width": 32,
+                  "height": 32,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "SUmk2",
+                      "x": 9,
+                      "y": 9,
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "chevron-right",
+                      "iconFontFamily": "lucide",
+                      "fill": "#00FF9C"
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "Dif4Z",
+                      "x": 3,
+                      "y": 3,
+                      "opacity": 0.4,
+                      "width": 9,
+                      "height": 9,
+                      "iconFontName": "chevron-right",
+                      "iconFontFamily": "lucide",
+                      "fill": "#00FF9C"
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "CQKJw",
+                      "x": 3,
+                      "y": 20,
+                      "opacity": 0.4,
+                      "width": 9,
+                      "height": 9,
+                      "iconFontName": "chevron-right",
+                      "iconFontFamily": "lucide",
+                      "fill": "#00FF9C"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "CODD2",
+                  "fill": "#EDEDF0",
+                  "content": "Runner",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "M7SzM",
+              "width": "fill_container",
+              "height": 20
+            },
+            {
+              "type": "text",
+              "id": "hXO3b",
+              "name": "cfg4",
+              "fill": "#5A5C66",
+              "content": "WORKSPACE",
+              "fontFamily": "JetBrains Mono",
+              "fontSize": 10,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "RFWlx",
+              "name": "nav_search_w",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "padding": 10,
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "mwUWb",
+                  "name": "navSearchLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "fyWKv",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "search",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    },
+                    {
+                      "type": "text",
+                      "id": "w6Q0B",
+                      "fill": "#9A9BA5",
+                      "content": "search",
+                      "fontFamily": "Inter",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zNhPv",
+              "name": "nav_r_w",
+              "width": "fill_container",
+              "fill": "#0E0E10",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#1F2127"
+              },
+              "gap": 8,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "k6Cv5",
+                  "name": "runnerIcon",
+                  "width": 12,
+                  "height": 12,
+                  "iconFontName": "terminal",
+                  "iconFontFamily": "lucide",
+                  "fill": "#EDEDF0"
+                },
+                {
+                  "type": "text",
+                  "id": "o5qbMW",
+                  "fill": "#EDEDF0",
+                  "content": "runner",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "j0iBz",
+              "name": "nav_c_w",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "ltRtY",
+                  "name": "crewIcon",
+                  "width": 12,
+                  "height": 12,
+                  "iconFontName": "users",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                },
+                {
+                  "type": "text",
+                  "id": "qgwDr",
+                  "fill": "#9A9BA5",
+                  "content": "crew",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ob9UB",
+              "name": "missionSpacer",
+              "width": "fill_container",
+              "height": 20
+            },
+            {
+              "type": "frame",
+              "id": "U44B9",
+              "name": "MissionHeader",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "EnxLu",
+                  "name": "MissionHeaderLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "i6Mx5",
+                      "name": "missionChev",
+                      "width": 10,
+                      "height": 10,
+                      "iconFontName": "chevron-down",
+                      "iconFontFamily": "lucide",
+                      "fill": "#5A5C66"
+                    },
+                    {
+                      "type": "text",
+                      "id": "QhTtd",
+                      "name": "missionLabel",
+                      "fill": "#5A5C66",
+                      "content": "MISSION",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "N1coQ",
+                      "name": "MissionCount",
+                      "fill": "#0E0E10",
+                      "cornerRadius": 999,
+                      "padding": [
+                        1,
+                        5
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "D35B0P",
+                          "name": "missionBadgeTxt",
+                          "fill": "#5A5C66",
+                          "content": "2",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rFyov",
+                  "name": "AddMissionBtn",
+                  "cornerRadius": 4,
+                  "padding": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "fMEza",
+                      "name": "addMissionIcon",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "hyY1X",
+              "name": "Mission1Active",
+              "width": "fill_container",
+              "fill": "#0E0E10",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#1F2127"
+              },
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "Qnqbt",
+                  "name": "m1Dot",
+                  "fill": "#00FF9C",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "WS6wc",
+                  "name": "m1Title",
+                  "fill": "#EDEDF0",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Create a temp go pr…",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "XkIFv",
+              "name": "Mission2Collapsed",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "H1y61",
+                  "name": "m2Dot",
+                  "fill": "#00FF9C",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "f0jZRW",
+                  "name": "m2Title",
+                  "fill": "#9A9BA5",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Investigate latency spike",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "jlJIm",
+              "name": "sessSpacer",
+              "width": "fill_container",
+              "height": 32
+            },
+            {
+              "type": "frame",
+              "id": "D9wu9",
+              "name": "SessionHeader",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "CXSEV",
+                  "name": "SessionHeaderLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "AhYO4",
+                      "name": "sessionChev",
+                      "width": 10,
+                      "height": 10,
+                      "iconFontName": "chevron-down",
+                      "iconFontFamily": "lucide",
+                      "fill": "#5A5C66"
+                    },
+                    {
+                      "type": "text",
+                      "id": "C2uRI",
+                      "name": "sessionLabel",
+                      "fill": "#5A5C66",
+                      "content": "CHAT",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "OXMNm",
+                      "name": "SessionCount",
+                      "fill": "#0E0E10",
+                      "cornerRadius": 999,
+                      "padding": [
+                        1,
+                        5
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "AdvXp",
+                          "name": "sessionBadgeTxt",
+                          "fill": "#5A5C66",
+                          "content": "2",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "QMypC",
+                  "name": "AddSessionBtn",
+                  "cornerRadius": 4,
+                  "padding": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "wstJX",
+                      "name": "addMissionIcon",
+                      "width": 12,
+                      "height": 12,
+                      "iconFontName": "plus",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "gbIkE",
+              "name": "active_sub1",
+              "width": "fill_container",
+              "fill": "#16171B",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#1F2127"
+              },
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "tmdWv",
+                  "fill": "#00FF9C",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "F3tKx",
+                  "fill": "#EDEDF0",
+                  "content": "Wire up event bus…",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "jKkfb",
+              "name": "mr2",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "NKoe1",
+                  "fill": "#00FF9C",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "OubUq",
+                  "fill": "#9A9BA5",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "@architect chat",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "vl4eb",
+              "name": "sidebar_spacer",
+              "width": "fill_container",
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "YJzKY",
+              "name": "sidebar_div",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#2A2C32"
+            },
+            {
+              "type": "frame",
+              "id": "nverW",
+              "name": "sidebar_settings",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 10,
+              "padding": 10,
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "lMaW6",
+                  "name": "left",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "E0hGFg",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Okz6P",
+                      "fill": "#9A9BA5",
+                      "content": "Settings",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JC3gA",
+                  "name": "toggleBtn",
+                  "width": 24,
+                  "height": 24,
+                  "cornerRadius": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Y5aAhY",
+                      "width": 14,
+                      "height": 14,
+                      "iconFontName": "chevrons-left",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "K6Ra1",
+          "name": "Main",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "#0E0E10",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "C1a5jS",
+              "name": "Topbar",
+              "width": "fill_container",
+              "fill": "#16171B",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#1F2127"
+              },
+              "padding": [
+                14,
+                24
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "k9L3jX",
+                  "fill": "#9A9BA5",
+                  "content": "Mission workspace",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "dgp3g",
+                  "fill": "#5A5C66",
+                  "content": "⋯",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "QmIKp",
+              "name": "Body",
+              "width": "fill_container",
+              "height": "fill_container"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "aOmHy",
+      "x": 1520,
+      "y": 7064,
+      "name": "Window · Sidebar collapsed (rail)",
+      "clip": true,
+      "width": 1440,
+      "height": 860,
+      "fill": "#0E0E10",
+      "cornerRadius": 12,
+      "children": [
+        {
+          "type": "frame",
+          "id": "TPbtC",
+          "name": "Rail",
+          "width": 52,
+          "height": "fill_container",
+          "fill": "#1F2127",
+          "stroke": {
+            "align": "inside",
+            "thickness": {
+              "right": 1
+            },
+            "fill": "#1F2127"
+          },
+          "layout": "vertical",
+          "gap": 4,
+          "padding": [
+            36,
+            0,
+            16,
+            0
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Dk3z7",
+              "name": "brandChevron",
+              "width": 32,
+              "height": 32,
+              "layout": "none",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "AjJGh",
+                  "x": 9,
+                  "y": 9,
+                  "width": 14,
+                  "height": 14,
+                  "iconFontName": "chevron-right",
+                  "iconFontFamily": "lucide",
+                  "fill": "#00FF9C"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "OE6u1",
+                  "x": 3,
+                  "y": 3,
+                  "opacity": 0.4,
+                  "width": 9,
+                  "height": 9,
+                  "iconFontName": "chevron-right",
+                  "iconFontFamily": "lucide",
+                  "fill": "#00FF9C"
+                },
+                {
+                  "type": "icon_font",
+                  "id": "SLJ3I",
+                  "x": 3,
+                  "y": 20,
+                  "opacity": 0.4,
+                  "width": 9,
+                  "height": 9,
+                  "iconFontName": "chevron-right",
+                  "iconFontFamily": "lucide",
+                  "fill": "#00FF9C"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "li58s",
+              "name": "toolbarDivider",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#2A2C32"
+            },
+            {
+              "type": "frame",
+              "id": "nXRDD",
+              "width": "fill_container",
+              "height": 8
+            },
+            {
+              "type": "frame",
+              "id": "o89gl",
+              "name": "nav_runner",
+              "width": 36,
+              "height": 36,
+              "fill": "#0E0E10",
+              "cornerRadius": 6,
+              "stroke": {
+                "align": "inside",
+                "thickness": 1,
+                "fill": "#1F2127"
+              },
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "OvETl",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "terminal",
+                  "iconFontFamily": "lucide",
+                  "fill": "#EDEDF0"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "PUmE2",
+              "name": "nav_crew",
+              "width": 36,
+              "height": 36,
+              "cornerRadius": 6,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "kXnCk",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "users",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "V1ADFv",
+              "name": "nav_search",
+              "width": 36,
+              "height": 36,
+              "cornerRadius": 6,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "r3Cvgk",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "search",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "gj5Nf",
+              "width": "fill_container",
+              "height": "fill_container"
+            },
+            {
+              "type": "frame",
+              "id": "dIflt",
+              "name": "railBottomDiv",
+              "width": "fill_container",
+              "height": 1,
+              "fill": "#2A2C32"
+            },
+            {
+              "type": "frame",
+              "id": "ZFcKI",
+              "name": "toggleBtn",
+              "width": 36,
+              "height": 36,
+              "cornerRadius": 6,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "UBD5g",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "chevrons-right",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ffBMk",
+              "name": "nav_settings",
+              "width": 36,
+              "height": 36,
+              "cornerRadius": 6,
+              "justifyContent": "center",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "MWF8z",
+                  "width": 16,
+                  "height": 16,
+                  "iconFontName": "settings",
+                  "iconFontFamily": "lucide",
+                  "fill": "#9A9BA5"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "wS6AN",
+          "name": "Main",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "#0E0E10",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "NnStG",
+              "name": "Topbar",
+              "width": "fill_container",
+              "fill": "#16171B",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "bottom": 1
+                },
+                "fill": "#1F2127"
+              },
+              "padding": [
+                14,
+                24
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "YTDvt",
+                  "fill": "#9A9BA5",
+                  "content": "Mission workspace",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "NhHbD",
+                  "fill": "#5A5C66",
+                  "content": "⋯",
+                  "fontFamily": "Inter",
+                  "fontSize": 18,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "B0VABe",
+              "name": "Body",
+              "width": "fill_container",
+              "height": "fill_container"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "r5aBQX",
+      "x": 50,
+      "y": 7939,
+      "fill": "#5A5C66",
+      "content": "OPEN — toggle in sidebar toolbar, ~64px from window edge",
+      "fontFamily": "JetBrains Mono",
+      "fontSize": 11,
+      "fontWeight": "600",
+      "letterSpacing": 1
+    },
+    {
+      "type": "text",
+      "id": "aqmkA",
+      "x": 1520,
+      "y": 7939,
+      "fill": "#5A5C66",
+      "content": "COLLAPSED — 52px rail; toggle at top points → to expand",
+      "fontFamily": "JetBrains Mono",
+      "fontSize": 11,
+      "fontWeight": "600",
+      "letterSpacing": 1
     }
   ]
 }

--- a/docs/features/02-collapsable-sidebar.md
+++ b/docs/features/02-collapsable-sidebar.md
@@ -20,8 +20,9 @@ that affordance.
 - Two-state collapse: **full** (current behavior, user-resizable) ↔
   **icon rail** (~52px wide, icon-only).
 - Toggle methods:
-  - Chevron button at the sidebar's right edge near the existing
-    resize handle.
+  - Chevron button at the bottom of the sidebar in both states —
+    on the right of the Settings row when expanded, as its own row
+    above Settings when in rail mode.
   - Keyboard shortcut `cmd+\\` (mac) / `ctrl+\\` (win/linux).
 - State persists in `localStorage` via a new
   `STORAGE_SIDEBAR_COLLAPSED` key in `src/lib/settings.ts`, using the
@@ -104,14 +105,20 @@ that affordance.
 
 ### Phase 3 — Toggle button + keyboard shortcut polish
 
-- Chevron button at the top-right corner of the aside, vertically
-  centered with the brand-mark row. Icon: `ChevronsLeft` when
-  expanded, `ChevronsRight` when collapsed (lucide).
-- Make sure the toggle is reachable by keyboard (focus order
-  follows brand → toggle → first nav row).
-- Verify the title-bar drag region above the toggle still works
-  (the toggle button must not eat the drag area — give it
-  `pointer-events-auto` only on the visible button bounds).
+- Chevron toggle lives at the bottom of the sidebar in both states.
+  - **Open state**: 24×24 button on the right of the bottom Settings
+    row (justify-between with the Settings link). Icon:
+    `ChevronsLeft` (lucide). Click → collapse.
+  - **Rail state**: 36×36 button as its own row above the Settings
+    icon, separated from the WORKSPACE icon stack by a 1px divider.
+    Icon: `ChevronsRight` (lucide). Click → expand.
+- Focus order in both states: `brand → first nav row → … →
+  settings → toggle` — the toggle is the last interactive element
+  in the aside.
+- Keep the title-bar drag region (`data-tauri-drag-region` h-7
+  strip) at the top of the aside in both states. The toggle no
+  longer interacts with this strip — they don't share a row
+  anymore — so no special pointer-events handling is required.
 
 ### Phase 4 — Pencil design + visual polish
 

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -7,11 +7,16 @@
 // (e.g., the activity event from `session_start_direct` triggered on
 // the chat page's mount) gets lost, leaving the SESSION list stale.
 
-import { useState, type ReactNode } from "react";
+import { useEffect, useState, type ReactNode } from "react";
 import { Outlet } from "react-router-dom";
 
 import { Sidebar } from "./Sidebar";
 import { UpdateToast } from "./UpdateToast";
+import {
+  STORAGE_SIDEBAR_COLLAPSED,
+  readStoredBool,
+  writeStoredBool,
+} from "../lib/settings";
 
 export function AppShell({ children }: { children?: ReactNode }) {
   // Settings modal state hoisted here so both the Sidebar's bottom
@@ -19,11 +24,45 @@ export function AppShell({ children }: { children?: ReactNode }) {
   // Toast → settings → download mirrors Quill's flow: the toast just
   // routes the user, the actual download/install lives in the pane.
   const [settingsOpen, setSettingsOpen] = useState(false);
+  // Sidebar collapsed/expanded lives at the shell so cmd+\ can toggle
+  // it from anywhere in the app, not just when the sidebar is the
+  // focused subtree.
+  const [collapsed, setCollapsed] = useState<boolean>(() =>
+    readStoredBool(STORAGE_SIDEBAR_COLLAPSED, false),
+  );
+  // Single source of truth for persistence — both the Sidebar's
+  // chevron click (setCollapsed via prop) and the cmd+\ keydown
+  // funnel through `collapsed`, so one effect keeps localStorage in
+  // sync. The harmless one-write at mount with the already-stored
+  // value is fine.
+  useEffect(() => {
+    writeStoredBool(STORAGE_SIDEBAR_COLLAPSED, collapsed);
+  }, [collapsed]);
+
+  // cmd+\ (mac) / ctrl+\ (others) toggles the sidebar. Mirrors the
+  // input-tag skip used by the ⌘K palette shortcut in Sidebar so we
+  // don't hijack a real backslash inside text fields.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "\\") return;
+      if (!(e.metaKey || e.ctrlKey)) return;
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName?.toLowerCase();
+      if (tag === "input" || tag === "textarea") return;
+      e.preventDefault();
+      setCollapsed((prev) => !prev);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
   return (
     <div className="flex h-screen overflow-hidden bg-bg text-fg">
       <Sidebar
         settingsOpen={settingsOpen}
         onSettingsOpenChange={setSettingsOpen}
+        collapsed={collapsed}
+        onCollapsedChange={setCollapsed}
       />
       <main className="relative flex flex-1 flex-col overflow-hidden">
         <div

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -32,6 +32,8 @@ import {
   Archive,
   ChevronDown,
   ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
   MoreHorizontal,
   Pin,
   PinOff,
@@ -95,9 +97,20 @@ interface SidebarProps {
   // outsiders trigger it.
   settingsOpen: boolean;
   onSettingsOpenChange: (open: boolean) => void;
+  // Collapsed/expanded state lives in AppShell so the global cmd+\
+  // shortcut can toggle it. The `width` resize state stays local —
+  // it's preserved across collapse/expand cycles so users get their
+  // last full width back when they re-open.
+  collapsed: boolean;
+  onCollapsedChange: (collapsed: boolean) => void;
 }
 
-export function Sidebar({ settingsOpen, onSettingsOpenChange }: SidebarProps) {
+export function Sidebar({
+  settingsOpen,
+  onSettingsOpenChange,
+  collapsed,
+  onCollapsedChange,
+}: SidebarProps) {
   const navigate = useNavigate();
   const location = useLocation();
 
@@ -524,139 +537,201 @@ export function Sidebar({ settingsOpen, onSettingsOpenChange }: SidebarProps) {
   return (
     <>
       <aside
-        style={{ width }}
-        className="relative flex h-full shrink-0 select-none flex-col overflow-hidden border-r border-line bg-raised"
+        style={{ width: collapsed ? 52 : width }}
+        className="relative flex h-full shrink-0 select-none flex-col overflow-hidden border-r border-line bg-raised transition-[width] duration-150"
       >
         <div data-tauri-drag-region className="h-7" />
 
-        <div className="flex items-center gap-2 px-5 pb-5 pt-1">
-          <BrandMark />
-          <span className="text-base font-semibold tracking-tight text-fg">
-            Runner
-          </span>
-        </div>
-
-        <div className="flex min-h-0 flex-1 flex-col pb-4">
-          {/* WORKSPACE keeps natural height; doesn't compete for the
-              flex-share allotted to MISSION + SESSION. */}
-          <div className="shrink-0">
-            <SectionHeader>WORKSPACE</SectionHeader>
-            <nav className="flex flex-col gap-0.5 px-3 pb-1">
-              <NavRow icon={Terminal} to="/runners" label="runner" />
-              <NavRow icon={Users} to="/crews" label="crew" />
-              {/* Search opens a command-palette modal — matches design
-                  `Fkoe8`. Default interaction is click-to-callout, not
-                  type-in-place, so this lives as a nav row alongside
-                  runner/crew rather than an inline input. The actual
-                  palette is a follow-up; for now the row stubs the
-                  callout. */}
-              <SearchNavRow onOpen={() => setPaletteOpen(true)} />
-            </nav>
-          </div>
-
-          <div className="h-5 shrink-0" />
-
-          {/* MISSION + SESSION always split the remaining vertical
-              space 1:2 (mission takes 1 share, session takes 2),
-              regardless of expand/collapse state. Collapsing a
-              section just hides its body — the section still claims
-              its share of height so the column rhythm doesn't jump
-              when toggling. Each expanded body scrolls independently
-              so a long SESSION list can't push MISSION off-screen. */}
-          <section className="flex min-h-0 flex-[1] basis-0 flex-col">
-            <CollapsibleSectionHeader
-              label="MISSION"
-              count={missions.length}
-              open={missionsOpen}
-              onToggle={toggleMissions}
-              onPlus={() => setCreatingMission(true)}
-              plusTitle="Start mission"
+        {collapsed ? (
+          // Rail body: single flex column. The h-7 drag strip above
+          // already contributes 28px of top padding; pt-2 brings the
+          // brand to y=36 to match the .pen frame's [36, 0, 16, 0]
+          // padding. gap-1 (4px) between siblings; explicit h-2
+          // spacer adds the 8px gap below the divider that the
+          // designer called for.
+          <div className="flex min-h-0 flex-1 flex-col items-center gap-1 pb-4 pt-2">
+            <BrandMark />
+            <div className="h-px w-full bg-line" />
+            <div className="h-2 w-full" />
+            <RailIconLink icon={Terminal} to="/runners" label="runner" />
+            <RailIconLink icon={Users} to="/crews" label="crew" />
+            <RailIconButton
+              icon={Search}
+              label="Search (⌘K)"
+              onClick={() => setPaletteOpen(true)}
             />
-            {missionsOpen ? (
-              <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-3 pt-1">
-                {missions.length === 0 ? (
-                  <p className="px-2.5 py-1 text-xs text-fg-3">
-                    No live missions.
-                  </p>
-                ) : (
-                  missions.map((m) => (
-                    <RuntimeRow
-                      key={m.id}
-                      selected={m.id === currentMissionId}
-                      label={m.title}
-                      onClick={() => openMission(m.id)}
-                      onContextMenu={(anchor) => openMissionMenu(m, anchor)}
-                      title={m.crew_name || ""}
-                      pinned={!!m.pinned_at}
-                      renaming={renamingMissionId === m.id}
-                      onRenameSubmit={(next) =>
-                        void submitMissionRename(m.id, next)
-                      }
-                      onRenameCancel={() => setRenamingMissionId(null)}
-                    />
-                  ))
-                )}
-              </div>
-            ) : null}
-          </section>
-
-          <div className="h-8 shrink-0" />
-
-          <section className="flex min-h-0 flex-[2] basis-0 flex-col">
-            <CollapsibleSectionHeader
-              label="CHAT"
-              count={directSessions.length}
-              open={sessionsOpen}
-              onToggle={toggleSessions}
-              onPlus={handleNewDirectChat}
-              plusTitle="Start a chat"
-            />
-            {sessionsOpen ? (
-              <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-3 pt-1">
-                {directSessions.length === 0 ? (
-                  <p className="px-2.5 py-1 text-xs text-fg-3">
-                    No chats yet.
-                  </p>
-                ) : (
-                  directSessions.map((s) => (
-                    <SessionRow
-                      key={s.session_id}
-                      session={s}
-                      selected={s.session_id === currentChatSessionId}
-                      renaming={renamingId === s.session_id}
-                      onClick={() => openDirectChat(s)}
-                      onContextMenu={(anchor) => openSessionMenu(s, anchor)}
-                      onRenameSubmit={(nextTitle) =>
-                        void submitRename(s.session_id, nextTitle)
-                      }
-                      onRenameCancel={() => setRenamingId(null)}
-                    />
-                  ))
-                )}
-              </div>
-            ) : null}
-          </section>
-
-          {/* Settings row — pinned at the bottom of the sidebar
-              column. Mirrors Pencil node `IJsUO` (sidebar settings).
-              Opens the SettingsModal as a centered overlay; modal
-              owns its open/close state effects. */}
-          <div className="shrink-0 border-t border-line px-3 pt-2">
+            {/* Archived rail icon — slot reserved for feature #31.
+                When the archived nav lands, render a RailIconLink
+                here pointing at its route (icon: lucide Archive).
+                Leaving this as a clearly-marked placeholder so the
+                merge with #31 is mechanical. */}
+            <div className="w-full flex-1" />
+            <div className="h-px w-full bg-line" />
             <button
               type="button"
-              onClick={() => setSettingsOpen(true)}
-              className="flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-fg-2 transition-colors hover:bg-raised hover:text-fg"
+              onClick={() => onCollapsedChange(false)}
+              title="Expand sidebar (⌘\\)"
+              aria-label="Expand sidebar"
+              className="flex h-9 w-9 cursor-pointer items-center justify-center rounded border border-transparent text-fg-2 transition-colors hover:border-line hover:bg-bg hover:text-fg"
             >
-              <SettingsIcon aria-hidden className="h-3.5 w-3.5" />
-              <span className="text-[13px]">Settings</span>
+              <ChevronsRight aria-hidden className="h-4 w-4" />
             </button>
+            <RailIconButton
+              icon={SettingsIcon}
+              label="Settings"
+              onClick={() => setSettingsOpen(true)}
+            />
           </div>
-        </div>
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col pb-4">
+            {/* Brand row — open state only. Toggle has moved to the
+                bottom Settings row, so this is brand + wordmark
+                only. */}
+            <div className="flex shrink-0 items-center gap-2 px-5 pb-5 pt-1">
+              <BrandMark />
+              <span className="text-base font-semibold tracking-tight text-fg">
+                Runner
+              </span>
+            </div>
+            {/* WORKSPACE keeps natural height; doesn't compete for the
+                flex-share allotted to MISSION + SESSION. */}
+            <div className="shrink-0">
+              <SectionHeader>WORKSPACE</SectionHeader>
+              <nav className="flex flex-col gap-0.5 px-3 pb-1">
+                <NavRow icon={Terminal} to="/runners" label="runner" />
+                <NavRow icon={Users} to="/crews" label="crew" />
+                {/* Search opens a command-palette modal — matches design
+                    `Fkoe8`. Default interaction is click-to-callout, not
+                    type-in-place, so this lives as a nav row alongside
+                    runner/crew rather than an inline input. The actual
+                    palette is a follow-up; for now the row stubs the
+                    callout. */}
+                <SearchNavRow onOpen={() => setPaletteOpen(true)} />
+              </nav>
+            </div>
 
+            <div className="h-5 shrink-0" />
+
+            {/* MISSION + SESSION always split the remaining vertical
+                space 1:2 (mission takes 1 share, session takes 2),
+                regardless of expand/collapse state. Collapsing a
+                section just hides its body — the section still claims
+                its share of height so the column rhythm doesn't jump
+                when toggling. Each expanded body scrolls independently
+                so a long SESSION list can't push MISSION off-screen. */}
+            <section className="flex min-h-0 flex-[1] basis-0 flex-col">
+              <CollapsibleSectionHeader
+                label="MISSION"
+                count={missions.length}
+                open={missionsOpen}
+                onToggle={toggleMissions}
+                onPlus={() => setCreatingMission(true)}
+                plusTitle="Start mission"
+              />
+              {missionsOpen ? (
+                <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-3 pt-1">
+                  {missions.length === 0 ? (
+                    <p className="px-2.5 py-1 text-xs text-fg-3">
+                      No live missions.
+                    </p>
+                  ) : (
+                    missions.map((m) => (
+                      <RuntimeRow
+                        key={m.id}
+                        selected={m.id === currentMissionId}
+                        label={m.title}
+                        onClick={() => openMission(m.id)}
+                        onContextMenu={(anchor) => openMissionMenu(m, anchor)}
+                        title={m.crew_name || ""}
+                        pinned={!!m.pinned_at}
+                        renaming={renamingMissionId === m.id}
+                        onRenameSubmit={(next) =>
+                          void submitMissionRename(m.id, next)
+                        }
+                        onRenameCancel={() => setRenamingMissionId(null)}
+                      />
+                    ))
+                  )}
+                </div>
+              ) : null}
+            </section>
+
+            <div className="h-8 shrink-0" />
+
+            <section className="flex min-h-0 flex-[2] basis-0 flex-col">
+              <CollapsibleSectionHeader
+                label="CHAT"
+                count={directSessions.length}
+                open={sessionsOpen}
+                onToggle={toggleSessions}
+                onPlus={handleNewDirectChat}
+                plusTitle="Start a chat"
+              />
+              {sessionsOpen ? (
+                <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-3 pt-1">
+                  {directSessions.length === 0 ? (
+                    <p className="px-2.5 py-1 text-xs text-fg-3">
+                      No chats yet.
+                    </p>
+                  ) : (
+                    directSessions.map((s) => (
+                      <SessionRow
+                        key={s.session_id}
+                        session={s}
+                        selected={s.session_id === currentChatSessionId}
+                        renaming={renamingId === s.session_id}
+                        onClick={() => openDirectChat(s)}
+                        onContextMenu={(anchor) => openSessionMenu(s, anchor)}
+                        onRenameSubmit={(nextTitle) =>
+                          void submitRename(s.session_id, nextTitle)
+                        }
+                        onRenameCancel={() => setRenamingId(null)}
+                      />
+                    ))
+                  )}
+                </div>
+              ) : null}
+            </section>
+
+            {/* Settings row — pinned at the bottom of the sidebar
+                column. Mirrors Pencil node `IJsUO` (sidebar settings).
+                The collapse toggle now lives on the right of this
+                row (24×24, ChevronsLeft) — see frame s31wik. The
+                Settings button keeps the rest of the row width via
+                flex-1 so its hit target stays large. */}
+            <div className="flex shrink-0 items-center gap-2 border-t border-line px-3 pt-2">
+              <button
+                type="button"
+                onClick={() => setSettingsOpen(true)}
+                className="flex flex-1 cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-fg-2 transition-colors hover:bg-raised hover:text-fg"
+              >
+                <SettingsIcon aria-hidden className="h-3.5 w-3.5" />
+                <span className="text-[13px]">Settings</span>
+              </button>
+              <button
+                type="button"
+                onClick={() => onCollapsedChange(true)}
+                title="Collapse sidebar (⌘\\)"
+                aria-label="Collapse sidebar"
+                className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-fg-3 transition-colors hover:bg-bg hover:text-fg"
+              >
+                <ChevronsLeft aria-hidden className="h-3.5 w-3.5" />
+              </button>
+            </div>
+          </div>
+        )}
+
+        {/* Resize handle is inert in rail mode (no width to drag). We
+            render a noop placeholder so the DOM stays stable, just
+            without the col-resize cursor / mousedown handler. */}
         <div
-          onMouseDown={handleResizeStart}
-          title="Drag to resize"
-          className="absolute right-0 top-0 z-20 h-full w-1 cursor-col-resize bg-transparent transition-colors hover:bg-accent/40"
+          onMouseDown={collapsed ? undefined : handleResizeStart}
+          title={collapsed ? undefined : "Drag to resize"}
+          className={
+            collapsed
+              ? "absolute right-0 top-0 z-20 h-full w-1 bg-transparent"
+              : "absolute right-0 top-0 z-20 h-full w-1 cursor-col-resize bg-transparent transition-colors hover:bg-accent/40"
+          }
         />
       </aside>
 
@@ -757,6 +832,64 @@ function NavRow({
         </>
       )}
     </NavLink>
+  );
+}
+
+// Icon-only nav row used in the collapsed rail. Reuses NavLink for
+// the active-state styling so the rail and full sidebar agree on
+// what's selected. The label is exposed via a native `title`
+// tooltip — there is no in-tree tooltip primitive, so we keep this
+// lightweight rather than introduce one for v1.
+function RailIconLink({
+  icon: Icon,
+  to,
+  label,
+}: {
+  icon: ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  to: string;
+  label: string;
+}) {
+  return (
+    <NavLink
+      to={to}
+      title={label}
+      aria-label={label}
+      className={({ isActive }) =>
+        `flex h-9 w-9 items-center justify-center rounded border transition-colors ${
+          isActive
+            ? "border-line bg-bg text-fg"
+            : "border-transparent text-fg-2 hover:border-line hover:bg-bg hover:text-fg"
+        }`
+      }
+    >
+      <Icon aria-hidden className="h-4 w-4" />
+    </NavLink>
+  );
+}
+
+// Icon-only button variant for non-routing actions in the rail
+// (search palette, settings). Border-transparent → border-line on
+// hover keeps the layout stable while matching the active treatment
+// on the link variant.
+function RailIconButton({
+  icon: Icon,
+  label,
+  onClick,
+}: {
+  icon: ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
+  label: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={label}
+      aria-label={label}
+      className="flex h-9 w-9 cursor-pointer items-center justify-center rounded border border-transparent text-fg-2 transition-colors hover:border-line hover:bg-bg hover:text-fg"
+    >
+      <Icon aria-hidden className="h-4 w-4" />
+    </button>
   );
 }
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -5,6 +5,7 @@
 // of truth so the modal and its consumers can't drift apart.
 
 export const STORAGE_AUTO_INSTALL_UPDATES = "settings.autoInstallUpdates";
+export const STORAGE_SIDEBAR_COLLAPSED = "runner.sidebar.collapsed";
 
 export function readStoredBool(key: string, defaultValue: boolean): boolean {
   try {


### PR DESCRIPTION
## Summary
- Two-state sidebar: full (user-resizable) ↔ 52px icon rail.
- Toggle lives at the bottom of the sidebar in both states (right of Settings when full, its own row above Settings in rail). `cmd+\` / `ctrl+\` also toggles.
- State persists via new `STORAGE_SIDEBAR_COLLAPSED` localStorage key; user's preferred full width is preserved across collapse/expand cycles.
- In rail mode MISSION/SESSION lists are entirely hidden; WORKSPACE icons (runner / crew / search) + Settings stack vertically with 36×36 hit targets and native `title` tooltips.
- Pencil frames `s31wik` (open) and `aOmHy` (rail) added to `design/runners-design.pen`.

Closes #34.

## Test plan
- [ ] `cmd+\` toggles full ↔ rail in either direction (and is skipped inside `<input>` / `<textarea>`).
- [ ] Bottom-row chevron does the same in both states.
- [ ] State persists across app restart.
- [ ] In rail mode every icon (runner / crew / search / settings) tooltips its label on hover and navigates / opens correctly.
- [ ] Resize handle works expanded, inert while collapsed, last full-width restored on expand.
- [ ] Title-bar drag region above the brand still drags the window.
- [ ] No regression in the per-section MISSION / CHAT collapse inside the expanded sidebar.
- [ ] `pnpm exec tsc --noEmit` and `pnpm run lint` clean.