### PR TITLE
fix(terminal): clickable URLs in prod + refit on panel toggles (#117, #108)

### DIFF
--- a/src/components/MessageBody.tsx
+++ b/src/components/MessageBody.tsx
@@ -12,7 +12,7 @@ import ReactMarkdown from "react-markdown";
 import remarkBreaks from "remark-breaks";
 import remarkGfm from "remark-gfm";
 
-import { open as openExternal } from "@tauri-apps/plugin-shell";
+import { openUrl } from "@tauri-apps/plugin-opener";
 
 export function MessageBody({ text }: { text: string }) {
   return (
@@ -29,7 +29,7 @@ export function MessageBody({ text }: { text: string }) {
               href={href ?? "#"}
               onClick={(e) => {
                 e.preventDefault();
-                if (href) void openExternal(href).catch(() => {});
+                if (href) void openUrl(href).catch(() => {});
               }}
               className="text-accent underline decoration-accent/40 underline-offset-2 hover:decoration-accent"
             >

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -291,6 +291,15 @@ export function RunnerTerminal({
       }
     };
     window.addEventListener("resize", refitAndPush);
+    // Panel toggles (left sidebar collapse, right rail) animate the
+    // container's width without firing window-resize, so the xterm
+    // grid and backend PTY geometry stay stale until the user nudges
+    // the OS window (#108). Observing the container catches those
+    // CSS-driven size changes; refitAndPush's activeRef + measurable-
+    // rect guards keep hidden panes from pushing stale geometry to
+    // the backend.
+    const ro = new ResizeObserver(() => refitAndPush());
+    ro.observe(containerRef.current);
 
     const refreshTerm = () => {
       const t = termRef.current;
@@ -346,6 +355,7 @@ export function RunnerTerminal({
     fitRef.current = fit;
 
     return () => {
+      ro.disconnect();
       window.removeEventListener("resize", refitAndPush);
       window.removeEventListener("focus", refreshTerm);
       document.removeEventListener("visibilitychange", onVisibility);

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -11,7 +11,7 @@
 import { useEffect, useRef } from "react";
 
 import { listen } from "@tauri-apps/api/event";
-import { open as openExternal } from "@tauri-apps/plugin-shell";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -156,8 +156,8 @@ export function RunnerTerminal({
       // Cmd+click on macOS to match iTerm/Terminal.app and avoid accidental
       // navigations during scrollback selection. Plain click on other OSes.
       if (navigator.platform.toLowerCase().includes("mac") && !event.metaKey) return;
-      void openExternal(uri).catch(() => {
-        // swallow — shell allowlist may reject
+      void openUrl(uri).catch((err) => {
+        console.error("[terminal] openUrl failed:", err);
       });
     });
     term.loadAddon(webLinks);

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -30,7 +30,7 @@ import {
 } from "lucide-react";
 
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
-import { open as openExternal } from "@tauri-apps/plugin-shell";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import { getVersion } from "@tauri-apps/api/app";
 
 import { api } from "../lib/api";
@@ -739,9 +739,9 @@ function AboutPane() {
       .catch(() => setVersion(""));
   }, []);
   const openLink = (url: string) => {
-    void openExternal(url).catch(() => {
+    void openUrl(url).catch(() => {
       // Fallback: window.open works in dev (browser preview) when
-      // the Tauri shell plugin isn't available.
+      // the Tauri opener plugin isn't available.
       window.open(url, "_blank");
     });
   };


### PR DESCRIPTION
## Summary

- **#117** — URLs in xterm were clickable in `pnpm tauri dev` but inert in the packaged `.app`. PR #114 wired `@xterm/addon-web-links` → `@tauri-apps/plugin-shell`'s `open()`, which has a known v2 dev-vs-prod parity issue (silent reject in release builds) made invisible by a swallowing `.catch`. Swapped all three call sites (`RunnerTerminal`, `MessageBody`, `SettingsModal`) to `@tauri-apps/plugin-opener`'s `openUrl` — purpose-built plugin, already registered in `lib.rs:39`, and `opener:default` in `capabilities/default.json:13` grants `http(s)`/`mailto:`/`tel:` per its ACL manifest. `RunnerTerminal`'s rejection now `console.error`s so the next regression is debuggable instead of silent.
- **#108** — `RunnerTerminal` only listened to `window.resize`. Panel toggles (left sidebar collapse via cmd+\\, right rail toggle in `MissionWorkspace` / `RunnerChat`) animate the container width without firing window-resize, leaving the xterm grid + backend PTY geometry stale until the user nudged the OS window. Added a `ResizeObserver` on `containerRef.current` calling the existing `refitAndPush` (its `activeRef` + measurable-rect guards already gate hidden panes correctly).

Closes #117, closes #108.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm lint` clean (modulo the pre-existing UpdateContext fast-refresh warning)
- [x] Packaged `.app` Cmd+click smoke for #117 — links open in default browser via Tauri opener (confirmed by maintainer)
- [ ] Toggle right rail in mission workspace with live PTY → xterm grid reflows during the 200ms animation, claude-code / codex prompts repaint to new width without nudging OS window
- [ ] Same on `RunnerChat`'s right side panel
- [ ] cmd+\\ to collapse left sidebar → same
- [ ] Tab-switch between PTY tabs in a workspace still refits the newly-active one (activation effect unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)