### PR TITLE
fix(ui): auto-resize mission input textarea on multi-line content

### DIFF
--- a/src/components/MissionInput.tsx
+++ b/src/components/MissionInput.tsx
@@ -39,11 +39,21 @@ export function MissionInput({
   const [pickerOpen, setPickerOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const pickerRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
 
   // Sync with new lead if the prop changes.
   useEffect(() => {
     setTarget((cur) => (handles.includes(cur) ? cur : leadHandle));
   }, [handles, leadHandle]);
+
+  // Autosize the textarea to fit content, capped at 240px. Reset to "auto"
+  // first so shrinking (e.g. after submit clears text) works as well as growth.
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 240)}px`;
+  }, [text]);
 
   useEffect(() => {
     if (!pickerOpen) return;
@@ -130,6 +140,7 @@ export function MissionInput({
       </div>
       <div className="flex items-end gap-3 rounded-lg border border-line bg-panel px-4 py-3">
         <textarea
+          ref={textareaRef}
           value={text}
           onChange={(e) => setText(e.target.value)}
           onKeyDown={onKeyDown}
@@ -140,7 +151,7 @@ export function MissionInput({
           }
           disabled={disabled}
           rows={1}
-          className="flex-1 resize-none bg-transparent text-[13px] text-fg placeholder:text-fg-3 focus:outline-none disabled:cursor-not-allowed"
+          className="flex-1 resize-none overflow-y-auto bg-transparent text-[13px] text-fg placeholder:text-fg-3 focus:outline-none disabled:cursor-not-allowed"
           style={{ minHeight: "24px", maxHeight: "240px" }}
         />
         <button


### PR DESCRIPTION
## Summary
- Fixes #83: the mission input textarea was stuck at one visible row because it had `rows={1}` + `resize-none` + a `maxHeight` cap but no autosize handler.
- Wires a `textareaRef` + `useEffect` on `text` that resets height to `auto` then to `min(scrollHeight, 240)px`.
- Adds `overflow-y-auto` so the 240px cap gains an internal scrollbar instead of clipping.

## Test plan
- [x] Plain typing wraps and the box grows vertically.
- [x] Shift+Enter inserts a newline and the box grows by one row each time, up to ~240px.
- [x] Past 240px the box stops growing; latest line stays visible via internal scroll.
- [x] After Send (text cleared) the box snaps back to the 1-row baseline.
- [x] Enter still submits; Shift+Enter still inserts newline.
- [x] `pnpm tsc --noEmit` + `pnpm lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)