### PR TITLE
feat(ui): app zoom + terminal font size settings

### DIFF
--- a/design/runners-design.pen
+++ b/design/runners-design.pen
@@ -21688,6 +21688,59 @@
                 },
                 {
                   "type": "frame",
+                  "id": "orgA9",
+                  "name": "nav_terminal",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "YosM3",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "terminal",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "n47As",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "TlGAL",
+                          "fill": "#EDEDF0",
+                          "content": "Terminal",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "tm9Qy",
+                          "fill": "#5A5C66",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "xterm appearance",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
                   "id": "AXoR7",
                   "name": "nav_updates",
                   "width": "fill_container",
@@ -22018,6 +22071,129 @@
                           "iconFontName": "folder-open",
                           "iconFontFamily": "lucide",
                           "fill": "#9A9BA5"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "zrsMd",
+                  "name": "row_app_zoom",
+                  "width": "fill_container",
+                  "gap": 24,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "wRDOD",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "BtX1D",
+                          "fill": "#EDEDF0",
+                          "content": "App zoom",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "xYM54",
+                          "fill": "#9A9BA5",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Whole-app scale. Doesn't apply to the runner terminal canvas — see Terminal pane.",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "KfYfw",
+                      "name": "zoom_stepper",
+                      "fill": "#0E0E10",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#1F2127"
+                      },
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "na4qj",
+                          "name": "btn_minus",
+                          "width": 30,
+                          "height": 30,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "CIrxP",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "minus",
+                              "iconFontFamily": "lucide",
+                              "fill": "#9A9BA5"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "l2C1JH",
+                          "name": "val",
+                          "width": 56,
+                          "height": 30,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "right": 1,
+                              "left": 1
+                            },
+                            "fill": "#1F2127"
+                          },
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "U8hn8",
+                              "fill": "#EDEDF0",
+                              "content": "100%",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "Q75aa",
+                          "name": "btn_plus",
+                          "width": 30,
+                          "height": 30,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "N36FhM",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "plus",
+                              "iconFontFamily": "lucide",
+                              "fill": "#9A9BA5"
+                            }
+                          ]
                         }
                       ]
                     }
@@ -28884,6 +29060,773 @@
       "fontSize": 11,
       "fontWeight": "600",
       "letterSpacing": 1
+    },
+    {
+      "type": "text",
+      "id": "N8zNYP",
+      "x": 15,
+      "y": 8030,
+      "name": "phaseLbl",
+      "fill": "#9A9BA5",
+      "content": "PHASE 5 · Settings — zoom & font size (#78)",
+      "fontFamily": "JetBrains Mono",
+      "fontSize": 13,
+      "fontWeight": "600",
+      "letterSpacing": 1
+    },
+    {
+      "type": "frame",
+      "id": "qUR5V",
+      "x": 9375,
+      "y": 4459,
+      "name": "Settings modal — Terminal",
+      "width": 1440,
+      "height": 900,
+      "fill": "#00000088",
+      "justifyContent": "center",
+      "alignItems": "center",
+      "children": [
+        {
+          "type": "frame",
+          "id": "h3j0L1",
+          "name": "Modal",
+          "clip": true,
+          "width": 680,
+          "height": 560,
+          "fill": "#16171B",
+          "cornerRadius": 12,
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "#1F2127"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000088",
+            "offset": {
+              "x": 0,
+              "y": 10
+            },
+            "blur": 40
+          },
+          "children": [
+            {
+              "type": "frame",
+              "id": "iNsBd",
+              "name": "sidebar",
+              "width": 200,
+              "height": "fill_container",
+              "fill": "#1F2127",
+              "stroke": {
+                "align": "inside",
+                "thickness": {
+                  "right": 1
+                },
+                "fill": "#1F2127"
+              },
+              "layout": "vertical",
+              "gap": 4,
+              "padding": [
+                16,
+                12
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "IE6JC",
+                  "name": "stitle",
+                  "fill": "#EDEDF0",
+                  "content": "Settings",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "frame",
+                  "id": "C8NPkx",
+                  "name": "ssp",
+                  "width": "fill_container",
+                  "height": 10
+                },
+                {
+                  "type": "frame",
+                  "id": "V2k4pJ",
+                  "name": "nav_general",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "sbz36",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "settings",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "YxJL6",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ETUAk",
+                          "fill": "#EDEDF0",
+                          "content": "General",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "U3kXSc",
+                          "fill": "#5A5C66",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Startup & defaults",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "JcRGF",
+                  "name": "nav_terminal",
+                  "width": "fill_container",
+                  "fill": "#0F2418",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Kmb8U",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "terminal",
+                      "iconFontFamily": "lucide",
+                      "fill": "#00FF9C"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "N6zQy0",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "H6Vt21",
+                          "fill": "#00FF9C",
+                          "content": "Terminal",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "d1JYdj",
+                          "fill": "#00CC7C",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "xterm appearance",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "RchiW",
+                  "name": "nav_updates",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "iSXZh",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "download",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "vF5Yl",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "QN71z",
+                          "fill": "#EDEDF0",
+                          "content": "Updates",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "B7zKsP",
+                          "fill": "#5A5C66",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Channel & auto-update",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "k1jrQ",
+                  "name": "nav_about",
+                  "width": "fill_container",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "KjYQT",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "info",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WonP1",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 1,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "acfAv",
+                          "fill": "#EDEDF0",
+                          "content": "About",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "PLE5t",
+                          "fill": "#5A5C66",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Version & links",
+                          "fontFamily": "Inter",
+                          "fontSize": 10,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "l1iZZL",
+              "name": "content",
+              "width": "fill_container",
+              "height": "fill_container",
+              "layout": "vertical",
+              "gap": 18,
+              "padding": [
+                20,
+                24
+              ],
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "vjvlP",
+                  "name": "sec_head",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 4,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "w2eWM",
+                      "fill": "#EDEDF0",
+                      "content": "Terminal",
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Atx1Y",
+                      "fill": "#9A9BA5",
+                      "content": "xterm appearance settings for the runner terminal.",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "LG0Rf",
+                  "name": "sct_div",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "#1F2127"
+                },
+                {
+                  "type": "frame",
+                  "id": "eObfc",
+                  "name": "row_font_family",
+                  "width": "fill_container",
+                  "gap": 24,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "sPID5",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "JkjES",
+                          "fill": "#EDEDF0",
+                          "content": "Font family",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "SZVVw",
+                          "fill": "#9A9BA5",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Typeface used by the embedded terminal.",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "A9eJu",
+                      "name": "dropdown",
+                      "fill": "#0E0E10",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#1F2127"
+                      },
+                      "gap": 8,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "gS7wA",
+                          "fill": "#EDEDF0",
+                          "content": "JetBrains Mono",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "EH4WF",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#9A9BA5"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "RRkzJ",
+                  "name": "row_term_font_size",
+                  "width": "fill_container",
+                  "gap": 24,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ruP3u",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "cfUnK",
+                          "fill": "#EDEDF0",
+                          "content": "Terminal font size",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Rld8A",
+                          "fill": "#9A9BA5",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Glyph size for the embedded terminal.",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "CcFty",
+                      "name": "font_size_stepper",
+                      "fill": "#0E0E10",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#1F2127"
+                      },
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "r5sWB",
+                          "name": "btn_minus",
+                          "width": 30,
+                          "height": 30,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "SN55O",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "minus",
+                              "iconFontFamily": "lucide",
+                              "fill": "#9A9BA5"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "veULB",
+                          "name": "val",
+                          "width": 64,
+                          "height": 30,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": {
+                              "right": 1,
+                              "left": 1
+                            },
+                            "fill": "#1F2127"
+                          },
+                          "gap": 3,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "tgVBz",
+                              "fill": "#EDEDF0",
+                              "content": "13",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "text",
+                              "id": "spnhB",
+                              "fill": "#5A5C66",
+                              "content": "px",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 10,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "hnl0M",
+                          "name": "btn_plus",
+                          "width": 30,
+                          "height": 30,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon_font",
+                              "id": "HufPc",
+                              "width": 14,
+                              "height": 14,
+                              "iconFontName": "plus",
+                              "iconFontFamily": "lucide",
+                              "fill": "#9A9BA5"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "hlNi4",
+                  "name": "row_cursor_style",
+                  "width": "fill_container",
+                  "gap": 24,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "Y0Eej",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "eWP8D",
+                          "fill": "#EDEDF0",
+                          "content": "Cursor style",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Rroou",
+                          "fill": "#9A9BA5",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Block, underline, or bar — affects the prompt caret only.",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "BzcvB",
+                      "name": "dropdown",
+                      "fill": "#0E0E10",
+                      "cornerRadius": 6,
+                      "stroke": {
+                        "align": "inside",
+                        "thickness": 1,
+                        "fill": "#1F2127"
+                      },
+                      "gap": 8,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "X7ZZbx",
+                          "fill": "#EDEDF0",
+                          "content": "Block",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "icon_font",
+                          "id": "X49ENy",
+                          "width": 12,
+                          "height": 12,
+                          "iconFontName": "chevron-down",
+                          "iconFontFamily": "lucide",
+                          "fill": "#9A9BA5"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "r80zS",
+                  "name": "row_scrollback",
+                  "width": "fill_container",
+                  "gap": 24,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "lny10",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 2,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "z4dV1",
+                          "fill": "#EDEDF0",
+                          "content": "Scrollback",
+                          "fontFamily": "Inter",
+                          "fontSize": 13,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "JNTJs",
+                          "fill": "#9A9BA5",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "Lines kept in history per session. Higher uses more memory.",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "YPa5L",
+                      "name": "chip_group",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "EMmp5",
+                          "name": "dropdown",
+                          "fill": "#0E0E10",
+                          "cornerRadius": 6,
+                          "stroke": {
+                            "align": "inside",
+                            "thickness": 1,
+                            "fill": "#1F2127"
+                          },
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "lvZq8",
+                              "fill": "#EDEDF0",
+                              "content": "10,000",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "icon_font",
+                              "id": "B4k9P",
+                              "width": 12,
+                              "height": 12,
+                              "iconFontName": "chevron-down",
+                              "iconFontFamily": "lucide",
+                              "fill": "#9A9BA5"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "dlmaf",
+                          "fill": "#9A9BA5",
+                          "content": "lines",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "bV4GH",
+                  "layoutPosition": "absolute",
+                  "x": 440,
+                  "y": 12,
+                  "name": "settingsClose",
+                  "width": 28,
+                  "height": 28,
+                  "cornerRadius": 6,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon_font",
+                      "id": "Iq1mO",
+                      "width": 16,
+                      "height": 16,
+                      "iconFontName": "x",
+                      "iconFontFamily": "lucide",
+                      "fill": "#9A9BA5"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -9,6 +9,7 @@
     "core:window:allow-close",
     "core:window:allow-set-focus",
     "core:window:allow-set-title",
+    "core:webview:allow-set-webview-zoom",
     "opener:default",
     "dialog:default",
     "fs:default",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,10 @@
 import { useEffect } from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { invoke } from "@tauri-apps/api/core";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { AppShell } from "./components/AppShell";
 import { UpdateProvider } from "./contexts/UpdateContext";
+import { readAppZoom } from "./lib/settings";
 import Crews from "./pages/Crews";
 import CrewEditor from "./pages/CrewEditor";
 import MissionWorkspace from "./pages/MissionWorkspace";
@@ -18,6 +20,22 @@ export default function App() {
   // enough to guarantee a non-blank webview before show.
   useEffect(() => {
     invoke("app_ready").catch(console.error);
+  }, []);
+
+  // Restore the user's persisted app zoom on boot. Skipped when the stored
+  // value is the default (1.0) so we don't roundtrip through Tauri for a
+  // no-op. Wrapped in try/catch because dev browser preview has no Tauri
+  // webview API.
+  useEffect(() => {
+    const zoom = readAppZoom();
+    if (zoom === 1.0) return;
+    try {
+      void getCurrentWebview().setZoom(zoom).catch(() => {
+        // best-effort — webview swap or platform refusal shouldn't block boot.
+      });
+    } catch {
+      // No Tauri runtime (dev browser preview).
+    }
   }, []);
 
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,18 +45,22 @@ export default function App() {
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey)) return;
-      if (e.altKey || e.shiftKey) return;
-      // With Cmd held, US keyboards deliver `=` unshifted for the
-      // `+` key, but other layouts/devices can send either — accept both.
+      if (e.altKey) return;
+      // `+` is reached via Shift+`=` on US layouts, so we must accept
+      // Shift specifically for the zoom-in branch. `-` and `0` are
+      // unshifted keys — Shift there is something else (e.g. Cmd+Shift+0
+      // is Safari's "Show downloads"), so we don't claim it.
       if (e.key === "+" || e.key === "=") {
         e.preventDefault();
         e.stopPropagation();
         nudgeAppZoom(1);
       } else if (e.key === "-") {
+        if (e.shiftKey) return;
         e.preventDefault();
         e.stopPropagation();
         nudgeAppZoom(-1);
       } else if (e.key === "0") {
+        if (e.shiftKey) return;
         e.preventDefault();
         e.stopPropagation();
         nudgeAppZoom("reset");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { AppShell } from "./components/AppShell";
 import { UpdateProvider } from "./contexts/UpdateContext";
+import { nudgeAppZoom } from "./lib/appZoom";
 import { readAppZoom } from "./lib/settings";
 import Crews from "./pages/Crews";
 import CrewEditor from "./pages/CrewEditor";
@@ -36,6 +37,33 @@ export default function App() {
     } catch {
       // No Tauri runtime (dev browser preview).
     }
+  }, []);
+
+  // Global Cmd/Ctrl +/-/0 zoom shortcuts. Capture phase so xterm's
+  // textarea doesn't swallow the key before us; preventDefault only on
+  // matches so other Cmd-key combos (copy, paste, etc.) still work.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (!(e.metaKey || e.ctrlKey)) return;
+      if (e.altKey || e.shiftKey) return;
+      // With Cmd held, US keyboards deliver `=` unshifted for the
+      // `+` key, but other layouts/devices can send either — accept both.
+      if (e.key === "+" || e.key === "=") {
+        e.preventDefault();
+        e.stopPropagation();
+        nudgeAppZoom(1);
+      } else if (e.key === "-") {
+        e.preventDefault();
+        e.stopPropagation();
+        nudgeAppZoom(-1);
+      } else if (e.key === "0") {
+        e.preventDefault();
+        e.stopPropagation();
+        nudgeAppZoom("reset");
+      }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
   }, []);
 
   return (

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -18,8 +18,15 @@ import "@xterm/xterm/css/xterm.css";
 
 import { api } from "../lib/api";
 import {
+  readTerminalCursorStyle,
+  readTerminalFontFamily,
   readTerminalFontSize,
+  readTerminalScrollback,
+  resolveTerminalFontStack,
+  STORAGE_TERMINAL_CURSOR_STYLE,
+  STORAGE_TERMINAL_FONT_FAMILY,
   STORAGE_TERMINAL_FONT_SIZE,
+  STORAGE_TERMINAL_SCROLLBACK,
 } from "../lib/settings";
 
 interface OutputEvent {
@@ -155,11 +162,11 @@ export function RunnerTerminal({
       cols: 80,
       rows: 24,
       theme: TERMINAL_THEME,
-      fontFamily:
-        'Menlo, "SF Mono", Monaco, Consolas, "Liberation Mono", monospace',
+      fontFamily: resolveTerminalFontStack(readTerminalFontFamily()),
       fontSize: readTerminalFontSize(),
       cursorBlink: true,
-      scrollback: 5000,
+      cursorStyle: readTerminalCursorStyle(),
+      scrollback: readTerminalScrollback(),
       allowProposedApi: true,
     });
     const fit = new FitAddon();
@@ -301,21 +308,32 @@ export function RunnerTerminal({
     window.addEventListener("focus", refreshTerm);
     document.addEventListener("visibilitychange", onVisibility);
 
-    // Live font-size updates from SettingsModal. localStorage's `storage`
-    // event doesn't fire in the originating window, so SettingsModal
-    // dispatches one synthetically after writing. We re-read through
-    // `readTerminalFontSize` so the clamp/normalize path is identical to
-    // mount-time — an out-of-range write can't poison `term.options`.
+    // Live updates from SettingsModal. localStorage's `storage` event
+    // doesn't fire in the originating window, so the modal dispatches a
+    // synthetic one after each write (via `notifySameWindowStorage`). We
+    // always re-read through the typed readers so the clamp/normalize
+    // path is identical to mount-time — an out-of-range write can't
+    // poison `term.options`.
     const onStorage = (e: StorageEvent) => {
-      if (e.key !== STORAGE_TERMINAL_FONT_SIZE) return;
       const t = termRef.current;
       if (!t) return;
-      const next = readTerminalFontSize();
       try {
-        t.options.fontSize = next;
-        fitRef.current?.fit();
+        if (e.key === STORAGE_TERMINAL_FONT_SIZE) {
+          t.options.fontSize = readTerminalFontSize();
+          fitRef.current?.fit();
+        } else if (e.key === STORAGE_TERMINAL_FONT_FAMILY) {
+          t.options.fontFamily = resolveTerminalFontStack(
+            readTerminalFontFamily(),
+          );
+          fitRef.current?.fit();
+        } else if (e.key === STORAGE_TERMINAL_CURSOR_STYLE) {
+          t.options.cursorStyle = readTerminalCursorStyle();
+        } else if (e.key === STORAGE_TERMINAL_SCROLLBACK) {
+          t.options.scrollback = readTerminalScrollback();
+        }
       } catch {
-        // teardown / hidden pane — next activation will refit.
+        // xterm may reject runtime mutation of some options; the next
+        // mount will pick up the persisted value either way.
       }
     };
     window.addEventListener("storage", onStorage);

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -280,7 +280,10 @@ export function RunnerTerminal({
         // session may have exited
       });
     };
-    const onResize = () => {
+    // Refit + push backend geometry when the pane is active and
+    // measurable. Hidden panes don't refit/push — the activation
+    // effect picks up the new metrics when they come to the front.
+    const refitAndPush = () => {
       if (!activeRef.current || !containerRef.current) return;
       const rect = containerRef.current.getBoundingClientRect();
       if (rect.width <= 0 || rect.height <= 0) return;
@@ -291,7 +294,7 @@ export function RunnerTerminal({
         // teardown
       }
     };
-    window.addEventListener("resize", onResize);
+    window.addEventListener("resize", refitAndPush);
 
     const refreshTerm = () => {
       const t = termRef.current;
@@ -320,12 +323,15 @@ export function RunnerTerminal({
       try {
         if (e.key === STORAGE_TERMINAL_FONT_SIZE) {
           t.options.fontSize = readTerminalFontSize();
-          fitRef.current?.fit();
+          // Cell metrics changed — refit and push the new PTY geometry
+          // so an active streaming TUI doesn't keep writing against
+          // stale cols/rows until the next window resize.
+          refitAndPush();
         } else if (e.key === STORAGE_TERMINAL_FONT_FAMILY) {
           t.options.fontFamily = resolveTerminalFontStack(
             readTerminalFontFamily(),
           );
-          fitRef.current?.fit();
+          refitAndPush();
         } else if (e.key === STORAGE_TERMINAL_CURSOR_STYLE) {
           t.options.cursorStyle = readTerminalCursorStyle();
         } else if (e.key === STORAGE_TERMINAL_SCROLLBACK) {
@@ -342,7 +348,7 @@ export function RunnerTerminal({
     fitRef.current = fit;
 
     return () => {
-      window.removeEventListener("resize", onResize);
+      window.removeEventListener("resize", refitAndPush);
       window.removeEventListener("focus", refreshTerm);
       document.removeEventListener("visibilitychange", onVisibility);
       window.removeEventListener("storage", onStorage);

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -17,6 +17,10 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import "@xterm/xterm/css/xterm.css";
 
 import { api } from "../lib/api";
+import {
+  readTerminalFontSize,
+  STORAGE_TERMINAL_FONT_SIZE,
+} from "../lib/settings";
 
 interface OutputEvent {
   session_id: string;
@@ -153,7 +157,7 @@ export function RunnerTerminal({
       theme: TERMINAL_THEME,
       fontFamily:
         'Menlo, "SF Mono", Monaco, Consolas, "Liberation Mono", monospace',
-      fontSize: 13,
+      fontSize: readTerminalFontSize(),
       cursorBlink: true,
       scrollback: 5000,
       allowProposedApi: true,
@@ -297,6 +301,25 @@ export function RunnerTerminal({
     window.addEventListener("focus", refreshTerm);
     document.addEventListener("visibilitychange", onVisibility);
 
+    // Live font-size updates from SettingsModal. localStorage's `storage`
+    // event doesn't fire in the originating window, so SettingsModal
+    // dispatches one synthetically after writing. We re-read through
+    // `readTerminalFontSize` so the clamp/normalize path is identical to
+    // mount-time — an out-of-range write can't poison `term.options`.
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== STORAGE_TERMINAL_FONT_SIZE) return;
+      const t = termRef.current;
+      if (!t) return;
+      const next = readTerminalFontSize();
+      try {
+        t.options.fontSize = next;
+        fitRef.current?.fit();
+      } catch {
+        // teardown / hidden pane — next activation will refit.
+      }
+    };
+    window.addEventListener("storage", onStorage);
+
     termRef.current = term;
     fitRef.current = fit;
 
@@ -304,6 +327,7 @@ export function RunnerTerminal({
       window.removeEventListener("resize", onResize);
       window.removeEventListener("focus", refreshTerm);
       document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("storage", onStorage);
       textarea?.removeEventListener("paste", onPaste, { capture: true });
       onDataDisposable.dispose();
       term.dispose();

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -33,20 +33,35 @@ import {
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { getVersion } from "@tauri-apps/api/app";
-import { getCurrentWebview } from "@tauri-apps/api/webview";
 
 import { api } from "../lib/api";
+import { applyAppZoom } from "../lib/appZoom";
 import {
+  notifySameWindowStorage,
   readAppZoom,
   readStoredBool,
+  readTerminalCursorStyle,
+  readTerminalFontFamily,
   readTerminalFontSize,
+  readTerminalScrollback,
+  STORAGE_APP_ZOOM,
   STORAGE_AUTO_INSTALL_UPDATES,
+  STORAGE_TERMINAL_CURSOR_STYLE,
+  STORAGE_TERMINAL_FONT_FAMILY,
   STORAGE_TERMINAL_FONT_SIZE,
+  STORAGE_TERMINAL_SCROLLBACK,
+  TERMINAL_CURSOR_STYLE_OPTIONS,
+  TERMINAL_FONT_FAMILY_OPTIONS,
   TERMINAL_FONT_SIZE_MAX,
   TERMINAL_FONT_SIZE_MIN,
-  writeAppZoom,
+  TERMINAL_SCROLLBACK_OPTIONS,
+  type TerminalCursorStyle,
+  type TerminalFontFamily,
   writeStoredBool,
+  writeTerminalCursorStyle,
+  writeTerminalFontFamily,
   writeTerminalFontSize,
+  writeTerminalScrollback,
   ZOOM_STEPS,
 } from "../lib/settings";
 import { useUpdate } from "../contexts/UpdateContext";
@@ -264,21 +279,25 @@ function GeneralPane() {
   };
   // App zoom — snap-to-step value driven by `ZOOM_STEPS`. Persist + apply
   // immediately so the user feels the change while picking. The boot-time
-  // apply in `App.tsx` is what makes it survive restarts.
+  // apply in `App.tsx` is what makes it survive restarts. Goes through
+  // the shared `applyAppZoom` so the stepper and the global Cmd+/- path
+  // can't drift.
   const [appZoom, setAppZoomState] = useState<number>(() => readAppZoom());
   const setAppZoom = (next: number) => {
     setAppZoomState(next);
-    writeAppZoom(next);
-    try {
-      void getCurrentWebview()
-        .setZoom(next)
-        .catch(() => {
-          // best-effort
-        });
-    } catch {
-      // No Tauri runtime (dev browser preview).
-    }
+    applyAppZoom(next);
   };
+  // Keep the visible % in sync when zoom changes from outside the modal
+  // (Cmd+/-/0 shortcut). `applyAppZoom` synthesizes a storage event after
+  // each write so we get a single notification path.
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key !== STORAGE_APP_ZOOM) return;
+      setAppZoomState(readAppZoom());
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
   return (
     <>
       <PaneHeader title="General" subtitle="Defaults and startup behavior." />
@@ -318,23 +337,34 @@ function TerminalPane() {
   const [fontSize, setFontSizeState] = useState<number>(() =>
     readTerminalFontSize(),
   );
+  const [fontFamily, setFontFamilyState] = useState<TerminalFontFamily>(() =>
+    readTerminalFontFamily(),
+  );
+  const [cursorStyle, setCursorStyleState] = useState<TerminalCursorStyle>(
+    () => readTerminalCursorStyle(),
+  );
+  const [scrollback, setScrollbackState] = useState<number>(() =>
+    readTerminalScrollback(),
+  );
   const setFontSize = (next: number) => {
     setFontSizeState(next);
     writeTerminalFontSize(next);
-    // localStorage's `storage` event only fires across windows by default;
-    // dispatch one ourselves so the mounted RunnerTerminal instances in the
-    // same window pick up the new size without a custom event bus.
-    try {
-      window.dispatchEvent(
-        new StorageEvent("storage", {
-          key: STORAGE_TERMINAL_FONT_SIZE,
-          newValue: String(next),
-        }),
-      );
-    } catch {
-      // best-effort — older runtimes without StorageEvent ctor still get
-      // the persisted value applied on next mount.
-    }
+    notifySameWindowStorage(STORAGE_TERMINAL_FONT_SIZE, String(next));
+  };
+  const setFontFamily = (next: TerminalFontFamily) => {
+    setFontFamilyState(next);
+    writeTerminalFontFamily(next);
+    notifySameWindowStorage(STORAGE_TERMINAL_FONT_FAMILY, next);
+  };
+  const setCursorStyle = (next: TerminalCursorStyle) => {
+    setCursorStyleState(next);
+    writeTerminalCursorStyle(next);
+    notifySameWindowStorage(STORAGE_TERMINAL_CURSOR_STYLE, next);
+  };
+  const setScrollback = (next: number) => {
+    setScrollbackState(next);
+    writeTerminalScrollback(next);
+    notifySameWindowStorage(STORAGE_TERMINAL_SCROLLBACK, String(next));
   };
   return (
     <>
@@ -347,6 +377,48 @@ function TerminalPane() {
         sub="Glyph size for the embedded terminal."
       >
         <FontSizeStepper value={fontSize} onChange={setFontSize} />
+      </Row>
+      <Row
+        label="Font family"
+        sub="Typeface used by the embedded terminal."
+      >
+        <StyledSelect
+          value={fontFamily}
+          options={TERMINAL_FONT_FAMILY_OPTIONS.map((f) => ({
+            value: f,
+            label: f,
+          }))}
+          onChange={(v) => setFontFamily(v as TerminalFontFamily)}
+        />
+      </Row>
+      <Row
+        label="Cursor style"
+        sub="Block, underline, or bar — affects the prompt caret only."
+      >
+        <StyledSelect
+          value={cursorStyle}
+          options={TERMINAL_CURSOR_STYLE_OPTIONS.map((c) => ({
+            value: c,
+            label: c[0].toUpperCase() + c.slice(1),
+          }))}
+          onChange={(v) => setCursorStyle(v as TerminalCursorStyle)}
+        />
+      </Row>
+      <Row
+        label="Scrollback"
+        sub="Lines kept in history per session. Higher uses more memory."
+      >
+        <div className="flex items-center gap-2">
+          <StyledSelect
+            value={String(scrollback)}
+            options={TERMINAL_SCROLLBACK_OPTIONS.map((n) => ({
+              value: String(n),
+              label: n.toLocaleString(),
+            }))}
+            onChange={(v) => setScrollback(Number.parseInt(v, 10))}
+          />
+          <span className="text-[12px] text-fg-2">lines</span>
+        </div>
       </Row>
     </>
   );

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -20,22 +20,34 @@ import {
   ExternalLink,
   Info,
   Loader2,
+  Minus,
+  Plus,
   RefreshCw,
   RotateCcw,
   Scale,
   Settings as SettingsIcon,
+  Terminal,
   X,
 } from "lucide-react";
 
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { getVersion } from "@tauri-apps/api/app";
+import { getCurrentWebview } from "@tauri-apps/api/webview";
 
 import { api } from "../lib/api";
 import {
+  readAppZoom,
   readStoredBool,
+  readTerminalFontSize,
   STORAGE_AUTO_INSTALL_UPDATES,
+  STORAGE_TERMINAL_FONT_SIZE,
+  TERMINAL_FONT_SIZE_MAX,
+  TERMINAL_FONT_SIZE_MIN,
+  writeAppZoom,
   writeStoredBool,
+  writeTerminalFontSize,
+  ZOOM_STEPS,
 } from "../lib/settings";
 import { useUpdate } from "../contexts/UpdateContext";
 import { StyledSelect } from "./ui/StyledSelect";
@@ -45,7 +57,7 @@ interface SettingsModalProps {
   onClose: () => void;
 }
 
-type Pane = "general" | "updates" | "about";
+type Pane = "general" | "terminal" | "updates" | "about";
 
 const PANES: { key: Pane; label: string; subtitle: string; icon: typeof SettingsIcon }[] = [
   {
@@ -53,6 +65,12 @@ const PANES: { key: Pane; label: string; subtitle: string; icon: typeof Settings
     label: "General",
     subtitle: "Startup & defaults",
     icon: SettingsIcon,
+  },
+  {
+    key: "terminal",
+    label: "Terminal",
+    subtitle: "xterm appearance",
+    icon: Terminal,
   },
   {
     key: "updates",
@@ -148,6 +166,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
             <X aria-hidden className="h-4 w-4" />
           </button>
           {pane === "general" ? <GeneralPane /> : null}
+          {pane === "terminal" ? <TerminalPane /> : null}
           {pane === "updates" ? <UpdatesPane /> : null}
           {pane === "about" ? <AboutPane /> : null}
         </div>
@@ -243,6 +262,23 @@ function GeneralPane() {
       // best-effort
     }
   };
+  // App zoom — snap-to-step value driven by `ZOOM_STEPS`. Persist + apply
+  // immediately so the user feels the change while picking. The boot-time
+  // apply in `App.tsx` is what makes it survive restarts.
+  const [appZoom, setAppZoomState] = useState<number>(() => readAppZoom());
+  const setAppZoom = (next: number) => {
+    setAppZoomState(next);
+    writeAppZoom(next);
+    try {
+      void getCurrentWebview()
+        .setZoom(next)
+        .catch(() => {
+          // best-effort
+        });
+    } catch {
+      // No Tauri runtime (dev browser preview).
+    }
+  };
   return (
     <>
       <PaneHeader title="General" subtitle="Defaults and startup behavior." />
@@ -268,7 +304,165 @@ function GeneralPane() {
           onChange={setDefaultWorkingDir}
         />
       </Row>
+      <Row
+        label="App zoom"
+        sub="Whole-app scale. Doesn't apply to the runner terminal canvas — see Terminal pane."
+      >
+        <ZoomStepper value={appZoom} onChange={setAppZoom} />
+      </Row>
     </>
+  );
+}
+
+function TerminalPane() {
+  const [fontSize, setFontSizeState] = useState<number>(() =>
+    readTerminalFontSize(),
+  );
+  const setFontSize = (next: number) => {
+    setFontSizeState(next);
+    writeTerminalFontSize(next);
+    // localStorage's `storage` event only fires across windows by default;
+    // dispatch one ourselves so the mounted RunnerTerminal instances in the
+    // same window pick up the new size without a custom event bus.
+    try {
+      window.dispatchEvent(
+        new StorageEvent("storage", {
+          key: STORAGE_TERMINAL_FONT_SIZE,
+          newValue: String(next),
+        }),
+      );
+    } catch {
+      // best-effort — older runtimes without StorageEvent ctor still get
+      // the persisted value applied on next mount.
+    }
+  };
+  return (
+    <>
+      <PaneHeader
+        title="Terminal"
+        subtitle="xterm appearance settings for the runner terminal."
+      />
+      <Row
+        label="Terminal font size"
+        sub="Glyph size for the embedded terminal."
+      >
+        <FontSizeStepper value={fontSize} onChange={setFontSize} />
+      </Row>
+    </>
+  );
+}
+
+// Generic [−] <value> [+] stepper matching pencil nodes `KfYfw` and `CcFty`.
+// Caller renders the value cell's contents and supplies its width.
+function Stepper({
+  valueCellWidth,
+  decDisabled,
+  incDisabled,
+  onDec,
+  onInc,
+  decAriaLabel,
+  incAriaLabel,
+  children,
+}: {
+  valueCellWidth: number;
+  decDisabled?: boolean;
+  incDisabled?: boolean;
+  onDec: () => void;
+  onInc: () => void;
+  decAriaLabel: string;
+  incAriaLabel: string;
+  children: React.ReactNode;
+}) {
+  const buttonClass =
+    "flex h-[30px] w-[30px] shrink-0 cursor-pointer items-center justify-center text-fg-3 transition-colors hover:text-fg disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:text-fg-3";
+  return (
+    <div className="flex h-[30px] items-center rounded-md border border-line bg-bg">
+      <button
+        type="button"
+        onClick={onDec}
+        disabled={decDisabled}
+        aria-label={decAriaLabel}
+        className={buttonClass}
+      >
+        <Minus aria-hidden className="h-3.5 w-3.5" />
+      </button>
+      <div
+        style={{ width: valueCellWidth }}
+        className="flex h-[30px] items-center justify-center border-x border-line"
+      >
+        {children}
+      </div>
+      <button
+        type="button"
+        onClick={onInc}
+        disabled={incDisabled}
+        aria-label={incAriaLabel}
+        className={buttonClass}
+      >
+        <Plus aria-hidden className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
+
+function ZoomStepper({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  // Snap a possibly-stale persisted value to the nearest known step so the
+  // user can always move with `−`/`+`; nothing in the modal hard-blocks
+  // off-step values.
+  const idx = ZOOM_STEPS.findIndex((s) => Math.abs(s - value) < 0.001);
+  const currentIdx = idx === -1 ? ZOOM_STEPS.indexOf(1.0) : idx;
+  const pct = Math.round(ZOOM_STEPS[currentIdx] * 100);
+  return (
+    <Stepper
+      valueCellWidth={56}
+      decDisabled={currentIdx <= 0}
+      incDisabled={currentIdx >= ZOOM_STEPS.length - 1}
+      decAriaLabel="Decrease zoom"
+      incAriaLabel="Increase zoom"
+      onDec={() => onChange(ZOOM_STEPS[Math.max(0, currentIdx - 1)])}
+      onInc={() =>
+        onChange(ZOOM_STEPS[Math.min(ZOOM_STEPS.length - 1, currentIdx + 1)])
+      }
+    >
+      <span className="font-mono text-[12px] font-medium text-fg">{pct}%</span>
+    </Stepper>
+  );
+}
+
+function FontSizeStepper({
+  value,
+  onChange,
+}: {
+  value: number;
+  onChange: (v: number) => void;
+}) {
+  const clamped = Math.max(
+    TERMINAL_FONT_SIZE_MIN,
+    Math.min(TERMINAL_FONT_SIZE_MAX, value),
+  );
+  return (
+    <Stepper
+      valueCellWidth={64}
+      decDisabled={clamped <= TERMINAL_FONT_SIZE_MIN}
+      incDisabled={clamped >= TERMINAL_FONT_SIZE_MAX}
+      decAriaLabel="Decrease terminal font size"
+      incAriaLabel="Increase terminal font size"
+      onDec={() => onChange(Math.max(TERMINAL_FONT_SIZE_MIN, clamped - 1))}
+      onInc={() => onChange(Math.min(TERMINAL_FONT_SIZE_MAX, clamped + 1))}
+    >
+      <span className="flex items-center gap-[3px]">
+        <span className="font-mono text-[12px] font-medium text-fg">
+          {clamped}
+        </span>
+        <span className="font-mono text-[10px] text-fg-3">px</span>
+      </span>
+    </Stepper>
   );
 }
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -373,12 +373,6 @@ function TerminalPane() {
         subtitle="xterm appearance settings for the runner terminal."
       />
       <Row
-        label="Terminal font size"
-        sub="Glyph size for the embedded terminal."
-      >
-        <FontSizeStepper value={fontSize} onChange={setFontSize} />
-      </Row>
-      <Row
         label="Font family"
         sub="Typeface used by the embedded terminal."
       >
@@ -390,6 +384,12 @@ function TerminalPane() {
           }))}
           onChange={(v) => setFontFamily(v as TerminalFontFamily)}
         />
+      </Row>
+      <Row
+        label="Terminal font size"
+        sub="Glyph size for the embedded terminal."
+      >
+        <FontSizeStepper value={fontSize} onChange={setFontSize} />
       </Row>
       <Row
         label="Cursor style"

--- a/src/lib/appZoom.ts
+++ b/src/lib/appZoom.ts
@@ -1,0 +1,42 @@
+// App-zoom apply path shared by the Settings stepper and the global
+// Cmd/Ctrl +/-/0 keyboard shortcuts. Lives here (not in `settings.ts`)
+// so the Tauri import stays out of the leaf-level settings helpers.
+
+import { getCurrentWebview } from "@tauri-apps/api/webview";
+
+import {
+  notifySameWindowStorage,
+  readAppZoom,
+  STORAGE_APP_ZOOM,
+  writeAppZoom,
+  ZOOM_STEPS,
+} from "./settings";
+
+export function applyAppZoom(next: number): void {
+  writeAppZoom(next);
+  try {
+    void getCurrentWebview()
+      .setZoom(next)
+      .catch(() => {
+        // best-effort — webview swap or platform refusal shouldn't block.
+      });
+  } catch {
+    // No Tauri runtime (dev browser preview).
+  }
+  notifySameWindowStorage(STORAGE_APP_ZOOM, String(next));
+}
+
+export function nudgeAppZoom(direction: 1 | -1 | "reset"): void {
+  if (direction === "reset") {
+    applyAppZoom(1.0);
+    return;
+  }
+  const cur = readAppZoom(); // already snapped to a known step
+  const idx = ZOOM_STEPS.indexOf(cur);
+  const safe = idx === -1 ? ZOOM_STEPS.indexOf(1.0) : idx;
+  const nextIdx =
+    direction === 1
+      ? Math.min(ZOOM_STEPS.length - 1, safe + 1)
+      : Math.max(0, safe - 1);
+  applyAppZoom(ZOOM_STEPS[nextIdx]);
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -6,6 +6,19 @@
 
 export const STORAGE_AUTO_INSTALL_UPDATES = "settings.autoInstallUpdates";
 export const STORAGE_SIDEBAR_COLLAPSED = "runner.sidebar.collapsed";
+export const STORAGE_APP_ZOOM = "settings.appZoom";
+export const STORAGE_TERMINAL_FONT_SIZE = "settings.terminalFontSize";
+
+// Public domain for the App-zoom and Terminal-font-size controls. Kept
+// here (not in SettingsModal) so the readers can snap/clamp to the same
+// domain the UI presents — boot and storage-event consumers can't drift
+// onto off-step or out-of-range values that the modal would never offer.
+export const ZOOM_STEPS: readonly number[] = [0.8, 0.9, 1.0, 1.1, 1.25, 1.5];
+export const TERMINAL_FONT_SIZE_MIN = 10;
+export const TERMINAL_FONT_SIZE_MAX = 20;
+
+const DEFAULT_APP_ZOOM = 1.0;
+const DEFAULT_TERMINAL_FONT_SIZE = 13;
 
 export function readStoredBool(key: string, defaultValue: boolean): boolean {
   try {
@@ -23,5 +36,59 @@ export function writeStoredBool(key: string, value: boolean): void {
   } catch {
     // best-effort — Safari private mode rejects setItem; in-session
     // state still works, persistence is what's lost.
+  }
+}
+
+export function readAppZoom(): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_APP_ZOOM);
+    if (raw == null) return DEFAULT_APP_ZOOM;
+    const parsed = Number.parseFloat(raw);
+    if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_APP_ZOOM;
+    // Snap to the nearest known step so off-step persisted values (older
+    // builds, hand-edited localStorage) still resolve to a value the UI
+    // can move from. No write-back — silent normalization on read only.
+    let nearest = ZOOM_STEPS[0];
+    let best = Math.abs(nearest - parsed);
+    for (let i = 1; i < ZOOM_STEPS.length; i += 1) {
+      const d = Math.abs(ZOOM_STEPS[i] - parsed);
+      if (d < best) {
+        best = d;
+        nearest = ZOOM_STEPS[i];
+      }
+    }
+    return nearest;
+  } catch {
+    return DEFAULT_APP_ZOOM;
+  }
+}
+
+export function writeAppZoom(value: number): void {
+  try {
+    localStorage.setItem(STORAGE_APP_ZOOM, String(value));
+  } catch {
+    // best-effort — see writeStoredBool.
+  }
+}
+
+export function readTerminalFontSize(): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_TERMINAL_FONT_SIZE);
+    if (raw == null) return DEFAULT_TERMINAL_FONT_SIZE;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_TERMINAL_FONT_SIZE;
+    if (parsed < TERMINAL_FONT_SIZE_MIN) return TERMINAL_FONT_SIZE_MIN;
+    if (parsed > TERMINAL_FONT_SIZE_MAX) return TERMINAL_FONT_SIZE_MAX;
+    return parsed;
+  } catch {
+    return DEFAULT_TERMINAL_FONT_SIZE;
+  }
+}
+
+export function writeTerminalFontSize(value: number): void {
+  try {
+    localStorage.setItem(STORAGE_TERMINAL_FONT_SIZE, String(value));
+  } catch {
+    // best-effort — see writeStoredBool.
   }
 }

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -8,17 +8,57 @@ export const STORAGE_AUTO_INSTALL_UPDATES = "settings.autoInstallUpdates";
 export const STORAGE_SIDEBAR_COLLAPSED = "runner.sidebar.collapsed";
 export const STORAGE_APP_ZOOM = "settings.appZoom";
 export const STORAGE_TERMINAL_FONT_SIZE = "settings.terminalFontSize";
+export const STORAGE_TERMINAL_FONT_FAMILY = "settings.terminalFontFamily";
+export const STORAGE_TERMINAL_CURSOR_STYLE = "settings.terminalCursorStyle";
+export const STORAGE_TERMINAL_SCROLLBACK = "settings.terminalScrollback";
 
-// Public domain for the App-zoom and Terminal-font-size controls. Kept
-// here (not in SettingsModal) so the readers can snap/clamp to the same
-// domain the UI presents — boot and storage-event consumers can't drift
-// onto off-step or out-of-range values that the modal would never offer.
+// Public domain for the App-zoom and Terminal-* controls. Kept here (not
+// in SettingsModal) so the readers can snap/clamp to the same domain the
+// UI presents — boot and storage-event consumers can't drift onto off-
+// step or out-of-range values that the modal would never offer.
 export const ZOOM_STEPS: readonly number[] = [0.8, 0.9, 1.0, 1.1, 1.25, 1.5];
 export const TERMINAL_FONT_SIZE_MIN = 10;
 export const TERMINAL_FONT_SIZE_MAX = 20;
 
+export type TerminalFontFamily =
+  | "System default"
+  | "Menlo"
+  | "Monaco"
+  | "SF Mono"
+  | "JetBrains Mono"
+  | "Fira Code";
+export const TERMINAL_FONT_FAMILY_OPTIONS: readonly TerminalFontFamily[] = [
+  "System default",
+  "Menlo",
+  "Monaco",
+  "SF Mono",
+  "JetBrains Mono",
+  "Fira Code",
+];
+
+export type TerminalCursorStyle = "block" | "underline" | "bar";
+export const TERMINAL_CURSOR_STYLE_OPTIONS: readonly TerminalCursorStyle[] = [
+  "block",
+  "underline",
+  "bar",
+];
+
+export const TERMINAL_SCROLLBACK_OPTIONS: readonly number[] = [
+  1000, 5000, 10000, 50000,
+];
+
 const DEFAULT_APP_ZOOM = 1.0;
 const DEFAULT_TERMINAL_FONT_SIZE = 13;
+const DEFAULT_TERMINAL_FONT_FAMILY: TerminalFontFamily = "System default";
+const DEFAULT_TERMINAL_CURSOR_STYLE: TerminalCursorStyle = "block";
+const DEFAULT_TERMINAL_SCROLLBACK = 10000;
+
+// The system default stack RunnerTerminal used to ship as a literal. Kept
+// as the fallback chain so that even when a user picks a specific face
+// (JetBrains Mono, Fira Code) we still degrade gracefully on machines
+// where that font isn't installed.
+const SYSTEM_FONT_STACK =
+  'Menlo, "SF Mono", Monaco, Consolas, "Liberation Mono", monospace';
 
 export function readStoredBool(key: string, defaultValue: boolean): boolean {
   try {
@@ -91,4 +131,88 @@ export function writeTerminalFontSize(value: number): void {
   } catch {
     // best-effort — see writeStoredBool.
   }
+}
+
+export function readTerminalFontFamily(): TerminalFontFamily {
+  try {
+    const raw = localStorage.getItem(STORAGE_TERMINAL_FONT_FAMILY);
+    if (raw == null) return DEFAULT_TERMINAL_FONT_FAMILY;
+    return (TERMINAL_FONT_FAMILY_OPTIONS as readonly string[]).includes(raw)
+      ? (raw as TerminalFontFamily)
+      : DEFAULT_TERMINAL_FONT_FAMILY;
+  } catch {
+    return DEFAULT_TERMINAL_FONT_FAMILY;
+  }
+}
+
+export function writeTerminalFontFamily(value: TerminalFontFamily): void {
+  try {
+    localStorage.setItem(STORAGE_TERMINAL_FONT_FAMILY, value);
+  } catch {
+    // best-effort
+  }
+}
+
+export function readTerminalCursorStyle(): TerminalCursorStyle {
+  try {
+    const raw = localStorage.getItem(STORAGE_TERMINAL_CURSOR_STYLE);
+    if (raw == null) return DEFAULT_TERMINAL_CURSOR_STYLE;
+    return (TERMINAL_CURSOR_STYLE_OPTIONS as readonly string[]).includes(raw)
+      ? (raw as TerminalCursorStyle)
+      : DEFAULT_TERMINAL_CURSOR_STYLE;
+  } catch {
+    return DEFAULT_TERMINAL_CURSOR_STYLE;
+  }
+}
+
+export function writeTerminalCursorStyle(value: TerminalCursorStyle): void {
+  try {
+    localStorage.setItem(STORAGE_TERMINAL_CURSOR_STYLE, value);
+  } catch {
+    // best-effort
+  }
+}
+
+export function readTerminalScrollback(): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_TERMINAL_SCROLLBACK);
+    if (raw == null) return DEFAULT_TERMINAL_SCROLLBACK;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed)) return DEFAULT_TERMINAL_SCROLLBACK;
+    return TERMINAL_SCROLLBACK_OPTIONS.includes(parsed)
+      ? parsed
+      : DEFAULT_TERMINAL_SCROLLBACK;
+  } catch {
+    return DEFAULT_TERMINAL_SCROLLBACK;
+  }
+}
+
+export function writeTerminalScrollback(value: number): void {
+  try {
+    localStorage.setItem(STORAGE_TERMINAL_SCROLLBACK, String(value));
+  } catch {
+    // best-effort
+  }
+}
+
+// localStorage's `storage` event only fires in *other* windows by spec.
+// Runner is single-window, so we synthesize one ourselves after writing
+// so same-window consumers (RunnerTerminal, GeneralPane) can react via
+// a single mechanism. Wrap the constructor in try/catch — older runtimes
+// without `StorageEvent`'s ctor still get apply-on-next-mount.
+export function notifySameWindowStorage(
+  key: string,
+  value: string | null,
+): void {
+  try {
+    window.dispatchEvent(new StorageEvent("storage", { key, newValue: value }));
+  } catch {
+    // best-effort
+  }
+}
+
+export function resolveTerminalFontStack(label: TerminalFontFamily): string {
+  return label === "System default"
+    ? SYSTEM_FONT_STACK
+    : `'${label}', ${SYSTEM_FONT_STACK}`;
 }


### PR DESCRIPTION
## Round 1 — App zoom + Terminal pane (font size)

- New **App zoom** row in General — six-step stepper (80/90/100/110/125/150) driving `getCurrentWebview().setZoom`, persisted in localStorage and restored on boot.
- New **Terminal** settings pane between General and Updates with a **Terminal font size** row (range 10–20, default 13). `RunnerTerminal` reads on mount and live-updates open xterm buffers via a synthetic `storage` event so the user sees the change without restarting the chat.
- Centralized `ZOOM_STEPS` and `TERMINAL_FONT_SIZE_MIN`/`MAX` in `src/lib/settings.ts`; readers snap/clamp on load so off-step or out-of-range persisted values can't diverge between boot and UI.
- Granted `core:webview:allow-set-webview-zoom` to the default capability — without it the `setZoom` calls were silently denied in the desktop app.

Design source-of-truth update lives in commit `33cf9ee` on this branch (frames `iIwkx`, `h3j0L1`).

## Round 2 — completed Terminal pane + keyboard shortcuts

- Three remaining rows from design frame `h3j0L1` are now live in **Settings → Terminal**:
  - **Font family** — `StyledSelect` over `System default`, `Menlo`, `Monaco`, `SF Mono`, `JetBrains Mono`, `Fira Code`. Default is `System default` (the existing fallback stack). Picking a named face prepends it to the existing stack so missing-font fallback stays graceful.
  - **Cursor style** — `Block` / `Underline` / `Bar`. Affects the xterm caret only.
  - **Scrollback** — `StyledSelect` over `1,000` / `5,000` / `10,000` / `50,000` with a `lines` suffix outside the trigger. Default raised to 10,000 (was 5,000 hardcoded in `RunnerTerminal`).
- `RunnerTerminal` consumes all three on mount and the existing `storage` listener handles the new keys via the typed readers — single normalization path.
- **Cmd/Ctrl + / − / 0** global zoom shortcuts. Window-level capture-phase keydown so xterm's textarea can't swallow the keys; `preventDefault` only on matches so Cmd+C/V etc. are untouched.
- New helper `src/lib/appZoom.ts` (`applyAppZoom` / `nudgeAppZoom`) so the stepper and the shortcuts share one apply path. Tauri imports stay out of `settings.ts`.
- New helper `notifySameWindowStorage` in `settings.ts` so the four terminal setters and the zoom setter share one synthetic-`storage` dispatch.
- GeneralPane now subscribes to `STORAGE_APP_ZOOM` storage events so the visible % updates while the modal is open if the user hits Cmd+/-.

Closes #78.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm run lint` clean (only the pre-existing react-refresh warning in `UpdateContext.tsx`)
- [x] `pnpm run build` clean
- [x] `cd src-tauri && cargo check` clean
- [ ] `pnpm tauri dev`: Settings → General → 100→110 → whole UI scales including the modal
- [ ] Quit + relaunch app → starts at persisted zoom
- [ ] Settings → Terminal → change font size to 15 while a runner chat is streaming → live re-rasterize, no dropped output
- [ ] Cmd+Plus / Cmd+Minus / Cmd+0 while focused inside a runner terminal zoom the whole UI (capture-phase listener bypasses xterm)
- [ ] Settings → Terminal → change Font family to JetBrains Mono → open terminal re-rasterizes (or falls back gracefully if not installed)
- [ ] Change Cursor style → reflects on the next blink in an open terminal
- [ ] Change Scrollback → next session at minimum picks up the new buffer size