### PR TITLE
fix(terminal): Shift+Enter newline regression — intercept WebKit keypress (#99)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,10 @@ jobs:
       # tried that path on PR #105 and it consistently hit the same
       # 5-min wall before completing.
       - name: Install system dependencies (cached)
-        uses: awalsh128/cache-apt-pkgs-action@v1
+        # Pinned to v1.6.0 (2025-10-15) — `@v1` moves to v1.5.3 which has
+        # had cache-restore flakes; v1.6.0 picks up the "ls error when no
+        # tar files exist in cache restore" fix plus a few other patches.
+        uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         timeout-minutes: 5
         with:
           packages: libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,23 +35,25 @@ jobs:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
       # Tauri 2 on Linux needs webkit2gtk and friends even for `cargo check`
-      # because tauri-runtime-wry links against them. We install them
-      # directly with apt-get (the canonical Tauri Linux CI pattern)
-      # instead of going through cache-apt-pkgs-action — the latter
-      # wraps apt-fast/aria2 which intermittently hangs on
-      # `Clean installing 4 packages...`, costing more in lost runs
-      # than the ~40s the cache layer saves on a hit.
-      - name: Install system dependencies
-        env:
-          DEBIAN_FRONTEND: noninteractive
+      # because tauri-runtime-wry links against them. cache-apt-pkgs-action
+      # caches the *installed filesystem* (not just the .debs), so a cache
+      # hit untars in ~3s. The cold path occasionally hangs on
+      # apt-fast/aria2 — `timeout-minutes` bounds that so a stalled cold
+      # install fails fast and surfaces in the PR checks instead of
+      # sitting indefinitely; rerun the job to retry. Bump the `version`
+      # key when the package list changes to invalidate the cache.
+      #
+      # Raw `apt-get install` (without this action) takes 5+ min on a
+      # cold runner because Azure's Ubuntu mirror serves the 177
+      # transitive deps slowly with occasional 60s `Ign:` retries —
+      # tried that path on PR #105 and it consistently hit the same
+      # 5-min wall before completing.
+      - name: Install system dependencies (cached)
+        uses: awalsh128/cache-apt-pkgs-action@v1
         timeout-minutes: 5
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends \
-            libwebkit2gtk-4.1-dev \
-            libgtk-3-dev \
-            libayatana-appindicator3-dev \
-            librsvg2-dev
+        with:
+          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
+          version: 1.0
       # Tauri's build script validates that every `bundle.externalBin`
       # entry exists for the active target on every cargo build,
       # including clippy / check / test. CI doesn't bundle, but it does

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,17 +35,23 @@ jobs:
           components: clippy, rustfmt
       - uses: Swatinem/rust-cache@v2
       # Tauri 2 on Linux needs webkit2gtk and friends even for `cargo check`
-      # because tauri-runtime-wry links against them. The `cache-apt-pkgs`
-      # action caches the resolved .deb tree in GitHub's actions cache,
-      # which cuts the install step from ~45s (apt mirror download +
-      # dpkg) to ~3s (untar from cache) on every subsequent run. Bump
-      # the `version` key to invalidate the cache when the package
-      # list below changes.
-      - name: Install system dependencies (cached)
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev librsvg2-dev
-          version: 1.0
+      # because tauri-runtime-wry links against them. We install them
+      # directly with apt-get (the canonical Tauri Linux CI pattern)
+      # instead of going through cache-apt-pkgs-action — the latter
+      # wraps apt-fast/aria2 which intermittently hangs on
+      # `Clean installing 4 packages...`, costing more in lost runs
+      # than the ~40s the cache layer saves on a hit.
+      - name: Install system dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        timeout-minutes: 5
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev
       # Tauri's build script validates that every `bundle.externalBin`
       # entry exists for the active target on every cargo build,
       # including clippy / check / test. CI doesn't bundle, but it does

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -199,8 +199,12 @@ export function RunnerTerminal({
     // Shift+Enter → ESC+CR so claude-code/codex insert a newline in their
     // input frame instead of submitting. Plain Enter falls through to the
     // default \r emission via onData above.
+    //
+    // We must intercept both keydown AND keypress: WKWebView fires a
+    // legacy `keypress` for Shift+Enter, and xterm's `_keyPress` will
+    // emit \r (same as plain Enter) unless this handler also returns
+    // false for that event (see #99).
     term.attachCustomKeyEventHandler((e) => {
-      if (e.type !== "keydown") return true;
       if (
         e.key === "Enter" &&
         e.shiftKey &&
@@ -208,11 +212,13 @@ export function RunnerTerminal({
         !e.altKey &&
         !e.metaKey
       ) {
-        const sid = sessionIdRef.current;
-        if (sid && !disabledRef.current) {
-          void api.session.injectStdin(sid, "\x1b\r").catch((err) => {
-            onErrorRef.current?.(String(err));
-          });
+        if (e.type === "keydown") {
+          const sid = sessionIdRef.current;
+          if (sid && !disabledRef.current) {
+            void api.session.injectStdin(sid, "\x1b\r").catch((err) => {
+              onErrorRef.current?.(String(err));
+            });
+          }
         }
         return false;
       }


### PR DESCRIPTION
## Summary
- Closes #99: Shift+Enter submits instead of inserting a newline in the embedded `RunnerTerminal`.
- Root cause: the custom key handler returned `false` for the Shift+Enter **keydown** but didn't suppress the subsequent WebKit **keypress**. xterm's `_keyPress` then emitted `\r` via `triggerDataEvent`, so the agent CLI saw `\x1b\r` (our injected newline) immediately followed by `\r` (submit) and treated the prompt as submitted.
- Fix: drop the `e.type !== "keydown"` short-circuit so the custom handler returns `false` for both the keydown **and** the keypress of Shift+Enter. Gate the stdin injection on keydown so `\x1b\r` is emitted exactly once. Plain Enter, `disabledRef` guard, and the Cmd+V image-paste path are untouched.

xterm.js version is unchanged at 6.0.0 since the original PR #64; the regression is consistent with a WKWebView behavior shift around the legacy `keypress` event for Shift+Enter.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm lint` clean (one unrelated pre-existing react-refresh warning in `UpdateContext.tsx`)
- [x] Manual: Shift+Enter inserts a newline in a live claude-code session, prompt stays open (confirmed by @yicheng47)
- [ ] Plain Enter still submits
- [ ] Codex runtime parity (Shift+Enter newline / Enter submit)
- [ ] Shift+Enter on a stopped/disabled pane doesn't surface "session not found"

🤖 Generated with [Claude Code](https://claude.com/claude-code)