### PR TITLE
ui(sidebar): hide ⌘K hint and surface Search at the top

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -557,7 +557,7 @@ export function Sidebar({
             <RailIconLink icon={Users} to="/crews" label="crew" />
             <RailIconButton
               icon={Search}
-              label="Search (⌘K)"
+              label="Search"
               onClick={() => setPaletteOpen(true)}
             />
             {/* Archived rail icon — slot reserved for feature #31.
@@ -894,20 +894,19 @@ function RailIconButton({
 }
 
 /// Search nav row — visually indistinguishable from runner/crew rows
-/// but opens the CommandPalette modal instead of routing.
+/// but opens the CommandPalette modal instead of routing. The ⌘K
+/// keyboard binding (registered above) still works; the shortcut
+/// hint just isn't displayed in the UI.
 function SearchNavRow({ onOpen }: { onOpen: () => void }) {
   return (
     <button
       type="button"
-      title="Search (⌘K)"
+      title="Search"
       onClick={onOpen}
-      className="flex w-full cursor-pointer items-center justify-between gap-2 rounded px-2.5 py-1.5 text-left text-sm text-fg-2 transition-colors hover:text-fg"
+      className="flex w-full cursor-pointer items-center gap-2 rounded px-2.5 py-1.5 text-left text-sm text-fg-2 transition-colors hover:text-fg"
     >
-      <span className="flex items-center gap-2">
-        <Search aria-hidden className="h-3 w-3 text-fg-2" />
-        <span>search</span>
-      </span>
-      <span className="font-mono text-[10px] text-fg-3">⌘K</span>
+      <Search aria-hidden className="h-3 w-3 text-fg-2" />
+      <span>search</span>
     </button>
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -553,13 +553,13 @@ export function Sidebar({
             <BrandMark />
             <div className="h-px w-full bg-line" />
             <div className="h-2 w-full" />
-            <RailIconLink icon={Terminal} to="/runners" label="runner" />
-            <RailIconLink icon={Users} to="/crews" label="crew" />
             <RailIconButton
               icon={Search}
               label="Search"
               onClick={() => setPaletteOpen(true)}
             />
+            <RailIconLink icon={Terminal} to="/runners" label="runner" />
+            <RailIconLink icon={Users} to="/crews" label="crew" />
             {/* Archived rail icon — slot reserved for feature #31.
                 When the archived nav lands, render a RailIconLink
                 here pointing at its route (icon: lucide Archive).
@@ -598,15 +598,16 @@ export function Sidebar({
             <div className="shrink-0">
               <SectionHeader>WORKSPACE</SectionHeader>
               <nav className="flex flex-col gap-0.5 px-3 pb-1">
-                <NavRow icon={Terminal} to="/runners" label="runner" />
-                <NavRow icon={Users} to="/crews" label="crew" />
                 {/* Search opens a command-palette modal — matches design
                     `Fkoe8`. Default interaction is click-to-callout, not
                     type-in-place, so this lives as a nav row alongside
-                    runner/crew rather than an inline input. The actual
-                    palette is a follow-up; for now the row stubs the
-                    callout. */}
+                    runner/crew rather than an inline input. Placed
+                    first in WORKSPACE because it's the highest-velocity
+                    entry point — jumping to any mission / runner /
+                    crew without scrolling the lists below. */}
                 <SearchNavRow onOpen={() => setPaletteOpen(true)} />
+                <NavRow icon={Terminal} to="/runners" label="runner" />
+                <NavRow icon={Users} to="/crews" label="crew" />
               </nav>
             </div>
 


### PR DESCRIPTION
## Summary

Two small sidebar tweaks that pair naturally:

1. **Hide the ⌘K shortcut hint** on both Search affordances (the WORKSPACE nav row and the collapsed-rail icon). The keyboard binding still works — only the visible badge and tooltip text are dropped.
2. **Move Search to the first position** in the WORKSPACE section, both expanded and collapsed. Search is the fastest path to any mission / runner / crew, so it belongs at the top instead of below the lists it lets you skip.

## Test plan

- [ ] Open the app. WORKSPACE shows **search → runner → crew** (was: runner → crew → search).
- [ ] Search row no longer renders the trailing `⌘K` badge.
- [ ] ⌘K (Cmd+K on macOS, Ctrl+K elsewhere) still opens the command palette — keyboard binding unchanged.
- [ ] Collapse the sidebar. The icon rail shows **Search → Runner → Crew** in that order.
- [ ] Hover the Search icon in the rail — tooltip reads `Search` (no `(⌘K)` suffix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)