### PR TITLE
chore: release v0.1.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "runner",
   "private": true,
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runner"
-version = "0.1.7"
+version = "0.1.8"
 description = "An editor for teams of local coding agents (Claude Code, Codex, and friends)"
 edition.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Runner",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "identifier": "com.wycstudios.runner",
   "build": {
     "beforeDevCommand": "npm run tauri:before:dev",


### PR DESCRIPTION
## Summary

Release v0.1.8.

Since v0.1.7:
- feat(ui): app zoom + terminal font size settings (#93)
- fix(mission): hide archived missions from search; lock archived workspace read-only (#95)

## Test plan

- [ ] CI green
- [ ] Tag push triggers release.yml and produces signed/notarized macOS DMGs