### PR TITLE
feat(mission): persist mission sessions across app restart (#115)

### DIFF
--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -12,6 +12,7 @@
 // and `mission_goal` (the human's intent, which the orchestrator routes to
 // the lead via the built-in rule in C8).
 
+use std::collections::HashSet;
 use std::path::Path;
 
 use chrono::Utc;
@@ -750,35 +751,63 @@ pub async fn mission_start(
 /// PTY children are NOT respawned here — that's an explicit per-slot
 /// `session_resume` call from the frontend, mirroring direct-chat
 /// resume UX.
+///
+/// Idempotent: when the app's startup reconciler (or a prior workspace
+/// mount) has already mounted the bus, this is a no-op that just
+/// returns the loaded mission row.
 #[tauri::command]
 pub async fn mission_attach(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     mission_id: String,
 ) -> Result<Mission> {
+    ensure_mission_router_mounted(&state, &app, &mission_id).await?;
+    let conn = state.db.get()?;
+    get(&conn, &mission_id)
+}
+
+/// Mount the in-memory Router + EventBus for `mission_id`, idempotently.
+///
+/// Called from two places:
+///  * `mission_attach` — workspace UI mount path; runs on every
+///    workspace navigation. After the startup reconciler runs, this is
+///    almost always a no-op.
+///  * `reattach_all_running_missions` — app startup path; runs once
+///    per running mission before session reattach so forwarder threads
+///    don't emit `mission_*` events into a non-existent subscriber.
+///
+/// Returns `Ok(())` (no-op) when the mission's router is already
+/// registered, or when the mission isn't in the `running` state.
+pub(crate) async fn ensure_mission_router_mounted(
+    state: &AppState,
+    app: &tauri::AppHandle,
+    mission_id: &str,
+) -> Result<()> {
     use crate::event_bus::{BusEmitter, TauriBusEvents};
     use crate::router::{
         open_log_for_mission, CompositeBusEmitter, Router, RouterSubscriber, StdinInjector,
     };
     use std::sync::Arc;
 
-    let mission = {
-        let conn = state.db.get()?;
-        get(&conn, &mission_id)?
-    };
-
     // Idempotent: if the router is already mounted for this mission,
     // just return. The frontend calls attach on every workspace mount
     // (including back-and-forth navigation), so this happens often.
-    if state.routers.get(&mission_id).is_some() {
-        return Ok(mission);
+    // Startup-side: the second mount path (workspace) finds the bus
+    // already mounted from the startup reconciler and returns here.
+    if state.routers.get(mission_id).is_some() {
+        return Ok(());
     }
+
+    let mission = {
+        let conn = state.db.get()?;
+        get(&conn, mission_id)?
+    };
 
     // Only running missions get rehydrated. Completed/aborted missions
     // are read-only — the workspace shows their feed via
     // mission_events_replay; no live router needed.
     if !matches!(mission.status, MissionStatus::Running) {
-        return Ok(mission);
+        return Ok(());
     }
 
     let (crew_name, allowed_signals) = {
@@ -791,9 +820,11 @@ pub async fn mission_attach(
         slot::list(&conn, &mission.crew_id)?
     };
 
-    // Pull the latest session_id per slot for this mission. Sessions
-    // are stopped post-restart, but the rows persist; resume picks up
-    // the same id. Filter to non-archived rows so a deleted-and-
+    // Pull the latest session_id per slot for this mission so the
+    // rebuilt Router can resolve `slot_handle → session_id` for stdin
+    // injection. Independent of whether the panes are alive: the
+    // mapping is what the Router holds in memory, not anything about
+    // pane state. Filter to non-archived rows so a deleted-and-
     // re-added slot doesn't pull a stale row.
     let session_pairs: Vec<(String, String)> = {
         let conn = state.db.get()?;
@@ -848,7 +879,62 @@ pub async fn mission_attach(
         .mount(mission.id.clone(), &mission_dir, &roster_handles, composite)?;
 
     state.routers.register(mission.id.clone(), router);
-    Ok(mission)
+    Ok(())
+}
+
+/// Walk every `running` mission and mount its Router + EventBus.
+///
+/// Runs once at app startup, before `SessionManager::reattach_running_sessions`,
+/// so the bus is in place when forwarder threads start emitting
+/// `mission_*` events. The NDJSON log is the source of truth; this
+/// just re-wires the in-memory fanout layer that died with the old
+/// process.
+///
+/// Per-mission isolation: if one mission's mount fails (corrupt log,
+/// missing crew row, etc.), it gets logged and the loop continues.
+/// The returned set lists every mission whose mount failed —
+/// callers pass it to `SessionManager::reattach_running_sessions`
+/// so those missions' alive panes are stopped instead of reattached
+/// (preserving the pre-eager-mount safety property that mission
+/// bytes never stream into a non-existent bus).
+pub(crate) async fn reattach_all_running_missions(
+    state: &AppState,
+    app: &tauri::AppHandle,
+) -> HashSet<String> {
+    let mission_ids = match state.db.get() {
+        Ok(conn) => list_running_mission_ids(&conn).unwrap_or_else(|e| {
+            eprintln!("runner: reattach_all_running_missions query failed: {e}");
+            Vec::new()
+        }),
+        Err(e) => {
+            eprintln!("runner: reattach_all_running_missions db pool unavailable: {e}");
+            Vec::new()
+        }
+    };
+
+    let mut failed = HashSet::new();
+    for mission_id in mission_ids {
+        if let Err(e) = ensure_mission_router_mounted(state, app, &mission_id).await {
+            eprintln!("runner: mission {mission_id} reattach failed: {e}");
+            failed.insert(mission_id);
+        }
+    }
+    failed
+}
+
+/// Return the ids of every mission that's currently `running` and not
+/// archived. Factored out of `reattach_all_running_missions` so the
+/// filter logic is unit-testable without an `AppHandle`.
+fn list_running_mission_ids(conn: &Connection) -> rusqlite::Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT id FROM missions
+           WHERE status = 'running' AND archived_at IS NULL
+           ORDER BY started_at ASC",
+    )?;
+    let ids = stmt
+        .query_map([], |r| r.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(ids)
 }
 
 /// Pause a mission by killing every live PTY but leaving the mission
@@ -2240,5 +2326,88 @@ mod tests {
             .expect("backfill must populate archived_at")
             .to_rfc3339();
         assert_eq!(backfilled_archived_at, original_stopped_at);
+    }
+
+    #[test]
+    fn list_running_mission_ids_filters_status_and_archive() {
+        // Startup reconciler should mount router + bus for `running`
+        // missions only — archived rows and completed/aborted rows
+        // are out of scope. Stable order by started_at so the
+        // iteration is reproducible across restarts.
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "C", None);
+        add_runner(&mut conn, &crew_id, "lead");
+        let tmp = tempfile::tempdir().unwrap();
+
+        let m_running_first = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                crew_id: crew_id.clone(),
+                title: "running-1".into(),
+                goal_override: Some("g".into()),
+                cwd: None,
+            },
+        )
+        .unwrap()
+        .mission
+        .id;
+        let m_running_second = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                crew_id: crew_id.clone(),
+                title: "running-2".into(),
+                goal_override: Some("g".into()),
+                cwd: None,
+            },
+        )
+        .unwrap()
+        .mission
+        .id;
+        let m_completed = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                crew_id: crew_id.clone(),
+                title: "completed".into(),
+                goal_override: Some("g".into()),
+                cwd: None,
+            },
+        )
+        .unwrap()
+        .mission
+        .id;
+        stop(&mut conn, tmp.path(), &m_completed).unwrap();
+
+        // A third running row that we manually mark archived to
+        // simulate a "soft-deleted while running" case the reconciler
+        // must ignore.
+        let m_archived = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                crew_id,
+                title: "running-archived".into(),
+                goal_override: Some("g".into()),
+                cwd: None,
+            },
+        )
+        .unwrap()
+        .mission
+        .id;
+        conn.execute(
+            "UPDATE missions SET archived_at = ?2 WHERE id = ?1",
+            params![m_archived, Utc::now().to_rfc3339()],
+        )
+        .unwrap();
+
+        let ids = list_running_mission_ids(&conn).unwrap();
+        assert_eq!(
+            ids,
+            vec![m_running_first, m_running_second],
+            "only non-archived running rows, ordered by started_at"
+        );
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -118,23 +118,51 @@ pub fn run() {
 
             let sessions = session::SessionManager::new(shell_path, runtime);
 
+            // Build the AppState up front so the mission-side
+            // reattach (next block) has access to the bus + router
+            // registries it needs to mount. The session-side reattach
+            // still runs from the local `sessions` Arc handle.
+            let state = AppState {
+                db: Arc::clone(&pool),
+                app_data_dir,
+                sessions: Arc::clone(&sessions),
+                buses: event_bus::BusRegistry::new(),
+                routers: router::RouterRegistry::new(),
+            };
+
+            // Mount router + bus for every `running` mission BEFORE
+            // session reattach starts. Forwarder threads begin
+            // emitting `mission_*` events as soon as `pipe-pane` is
+            // installed; if the bus isn't mounted yet, those events
+            // get fanout-dropped. The NDJSON log is unaffected (the
+            // agent writes straight through the bundled CLI) — this
+            // is purely about the in-memory fanout layer.
+            //
+            // Returns the set of mission ids whose mount FAILED;
+            // session reattach uses it to fall back to the
+            // stop+mark-stopped path for those missions' alive
+            // panes (matches the pre-eager-mount safety property).
+            let app_handle = app.handle().clone();
+            let failed_mission_ids = tauri::async_runtime::block_on(
+                commands::mission::reattach_all_running_missions(&state, &app_handle),
+            );
+
             // Reattach to any live tmux panes from a prior Runner
             // process. Rows whose pane is still alive stay
             // `running` and the manager rebuilds its forwarder
             // thread + handle for them. Rows whose pane is gone
             // (or has exited) get flipped to stopped/crashed via
-            // the runtime's exit code.
+            // the runtime's exit code. Mission rows whose router
+            // mount failed are stopped instead.
             let events_for_reattach: Arc<dyn session::manager::SessionEvents> =
                 Arc::new(session::manager::TauriSessionEvents(app.handle().clone()));
-            sessions.reattach_running_sessions(Arc::clone(&pool), events_for_reattach);
+            sessions.reattach_running_sessions(
+                Arc::clone(&pool),
+                events_for_reattach,
+                &failed_mission_ids,
+            );
 
-            app.manage(AppState {
-                db: pool,
-                app_data_dir,
-                sessions,
-                buses: event_bus::BusRegistry::new(),
-                routers: router::RouterRegistry::new(),
-            });
+            app.manage(state);
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1632,6 +1632,7 @@ impl SessionManager {
         self: &Arc<Self>,
         pool: Arc<DbPool>,
         events: Arc<dyn SessionEvents>,
+        failed_mission_ids: &HashSet<String>,
     ) {
         let now = Utc::now().to_rfc3339();
         let rows: Vec<RowSnap> = match collect_running_rows(&pool) {
@@ -1642,7 +1643,7 @@ impl SessionManager {
             }
         };
         for row in rows {
-            self.reattach_one(row, &now, &pool, &events);
+            self.reattach_one(row, &now, &pool, &events, failed_mission_ids);
         }
     }
 
@@ -1652,6 +1653,7 @@ impl SessionManager {
         now: &str,
         pool: &Arc<DbPool>,
         events: &Arc<dyn SessionEvents>,
+        failed_mission_ids: &HashSet<String>,
     ) {
         // No runtime metadata persisted (legacy row, or a row
         // that crashed before we got a chance to write the
@@ -1661,53 +1663,54 @@ impl SessionManager {
             return;
         };
 
-        // Query status FIRST so we can apply the dead-pane crash
-        // discrimination uniformly (mission OR direct, alive OR
-        // dead). The mission carve-out below only fires for
-        // *alive* mission panes — dead missions still need to
-        // surface their exit code so the workspace shows
-        // crashed-vs-stopped correctly after restart.
+        // Query status so we can apply the dead-pane crash
+        // discrimination uniformly across mission and direct rows.
         let status = self.runtime.status(&rt_session);
-        let is_mission = row.mission_id.is_some();
+
+        // Mission rows whose router+bus mount failed earlier in
+        // startup must not have their alive panes reattached —
+        // forwarder bytes would land on no subscriber and
+        // mission_* events appended in the window before workspace
+        // mount would be silently dropped. Fall back to the
+        // pre-eager-mount path: stop the pane, mark the row
+        // stopped, let the user resume from the workspace
+        // (mission_attach on workspace mount retries the bus mount).
+        let mission_mount_failed = row
+            .mission_id
+            .as_ref()
+            .map(|m| failed_mission_ids.contains(m))
+            .unwrap_or(false);
 
         match status {
-            Ok(Some(s)) if s.alive => {
-                if is_mission {
-                    // Mission session + alive: refuse to reattach.
-                    // The mission's bus + router don't mount
-                    // until `mission_attach` fires from the
-                    // workspace UI, and `router::mod` doesn't
-                    // replay stdin side effects on
-                    // reconstruction. Reattaching the PTY
-                    // without the bus would silently miss
-                    // ask_lead / human_said / runner_status
-                    // events appended after restart. Kill the
-                    // pane and mark the row stopped; the user
-                    // can resume from the workspace, which
-                    // mounts the bus + router properly.
-                    if let Err(e) = self.runtime.stop(&rt_session) {
-                        // Pane refused to die; leave the row
-                        // alone (still `running`) so the user's
-                        // eventual `mission_attach` from the
-                        // workspace can find it via the
-                        // existing reconcile path. Marking it
-                        // stopped here would create a UI/DB-
-                        // vs-tmux mismatch.
-                        eprintln!(
-                            "runner: reattach failed to stop mission session {}: {e}",
-                            row_dbg(&row.id)
-                        );
-                        return;
-                    }
-                    mark_session_stopped(pool, &row.id, now);
+            Ok(Some(s)) if s.alive && mission_mount_failed => {
+                if let Err(e) = self.runtime.stop(&rt_session) {
+                    // Pane refused to die; leave the row alone
+                    // (still `running`) so the user's eventual
+                    // `mission_attach` from the workspace can find
+                    // it via the existing reconcile path. Marking
+                    // it stopped here would create a UI/DB-vs-tmux
+                    // mismatch.
+                    eprintln!(
+                        "runner: reattach failed to stop mission session {} \
+                         after mount failure: {e}",
+                        row_dbg(&row.id)
+                    );
                     return;
                 }
-                // Direct chat + alive: re-attach. On failure,
-                // try to kill the orphan pane before marking the
-                // row stopped — but only mark stopped if the
-                // kill actually succeeded; otherwise the agent
-                // is still running and lying in the DB would
-                // strand it.
+                mark_session_stopped(pool, &row.id, now);
+            }
+            Ok(Some(s)) if s.alive => {
+                // Mission and direct rows take the same alive-pane
+                // path: rebuild the SessionHandle + forwarder. For
+                // mission rows the bus + router are mounted earlier
+                // in startup by `mission::reattach_all_running_missions`,
+                // so `mission_*` events emitted between pipe-pane
+                // install and workspace mount reach Tauri subscribers.
+                // On failure, try to kill the orphan pane before
+                // marking the row stopped — but only mark stopped if
+                // the kill actually succeeded; otherwise the agent
+                // is still running and lying in the DB would strand
+                // it.
                 let id = row.id.clone();
                 let rt_for_cleanup = rt_session.clone();
                 if let Err(e) = self.attach_existing(row, rt_session, pool, events) {
@@ -4153,7 +4156,7 @@ mod tests {
             s.exit_code = None;
         }
         let mgr = mgr_with_fake(None, Arc::clone(&fake));
-        mgr.reattach_running_sessions(Arc::clone(&pool), capture());
+        mgr.reattach_running_sessions(Arc::clone(&pool), capture(), &HashSet::new());
 
         // Row should still be running.
         let status: String = pool
@@ -4189,7 +4192,7 @@ mod tests {
             s.exit_code = Some(42);
         }
         let mgr = mgr_with_fake(None, Arc::clone(&fake));
-        mgr.reattach_running_sessions(Arc::clone(&pool), capture());
+        mgr.reattach_running_sessions(Arc::clone(&pool), capture(), &HashSet::new());
 
         let status: String = pool
             .get()
@@ -4207,14 +4210,12 @@ mod tests {
     }
 
     #[test]
-    fn reattach_running_sessions_kills_mission_panes_to_avoid_routing_drift() {
-        // Mission sessions don't reattach at startup — an agent
-        // appending bus events while Runner is closed and then
-        // reattaching without the mission's bus + router mounted
-        // would silently miss routing of those events. Kill the
-        // pane (so it doesn't keep running), mark the row stopped
-        // (so the user can resume from the workspace, which
-        // mounts the bus). Direct chats are unaffected.
+    fn reattach_running_sessions_reattaches_live_mission_panes() {
+        // Mission sessions take the same alive-pane path as direct
+        // chats. The bus + router are mounted earlier in startup by
+        // `mission::reattach_all_running_missions`, so the pane is
+        // safe to reattach: events emitted between pipe-pane install
+        // and workspace mount land on the already-live bus.
         let pool = pool_with_schema();
         let now = Utc::now().to_rfc3339();
         let runner_id = ulid::Ulid::new().to_string();
@@ -4265,18 +4266,107 @@ mod tests {
         }
 
         let fake = fake_runtime();
-        // Pane is alive — without the mission carve-out, the
-        // current code would happily reattach.
+        // Pane is alive — reattach should rebuild the SessionHandle.
         {
             let mut s = fake.status_response.lock().unwrap();
             s.alive = true;
             s.exit_code = None;
         }
         let mgr = mgr_with_fake(None, Arc::clone(&fake));
-        mgr.reattach_running_sessions(Arc::clone(&pool), capture());
+        mgr.reattach_running_sessions(Arc::clone(&pool), capture(), &HashSet::new());
 
-        // Row marked stopped (the user resumes from the workspace,
-        // which is where the bus + router mount).
+        // Row stays `running` — the pane is alive and the manager
+        // has rebuilt its handle for it.
+        let status: String = pool
+            .get()
+            .unwrap()
+            .query_row(
+                "SELECT status FROM sessions WHERE id = ?1",
+                params![session_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(status, "running");
+        // Manager has the session in its live map again.
+        assert!(mgr.sessions.lock().unwrap().contains_key(&session_id));
+        // Nothing was stopped — the pane keeps running.
+        assert_eq!(fake.stops.lock().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn reattach_running_sessions_stops_live_mission_panes_when_mount_failed() {
+        // If `mission::reattach_all_running_missions` failed to
+        // mount a mission's router+bus (corrupt log, missing crew,
+        // etc.), reattaching its alive panes would stream forwarder
+        // bytes into a non-existent subscriber and silently drop
+        // mission_* events. Fall back to the pre-eager-mount safety
+        // path: stop the pane and mark the row stopped so the user
+        // can resume from the workspace, where mission_attach will
+        // retry the mount.
+        let pool = pool_with_schema();
+        let now = Utc::now().to_rfc3339();
+        let runner_id = ulid::Ulid::new().to_string();
+        let session_id = ulid::Ulid::new().to_string();
+        let crew_id = "c-mount-failed".to_string();
+        let mission_id = ulid::Ulid::new().to_string();
+        {
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "INSERT INTO crews (id, name, created_at, updated_at)
+                 VALUES (?1, 'c', ?2, ?2)",
+                params![crew_id, now],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'mr', 'M', 'shell', '/bin/sh',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+                params![runner_id, now],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO missions (id, crew_id, title, status, started_at)
+                 VALUES (?1, ?2, 't', 'running', ?3)",
+                params![mission_id, crew_id, now],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO sessions
+                    (id, mission_id, runner_id, status, started_at,
+                     runtime, runtime_socket, runtime_session,
+                     runtime_window, runtime_pane)
+                 VALUES (?1, ?2, ?3, 'running', ?4,
+                         'tmux', 'runner', ?5, 'main', ?6)",
+                params![
+                    session_id,
+                    mission_id,
+                    runner_id,
+                    now,
+                    format!("runner-{session_id}"),
+                    format!("%{session_id}"),
+                ],
+            )
+            .unwrap();
+        }
+
+        let fake = fake_runtime();
+        // Pane is alive — the failed-mount carve-out must override
+        // the uniform reattach and stop it.
+        {
+            let mut s = fake.status_response.lock().unwrap();
+            s.alive = true;
+            s.exit_code = None;
+        }
+        let mgr = mgr_with_fake(None, Arc::clone(&fake));
+        let mut failed = HashSet::new();
+        failed.insert(mission_id.clone());
+        mgr.reattach_running_sessions(Arc::clone(&pool), capture(), &failed);
+
+        // Row flips to stopped — workspace mount path will retry
+        // and resume spawns a fresh pane.
         let status: String = pool
             .get()
             .unwrap()
@@ -4287,10 +4377,10 @@ mod tests {
             )
             .unwrap();
         assert_eq!(status, "stopped");
-        // Manager should NOT have the session in its live map.
+        // Manager must NOT hold a live handle for this session.
         assert!(!mgr.sessions.lock().unwrap().contains_key(&session_id));
-        // The runtime should have observed exactly one stop call
-        // — kill the pane so it doesn't keep producing events.
+        // Exactly one stop call — the safety carve-out tearing down
+        // the pane so it stops streaming bytes.
         assert_eq!(fake.stops.lock().unwrap().len(), 1);
     }
 
@@ -4322,7 +4412,7 @@ mod tests {
 
         let fake = fake_runtime();
         let mgr = mgr_with_fake(None, Arc::clone(&fake));
-        mgr.reattach_running_sessions(Arc::clone(&pool), capture());
+        mgr.reattach_running_sessions(Arc::clone(&pool), capture(), &HashSet::new());
 
         let status: String = pool
             .get()


### PR DESCRIPTION
## Summary

- Make mission panes survive app restart: drop the `is_mission` carve-out in `reattach_running_sessions` so mission and direct rows take the same alive-pane path.
- Mount mission bus + router eagerly at app startup via new `mission::reattach_all_running_missions`, called from `lib.rs::run` before session reattach so forwarder threads emit into a live subscriber.
- Per-mission error isolation: failed mounts are returned as a `HashSet<String>` and session reattach re-applies the stop+mark-stopped fallback only for those missions, preserving the safety property that bytes never stream into a non-existent bus.

Extracts `ensure_mission_router_mounted` from `mission_attach`; the command becomes a 4-line wrapper. Workspace-mount call still fires on navigation and finds the bus already mounted after restart.

Spec: [`docs/features/10-mission-session-persistence.md`](./docs/features/10-mission-session-persistence.md). Closes #115.

## Test plan

- [x] `cargo test --workspace` — 276 pass (+1 new), 6 ignored, 0 failed
- [x] `pnpm exec tsc --noEmit` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Manual smoke (two-slot mission, mid-response quit + reopen, lead stream continues, no resume prompt)
- [x] Manual smoke (`tmux -L runner kill-server` between quit + reopen, slots flip to stopped/crashed with resume affordance — pre-existing behavior preserved)
- [x] Manual smoke (events appended between restart and workspace mount fanout-emit to subscribers)

### Test coverage notes

- Renamed `reattach_running_sessions_kills_mission_panes_to_avoid_routing_drift` → `reattach_running_sessions_reattaches_live_mission_panes` with inverted assertions.
- Added sibling `reattach_running_sessions_stops_live_mission_panes_when_mount_failed` that locks in the failed-mount fallback.
- Added `list_running_mission_ids_filters_status_and_archive` for the startup query filter.
- Did not add a `FakeRuntime` test for `reattach_all_running_missions` end-to-end — would have required exposing the manager-side `#[cfg(test)]` stub runtime + building an `AppState` in the commands tests module (no existing pattern). The new manager-level failed-mount test exercises the actual safety property.

### Known residual risk (non-blocking, follow-up worthy)

If the initial `SELECT id FROM missions WHERE status = 'running'` query itself fails at startup, the returned failed set is empty — so session reattach would attach every alive mission pane uniformly without a bus mounted. Not addressed because (a) a DB pool error at startup leaves the app non-functional anyway, (b) the requested scope was per-mission helper failures, (c) a fix would change startup-failure semantics.

## Out of scope (deferred)

- Transcript-based resume when the tmux server is gone (OS reboot, OOM, `pkill tmux`).
- UI persistence-status badge.
- History limit bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)