### PR TITLE
chore: release v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "runner",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.1.5",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runner"
-version = "0.1.4"
+version = "0.1.5"
 description = "An editor for teams of local coding agents (Claude Code, Codex, and friends)"
 edition.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Runner",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "identifier": "com.wycstudios.runner",
   "build": {
     "beforeDevCommand": "npm run tauri:before:dev",


### PR DESCRIPTION
## Summary

- Version bump 0.1.4 → 0.1.5 across `package.json`, `src-tauri/tauri.conf.json`, `src-tauri/Cargo.toml`, `Cargo.lock`.

## Changes since v0.1.4

- feat(ui): collapsable sidebar with full ↔ icon rail (#80, closes #34)
- fix(ui): hide main window until first frame paints (#76, closes #63)
- fix(ui): render single newlines as line breaks in message body (#75, closes #46)
- test(fixtures): add designer slot to Build squad

## Test plan

- [ ] CI green on this PR
- [ ] Release workflow builds + notarizes both arches
- [ ] DMGs install + launch on Apple Silicon