### PR TITLE
fix(mission): hide archived missions from search; lock archived workspace read-only

### DIFF
--- a/src-tauri/migrations/0004_mission_archived_at.sql
+++ b/src-tauri/migrations/0004_mission_archived_at.sql
@@ -1,0 +1,23 @@
+-- Adds `archived_at` to missions so the workspace can tell a completed
+-- mission from one the operator explicitly archived. Mirrors the
+-- sessions table's `archived_at` column and the same `archived_at IS
+-- NULL` filter idiom used in `session_list_recent_direct`.
+--
+-- The `status` enum is left alone — a mission can still be running,
+-- completed, or aborted. `archived_at IS NOT NULL` is the read-only /
+-- hidden-from-search discriminator and lives on its own column so a
+-- future split (e.g. listing aborted-but-not-archived runs) is a SQL
+-- change, not a schema migration.
+--
+-- Backfill: today `mission_archive` is the only writer that flips a row
+-- to `completed`, so every existing `completed` row was archived. Stamp
+-- their `archived_at` with `stopped_at` so post-migration filters treat
+-- them as archived. Aborted rows (failed spawn/mount during start) are
+-- intentionally left with NULL `archived_at`: they were never
+-- successfully archived and should not silently disappear from list().
+
+ALTER TABLE missions ADD COLUMN archived_at TEXT;
+
+UPDATE missions
+   SET archived_at = stopped_at
+ WHERE status = 'completed' AND archived_at IS NULL;

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -66,6 +66,7 @@ fn row_to_mission(row: &Row<'_>) -> rusqlite::Result<Mission> {
     let started_at: String = row.get("started_at")?;
     let stopped_at: Option<String> = row.get("stopped_at")?;
     let pinned_at: Option<String> = row.get("pinned_at")?;
+    let archived_at: Option<String> = row.get("archived_at")?;
 
     let status = match status.as_str() {
         "running" => MissionStatus::Running,
@@ -95,6 +96,7 @@ fn row_to_mission(row: &Row<'_>) -> rusqlite::Result<Mission> {
         started_at: parse_ts(started_at)?,
         stopped_at: stopped_at.map(parse_ts).transpose()?,
         pinned_at: pinned_at.map(parse_ts).transpose()?,
+        archived_at: archived_at.map(parse_ts).transpose()?,
     })
 }
 
@@ -102,10 +104,18 @@ pub fn list(conn: &Connection, crew_id: Option<&str>) -> Result<Vec<Mission>> {
     // Pinned missions float to the top, then most-recently-started.
     // Sort key: NULL pinned_at sorts last (DESC), older pinned_at
     // sorts after newer (last-pinned first feels right for testing).
+    //
+    // `archived_at IS NULL` is the single chokepoint that hides
+    // archived missions from every surface that lists missions: the
+    // ⌘K palette, the sidebar tray, the Missions page summary. New
+    // surfaces inherit the filter by going through this helper. To
+    // open an archived mission by direct URL, use `get()` instead —
+    // it intentionally does NOT filter.
     let sql = "SELECT id, crew_id, title, status, goal_override, cwd,
-                      started_at, stopped_at, pinned_at
+                      started_at, stopped_at, pinned_at, archived_at
                  FROM missions
                  WHERE (?1 IS NULL OR crew_id = ?1)
+                   AND archived_at IS NULL
                  ORDER BY pinned_at IS NULL, pinned_at DESC, started_at DESC";
     let mut stmt = conn.prepare(sql)?;
     let rows = stmt.query_map(params![crew_id], row_to_mission)?;
@@ -128,9 +138,12 @@ pub struct MissionSummary {
 }
 
 pub fn get(conn: &Connection, id: &str) -> Result<Mission> {
+    // Intentionally no `archived_at` filter — opening an archived
+    // mission by direct URL has to still resolve so the workspace can
+    // render it read-only.
     conn.query_row(
         "SELECT id, crew_id, title, status, goal_override, cwd,
-                started_at, stopped_at, pinned_at
+                started_at, stopped_at, pinned_at, archived_at
            FROM missions WHERE id = ?1",
         params![id],
         row_to_mission,
@@ -294,10 +307,16 @@ pub fn stop(conn: &mut Connection, app_data_dir: &Path, id: &str) -> Result<Miss
     // a `mission_stopped` event (duplicate terminal). With `WHERE status =
     // 'running'`, the slower of the two updates 0 rows and is rejected
     // below, so only one writer ever reaches the log append.
+    //
+    // `archived_at` is set in the same UPDATE: `stop()` is reached only
+    // via `mission_archive`, so a terminal stop is by definition an
+    // archive. Atomic with the status flip means a row never observes
+    // `status='completed' AND archived_at IS NULL` (other than
+    // pre-existing rows the migration backfilled).
     let stopped_at = now();
     let affected = tx.execute(
         "UPDATE missions
-            SET status = 'completed', stopped_at = ?1
+            SET status = 'completed', stopped_at = ?1, archived_at = ?1
           WHERE id = ?2 AND status = 'running'",
         params![stopped_at.to_rfc3339(), id],
     )?;
@@ -982,8 +1001,16 @@ pub async fn mission_reset(
     write_roster_sidecar(&mission_dir, &roster)?;
 
     // 5. Update mission row: status back to running, started_at
-    // refreshed (this IS a fresh run), stopped_at cleared. Title /
-    // goal_override / cwd / pinned_at preserved.
+    // refreshed (this IS a fresh run), stopped_at + archived_at
+    // cleared. Title / goal_override / cwd / pinned_at preserved.
+    //
+    // archived_at must be cleared in lockstep with the status flip:
+    // reset is a return-to-running, and `list()` keys on `archived_at
+    // IS NULL`, so leaving the stamp would make a freshly-reset live
+    // mission vanish from the sidebar / palette. The UI gates reset
+    // on `status === 'running'` today so this can't happen via the
+    // workspace, but `mission_reset` is a public Tauri command and
+    // the backend invariant has to hold regardless of caller.
     let started_at_dt = now();
     {
         let conn = state.db.get()?;
@@ -991,7 +1018,8 @@ pub async fn mission_reset(
             "UPDATE missions
                 SET status = 'running',
                     started_at = ?1,
-                    stopped_at = NULL
+                    stopped_at = NULL,
+                    archived_at = NULL
               WHERE id = ?2",
             params![started_at_dt.to_rfc3339(), id],
         )?;
@@ -1588,9 +1616,13 @@ mod tests {
         )
         .unwrap()
         .mission;
-        // One-live-mission-per-crew rule: stop the first before starting the second.
-        stop(&mut conn, tmp.path(), &m1.id).unwrap();
-        // Force a distinct started_at.
+        // Per #55 concurrent missions on one crew are allowed, so we
+        // don't need to stop m1 before starting m2. We also avoid
+        // stop() here because it now stamps `archived_at` atomically
+        // with the status flip — calling it would hide m1 from
+        // list(), which would defeat this test's purpose (verifying
+        // the crew filter + ordering, not the archive filter; the
+        // latter has its own test).
         std::thread::sleep(std::time::Duration::from_millis(5));
         let m2 = start(
             &mut conn,
@@ -1973,5 +2005,240 @@ mod tests {
             missions.is_empty(),
             "mission row must be rolled back; found {missions:?}"
         );
+    }
+
+    #[test]
+    fn list_excludes_archived_missions() {
+        // `archived_at IS NULL` filter at SQL hides archived missions
+        // from every list surface (sidebar, ⌘K palette, summary). Open
+        // by direct URL still resolves through `get()`.
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "A", None);
+        add_runner(&mut conn, &crew_id, "lead");
+        let tmp = tempfile::tempdir().unwrap();
+
+        let out = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                crew_id: crew_id.clone(),
+                title: "live".into(),
+                goal_override: Some("go".into()),
+                cwd: None,
+            },
+        )
+        .unwrap();
+
+        // Visible while running.
+        assert_eq!(
+            list(&conn, Some(&crew_id)).unwrap().len(),
+            1,
+            "running mission must list"
+        );
+
+        // Archive it (stop() flips status AND stamps archived_at atomically).
+        let archived = stop(&mut conn, tmp.path(), &out.mission.id).unwrap();
+        assert!(archived.archived_at.is_some());
+
+        // Hidden from list().
+        assert!(
+            list(&conn, Some(&crew_id)).unwrap().is_empty(),
+            "archived mission must not appear in list"
+        );
+        // Still resolves by id via get().
+        let fetched = get(&conn, &out.mission.id).unwrap();
+        assert!(fetched.archived_at.is_some());
+        assert_eq!(fetched.status, MissionStatus::Completed);
+    }
+
+    #[test]
+    fn stop_sets_archived_at_alongside_status() {
+        // stop() is the only path to status='completed' (only called
+        // from mission_archive); the same UPDATE must stamp
+        // archived_at so a future row can never be observed as
+        // completed-but-not-archived.
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "A", None);
+        add_runner(&mut conn, &crew_id, "lead");
+        let tmp = tempfile::tempdir().unwrap();
+
+        let out = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                crew_id,
+                title: "m".into(),
+                goal_override: Some("go".into()),
+                cwd: None,
+            },
+        )
+        .unwrap();
+        let stopped = stop(&mut conn, tmp.path(), &out.mission.id).unwrap();
+
+        assert_eq!(stopped.status, MissionStatus::Completed);
+        let stopped_ts = stopped.stopped_at.expect("stopped_at populated");
+        let archived_ts = stopped.archived_at.expect("archived_at populated");
+        assert_eq!(stopped_ts, archived_ts, "must share the timestamp");
+    }
+
+    #[test]
+    fn aborted_missions_stay_visible_in_list() {
+        // 0004 backfill is narrow: only `status='completed'` rows get
+        // archived_at; aborted rows (spawn-failure rollback) stay in
+        // the visible list because they're triage state, not archive.
+        // Simulate the production rollback path's UPDATE.
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "A", None);
+        add_runner(&mut conn, &crew_id, "lead");
+        let tmp = tempfile::tempdir().unwrap();
+
+        let out = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                crew_id: crew_id.clone(),
+                title: "m".into(),
+                goal_override: Some("go".into()),
+                cwd: None,
+            },
+        )
+        .unwrap();
+        // Mirror mission_start's rollback path: flip to aborted
+        // without setting archived_at.
+        conn.execute(
+            "UPDATE missions SET status = 'aborted', stopped_at = ?1 WHERE id = ?2",
+            params![now().to_rfc3339(), out.mission.id],
+        )
+        .unwrap();
+
+        let listed = list(&conn, Some(&crew_id)).unwrap();
+        assert_eq!(listed.len(), 1, "aborted mission must remain in list");
+        assert!(
+            listed[0].archived_at.is_none(),
+            "aborted mission must not be archived"
+        );
+        assert_eq!(listed[0].status, MissionStatus::Aborted);
+    }
+
+    #[test]
+    fn reset_clears_archived_at() {
+        // mission_reset's step-5 UPDATE (in production) flips status
+        // back to running and must clear archived_at in lockstep —
+        // otherwise the freshly-reset live row stays hidden from
+        // list() (which filters archived_at IS NULL). The UI today
+        // gates reset on status='running', but the backend invariant
+        // has to hold regardless of caller. Simulate the reset UPDATE
+        // directly here so the test stays focused on the SQL contract.
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "A", None);
+        add_runner(&mut conn, &crew_id, "lead");
+        let tmp = tempfile::tempdir().unwrap();
+
+        let out = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                crew_id: crew_id.clone(),
+                title: "m".into(),
+                goal_override: Some("go".into()),
+                cwd: None,
+            },
+        )
+        .unwrap();
+        let archived = stop(&mut conn, tmp.path(), &out.mission.id).unwrap();
+        assert!(archived.archived_at.is_some(), "stop() must archive");
+        assert!(
+            list(&conn, Some(&crew_id)).unwrap().is_empty(),
+            "archived row hidden before reset"
+        );
+
+        // Mirror mission_reset's step-5 SQL (mission.rs:1009-1019).
+        conn.execute(
+            "UPDATE missions
+                SET status = 'running',
+                    started_at = ?1,
+                    stopped_at = NULL,
+                    archived_at = NULL
+              WHERE id = ?2",
+            params![now().to_rfc3339(), out.mission.id],
+        )
+        .unwrap();
+
+        let listed = list(&conn, Some(&crew_id)).unwrap();
+        assert_eq!(
+            listed.len(),
+            1,
+            "reset must make the mission visible to list() again"
+        );
+        assert_eq!(listed[0].id, out.mission.id);
+        assert!(listed[0].archived_at.is_none(), "archived_at cleared");
+        assert_eq!(listed[0].status, MissionStatus::Running);
+        assert!(listed[0].stopped_at.is_none(), "stopped_at cleared");
+    }
+
+    #[test]
+    fn migration_backfills_archived_at_for_completed_rows() {
+        // The 0004 migration runs once on first open. Simulate the
+        // pre-migration state by inserting a `completed` row with
+        // `archived_at` already nulled out (which is how the column
+        // would look pre-migration), then re-run the migration body
+        // and assert the backfill stamped archived_at = stopped_at.
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "A", None);
+        add_runner(&mut conn, &crew_id, "lead");
+        let tmp = tempfile::tempdir().unwrap();
+
+        // Seed a "pre-migration" completed mission. Use the production
+        // stop() then NULL out archived_at to mimic the state of rows
+        // that existed before the 0004 column landed.
+        let out = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                crew_id: crew_id.clone(),
+                title: "old".into(),
+                goal_override: Some("g".into()),
+                cwd: None,
+            },
+        )
+        .unwrap();
+        let stopped = stop(&mut conn, tmp.path(), &out.mission.id).unwrap();
+        let original_stopped_at = stopped.stopped_at.unwrap().to_rfc3339();
+        conn.execute(
+            "UPDATE missions SET archived_at = NULL WHERE id = ?1",
+            params![out.mission.id],
+        )
+        .unwrap();
+
+        // Sanity: row currently looks pre-migration.
+        let pre: Option<String> = conn
+            .query_row(
+                "SELECT archived_at FROM missions WHERE id = ?1",
+                params![out.mission.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert!(pre.is_none());
+
+        // Re-run the 0004 backfill statement and assert the post state.
+        conn.execute(
+            "UPDATE missions
+                SET archived_at = stopped_at
+              WHERE status = 'completed' AND archived_at IS NULL",
+            [],
+        )
+        .unwrap();
+
+        let backfilled = get(&conn, &out.mission.id).unwrap();
+        let backfilled_archived_at = backfilled
+            .archived_at
+            .expect("backfill must populate archived_at")
+            .to_rfc3339();
+        assert_eq!(backfilled_archived_at, original_stopped_at);
     }
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -369,10 +369,7 @@ pub async fn session_get(
     get_direct(&conn, &session_id)
 }
 
-fn get_direct(
-    conn: &rusqlite::Connection,
-    session_id: &str,
-) -> Result<Option<DirectSessionEntry>> {
+fn get_direct(conn: &rusqlite::Connection, session_id: &str) -> Result<Option<DirectSessionEntry>> {
     let mut stmt = conn.prepare(
         "SELECT s.id        AS session_id,
                 s.runner_id AS runner_id,

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -354,12 +354,25 @@ pub async fn session_list_recent_direct(
 /// Returns `None` if the id doesn't exist. Mission sessions are not
 /// returned here — this command is for direct chats only, matching
 /// the surface that `listRecentDirect` covers.
+///
+/// The SQL lives in `get_direct(...)` below so the test module can
+/// exercise the real query against an in-memory DB without spinning
+/// up an `AppState`. If a future refactor adds `AND archived_at IS
+/// NULL` to that helper's WHERE clause, the archived-row tests fail
+/// and the chat-page lockdown stays honest.
 #[tauri::command]
 pub async fn session_get(
     state: State<'_, AppState>,
     session_id: String,
 ) -> Result<Option<DirectSessionEntry>> {
     let conn = state.db.get()?;
+    get_direct(&conn, &session_id)
+}
+
+fn get_direct(
+    conn: &rusqlite::Connection,
+    session_id: &str,
+) -> Result<Option<DirectSessionEntry>> {
     let mut stmt = conn.prepare(
         "SELECT s.id        AS session_id,
                 s.runner_id AS runner_id,
@@ -732,6 +745,142 @@ mod tests {
         assert!(
             !ids.contains(&"pinned-archived"),
             "archived rows must be excluded from the SESSION tray"
+        );
+    }
+
+    fn seed_runner(conn: &rusqlite::Connection) -> String {
+        let runner_id = ulid::Ulid::new().to_string();
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO runners
+                (id, handle, display_name, runtime, command,
+                 created_at, updated_at)
+             VALUES (?1, 'r', 'R', 'shell', '/bin/sh', ?2, ?2)",
+            params![runner_id, now],
+        )
+        .unwrap();
+        runner_id
+    }
+
+    fn insert_direct_session(
+        conn: &rusqlite::Connection,
+        runner_id: &str,
+        archived: bool,
+    ) -> String {
+        let id = ulid::Ulid::new().to_string();
+        let now = Utc::now();
+        let archived_at: Option<String> = if archived {
+            Some(now.to_rfc3339())
+        } else {
+            None
+        };
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, status, started_at, archived_at)
+             VALUES (?1, NULL, ?2, 'stopped', ?3, ?4)",
+            params![id, runner_id, now.to_rfc3339(), archived_at],
+        )
+        .unwrap();
+        id
+    }
+
+    #[test]
+    fn session_get_returns_archived_row() {
+        // Whole reason this command exists: listRecentDirect filters
+        // archived rows, so RunnerChat needs an unfiltered fallback to
+        // detect an archived direct-URL navigation and render
+        // read-only. A future refactor that adds `archived_at IS NULL`
+        // to get_direct's WHERE breaks the chat-page lockdown — this
+        // test fails if it ever does.
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let runner_id = seed_runner(&conn);
+        let session_id = insert_direct_session(&conn, &runner_id, /*archived*/ true);
+
+        let row = get_direct(&conn, &session_id).unwrap();
+        let row = row.expect("archived row must be returned");
+        assert_eq!(row.session_id, session_id);
+        assert!(
+            row.archived_at.is_some(),
+            "archived_at must be populated for archived rows"
+        );
+    }
+
+    #[test]
+    fn session_get_populates_archived_at_when_set() {
+        // Belt-and-suspenders for the column round-trip: archived
+        // direct sessions returned by get_direct must carry the
+        // timestamp the row was archived with, not a recoded `now()`.
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let runner_id = seed_runner(&conn);
+        let id = ulid::Ulid::new().to_string();
+        let now = Utc::now().to_rfc3339();
+        let archived_at = "2025-01-01T00:00:00+00:00";
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, status, started_at, archived_at)
+             VALUES (?1, NULL, ?2, 'stopped', ?3, ?4)",
+            params![id, runner_id, now, archived_at],
+        )
+        .unwrap();
+
+        let row = get_direct(&conn, &id).unwrap().unwrap();
+        let got = row.archived_at.expect("archived_at populated").to_rfc3339();
+        assert_eq!(got, archived_at);
+    }
+
+    #[test]
+    fn session_get_returns_none_for_unknown_id() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let row = get_direct(&conn, "01HZUNKNOWNUNKNOWNUNKNOWN").unwrap();
+        assert!(row.is_none());
+    }
+
+    #[test]
+    fn session_get_returns_none_for_mission_session() {
+        // `mission_id IS NULL` filter scopes this command to direct
+        // chats only — mission sessions go through `session_list`
+        // instead. Dropping that filter would let an archived
+        // mission's PTY row leak into RunnerChat's lookup and confuse
+        // the read-only branch (mission sessions don't have a
+        // /runners/:handle/chat URL).
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let runner_id = seed_runner(&conn);
+
+        // Seed a crew + mission so the FK is satisfied. The mission
+        // table's other NOT NULL columns are populated minimally.
+        let crew_id = ulid::Ulid::new().to_string();
+        let mission_id = ulid::Ulid::new().to_string();
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO crews (id, name, created_at, updated_at)
+             VALUES (?1, 'C', ?2, ?2)",
+            params![crew_id, now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO missions
+                (id, crew_id, title, status, started_at)
+             VALUES (?1, ?2, 't', 'running', ?3)",
+            params![mission_id, crew_id, now],
+        )
+        .unwrap();
+        let session_id = ulid::Ulid::new().to_string();
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, status, started_at)
+             VALUES (?1, ?2, ?3, 'stopped', ?4)",
+            params![session_id, mission_id, runner_id, now],
+        )
+        .unwrap();
+
+        let row = get_direct(&conn, &session_id).unwrap();
+        assert!(
+            row.is_none(),
+            "mission sessions must not leak through session_get"
         );
     }
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -12,7 +12,7 @@
 
 use std::sync::Arc;
 
-use rusqlite::{params, Row};
+use rusqlite::{params, OptionalExtension, Row};
 use serde::{Deserialize, Serialize};
 use tauri::{Emitter, State};
 
@@ -256,6 +256,13 @@ pub struct DirectSessionEntry {
     /// `true` iff `pinned_at IS NOT NULL`. Pinned rows render with a
     /// pin glyph and sort to the top of the tray.
     pub pinned: bool,
+    /// When set, the session has been archived: hidden from the SESSION
+    /// tray and `session_list_recent_direct`. Returned here so
+    /// `session_get` (unfiltered) can tell the chat page to render
+    /// read-only when the user navigates to an archived session by
+    /// direct URL. `listRecentDirect` filters these out at SQL, so
+    /// rows from that surface always carry `archived_at: None`.
+    pub archived_at: Option<Timestamp>,
 }
 
 #[tauri::command]
@@ -277,6 +284,7 @@ pub async fn session_list_recent_direct(
                 s.cwd       AS cwd,
                 s.started_at,
                 s.stopped_at,
+                s.archived_at,
                 CASE WHEN s.agent_session_key IS NOT NULL THEN 1 ELSE 0 END AS resumable,
                 CASE WHEN s.pinned_at         IS NOT NULL THEN 1 ELSE 0 END AS pinned
            FROM sessions s
@@ -312,6 +320,7 @@ pub async fn session_list_recent_direct(
         };
         let started_at: Option<String> = row.get("started_at")?;
         let stopped_at: Option<String> = row.get("stopped_at")?;
+        let archived_at: Option<String> = row.get("archived_at")?;
         let resumable: i64 = row.get("resumable")?;
         let pinned: i64 = row.get("pinned")?;
         Ok(DirectSessionEntry {
@@ -325,10 +334,94 @@ pub async fn session_list_recent_direct(
             stopped_at: stopped_at.map(parse_ts).transpose()?,
             resumable: resumable != 0,
             pinned: pinned != 0,
+            archived_at: archived_at.map(parse_ts).transpose()?,
         })
     })?;
     rows.collect::<rusqlite::Result<Vec<_>>>()
         .map_err(Into::into)
+}
+
+/// Unfiltered single-row lookup for a direct-chat session.
+///
+/// `session_list_recent_direct` hides archived rows (`archived_at IS
+/// NOT NULL`) from the SESSION tray, but the `/runners/:handle/chat/
+/// :sessionId` route still mounts when the user navigates by direct
+/// URL. RunnerChat falls back to this helper when the list lookup
+/// misses so it can detect an archived row and render the workspace
+/// read-only (no PTY attach, no Resume, no live composer) instead of
+/// silently failing to find the session.
+///
+/// Returns `None` if the id doesn't exist. Mission sessions are not
+/// returned here — this command is for direct chats only, matching
+/// the surface that `listRecentDirect` covers.
+#[tauri::command]
+pub async fn session_get(
+    state: State<'_, AppState>,
+    session_id: String,
+) -> Result<Option<DirectSessionEntry>> {
+    let conn = state.db.get()?;
+    let mut stmt = conn.prepare(
+        "SELECT s.id        AS session_id,
+                s.runner_id AS runner_id,
+                r.handle    AS handle,
+                s.status    AS status,
+                s.title     AS title,
+                s.cwd       AS cwd,
+                s.started_at,
+                s.stopped_at,
+                s.archived_at,
+                CASE WHEN s.agent_session_key IS NOT NULL THEN 1 ELSE 0 END AS resumable,
+                CASE WHEN s.pinned_at         IS NOT NULL THEN 1 ELSE 0 END AS pinned
+           FROM sessions s
+           JOIN runners r ON r.id = s.runner_id
+          WHERE s.id = ?1
+            AND s.mission_id IS NULL",
+    )?;
+    let row = stmt
+        .query_row(params![session_id], |row| {
+            let status: String = row.get("status")?;
+            let status = match status.as_str() {
+                "running" => SessionStatus::Running,
+                "stopped" => SessionStatus::Stopped,
+                "crashed" => SessionStatus::Crashed,
+                other => {
+                    return Err(rusqlite::Error::FromSqlConversionFailure(
+                        0,
+                        rusqlite::types::Type::Text,
+                        format!("unknown session status {other:?}").into(),
+                    ))
+                }
+            };
+            let parse_ts = |s: String| -> rusqlite::Result<Timestamp> {
+                s.parse().map_err(|e: chrono::ParseError| {
+                    rusqlite::Error::FromSqlConversionFailure(
+                        0,
+                        rusqlite::types::Type::Text,
+                        Box::new(e),
+                    )
+                })
+            };
+            let started_at: Option<String> = row.get("started_at")?;
+            let stopped_at: Option<String> = row.get("stopped_at")?;
+            let archived_at: Option<String> = row.get("archived_at")?;
+            let resumable: i64 = row.get("resumable")?;
+            let pinned: i64 = row.get("pinned")?;
+            Ok(DirectSessionEntry {
+                session_id: row.get("session_id")?,
+                runner_id: row.get("runner_id")?,
+                handle: row.get("handle")?,
+                status,
+                title: row.get("title")?,
+                cwd: row.get("cwd")?,
+                started_at: started_at.map(parse_ts).transpose()?,
+                stopped_at: stopped_at.map(parse_ts).transpose()?,
+                resumable: resumable != 0,
+                pinned: pinned != 0,
+                archived_at: archived_at.map(parse_ts).transpose()?,
+            })
+        })
+        .optional()?;
+    Ok(row)
 }
 
 /// Soft-delete a session: hides it from the SESSION sidebar tray. The row

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -78,10 +78,15 @@ fn init_connection(conn: &mut Connection) -> rusqlite::Result<()> {
 // schema add — no data backfill, existing rows keep NULL runtime
 // metadata, which the manager (post-Step 9) treats as "legacy
 // portable-pty session, can't reattach."
+// 0004: adds `archived_at` to missions so the workspace can filter
+// archived missions out of search/list surfaces without conflating
+// them with `status = 'completed'`. Backfills existing completed
+// rows so their archived_at = stopped_at.
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, include_str!("../migrations/0001_init.sql")),
     (2, include_str!("../migrations/0002_persona_only_seeds.sql")),
     (3, include_str!("../migrations/0003_session_runtime.sql")),
+    (4, include_str!("../migrations/0004_mission_archived_at.sql")),
 ];
 
 // Default-data seed: ships the Build squad starter crew on first launch.

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -86,7 +86,10 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (1, include_str!("../migrations/0001_init.sql")),
     (2, include_str!("../migrations/0002_persona_only_seeds.sql")),
     (3, include_str!("../migrations/0003_session_runtime.sql")),
-    (4, include_str!("../migrations/0004_mission_archived_at.sql")),
+    (
+        4,
+        include_str!("../migrations/0004_mission_archived_at.sql"),
+    ),
 ];
 
 // Default-data seed: ships the Build squad starter crew on first launch.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -173,6 +173,7 @@ pub fn run() {
             commands::mission::mission_post_human_signal,
             commands::session::session_list,
             commands::session::session_list_recent_direct,
+            commands::session::session_get,
             commands::session::session_archive,
             commands::session::session_rename,
             commands::session::session_pin,

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -106,6 +106,12 @@ pub struct Mission {
     pub started_at: Timestamp,
     pub stopped_at: Option<Timestamp>,
     pub pinned_at: Option<Timestamp>,
+    // `archived_at IS NOT NULL` is the read-only / hide-from-search
+    // discriminator. Set by `mission_archive` alongside the status
+    // flip; on its own column so the `status` enum stays focused on
+    // lifecycle (running / completed / aborted) and so we can add an
+    // "Archived" view later without touching the status grammar.
+    pub archived_at: Option<Timestamp>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -2732,6 +2732,7 @@ mod tests {
             started_at: Utc::now(),
             stopped_at: None,
             pinned_at: None,
+            archived_at: None,
         }
     }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -56,6 +56,12 @@ export interface DirectSessionEntry {
   stopped_at: string | null;
   resumable: boolean;
   pinned: boolean;
+  // Set when the session has been archived. `listRecentDirect` filters
+  // these at SQL so rows from that endpoint always have `archived_at:
+  // null`. `session_get` is the unfiltered lookup the chat page uses
+  // to detect an archived direct-URL navigation and lock the
+  // workspace read-only.
+  archived_at: string | null;
 }
 
 export const api = {
@@ -141,6 +147,12 @@ export const api = {
       invoke<SessionRow[]>("session_list", { missionId }),
     listRecentDirect: () =>
       invoke<DirectSessionEntry[]>("session_list_recent_direct"),
+    /** Unfiltered single-row lookup (includes archived rows). Used by
+     *  RunnerChat to detect an archived direct-URL navigation so the
+     *  workspace can render read-only. Returns null if the id is
+     *  unknown or belongs to a mission session. */
+    get: (sessionId: string) =>
+      invoke<DirectSessionEntry | null>("session_get", { sessionId }),
     archive: (sessionId: string) =>
       invoke<void>("session_archive", { sessionId }),
     rename: (sessionId: string, title: string | null) =>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -140,6 +140,12 @@ export interface Mission {
   started_at: Timestamp;
   stopped_at: Timestamp | null;
   pinned_at: Timestamp | null;
+  // archived_at != null → mission is archived. The workspace renders
+  // read-only (no PTY mount, no Resume/Stop) and the row is filtered
+  // out of list() at SQL so search/sidebar surfaces never see it. Use
+  // this as the single discriminator — don't key UX off
+  // status === 'completed'.
+  archived_at: Timestamp | null;
 }
 
 export type SessionStatus = "running" | "stopped" | "crashed";

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -379,6 +379,11 @@ export default function MissionWorkspace() {
   // crash on one worker shouldn't gate human-to-lead messaging.
   const anySessionLive =
     sessions.length > 0 && sessions.some((s) => s.status === "running");
+  // archived_at is the single discriminator across the workspace —
+  // status pill, no-PTY render branch, hidden actions. We don't key
+  // any UX off `status === 'completed'` because the migration may
+  // later widen archive to include other terminal states.
+  const isArchived = mission?.archived_at != null;
 
   // Project ask_human → human_question pairings + human_response
   // resolutions out of the feed. Mirrors the router's reconstruct_from_log
@@ -492,15 +497,17 @@ export default function MissionWorkspace() {
                   | "archived"
                   | "aborted"
                   | "resuming";
-                const display: Display = resumingAll
-                  ? "resuming"
-                  : mission.status === "running"
-                    ? anySessionLive
-                      ? "running"
-                      : "stopped"
-                    : mission.status === "completed"
-                      ? "archived"
-                      : "aborted";
+                const display: Display = isArchived
+                  ? "archived"
+                  : resumingAll
+                    ? "resuming"
+                    : mission.status === "running"
+                      ? anySessionLive
+                        ? "running"
+                        : "stopped"
+                      : mission.status === "completed"
+                        ? "archived"
+                        : "aborted";
                 const pillClass =
                   display === "running"
                     ? "bg-accent/15 text-accent"
@@ -528,6 +535,16 @@ export default function MissionWorkspace() {
                   </span>
                 );
               })() : null}
+              {/* Unambiguous read-only affordance for archived
+                  missions — the status pill alone reads too easily
+                  as just another state. Muted chip beside the title
+                  so the workspace clearly communicates that nothing
+                  here will accept input. */}
+              {isArchived ? (
+                <span className="inline-flex shrink-0 items-center rounded border border-line bg-raised px-2 py-0.5 text-[10px] font-medium text-fg-2">
+                  Archived · read-only
+                </span>
+              ) : null}
             </div>
             <span className="truncate text-[11px] leading-tight text-fg-3">
               {sessions.length} runner{sessions.length === 1 ? "" : "s"}
@@ -627,18 +644,23 @@ export default function MissionWorkspace() {
             >
               feed
             </TabButton>
-            {openTabs
-              .map((tabId) => sessions.find((s) => s.id === tabId))
-              .filter((s): s is SessionRow => s !== undefined)
-              .map((s) => (
-                <PtyTabButton
-                  key={s.id}
-                  handle={s.handle}
-                  active={activeTab === s.id}
-                  onClick={() => setActiveTab(s.id)}
-                  onClose={() => onCloseTab(s.id)}
-                />
-              ))}
+            {/* Archived missions render feed only — skip the per-PTY
+                tabs so no xterm canvas ever mounts. The Pane block
+                below applies the same gate. */}
+            {!isArchived
+              ? openTabs
+                  .map((tabId) => sessions.find((s) => s.id === tabId))
+                  .filter((s): s is SessionRow => s !== undefined)
+                  .map((s) => (
+                    <PtyTabButton
+                      key={s.id}
+                      handle={s.handle}
+                      active={activeTab === s.id}
+                      onClick={() => setActiveTab(s.id)}
+                      onClose={() => onCloseTab(s.id)}
+                    />
+                  ))
+              : null}
           </div>
 
           <div className="relative flex flex-1 min-h-0 flex-col">
@@ -697,20 +719,25 @@ export default function MissionWorkspace() {
               ) : null}
             </Pane>
 
-            {openTabs
-              .map((tabId) => sessions.find((s) => s.id === tabId))
-              .filter((s): s is SessionRow => s !== undefined)
-              .map((s) => (
-                <Pane key={s.id} active={activeTab === s.id}>
-                  <SlotPtyPane
-                    session={s}
-                    active={activeTab === s.id}
-                    forcedResuming={resumingAll && !archivingMission}
-                    onError={setError}
-                    onResumeMission={() => void resumeMission()}
-                  />
-                </Pane>
-              ))}
+            {/* Skip per-session PTY panes for archived missions so
+                no xterm canvas ever mounts. The feed Pane stays
+                rendered above as the only surface. */}
+            {!isArchived
+              ? openTabs
+                  .map((tabId) => sessions.find((s) => s.id === tabId))
+                  .filter((s): s is SessionRow => s !== undefined)
+                  .map((s) => (
+                    <Pane key={s.id} active={activeTab === s.id}>
+                      <SlotPtyPane
+                        session={s}
+                        active={activeTab === s.id}
+                        forcedResuming={resumingAll && !archivingMission}
+                        onError={setError}
+                        onResumeMission={() => void resumeMission()}
+                      />
+                    </Pane>
+                  ))
+              : null}
             {/* Centered amber pill + scrim while a mission archive
                 is in flight — fired from either the sidebar kebab
                 or this workspace's own kebab. Scrim matches the

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -497,6 +497,12 @@ export default function MissionWorkspace() {
                   | "archived"
                   | "aborted"
                   | "resuming";
+                // archived_at short-circuits at the top. The
+                // remaining branches only see non-archived rows, so
+                // any status='completed' here would mean a row that
+                // missed the migration backfill — fall through to
+                // 'aborted' since it's terminal-but-not-archived and
+                // the worker pill copy reads correctly for triage.
                 const display: Display = isArchived
                   ? "archived"
                   : resumingAll
@@ -505,9 +511,7 @@ export default function MissionWorkspace() {
                       ? anySessionLive
                         ? "running"
                         : "stopped"
-                      : mission.status === "completed"
-                        ? "archived"
-                        : "aborted";
+                      : "aborted";
                 const pillClass =
                   display === "running"
                     ? "bg-accent/15 text-accent"

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -143,6 +143,11 @@ export default function RunnerChat() {
   const activeSession = directSessions.find((s) => s.id === sessionId) ?? null;
   const status = activeSession?.status ?? "running";
   const exitCode = activeSession?.exitCode ?? null;
+  // Archived rows can be reached by direct URL but render read-only.
+  // We don't attach a PTY, mount RunnerTerminal, or expose Resume /
+  // End / Archive — the row is terminal and the operator can only
+  // read the meta + go back to the runner.
+  const isArchived = chatMeta?.archived_at != null;
 
   const upsertSession = useCallback((next: DirectSessionPane) => {
     setDirectSessions((prev) => {
@@ -209,11 +214,16 @@ export default function RunnerChat() {
     };
   }, [handle]);
 
-  // Pull this chat's metadata (started_at, cwd, title) by finding it
-  // inside the direct-sessions list. Refetched on session/exit so
-  // status changes flip the header pill. We piggyback on
-  // listRecentDirect rather than adding a new "session_get" command —
-  // it's the same query the sidebar uses, so the two surfaces agree.
+  // Pull this chat's metadata (started_at, cwd, title) for the header.
+  // Refetched on session/exit so status changes flip the pill.
+  //
+  // Primary lookup: `listRecentDirect` — same SELECT the sidebar
+  // uses, so the two surfaces agree on un-archived rows. Archived
+  // sessions are filtered out at SQL, so direct-URL navigation to
+  // an archived session would miss; we fall back to the unfiltered
+  // `session_get` so the chat page can detect the archived state
+  // and lock the workspace read-only instead of treating the row
+  // as missing.
   const refreshChatMeta = useCallback(async () => {
     if (!sessionId) {
       setChatMeta(null);
@@ -221,7 +231,16 @@ export default function RunnerChat() {
     }
     try {
       const rows = await api.session.listRecentDirect();
-      setChatMeta(rows.find((r) => r.session_id === sessionId) ?? null);
+      const found = rows.find((r) => r.session_id === sessionId);
+      if (found) {
+        setChatMeta(found);
+        return;
+      }
+      // Missed in the visible list — could be archived. The
+      // unfiltered get returns the row regardless so the read-only
+      // branch below can render the right UX.
+      const archived = await api.session.get(sessionId);
+      setChatMeta(archived);
     } catch (e) {
       console.error("RunnerChat: refreshChatMeta failed", e);
     }
@@ -370,10 +389,13 @@ export default function RunnerChat() {
     if (startedKeyRef.current === requestKey) return;
     startedKeyRef.current = requestKey;
     setErr(null);
-    if (sessionId && handle) {
+    // Skip attach for archived rows: the workspace renders read-only,
+    // so mounting RunnerTerminal would spawn a PTY listener for a row
+    // that's terminal by definition.
+    if (sessionId && handle && !isArchived) {
       attach(sessionId, handle, state?.sessionStatus ?? "stopped");
     }
-  }, [attach, handle, sessionId, state?.sessionStatus]);
+  }, [attach, handle, sessionId, state?.sessionStatus, isArchived]);
 
   async function endChat() {
     if (!sessionId || !handle) return;
@@ -580,6 +602,11 @@ export default function RunnerChat() {
                 <span className={`inline-block h-1.5 w-1.5 rounded-full ${statusDotClass}`} />
                 {sessionId ? statusLabel : "starting"}
               </span>
+              {isArchived ? (
+                <span className="inline-flex shrink-0 items-center rounded border border-line bg-raised px-2 py-0.5 text-[10px] font-medium text-fg-2">
+                  Archived · read-only
+                </span>
+              ) : null}
             </div>
             {metaParts.length > 0 ? (
               <div className="flex min-w-0 items-center gap-2 text-[11px] text-fg-2">
@@ -598,7 +625,16 @@ export default function RunnerChat() {
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-2">
-          {chatState === "resuming" ? (
+          {isArchived ? (
+            // Archived rows are terminal: no Resume / Stop / Archive.
+            // Only surface the navigation escape hatch.
+            <button
+              onClick={() => navigate(`/runners/${handle}`)}
+              className="cursor-pointer rounded border border-line bg-raised px-2.5 py-1.5 text-xs text-fg hover:border-fg-3"
+            >
+              Back to runner
+            </button>
+          ) : chatState === "resuming" ? (
             <button
               type="button"
               disabled
@@ -645,10 +681,10 @@ export default function RunnerChat() {
           )}
           {/* Topbar overflow menu — Pin / Rename / Archive, matching
               the design's `session_ctx_menu` (`P5CLA` / `L31Zb`) and
-              the mission topbar's `MissionKebab`. Only meaningful
-              once the chat row exists in the DB (sessionId + meta
-              loaded). */}
-          {sessionId && chatMeta ? (
+              the mission topbar's `MissionKebab`. Hidden for archived
+              rows: Pin/Rename make no sense for a terminal row, and
+              Archive is a no-op. */}
+          {sessionId && chatMeta && !isArchived ? (
             <ChatKebab
               pinned={chatMeta.pinned}
               open={kebabOpen}
@@ -710,9 +746,23 @@ export default function RunnerChat() {
           PTY output into their buffers, so switching sessions preserves the
           real terminal state. When the active pane's session has exited the
           xterm dims and a "Session ended" card overlays the center —
-          mirrors Pencil node `vS5ce`. */}
+          mirrors Pencil node `vS5ce`.
+          Archived rows render a static placeholder instead — no xterm,
+          no PTY listener, no live data path. */}
       <div className="relative flex-1 overflow-hidden p-4">
-        {directSessions.length === 0 ? (
+        {isArchived ? (
+          <div className="flex h-full items-center justify-center">
+            <div className="flex max-w-md flex-col items-center gap-2 rounded border border-line bg-raised px-6 py-5 text-center">
+              <span className="text-[13px] font-semibold text-fg">
+                Session ended — terminal closed
+              </span>
+              <span className="text-[12px] text-fg-2">
+                This chat was archived. The PTY is gone and the workspace is
+                read-only.
+              </span>
+            </div>
+          </div>
+        ) : directSessions.length === 0 ? (
           <div className="text-sm text-fg-3">Starting…</div>
         ) : (
           directSessions.map((s) => {

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -99,6 +99,17 @@ export default function RunnerChat() {
   // meta line. Pulled from session_list_recent_direct so the chat
   // surface and the sidebar agree on the truth.
   const [chatMeta, setChatMeta] = useState<DirectSessionEntry | null>(null);
+  // chatMeta is async (listRecentDirect → session_get fallback) and is
+  // the only source of `archived_at`. Until it resolves we don't know
+  // whether the URL points at an archived row, and we can't safely
+  // attach a PTY or mount RunnerTerminal — that would briefly subscribe
+  // to session/output and call outputSnapshot for an archived row
+  // before the read-only branch kicks in. Gate both the attach effect
+  // and the body render on this flag; it flips true once the first
+  // refresh completes (success or miss). Per-sessionId so back-forward
+  // navigation to a different chat doesn't reuse the stale flag.
+  const [metaLoadedFor, setMetaLoadedFor] = useState<string | null>(null);
+  const metaLoaded = sessionId != null && metaLoadedFor === sessionId;
   // True while the user has clicked Resume and we're waiting for the
   // resumed PTY to come back online. Drives the cyan status pill, the
   // header "Resuming…" affordance, and the centered Resuming pill
@@ -227,6 +238,7 @@ export default function RunnerChat() {
   const refreshChatMeta = useCallback(async () => {
     if (!sessionId) {
       setChatMeta(null);
+      setMetaLoadedFor(null);
       return;
     }
     try {
@@ -243,6 +255,11 @@ export default function RunnerChat() {
       setChatMeta(archived);
     } catch (e) {
       console.error("RunnerChat: refreshChatMeta failed", e);
+    } finally {
+      // Flag flips regardless of outcome so the body render can leave
+      // the neutral loading state — a network failure shouldn't strand
+      // the user on a perpetual spinner.
+      setMetaLoadedFor(sessionId);
     }
   }, [sessionId]);
 
@@ -387,6 +404,13 @@ export default function RunnerChat() {
   useEffect(() => {
     const requestKey = [handle ?? "", sessionId ?? ""].join(" ");
     if (startedKeyRef.current === requestKey) return;
+    // Wait for chatMeta to resolve before attaching. Without this
+    // gate, the brief window between mount and the first
+    // refreshChatMeta resolution would attach a PTY listener even
+    // for archived sessions (chatMeta is null → isArchived false),
+    // briefly subscribing to session/output + calling
+    // outputSnapshot before the read-only branch takes over.
+    if (!metaLoaded) return;
     startedKeyRef.current = requestKey;
     setErr(null);
     // Skip attach for archived rows: the workspace renders read-only,
@@ -395,7 +419,7 @@ export default function RunnerChat() {
     if (sessionId && handle && !isArchived) {
       attach(sessionId, handle, state?.sessionStatus ?? "stopped");
     }
-  }, [attach, handle, sessionId, state?.sessionStatus, isArchived]);
+  }, [attach, handle, sessionId, state?.sessionStatus, isArchived, metaLoaded]);
 
   async function endChat() {
     if (!sessionId || !handle) return;
@@ -750,7 +774,15 @@ export default function RunnerChat() {
           Archived rows render a static placeholder instead — no xterm,
           no PTY listener, no live data path. */}
       <div className="relative flex-1 overflow-hidden p-4">
-        {isArchived ? (
+        {!metaLoaded && sessionId ? (
+          // Neutral loading state until chatMeta resolves. Rendering
+          // the terminal map here would briefly mount RunnerTerminal
+          // for archived rows (chatMeta null → isArchived false) and
+          // fire a session/output subscribe + outputSnapshot call
+          // before the read-only branch takes over. The flash is short
+          // but visible and contradicts the 'no PTY listener' goal.
+          <div className="text-sm text-fg-3">Loading chat…</div>
+        ) : isArchived ? (
           <div className="flex h-full items-center justify-center">
             <div className="flex max-w-md flex-col items-center gap-2 rounded border border-line bg-raised px-6 py-5 text-center">
               <span className="text-[13px] font-semibold text-fg">


### PR DESCRIPTION
Closes #85.

## Summary

- Search (⌘K palette) no longer surfaces archived missions; filter lives at the SQL chokepoint (`list()`) so sidebar / palette / summary all inherit.
- Archived mission workspaces render feed-only — no xterm canvases mount, no PTY tabs, no Resume / Stop / kebab — with an unambiguous "Archived · read-only" chip.
- Archived direct-session URLs (`/runners/:handle/chat/:sessionId`) lock down the same way: no PTY attach, no Resume / End / Archive, static "Session ended — terminal closed" placeholder.

## Data model

New `archived_at TEXT` column on `missions` (mirrors the existing column on `sessions`). `archived_at IS NOT NULL` is the single read-only / hide-from-search discriminator across both surfaces — UX never keys off `status === 'completed'`.

Migration 0004 backfills existing completed rows with `archived_at = stopped_at`. Today `mission_archive` is the only path to `status = 'completed'`, so the backfill is exact. Aborted rows (spawn-failure rollback) intentionally stay unarchived — triage state, not archive — so they remain in `list()` until explicitly archived.

## Invariants

- `stop()` (only caller: `mission_archive`) stamps `archived_at = now()` in the same atomic UPDATE as `status='completed'`. A row can never be observed as completed-without-archived.
- `mission_reset` step-5 clears `archived_at` alongside the flip back to `running`, so a reset row reappears in `list()`.
- `mission_get` is intentionally unfiltered: direct-URL nav to an archived mission still resolves so the workspace can render read-only.
- New `session_get` RPC mirrors that pattern for direct sessions (`listRecentDirect` already filtered archived; the chat page falls back to `session_get` on a miss).

## Tests

5 new mission tests:
- `list_excludes_archived_missions`
- `stop_sets_archived_at_alongside_status`
- `aborted_missions_stay_visible_in_list` (narrow backfill verification)
- `migration_backfills_archived_at_for_completed_rows`
- `reset_clears_archived_at`

`cargo test --workspace`: 266 passing. `tsc` + lint clean.

## Test plan

- [ ] Archive a mission → ⌘K does not list it.
- [ ] Open archived mission by direct URL → feed renders, no xterm mounts, "Archived · read-only" chip visible, no Resume / Stop / kebab.
- [ ] Archive a direct chat → sidebar drops it; direct-URL nav shows the "Session ended" placeholder, no PTY.
- [ ] Existing stopped/completed missions show up as archived after migration (one-time backfill).
- [ ] Aborted missions still appear in ⌘K + sidebar.
- [ ] Reset a (running) mission → still listed and live afterwards.