### PR TITLE
fix(session): blind-Enter fallback on resume-continue verify failure

### DIFF
--- a/docs/impls/0005-first-prompt-readback.md
+++ b/docs/impls/0005-first-prompt-readback.md
@@ -481,3 +481,57 @@ confirm all three show the persona as the first user turn; (b) start
 a fresh codex-lead mission with a long preamble+brief (≥2KB), confirm
 the lead receives the launch prompt and submits it (covers the
 tail-marker path).
+
+## Addendum: resume-continue caller policy (issue #94)
+
+`schedule_continue_on_resume` pastes the literal `continue` (8 bytes)
+into a freshly resumed claude-code pane so the agent picks up where
+it left off without the user touching the keyboard. The body is 8
+bytes — below `PLACEHOLDER_MIN_BODY_LEN = 64` — so the placeholder
+delta gate inside `inject_paste_with_verify` is closed and only the
+head/tail-marker delta for "continue" can ack the paste. Three real-
+world conditions defeat that single ack signal:
+
+1. **Capture race.** The 600ms render-wait isn't always enough; the
+   pane snapshot we take post-paste sometimes hasn't repainted yet.
+2. **TUI line-wrap.** When the composer happens to wrap mid-word,
+   the rendered "continue" gets split across a soft-wrap boundary
+   and the literal 8-char substring search misses it.
+3. **Stale transcript content.** A resumed pane that already has the
+   word "continue" scrolled into view (the agent's last turn echoed
+   it, the user typed it earlier, etc.) makes `before_head_count`
+   match `after_head_count`. Delta = 0, verify rejects.
+
+Originally the caller just logged the verify failure and gave up —
+leaving the user staring at a pane with `continue` typed into the
+composer but no Enter sent. The fix layers a **caller-side recovery
+policy** on top of the unchanged strict primitive:
+
+- On verify success, `inject_paste_with_verify` sends Enter and
+  returns Ok. Fallback path does not fire.
+- On verify failure (Err), the caller sends one fallback Enter via
+  `SessionManager::send_enter`. Two cases land here:
+  - Paste body did land but readback missed it → Enter submits the
+    visible "continue" and the agent resumes. User's intent.
+  - Paste body did not land → Enter on an empty claude-code composer
+    is a no-op. Cheap.
+
+The downside of NOT recovering (user stuck, has to type manually)
+clearly outweighs the downside of a stray Enter on this specific
+caller. The policy is intentionally caller-local: `inject_first_turn`
+and other callers paste multi-KB launch prompts where a stray Enter
+on a partial body would submit garbage. Those callers keep the
+strict "only Enter on verified paste" contract guarded by
+`continue_resume_rejects_stale_placeholder`.
+
+Tests added alongside the fix:
+- `continue_resume_falls_back_to_enter_on_verify_failure` — exact
+  one fallback Enter on stale-placeholder Err.
+- `continue_resume_no_double_enter_on_verify_success` — exactly one
+  Enter on the happy path; fallback does not double-fire.
+- `continue_resume_skips_for_non_claude_runtime` — no paste, no Enter
+  for shell / codex.
+
+Distinct stderr logs (`verify failed … sending fallback Enter` vs.
+`fallback Enter … failed`) let us detect frequency in the field
+without re-instrumenting.

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1441,6 +1441,25 @@ impl SessionManager {
         )))
     }
 
+    /// Send a bare Enter keystroke to a live session's pane. Used by
+    /// `schedule_continue_on_resume` as a recovery path when
+    /// `inject_paste_with_verify` couldn't confirm the "continue"
+    /// body landed: see that caller for the safety rationale (stray
+    /// Enter on an empty composer is a no-op for claude-code, so the
+    /// downside of NOT recovering — user stuck — outweighs it).
+    pub(crate) fn send_enter(&self, session_id: &str) -> Result<()> {
+        let rt_session = self
+            .sessions
+            .lock()
+            .unwrap()
+            .get(session_id)
+            .map(|h| h.runtime_session.clone())
+            .ok_or_else(|| Error::msg(format!("session not found: {session_id}")))?;
+        self.runtime
+            .send_key(&rt_session, "Enter")
+            .map_err(Into::into)
+    }
+
     /// Resize the session's pane. The frontend calls this after
     /// xterm fits its container — without it, claude-code stays at
     /// the spawn-time grid regardless of how big the visible grid
@@ -2102,6 +2121,23 @@ fn schedule_direct_first_prompt(
 /// is 0, and the body length (`continue` is 8 bytes < 64) skips
 /// the placeholder gate entirely; only the head/tail-marker delta
 /// for "continue" can accept.
+///
+/// Caller-side recovery policy: when `inject_paste_with_verify`
+/// returns Err for this caller, we still send one fallback Enter
+/// keystroke. Two paths land us in that Err. (1) The paste body
+/// landed in the composer but readback never observed the
+/// head/tail marker (capture race, TUI line-wrap, or prior
+/// transcript content matching the marker) — Enter submits the
+/// visible "continue" and the agent resumes, exactly the user's
+/// intent. (2) The paste truly didn't land — Enter on an empty
+/// claude-code composer is a no-op.
+///
+/// Both paths beat the alternative of giving up silently and
+/// leaving the user stuck with no auto-continue. This is a
+/// caller-policy decision; `inject_paste_with_verify` keeps its
+/// strict "only Enter on verified paste" contract for callers like
+/// `inject_first_turn` that paste long mission prompts where a
+/// stray Enter on a partial body would be destructive.
 fn schedule_continue_on_resume(
     mgr: &Arc<SessionManager>,
     session_id: String,
@@ -2118,13 +2154,29 @@ fn schedule_continue_on_resume(
     if config.initial_wait.is_zero() && config.between_attempts.is_zero() {
         // Inline path under `cfg(test)` so synchronous output
         // assertions can observe the injection.
-        let _ = mgr.inject_paste_with_verify(&session_id, b"continue", config);
+        if let Err(e) = mgr.inject_paste_with_verify(&session_id, b"continue", config) {
+            eprintln!(
+                "runner: continue-on-resume verify failed for {session_id}: {e}; sending fallback Enter"
+            );
+            if let Err(ee) = mgr.send_enter(&session_id) {
+                eprintln!(
+                    "runner: continue-on-resume fallback Enter for {session_id} failed: {ee}"
+                );
+            }
+        }
         return;
     }
     let mgr = Arc::clone(mgr);
     std::thread::spawn(move || {
         if let Err(e) = mgr.inject_paste_with_verify(&session_id, b"continue", config) {
-            eprintln!("runner: continue-on-resume for {session_id} failed: {e}");
+            eprintln!(
+                "runner: continue-on-resume verify failed for {session_id}: {e}; sending fallback Enter"
+            );
+            if let Err(ee) = mgr.send_enter(&session_id) {
+                eprintln!(
+                    "runner: continue-on-resume fallback Enter for {session_id} failed: {ee}"
+                );
+            }
         }
     });
 }
@@ -4376,6 +4428,121 @@ mod tests {
         assert!(
             enters.is_empty(),
             "stale placeholder must not trigger Enter; got {enters:?}",
+        );
+    }
+
+    /// Helper: build a claude-code Runner for the resume-continue
+    /// flow tests. The shared `runner()` helper hardcodes
+    /// `runtime: "shell"`, which `schedule_continue_on_resume`
+    /// short-circuits on.
+    fn claude_runner() -> Runner {
+        let mut r = runner("/bin/true", &[]);
+        r.runtime = "claude-code".into();
+        r
+    }
+
+    fn resume_plan_resuming() -> router::runtime::ResumePlan {
+        router::runtime::ResumePlan {
+            args: Vec::new(),
+            prepend: false,
+            assigned_key: Some("k".into()),
+            resuming: true,
+        }
+    }
+
+    #[test]
+    fn continue_resume_falls_back_to_enter_on_verify_failure() {
+        // Mirror `continue_resume_rejects_stale_placeholder`: a
+        // resumed pane already shows old `[Pasted text #N ...]`
+        // content, the head/tail-marker delta for "continue" stays
+        // 0 across all attempts, and `inject_paste_with_verify`
+        // returns Err. The end-to-end resume-continue caller must
+        // recover by sending exactly one fallback Enter — that's
+        // the whole point of the policy. `inject_paste_with_verify`
+        // semantics are unchanged; the recovery lives in
+        // `schedule_continue_on_resume`.
+        let fake = fake_runtime();
+        let mgr = mgr_with_fake(None, Arc::clone(&fake));
+        register_fake_session(&mgr, &fake, "S-CONT-FB");
+        let stale = b"...prior conversation...\n[Pasted text #5 +20 lines]\n>";
+        fake.set_pane_pre_paste(stale);
+        fake.set_pane_post_paste(stale);
+
+        let r = claude_runner();
+        let plan = resume_plan_resuming();
+        super::schedule_continue_on_resume(&mgr, "S-CONT-FB".into(), &r, &plan);
+
+        let pastes = fake.pastes();
+        assert_eq!(
+            pastes.len(),
+            FIRST_PROMPT_CONFIG.max_attempts,
+            "expected max_attempts pastes; got {pastes:?}",
+        );
+        let enters: Vec<_> = fake
+            .keys()
+            .into_iter()
+            .filter(|(_, k)| k == "Enter")
+            .collect();
+        assert_eq!(
+            enters.len(),
+            1,
+            "expected exactly one fallback Enter on verify failure; got {enters:?}",
+        );
+    }
+
+    #[test]
+    fn continue_resume_no_double_enter_on_verify_success() {
+        // Default FakeRuntime (empty `pane_post_paste`) makes
+        // `capture_visible` synthesize a snapshot containing the last
+        // paste body, so the head-marker delta hits ≥ 1 on attempt 1
+        // and `inject_paste_with_verify` sends Enter and returns Ok.
+        // The fallback path must NOT fire — otherwise the agent gets
+        // two Enters and submits a stray empty turn.
+        let fake = fake_runtime();
+        let mgr = mgr_with_fake(None, Arc::clone(&fake));
+        register_fake_session(&mgr, &fake, "S-CONT-OK");
+
+        let r = claude_runner();
+        let plan = resume_plan_resuming();
+        super::schedule_continue_on_resume(&mgr, "S-CONT-OK".into(), &r, &plan);
+
+        let pastes = fake.pastes();
+        assert_eq!(pastes.len(), 1, "expected one paste; got {pastes:?}");
+        let enters: Vec<_> = fake
+            .keys()
+            .into_iter()
+            .filter(|(_, k)| k == "Enter")
+            .collect();
+        assert_eq!(
+            enters.len(),
+            1,
+            "verify-success path must send exactly one Enter (no fallback double); got {enters:?}",
+        );
+    }
+
+    #[test]
+    fn continue_resume_skips_for_non_claude_runtime() {
+        // codex / shell don't have a real "continue" semantic — the
+        // function must no-op (no paste, no Enter) regardless of
+        // `plan.resuming`.
+        let fake = fake_runtime();
+        let mgr = mgr_with_fake(None, Arc::clone(&fake));
+        register_fake_session(&mgr, &fake, "S-CONT-SHELL");
+
+        let mut r = runner("/bin/true", &[]);
+        r.runtime = "shell".into();
+        let plan = resume_plan_resuming();
+        super::schedule_continue_on_resume(&mgr, "S-CONT-SHELL".into(), &r, &plan);
+
+        assert!(
+            fake.pastes().is_empty(),
+            "no paste for non-claude runtime; got {:?}",
+            fake.pastes()
+        );
+        assert!(
+            fake.keys().is_empty(),
+            "no key events for non-claude runtime; got {:?}",
+            fake.keys()
         );
     }
 }


### PR DESCRIPTION
## Summary
- Resuming a mission now reliably auto-submits `continue` even when paste-verify can't observe the marker delta (capture race, line-wrap, or a transcript already containing "continue").
- Fix is caller-local in `schedule_continue_on_resume`: on `inject_paste_with_verify` Err, send one fallback Enter. Either the paste landed and we missed it (Enter submits, user's intent) or it didn't (Enter on empty claude-code composer is a no-op).
- Strict `inject_paste_with_verify` contract preserved — `inject_first_turn` and other multi-KB callers unaffected. Existing `continue_resume_rejects_stale_placeholder` guard test still passes verbatim.

Fixes #94

## Changes
- `src-tauri/src/session/manager.rs` — new `SessionManager::send_enter` helper (same rt_session lookup pattern as the primitive); fallback wired into both the inline `cfg(test)` and spawned-thread paths of `schedule_continue_on_resume`; extended docstring; distinct stderr logs for verify failure vs fallback Enter failure (field debuggability).
- `docs/impls/0005-first-prompt-readback.md` — appended "Addendum: resume-continue caller policy (issue #94)" covering the three failure modes, recovery policy, layering rationale, and test names.

## Tests
Three new tests in `mod tests` alongside the existing strict-primitive guard:
- `continue_resume_falls_back_to_enter_on_verify_failure` — stale-placeholder pane; asserts max_attempts pastes + exactly one fallback Enter.
- `continue_resume_no_double_enter_on_verify_success` — happy path; asserts one paste + exactly one Enter (no fallback double).
- `continue_resume_skips_for_non_claude_runtime` — shell runtime; asserts no paste / no key events.

## Test plan
- [x] `cargo test` — 229 passed, 0 failed, 6 ignored (3 new tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `continue_resume_rejects_stale_placeholder` still passes verbatim
- [ ] Manual: resume a mission whose transcript contains the word "continue" — agent auto-continues without keyboard nudge

🤖 Generated with [Claude Code](https://claude.com/claude-code)