### PR TITLE
fix(terminal): image paste — restore NSPasteboard so agent sees real bytes

### DIFF
--- a/docs/features/07-zoom-and-font-size.md
+++ b/docs/features/07-zoom-and-font-size.md
@@ -1,4 +1,4 @@
-# 07 — App zoom & terminal font size in General settings
+# 07 — App zoom (General) & terminal font size (new Terminal pane)
 
 > Tracking issue: [#78](https://github.com/yicheng47/runner/issues/78)
 
@@ -17,10 +17,16 @@ Two recurring asks from users on different display sizes:
    own renderer and needs its own font-size knob to stay crisp; a
    webview zoom on a canvas-rendered terminal blurs.
 
-The General pane in Settings is the right home: it already owns
-"Defaults and startup behavior" and is where users go to look first.
-Two new rows: one for **App zoom** (whole-UI scale) and one for
-**Terminal font size** (xterm-only).
+Settings split:
+
+- **App zoom** lives in the existing **General** pane — it's a
+  whole-app affordance and belongs next to other startup/defaults.
+- **Terminal font size** lives in a new dedicated **Terminal** pane
+  in the Settings sidebar. It's the first xterm-specific knob, but
+  it won't be the last: cursor style, scrollback length, copy-on-
+  select, shell preference are all natural future neighbours. Giving
+  terminal settings their own home now avoids overstuffing General
+  later.
 
 ## Scope
 
@@ -37,7 +43,13 @@ Two new rows: one for **App zoom** (whole-UI scale) and one for
   - Applied at app boot (a small effect in `App.tsx` reads the stored
     value and calls `setZoom` once on mount) and immediately on
     change.
-- **Terminal font size row** in `GeneralPane`:
+- **New `TerminalPane`** in `SettingsModal.tsx`:
+  - Add `"terminal"` to the `Pane` union and an entry to `PANES`
+    (lucide `Terminal` icon, subtitle e.g. "xterm appearance").
+    Insert between **General** and **Updates** in the sidebar.
+  - Render a `<TerminalPane />` component that hosts the terminal-
+    scoped rows; future terminal settings land here.
+- **Terminal font size row** in the new `TerminalPane`:
   - Control: a `StyledSelect` with `Small (12)`, `Default (13)`,
     `Large (15)`, `Extra large (17)`. Default `Default (13)`.
   - Persisted in localStorage at `settings.terminalFontSize`
@@ -76,12 +88,13 @@ Two new rows: one for **App zoom** (whole-UI scale) and one for
 
 ### Key decisions
 
-1. **Two distinct settings, not one.** Webview zoom handles DOM-rendered
-   surfaces correctly but blurs xterm's canvas. xterm's own
-   `fontSize` produces crisp glyphs but doesn't affect the rest of
-   the UI. They're load-bearing in different layers, so they get
-   different controls. Naming makes the distinction visible:
-   "App zoom" vs. "Terminal font size".
+1. **Two distinct settings, in two different panes.** Webview zoom
+   handles DOM-rendered surfaces correctly but blurs xterm's canvas.
+   xterm's own `fontSize` produces crisp glyphs but doesn't affect
+   the rest of the UI. They're load-bearing in different layers, so
+   they get different controls. Putting them in different panes
+   (General vs. Terminal) makes the distinction visible and gives
+   future terminal-only settings a natural home.
 2. **Discrete steps, not a free slider.** Six zoom steps and four
    font-size steps cover the realistic range and avoid users
    landing on weird non-integer pixel sizes that subpixel-rasterise
@@ -111,18 +124,20 @@ Two new rows: one for **App zoom** (whole-UI scale) and one for
   effects today), add a one-shot effect that reads the stored zoom
   and calls `getCurrentWebview().setZoom(stored)`. No-op on `1.0`.
 
-### Phase 2 — `GeneralPane` rows
+### Phase 2 — Settings UI
 
-- Two new `<Row>`s in `GeneralPane`:
-  - `App zoom` — `−` / `<percent>` / `+` cluster (decision: stepper
-    cluster matches the rest of the modal; alternative is
-    `StyledSelect` with the discrete options). Picks one and
-    documents the choice in the implementation PR.
-  - `Terminal font size` — `StyledSelect` over the four named
-    sizes.
-- Both write through to localStorage immediately on change.
-- App zoom also calls `setZoom(next)` so the change is felt
-  immediately; the persisted value is the ground truth on next boot.
+- **`GeneralPane`**: add an `App zoom` `<Row>` — `−` / `<percent>` /
+  `+` cluster (decision: stepper cluster matches the rest of the
+  modal; alternative is `StyledSelect` with the discrete options).
+  Picks one and documents the choice in the implementation PR.
+  Writes through to localStorage immediately and calls `setZoom(next)`
+  so the change is felt right away; the persisted value is the
+  ground truth on next boot.
+- **New `TerminalPane`**: add `"terminal"` to the `Pane` union and
+  to the `PANES` array in `SettingsModal.tsx`, render the new pane
+  in the content switch, and add a `Terminal font size` `<Row>` —
+  `StyledSelect` over the four named sizes — writing through to
+  localStorage on change.
 
 ### Phase 3 — `RunnerTerminal` consumption + live update
 
@@ -145,9 +160,10 @@ Two new rows: one for **App zoom** (whole-UI scale) and one for
       modal open.
 - [ ] Reset to 100%: UI restores; localStorage key cleared (or set
       to `"1"`, decided in Phase 1).
-- [ ] Open a runner chat with a streaming session, change Terminal
-      font size to Large: text re-rasterises to 15px, no dropped
-      output, cursor stays correct.
+- [ ] Open Settings → **Terminal** pane (new sidebar entry between
+      General and Updates) → with a runner chat streaming, change
+      Terminal font size to Large: text re-rasterises to 15px, no
+      dropped output, cursor stays correct.
 - [ ] Change font size with no terminal mounted: open a new runner
       chat afterwards → new chat picks up the stored size on first
       render.

--- a/docs/impls/0006-image-paste.md
+++ b/docs/impls/0006-image-paste.md
@@ -1,0 +1,159 @@
+# Image paste into runner terminal
+
+> Bugfix for #79. Restores NSPasteboard mid-paste so the embedded
+> xterm's `Cmd+V` of a PNG produces the same agent attachment a host
+> `Terminal.app` paste would — `[Image x]` placeholder with the real
+> screenshot bytes attached.
+
+## Why
+
+After v0.1.3 a paste handler was wired onto xterm's hidden textarea
+(`RunnerTerminal.tsx:225`, capture phase) to swallow image pastes and
+inject `\x16` so claude-code / codex shell out to read the system
+clipboard themselves. Field reports said it still wasn't working —
+Cmd+V on a screenshot landed in the agent as an attachment described
+as "a generic macOS PNG file icon, not actual content." The same
+Cmd+V from the user's host `Terminal.app` running `claude` directly
+works fine.
+
+The difference is WKWebView. When WKWebView dispatches the JS `paste`
+event, it materializes image clipboard items into `File` objects by
+writing the image bytes to a temp file under the hood. As a side
+effect it mutates NSPasteboard so `public.png` now resolves to the
+temp file's *icon* rather than the original screenshot bytes.
+`preventDefault()` doesn't help — the mutation happens before JS sees
+the event. By the time our `\x16` reaches `claude` and `claude` reads
+NSPasteboard, the OS clipboard has already been overwritten.
+
+## Considered alternatives
+
+1. **Type the path into the prompt**: read the bytes JS-side, persist
+   to disk via Rust, type the absolute path with a trailing space.
+   Verified the bytes survive end-to-end, but the agent then shows
+   the raw path in the prompt instead of its native `[Image x]`
+   placeholder. The user can submit and the agent reads the file
+   from disk, but the UX is markedly worse than a host-terminal
+   paste. Rejected.
+2. **Re-implement `[Image x]` placeholder ourselves** (write a
+   placeholder + send the file via some side channel). Requires
+   guessing each CLI's internal protocol; brittle. Rejected.
+3. **Restore NSPasteboard before the agent's clipboard read runs**
+   (this doc). Native `[Image x]` flow keeps working, no per-CLI
+   custom protocol. Selected.
+
+## Fix
+
+End-to-end pipeline:
+
+1. `RunnerTerminal.tsx` `onPaste` (capture phase on xterm's hidden
+   `<textarea>`):
+   - Iterate `clipboardData.items`, find the first with
+     `type === "image/png"`, get the `File` via `getAsFile()`. We
+     filter to PNG only — see "PNG-only" below.
+   - `preventDefault()` + `stopImmediatePropagation()` so xterm.js's
+     bubble-phase text-paste handler doesn't also run.
+   - `await file.arrayBuffer()` → `Uint8Array` (the original bytes
+     WebKit captured when it built the JS event, before the
+     downstream pbpaste sees the corrupted clipboard).
+   - `await api.session.pasteImage(bytes)` — Rust side restores
+     NSPasteboard.
+   - `await api.session.injectStdin(sid, "\x16")` — agent CLI now
+     sees Ctrl-V, reads NSPasteboard, gets the real bytes, renders
+     its `[Image x]` placeholder.
+
+2. New Rust command `session_paste_image(bytes)`
+   (`src-tauri/src/commands/session.rs`):
+   - Writes `bytes` to a `tempfile::NamedTempFile` in `$TMPDIR` with
+     prefix `runner-paste-` and suffix `.png`. `NamedTempFile` is
+     deleted on `Drop`, so the file is gone before the command
+     returns — pasted screenshots can be sensitive, shouldn't
+     accumulate, and the OS reaper isn't load-bearing.
+   - On macOS, runs:
+
+     ```
+     osascript -e 'set the clipboard to (read POSIX file "<path>" as «class PNGf»)'
+     ```
+
+     `«class PNGf»` is the four-char OSType code for PNG; the
+     statement reads the file as PNG bytes and writes them to
+     NSPasteboard's `public.png` representation, overwriting whatever
+     icon WebKit left there. The path is interpolated via Rust's
+     `{:?}` debug format so paths with spaces or quotes survive (the
+     escape syntax `\\` / `\"` is shared between Rust string literals
+     and AppleScript string literals).
+   - On non-macOS the command is a no-op — the embedded webview's
+     paste behavior on Linux / Windows hasn't been audited and the
+     runner doesn't ship there yet.
+   - Returns `Result<()>`. An `osascript` failure propagates up
+     through Tauri's invoke into the JS catch, which surfaces via
+     `onErrorRef`.
+
+3. Wired into the Tauri invoke handler in `lib.rs`.
+
+Plain-text pastes are unchanged: when no clipboard item has an
+`image/png` type, the handler returns early without `preventDefault`,
+and xterm.js's bubble-phase paste handler runs normally.
+
+## PNG-only
+
+The AppleScript writes the bytes verbatim into the `public.png`
+pasteboard flavor. If we let a JPEG or GIF through, NSPasteboard
+would end up with `public.png` populated by non-PNG bytes — the agent
+would attach an image that fails to decode. The frontend filter to
+`image/png` and the doc-comment in the Rust command both call this
+out; broadening to JPEG / GIF / WebP needs either a per-MIME OSType
+map (`«class JPEG»`, `«class GIFf»`, etc.) or a transcode step in
+Rust. Out of scope for v1; macOS screenshots are PNG, which is the
+common-case paste.
+
+## Considered: `arboard` / `tauri-plugin-clipboard-manager`
+
+Both expose a "set image" API that bypasses `osascript`. Rejected for
+v1:
+
+- `arboard::Clipboard::set_image` takes pre-decoded RGBA, not PNG
+  bytes — we'd need to add the `image` crate to decode first, then
+  arboard re-encodes. Two unnecessary passes.
+- `tauri-plugin-clipboard-manager` adds a plugin we'd otherwise not
+  use. The single `osascript` call is the lightest path.
+
+If we later need cross-platform support, arboard + the `image` crate
+(or the plugin) becomes the right shape; the surface here stays the
+same.
+
+## What this replaces
+
+- The earlier `\x16`-then-let-the-CLI-read-pbpaste path was correct
+  in spirit but structurally broken across the webview boundary —
+  the clipboard the CLI reads is no longer the clipboard the user
+  copied.
+- The intermediate "type the path into the prompt" pass got the
+  bytes through but lost the native `[Image x]` rendering. Replaced
+  by the clipboard-restore + `\x16` pipeline.
+- The earlier `[#79 paste items]` diagnostic `console.log` is gone
+  — we now control the full path end-to-end and don't need to
+  probe.
+
+## Out of scope
+
+- **Drag-and-drop into the embedded terminal.** xterm.js's textarea
+  fires `drop` events, but Tauri's webview drop handling needs its
+  own wiring. Paste covers the immediate UX gap; drop is a
+  follow-up.
+- **Multi-image pastes.** Handler picks the *first* `image/png`
+  item; multi-image clipboards are rare.
+- **Non-PNG image formats.** See "PNG-only" above.
+- **Linux / Windows clipboard restore.** Both ship with different
+  clipboard models; we'd need separate platform branches and a
+  non-`osascript` mechanism. Out of scope until the runner ships on
+  those platforms.
+
+## Verification
+
+- Locally confirmed: after the osascript call, `osascript -e
+  'clipboard info'` reports `«class PNGf»` populated at the exact
+  byte count of the source PNG.
+- User-confirmed end-to-end paste of a real screenshot now renders
+  as `[Image x]` with the actual content in the runner chat.
+- `pnpm tsc --noEmit`, `pnpm lint`, `cargo check`, `cargo clippy` —
+  clean.

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -142,6 +142,78 @@ pub async fn session_output_snapshot(
     Ok(state.sessions.output_snapshot(&session_id))
 }
 
+/// Restore NSPasteboard for an image paste that came in through the
+/// webview, so the agent CLI's own `pbpaste -Prefer png` returns the
+/// real bytes and renders its native `[Image x]` placeholder in the
+/// prompt.
+///
+/// Why: when the user presses Cmd+V over the WKWebView, WebKit
+/// materializes the image clipboard item into a `File` object (a temp
+/// file under the hood). As a side effect NSPasteboard's `public.png`
+/// representation becomes the OS-rendered icon of that temp file
+/// rather than the original screenshot bytes. The agent CLI's
+/// subsequent `pbpaste -Prefer png` then returns the icon, not the
+/// screenshot (#79).
+///
+/// Fix: the frontend grabs the original bytes off the `ClipboardEvent`
+/// File before they reach the child process, ships them here, we write
+/// them to a temp PNG, and use `osascript` to re-populate NSPasteboard
+/// with the real bytes. The frontend then injects Ctrl-V (`\x16`); the
+/// agent's existing `pbpaste`-based attach flow runs unchanged.
+///
+/// macOS-only; on other platforms this is a no-op temp-file write (the
+/// embedded webview's paste behavior on Linux/Windows hasn't been
+/// audited and the runner doesn't ship there yet).
+#[tauri::command]
+pub async fn session_paste_image(bytes: Vec<u8>, ext: String) -> Result<()> {
+    use std::io::Write;
+    let safe_ext = sanitize_image_ext(&ext);
+    let filename = format!("runner-paste-{}.{}", ulid::Ulid::new(), safe_ext);
+    let path = std::env::temp_dir().join(filename);
+    {
+        let mut f = std::fs::File::create(&path)?;
+        f.write_all(&bytes)?;
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        // AppleScript: read the temp file as PNG bytes and write them
+        // to NSPasteboard's `public.png` representation. `«class PNGf»`
+        // is the four-char OSType code for PNG. The `{:?}` debug
+        // format quotes the path with `\\` / `\"` escapes that
+        // AppleScript also accepts, so paths with spaces or quotes
+        // pass through safely.
+        let path_str = path.to_string_lossy();
+        let script = format!(
+            "set the clipboard to (read POSIX file {:?} as «class PNGf»)",
+            path_str
+        );
+        let status = std::process::Command::new("osascript")
+            .arg("-e")
+            .arg(&script)
+            .status()
+            .map_err(|e| Error::msg(format!("osascript spawn failed: {e}")))?;
+        if !status.success() {
+            return Err(Error::msg(format!(
+                "osascript exited with status {:?}",
+                status.code()
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn sanitize_image_ext(s: &str) -> &'static str {
+    match s.to_ascii_lowercase().as_str() {
+        "png" => "png",
+        "jpg" | "jpeg" => "jpg",
+        "gif" => "gif",
+        "webp" => "webp",
+        _ => "png",
+    }
+}
+
 /// One row per direct-chat *session* in the sidebar SESSION tray. Each
 /// runner can host multiple parallel chats — see
 /// docs/impls/0003-direct-chats.md — so the tray is flat (not collapsed per

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -142,48 +142,65 @@ pub async fn session_output_snapshot(
     Ok(state.sessions.output_snapshot(&session_id))
 }
 
-/// Restore NSPasteboard for an image paste that came in through the
-/// webview, so the agent CLI's own `pbpaste -Prefer png` returns the
-/// real bytes and renders its native `[Image x]` placeholder in the
-/// prompt.
+/// Restore NSPasteboard for a PNG paste that came in through the
+/// webview, so the agent CLI's NSPasteboard read returns the real
+/// bytes and renders its native `[Image x]` placeholder in the prompt.
 ///
 /// Why: when the user presses Cmd+V over the WKWebView, WebKit
 /// materializes the image clipboard item into a `File` object (a temp
 /// file under the hood). As a side effect NSPasteboard's `public.png`
 /// representation becomes the OS-rendered icon of that temp file
 /// rather than the original screenshot bytes. The agent CLI's
-/// subsequent `pbpaste -Prefer png` then returns the icon, not the
-/// screenshot (#79).
+/// subsequent clipboard read then returns the icon, not the screenshot
+/// (#79).
 ///
 /// Fix: the frontend grabs the original bytes off the `ClipboardEvent`
-/// File before they reach the child process, ships them here, we write
-/// them to a temp PNG, and use `osascript` to re-populate NSPasteboard
-/// with the real bytes. The frontend then injects Ctrl-V (`\x16`); the
-/// agent's existing `pbpaste`-based attach flow runs unchanged.
+/// File before they reach the child process, ships them here, we
+/// write them to a `NamedTempFile`, and use `osascript` to repopulate
+/// NSPasteboard with the real bytes. The frontend then injects Ctrl-V
+/// (`\x16`); the agent's existing paste-attach flow runs unchanged.
 ///
-/// macOS-only; on other platforms this is a no-op temp-file write (the
-/// embedded webview's paste behavior on Linux/Windows hasn't been
-/// audited and the runner doesn't ship there yet).
+/// PNG-only. AppleScript writes the bytes verbatim into the
+/// `public.png` pasteboard flavor, so non-PNG payloads would end up
+/// labeled PNG with non-PNG bytes. The frontend filters to
+/// `image/png` for the same reason. JPEG/GIF/WebP support is a
+/// follow-up that would need either a per-MIME OSType map or a
+/// transcode step.
+///
+/// macOS-only; on other platforms this is a no-op (the embedded
+/// webview's paste behavior on Linux/Windows hasn't been audited and
+/// the runner doesn't ship there yet).
 #[tauri::command]
-pub async fn session_paste_image(bytes: Vec<u8>, ext: String) -> Result<()> {
-    use std::io::Write;
-    let safe_ext = sanitize_image_ext(&ext);
-    let filename = format!("runner-paste-{}.{}", ulid::Ulid::new(), safe_ext);
-    let path = std::env::temp_dir().join(filename);
+pub async fn session_paste_image(bytes: Vec<u8>) -> Result<()> {
+    #[cfg(not(target_os = "macos"))]
     {
-        let mut f = std::fs::File::create(&path)?;
-        f.write_all(&bytes)?;
+        let _ = bytes;
+        Ok(())
     }
 
     #[cfg(target_os = "macos")]
     {
-        // AppleScript: read the temp file as PNG bytes and write them
-        // to NSPasteboard's `public.png` representation. `«class PNGf»`
+        use std::io::Write;
+        // NamedTempFile so the file is removed on drop — pasted
+        // screenshots can be sensitive and shouldn't accumulate in
+        // $TMPDIR. The OS would eventually reap them, but explicit
+        // cleanup is cheaper and matches the value's lifetime:
+        // osascript reads the bytes into NSPasteboard synchronously,
+        // and after that we don't need the file.
+        let mut tmp = tempfile::Builder::new()
+            .prefix("runner-paste-")
+            .suffix(".png")
+            .tempfile_in(std::env::temp_dir())?;
+        tmp.write_all(&bytes)?;
+        tmp.flush()?;
+
+        let path_str = tmp.path().to_string_lossy();
+        // AppleScript: read the temp file's bytes and write them to
+        // NSPasteboard's `public.png` representation. `«class PNGf»`
         // is the four-char OSType code for PNG. The `{:?}` debug
         // format quotes the path with `\\` / `\"` escapes that
         // AppleScript also accepts, so paths with spaces or quotes
         // pass through safely.
-        let path_str = path.to_string_lossy();
         let script = format!(
             "set the clipboard to (read POSIX file {:?} as «class PNGf»)",
             path_str
@@ -193,24 +210,15 @@ pub async fn session_paste_image(bytes: Vec<u8>, ext: String) -> Result<()> {
             .arg(&script)
             .status()
             .map_err(|e| Error::msg(format!("osascript spawn failed: {e}")))?;
+        // tmp drops here either way — file is removed regardless of
+        // osascript's success.
         if !status.success() {
             return Err(Error::msg(format!(
                 "osascript exited with status {:?}",
                 status.code()
             )));
         }
-    }
-
-    Ok(())
-}
-
-fn sanitize_image_ext(s: &str) -> &'static str {
-    match s.to_ascii_lowercase().as_str() {
-        "png" => "png",
-        "jpg" | "jpeg" => "jpg",
-        "gif" => "gif",
-        "webp" => "webp",
-        _ => "png",
+        Ok(())
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -181,6 +181,7 @@ pub fn run() {
             commands::session::session_kill,
             commands::session::session_resize,
             commands::session::session_output_snapshot,
+            commands::session::session_paste_image,
             commands::session::session_start_direct,
         ])
         .run(tauri::generate_context!())

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -208,39 +208,49 @@ export function RunnerTerminal({
       return true;
     });
 
-    // Image paste support. claude-code and codex already know how to
-    // attach a clipboard image when they see Ctrl+V (\x16) on stdin —
-    // they shell out to `pbpaste -Prefer png` (or the platform
-    // equivalent) and read the OS clipboard themselves. The bug surface
-    // is that on macOS the user instinctively presses Cmd+V, which the
-    // WebView intercepts as a *text* paste; xterm.js's default handler
-    // then drops the image and pastes whatever placeholder text rep the
-    // OS attached, so the keystroke that would have triggered the CLI's
-    // clipboard read never reaches the PTY.
+    // Image paste support. We can't trust the OS clipboard across the
+    // WKWebView boundary: when the user presses Cmd+V over the webview,
+    // WebKit materializes the image into a `File` (a temp file under
+    // the hood), and as a side effect NSPasteboard's `public.png`
+    // representation becomes the *icon* for that temp file rather than
+    // the original screenshot bytes. So the agent CLI's own
+    // `pbpaste -Prefer png` (triggered by Ctrl-V) gets a generic file
+    // icon instead of what the user copied (#79).
     //
-    // Fix: when the paste event carries an image, swallow xterm.js's
-    // text-paste handler and inject \x16 instead. The agent CLI takes
-    // it from there. Pure-text pastes fall through to xterm.js's
-    // default behavior unchanged.
+    // Fix: read the bytes off the `ClipboardEvent`'s File ourselves
+    // (still the original screenshot at that point), ship them to Rust,
+    // which writes them back to NSPasteboard's `public.png` so the
+    // agent's existing pbpaste-based flow returns the real bytes.
+    // Then inject Ctrl-V (`\x16`) — claude-code / codex see Ctrl-V as
+    // they would in a host terminal, attach the image with their
+    // native `[Image x]` placeholder. Pure-text pastes fall through
+    // to xterm.js's default behavior unchanged.
     const onPaste = (e: ClipboardEvent) => {
       const sid = sessionIdRef.current;
       if (!sid || disabledRef.current) return;
       const items = e.clipboardData?.items;
       if (!items) return;
-      let hasImage = false;
+      let imageFile: File | null = null;
       for (let i = 0; i < items.length; i += 1) {
         const it = items[i];
-        if (it.kind === "file" && it.type.startsWith("image/")) {
-          hasImage = true;
-          break;
+        if (it.type.startsWith("image/")) {
+          imageFile = it.getAsFile();
+          if (imageFile) break;
         }
       }
-      if (!hasImage) return;
+      if (!imageFile) return;
       e.preventDefault();
       e.stopImmediatePropagation();
-      void api.session.injectStdin(sid, "\x16").catch((err) => {
-        onErrorRef.current?.(String(err));
-      });
+      const ext = imageFile.type.slice("image/".length) || "png";
+      void (async () => {
+        try {
+          const buf = await imageFile.arrayBuffer();
+          await api.session.pasteImage(new Uint8Array(buf), ext);
+          await api.session.injectStdin(sid, "\x16");
+        } catch (err) {
+          onErrorRef.current?.(String(err));
+        }
+      })();
     };
     const textarea = term.textarea;
     textarea?.addEventListener("paste", onPaste, { capture: true });

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -230,10 +230,17 @@ export function RunnerTerminal({
       if (!sid || disabledRef.current) return;
       const items = e.clipboardData?.items;
       if (!items) return;
+      // PNG-only for now. The clipboard-restore path writes the
+      // bytes verbatim into NSPasteboard's `public.png` flavor, so
+      // non-PNG payloads would end up labeled PNG with non-PNG bytes
+      // and decode as garbage in the agent. macOS screenshots are
+      // PNG; JPEG/GIF/WebP support needs either a per-MIME OSType
+      // map or a transcode step — out of scope for v1 (#79
+      // follow-up).
       let imageFile: File | null = null;
       for (let i = 0; i < items.length; i += 1) {
         const it = items[i];
-        if (it.type.startsWith("image/")) {
+        if (it.type === "image/png") {
           imageFile = it.getAsFile();
           if (imageFile) break;
         }
@@ -241,11 +248,10 @@ export function RunnerTerminal({
       if (!imageFile) return;
       e.preventDefault();
       e.stopImmediatePropagation();
-      const ext = imageFile.type.slice("image/".length) || "png";
       void (async () => {
         try {
           const buf = await imageFile.arrayBuffer();
-          await api.session.pasteImage(new Uint8Array(buf), ext);
+          await api.session.pasteImage(new Uint8Array(buf));
           await api.session.injectStdin(sid, "\x16");
         } catch (err) {
           onErrorRef.current?.(String(err));

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -164,10 +164,9 @@ export const api = {
       invoke<void>("session_resize", { sessionId, cols, rows }),
     outputSnapshot: (sessionId: string) =>
       invoke<SessionOutputEvent[]>("session_output_snapshot", { sessionId }),
-    pasteImage: (bytes: Uint8Array, ext: string) =>
+    pasteImage: (bytes: Uint8Array) =>
       invoke<void>("session_paste_image", {
         bytes: Array.from(bytes),
-        ext,
       }),
     startDirect: (
       runnerId: string,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -164,6 +164,11 @@ export const api = {
       invoke<void>("session_resize", { sessionId, cols, rows }),
     outputSnapshot: (sessionId: string) =>
       invoke<SessionOutputEvent[]>("session_output_snapshot", { sessionId }),
+    pasteImage: (bytes: Uint8Array, ext: string) =>
+      invoke<void>("session_paste_image", {
+        bytes: Array.from(bytes),
+        ext,
+      }),
     startDirect: (
       runnerId: string,
       cwd: string | null,


### PR DESCRIPTION
Closes #79.

## Problem

`Cmd+V` of a screenshot into a runner chat's embedded terminal landed in the agent as a "generic macOS PNG file icon, not actual content." The same paste from a host `Terminal.app` running `claude` worked fine — only Runner's embedded terminal failed.

## Why

WKWebView is in the path. When it dispatches the JS `paste` event, it materializes the image clipboard item into a JS `File` by writing the bytes to a temp file under the hood, and as a side effect mutates NSPasteboard so `public.png` now resolves to the OS-rendered icon of *that temp file* rather than the original screenshot bytes. `preventDefault()` doesn't help — the mutation happens before JS sees the event. By the time the agent CLI's `pbpaste` runs, NSPasteboard's `public.png` is the file-icon PNG.

## Fix

Read the original bytes off the `ClipboardEvent`'s `File` (still intact at that point), ship them to Rust, write to `$TMPDIR/runner-paste-<ulid>.<ext>`, then re-populate NSPasteboard with the real bytes via:

```
osascript -e 'set the clipboard to (read POSIX file "<path>" as «class PNGf»)'
```

Frontend then injects Ctrl-V (`\x16`). The agent's existing paste flow runs unchanged and shows its native `[Image x]` placeholder with the correct attachment — same UX as a host-terminal paste.

## Considered & rejected

- **`\x16`-only** (the original implementation): structurally broken across the webview boundary — NSPasteboard is no longer the clipboard the user copied.
- **Type the path into the prompt**: gets the bytes through but loses the agent's native `[Image x]` rendering. Worse UX than a host paste.
- **Clipboard-restore + `\x16`** (this PR): preserves native UX, no per-CLI custom protocol.

Full design notes in `docs/impls/0006-image-paste.md`.

## Verification

- [x] Sanity-test the osascript syntax locally: `clipboard info` reports `«class PNGf»` populated at the correct byte count after the call.
- [x] User confirmed end-to-end paste of a real screenshot now shows `[Image x]` with the actual content in the runner chat.
- [x] `pnpm tsc --noEmit`, `pnpm lint`, `cargo check`, `cargo clippy` — all clean.

## Test plan

- [ ] `Shift+Cmd+Ctrl+4` → Cmd+V in a runner chat's terminal → agent shows `[Image x]` with the real screenshot.
- [ ] `Cmd+C` a PNG file in Finder → Cmd+V in a runner chat's terminal → same `[Image x]` rendering with the file's real bytes.
- [ ] Plain-text paste still works (xterm.js default path).
- [ ] Pasting with no live session is a silent no-op.