### PR TITLE
chore: release v0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "runner"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "runner",
   "private": true,
-  "version": "0.1.8",
+  "version": "0.1.9",
   "type": "module",
   "engines": {
     "node": ">=22.12.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "runner"
-version = "0.1.8"
+version = "0.1.9"
 description = "An editor for teams of local coding agents (Claude Code, Codex, and friends)"
 edition.workspace = true
 authors.workspace = true

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Runner",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "identifier": "com.wycstudios.runner",
   "build": {
     "beforeDevCommand": "npm run tauri:before:dev",


### PR DESCRIPTION
Version bump for the v0.1.9 release.

## Changes since v0.1.8

**Bug fixes**
- fix(terminal): Shift+Enter newline regression — intercept WebKit keypress (#99 → #105)
- fix(ui): auto-resize mission input textarea on multi-line content (#83 → #102)
- fix(session): blind-Enter fallback on resume-continue verify failure (#94 → #98)

**Docs / planning**
- docs(features): add spec 08 — hide system signals from the mission feed (#97 → #103)

**Internal (agent tooling)**
- chore(skills): add P0–P3 priority workflow to /bug and /feature

## Test plan

- [ ] CI green on this PR
- [ ] After merge + tag, the v0.1.9 release workflow builds + notarizes both Apple Silicon and Intel DMGs