### PR TITLE
chore: release v0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "runner",
   "private": true,
-  "version": "0.1.6",
+  "version": "0.1.7",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runner"
-version = "0.1.6"
+version = "0.1.7"
 description = "An editor for teams of local coding agents (Claude Code, Codex, and friends)"
 edition.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Runner",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "identifier": "com.wycstudios.runner",
   "build": {
     "beforeDevCommand": "npm run tauri:before:dev",


### PR DESCRIPTION
Release v0.1.7.

## Highlights since v0.1.6

- **feat(session):** deliver the first user turn (mission lead launch prompt, per-slot persona, direct-chat persona) via the agent CLI's positional `[PROMPT]` argv at process spawn — eliminating the post-spawn paste race that left the goal buffered but unsubmitted on mission start (#90, closes #88).
- **fix(persist):** persistence-layer caps on `system_prompt` (16 KB), mission `goal_override` (8 KB), and `crew.goal` (8 KB) so the composed launch prompt always fits the runtime argv slot (#90).
- **ui(sidebar):** hide the `⌘K` shortcut hint on the search affordances; move Search to the first position in WORKSPACE so it sits above the runner / crew rows in both expanded and rail layouts (#91).