### PR TITLE
fix(router): reframe human-reply guidance from mandate to guideline (#128)

### DIFF
--- a/src-tauri/src/router/prompt.rs
+++ b/src-tauri/src/router/prompt.rs
@@ -97,9 +97,9 @@ pub(crate) const WORKER_COORDINATION_PREAMBLE: &str = r#"You are a worker in a c
 - `runner status idle` — report you've finished the current task. The lead view uses this to dispatch the next slot.
 
 == Replying to the human ==
-The human is watching the workspace feed, NOT your TUI. When the human speaks to you directly (raw input lands in your TUI, often prefixed with `[human_said]`), reply via:
+The human is watching the workspace feed, NOT your TUI — plain TUI output (typing into your editor, printing to stdout) stays in your local scrollback only. When the human asks you a question or gives you a directive (raw input lands in your TUI, often prefixed with `[human_said]`), reply via:
     runner msg post --to human "<your reply>"
-Plain TUI output (typing into your editor, printing to stdout) stays in your local scrollback only — it never reaches the human. The `--to human` route is the only way your reply lands in the workspace feed."#;
+That route is what lands your reply in the workspace feed. For passing remarks ("got it", "noted") or when your TUI output already conveys the answer, no `runner msg post` call is needed — silence is fine."#;
 
 pub fn compose_launch_prompt(input: &LaunchPromptInput<'_>) -> String {
     let mut out = String::new();
@@ -149,7 +149,7 @@ pub fn compose_launch_prompt(input: &LaunchPromptInput<'_>) -> String {
         "- Reply to a worker with `runner msg post --to <handle> \"…\"`; broadcasts omit `--to`.\n",
     );
     out.push_str(
-        "- Reply to the HUMAN with `runner msg post --to human \"…\"`. The human watches the workspace feed, not your TUI — typing answers into the TUI keeps them in your local scrollback only. `human` is a reserved virtual handle for this two-way path.\n",
+        "- Reply to the HUMAN with `runner msg post --to human \"…\"` when they ask a question or give a directive — that route lands the reply in the workspace feed (typing answers into the TUI keeps them in your local scrollback only). For passing remarks, silence is fine. `human` is a reserved virtual handle for this two-way path.\n",
     );
     out.push_str("- Read your inbox with `runner msg read` — it's pull-based.\n");
     out.push_str(
@@ -216,6 +216,23 @@ mod tests {
             allowed_signals: &[],
         });
         assert!(prompt.contains("(no goal set"));
+    }
+
+    #[test]
+    fn worker_preamble_frames_human_reply_as_guideline_not_mandate() {
+        // Guardrail against regressing the #128 fix: the human-reply
+        // section must explicitly say silence is fine for passing
+        // remarks, so agents stop posting "got it"/"noted" on every
+        // human_said.
+        let body = compose_worker_first_turn(None);
+        assert!(
+            body.contains("silence is fine"),
+            "preamble should tell workers silence is acceptable for passing remarks; got: {body}",
+        );
+        assert!(
+            body.contains("no `runner msg post` call is needed"),
+            "preamble should explicitly note no msg post is needed for passing remarks; got: {body}",
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Worker preamble (`WORKER_COORDINATION_PREAMBLE`) no longer mandates `runner msg post --to human` on every `[human_said]`. The "land in the feed" framing is preserved but conditioned on "when the human asks you a question or gives you a directive"; passing remarks ("got it", "noted") and cases where TUI output already conveys the answer are explicitly "silence is fine."
- Lead coordination block (`compose_launch_prompt`) mirrors the same softening in its bulleted form: reply when meaningful, stay silent on passing remarks.
- New unit test `worker_preamble_frames_human_reply_as_guideline_not_mandate` asserts the preamble contains both `silence is fine` and ``no `runner msg post` call is needed`` — guardrail against silently regressing to a mandate later.

## Follow-ups (out of scope here)

Both noted in #128 as adjacent symptoms in the same area; they need separate signaling/UX work and were deliberately left out of this PR:

- **#128 §1 — side-channel TUI typing:** when the human types directly into an agent's PTY tab (not via `human_said`), the agent currently has no way to distinguish that input from injected `human_said` and still routes replies into the feed. Needs a signal so agents know the input came from the TUI side-channel.
- **#128 §2 — reply duplication:** agents often render their reply in the PTY chat window as part of normal turn output AND also post via `runner msg post --to human`, so the human sees it twice if both surfaces are open. Needs a UX decision on which surface owns the reply.

Closes #128

## Test plan

- [x] `cargo test -p runner --lib router::prompt::` → 4/4 pass (3 existing + 1 new guardrail).
- [x] `cargo test -p runner --lib router::` → 66/66 pass, no regression in adjacent router code.
- [ ] Manual repro from #128: send `→ @architect perfect, smoke test passed.` from MissionInput and verify no architect-authored "got it" / "acknowledged" message appears in the feed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)