### PR TITLE
fix(ui): clickable URLs in terminal and message feed (#100)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@tauri-apps/plugin-shell": "^2",
     "@tauri-apps/plugin-updater": "^2.10.0",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-web-links": "^0.11.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "lucide-react": "^0.577.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@xterm/addon-fit':
         specifier: ^0.11.0
         version: 0.11.0
+      '@xterm/addon-web-links':
+        specifier: ^0.11.0
+        version: 0.11.0(@xterm/xterm@6.0.0)
       '@xterm/addon-webgl':
         specifier: ^0.19.0
         version: 0.19.0
@@ -842,6 +845,11 @@ packages:
 
   '@xterm/addon-fit@0.11.0':
     resolution: {integrity: sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==}
+
+  '@xterm/addon-web-links@0.11.0':
+    resolution: {integrity: sha512-nIHQ38pQI+a5kXnRaTgwqSHnX7KE6+4SVoceompgHL26unAxdfP6IPqUTSYPQgSwM56hsElfoNrrW5V7BUED/Q==}
+    peerDependencies:
+      '@xterm/xterm': ^5.0.0
 
   '@xterm/addon-webgl@0.19.0':
     resolution: {integrity: sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==}
@@ -2412,6 +2420,10 @@ snapshots:
       - supports-color
 
   '@xterm/addon-fit@0.11.0': {}
+
+  '@xterm/addon-web-links@0.11.0(@xterm/xterm@6.0.0)':
+    dependencies:
+      '@xterm/xterm': 6.0.0
 
   '@xterm/addon-webgl@0.19.0': {}
 

--- a/src/components/MessageBody.tsx
+++ b/src/components/MessageBody.tsx
@@ -12,26 +12,26 @@ import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
+import { open as openExternal } from "@tauri-apps/plugin-shell";
+
 export function MessageBody({ text }: { text: string }) {
   return (
     <div className="prose-message">
       <ReactMarkdown
         remarkPlugins={[remarkGfm, remarkBreaks]}
         components={{
-          // Open links in a new window via the Tauri shell. Plain
-          // anchors would crash the webview by trying to navigate
-          // away from the SPA. For now we render as a styled span
-          // that copies the URL on click — a real opener is a
-          // follow-up.
+          // Route clicks through Tauri's shell-opener so the URL
+          // lands in the user's default browser. preventDefault stays
+          // because a bare anchor navigation would tear the WKWebView
+          // off the SPA.
           a: ({ children, href }) => (
             <a
               href={href ?? "#"}
               onClick={(e) => {
                 e.preventDefault();
-                if (href) navigator.clipboard?.writeText(href).catch(() => {});
+                if (href) void openExternal(href).catch(() => {});
               }}
               className="text-accent underline decoration-accent/40 underline-offset-2 hover:decoration-accent"
-              title={href ? `Click to copy: ${href}` : undefined}
             >
               {children}
             </a>

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -11,8 +11,10 @@
 import { useEffect, useRef } from "react";
 
 import { listen } from "@tauri-apps/api/event";
+import { open as openExternal } from "@tauri-apps/plugin-shell";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import "@xterm/xterm/css/xterm.css";
 
@@ -150,6 +152,15 @@ export function RunnerTerminal({
     });
     const fit = new FitAddon();
     term.loadAddon(fit);
+    const webLinks = new WebLinksAddon((event, uri) => {
+      // Cmd+click on macOS to match iTerm/Terminal.app and avoid accidental
+      // navigations during scrollback selection. Plain click on other OSes.
+      if (navigator.platform.toLowerCase().includes("mac") && !event.metaKey) return;
+      void openExternal(uri).catch(() => {
+        // swallow — shell allowlist may reject
+      });
+    });
+    term.loadAddon(webLinks);
     term.open(containerRef.current);
     try {
       const webgl = new WebglAddon();


### PR DESCRIPTION
## Summary
- **Terminal**: load `@xterm/addon-web-links` in `RunnerTerminal`. URLs in xterm output now hover-underline and open via Tauri's shell-opener. macOS uses Cmd+click (matching iTerm/Terminal.app, avoids selection conflicts); plain click on other platforms.
- **Feed**: `MessageBody`'s anchor renderer used to copy the URL to the clipboard (a `// follow-up` placeholder). Swap it to `openExternal(href)` while keeping `preventDefault` so WKWebView doesn't tear off the SPA. Covers both `EventFeed` and `AskHumanCard`. Plain click on all platforms.

Fixes #100 and the feed-link follow-up surfaced during smoke testing.

## Test plan
- [ ] In a runner session, `echo https://github.com/yicheng47/runner` into the terminal → hover shows underline + pointer; Cmd+click opens in default browser.
- [ ] Multi-line URL (wrapped across two rows) still resolves as one link.
- [ ] In a mission or direct-chat feed, a message containing a markdown link `[label](url)` is clickable and opens in the browser.
- [ ] A message containing a bare `https://…` URL (autolinked by remark-gfm) is also clickable.
- [ ] No regressions in Shift+Enter newline, image paste, terminal resize, or feed message rendering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)