### PR TITLE
chore: release v0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "runner",
   "private": true,
-  "version": "0.1.5",
+  "version": "0.1.6",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runner"
-version = "0.1.5"
+version = "0.1.6"
 description = "An editor for teams of local coding agents (Claude Code, Codex, and friends)"
 edition.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Runner",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "identifier": "com.wycstudios.runner",
   "build": {
     "beforeDevCommand": "npm run tauri:before:dev",


### PR DESCRIPTION
Release v0.1.6.

## Highlights since v0.1.5

- **fix(terminal):** image paste in the embedded terminal restores `NSPasteboard` so the agent CLI gets real PNG bytes instead of WebKit's temp-file icon (#82).
- **feat(ui):** `Browse…` system folder picker on the runner Working directory field in both Create Runner and Edit Runner, matching Start Mission's affordance (#84).
- **feat(ui):** Edit Runner form revamp — Command is now bound to Runtime, Thinking effort becomes a per-runtime dropdown (claude-code vs codex enum), Model + Effort sit above Permission mode (#84).