### PR TITLE
fix(sidebar): StartChatModal for CHAT + button (#104)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,10 +4,10 @@
 //   - WORKSPACE: search (placeholder), runner, crew nav links.
 //   - MISSION:   collapsible header with count + `+` (Start Mission), one row
 //                per running mission. The currently-open mission is highlighted.
-//   - SESSION:   collapsible header with count + `+` (opens an inline
-//                runner-picker popover that spawns a direct chat in
-//                place), one row per live direct-chat. The currently-
-//                open direct chat is highlighted.
+//   - SESSION:   collapsible header with count + `+` (opens the
+//                StartChat modal — runner pick + optional chat name +
+//                working dir), one row per live direct-chat. The
+//                currently-open direct chat is highlighted.
 //
 // MISSION pulls from `mission_list_summary` (filtered to status === "running").
 // SESSION continues to consume `runner/activity` events for live direct chats.
@@ -53,9 +53,9 @@ import {
   unmarkArchivingMission,
   unmarkArchivingSession,
 } from "../lib/archivingState";
-import { readDefaultWorkingDir } from "../lib/settings";
-import type { AppendedEvent, MissionSummary, Runner } from "../lib/types";
+import type { AppendedEvent, MissionSummary } from "../lib/types";
 import { StartMissionModal } from "./StartMissionModal";
+import { StartChatModal } from "./StartChatModal";
 import { SettingsModal } from "./SettingsModal";
 import { CommandPalette } from "./CommandPalette";
 
@@ -167,16 +167,9 @@ export function Sidebar({
   // Cancel (Escape / blur with no change) → close without write.
   const [renamingId, setRenamingId] = useState<string | null>(null);
 
-  // CHAT `+` runner-picker popover. Lazy-loaded on first open; the cached
-  // list stays around so subsequent opens render immediately while a
-  // refetch runs in the background. `spawningRunnerId` gates concurrent
-  // spawns and drives the per-row "Starting…" affordance.
-  const [chatPickerOpen, setChatPickerOpen] = useState(false);
-  const [pickerRunners, setPickerRunners] = useState<Runner[] | null>(null);
-  const [pickerLoading, setPickerLoading] = useState(false);
-  const [pickerError, setPickerError] = useState<string | null>(null);
-  const [spawningRunnerId, setSpawningRunnerId] = useState<string | null>(null);
-  const chatPickerRef = useRef<HTMLDivElement | null>(null);
+  // CHAT `+` opens the StartChat modal. State is a single boolean —
+  // the modal owns its own field state and runner-list fetch.
+  const [creatingChat, setCreatingChat] = useState(false);
 
   // Identify the currently-open runtime so we can highlight the matching
   // sidebar row. `useMatch` returns null when the URL doesn't match.
@@ -491,83 +484,12 @@ export function Sidebar({
     [navigate, location.pathname],
   );
 
-  // CHAT `+` button — opens an inline runner-picker popover (GH #104).
-  // Direct chats are spawned from a runner; the popover lets the user
-  // pick one without leaving the sidebar context. We also force the
-  // CHAT section open so the spawned row lands visibly. Runner list is
-  // lazy-loaded on each open (small, rare).
-  const openChatPicker = useCallback(() => {
-    setChatPickerOpen(true);
-    setPickerError(null);
-    if (!sessionsOpen) {
-      setSessionsOpen(true);
-      setStoredFlag(STORAGE_SESSION_OPEN, true);
-    }
-    setPickerLoading(true);
-    api.runner
-      .list()
-      .then((rows) => setPickerRunners(rows))
-      .catch((e) => setPickerError(String(e)))
-      .finally(() => setPickerLoading(false));
-  }, [sessionsOpen]);
-
-  const closeChatPicker = useCallback(() => {
-    setChatPickerOpen(false);
-    setPickerError(null);
+  // CHAT `+` button — opens the StartChat modal (GH #104). The modal is
+  // a takeover, so we don't pre-expand the SESSION section; the new
+  // chat row will be visible on return from the spawned chat URL.
+  const handleNewDirectChat = useCallback(() => {
+    setCreatingChat(true);
   }, []);
-
-  // Spawn a direct chat for the picked runner. Mirrors the spawn-then-
-  // navigate dance in Runners.tsx / RunnerDetail.tsx — the
-  // working_dir-vs-fallback rule is load-bearing: only override cwd
-  // when the runner has none of its own.
-  const spawnDirectChatFromPicker = useCallback(
-    async (runner: Runner) => {
-      if (spawningRunnerId) return;
-      setSpawningRunnerId(runner.id);
-      setPickerError(null);
-      try {
-        const fallbackCwd = runner.working_dir
-          ? null
-          : (readDefaultWorkingDir() || null);
-        const spawned = await api.session.startDirect(
-          runner.id,
-          fallbackCwd,
-          null,
-          null,
-        );
-        setChatPickerOpen(false);
-        navigate(`/runners/${runner.handle}/chat/${spawned.id}`, {
-          state: { sessionStatus: "running" },
-        });
-      } catch (e) {
-        setPickerError(String(e));
-      } finally {
-        setSpawningRunnerId(null);
-      }
-    },
-    [navigate, spawningRunnerId],
-  );
-
-  // Outside-click + Escape close. Mirrors the crewPickerRef pattern in
-  // StartMissionModal.tsx.
-  useEffect(() => {
-    if (!chatPickerOpen) return;
-    const onMouseDown = (e: MouseEvent) => {
-      if (!chatPickerRef.current) return;
-      if (!chatPickerRef.current.contains(e.target as Node)) {
-        setChatPickerOpen(false);
-      }
-    };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setChatPickerOpen(false);
-    };
-    document.addEventListener("mousedown", onMouseDown);
-    document.addEventListener("keydown", onKey);
-    return () => {
-      document.removeEventListener("mousedown", onMouseDown);
-      document.removeEventListener("keydown", onKey);
-    };
-  }, [chatPickerOpen]);
 
   const toggleMissions = useCallback(() => {
     setMissionsOpen((prev) => {
@@ -744,75 +666,15 @@ export function Sidebar({
             <div className="h-8 shrink-0" />
 
             <section className="flex min-h-0 flex-[2] basis-0 flex-col">
-              <div ref={chatPickerRef} className="relative">
-                <CollapsibleSectionHeader
-                  label="CHAT"
-                  count={directSessions.length}
-                  open={sessionsOpen}
-                  onToggle={toggleSessions}
-                  onPlus={openChatPicker}
-                  plusTitle="Start a chat"
-                  plusExpanded={chatPickerOpen}
-                />
-                {chatPickerOpen ? (
-                  <div
-                    role="listbox"
-                    aria-label="Pick a runner to chat with"
-                    className="absolute left-3 right-3 top-full z-30 mt-1 max-h-56 overflow-y-auto rounded-md border border-line bg-panel p-1 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
-                  >
-                    {pickerRunners === null && pickerLoading ? (
-                      <div className="px-2.5 py-2 text-xs text-fg-3">
-                        Loading…
-                      </div>
-                    ) : pickerError && (pickerRunners?.length ?? 0) === 0 ? (
-                      <div className="px-2.5 py-1 text-[11px] text-danger">
-                        {pickerError}
-                      </div>
-                    ) : pickerRunners && pickerRunners.length === 0 ? (
-                      <button
-                        type="button"
-                        onClick={() => {
-                          closeChatPicker();
-                          navigate("/runners");
-                        }}
-                        className="flex w-full cursor-pointer items-center gap-1 rounded px-2.5 py-2 text-left text-xs text-fg-2 transition-colors hover:bg-raised hover:text-fg"
-                      >
-                        No runners yet · Create one →
-                      </button>
-                    ) : (
-                      <>
-                        {(pickerRunners ?? []).map((r) => {
-                          const thisSpawning = spawningRunnerId === r.id;
-                          const disabled = spawningRunnerId !== null;
-                          return (
-                            <button
-                              key={r.id}
-                              type="button"
-                              role="option"
-                              aria-selected={false}
-                              disabled={disabled}
-                              onClick={() => void spawnDirectChatFromPicker(r)}
-                              className="flex w-full cursor-pointer items-center justify-between gap-2 rounded px-2.5 py-2 text-left transition-colors hover:bg-raised disabled:cursor-default disabled:opacity-60 disabled:hover:bg-transparent"
-                            >
-                              <span className="truncate font-mono text-[13px] text-fg">
-                                @{r.handle}
-                              </span>
-                              <span className="shrink-0 rounded bg-bg px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-fg-2">
-                                {thisSpawning ? "Starting…" : r.runtime}
-                              </span>
-                            </button>
-                          );
-                        })}
-                        {pickerError ? (
-                          <p className="px-2.5 py-1 text-[11px] text-danger">
-                            {pickerError}
-                          </p>
-                        ) : null}
-                      </>
-                    )}
-                  </div>
-                ) : null}
-              </div>
+              <CollapsibleSectionHeader
+                label="CHAT"
+                count={directSessions.length}
+                open={sessionsOpen}
+                onToggle={toggleSessions}
+                onPlus={handleNewDirectChat}
+                plusTitle="Start a chat"
+                plusExpanded={creatingChat}
+              />
               {sessionsOpen ? (
                 <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-3 pt-1">
                   {directSessions.length === 0 ? (
@@ -898,6 +760,17 @@ export function Sidebar({
           setCreatingMission(false);
           void refreshMissions();
           navigate(`/missions/${mission.id}`);
+        }}
+      />
+
+      <StartChatModal
+        open={creatingChat}
+        onClose={() => setCreatingChat(false)}
+        onStarted={(spawned, handle) => {
+          setCreatingChat(false);
+          navigate(`/runners/${handle}/chat/${spawned.id}`, {
+            state: { sessionStatus: "running" },
+          });
         }}
       />
 
@@ -1074,8 +947,8 @@ function CollapsibleSectionHeader({
   onToggle: () => void;
   onPlus: () => void;
   plusTitle: string;
-  /** When the `+` opens a popover, pass `true` while it's open so the
-   *  trigger advertises `aria-haspopup="listbox"` + `aria-expanded`. */
+  /** When the `+` opens a dialog (modal), pass its open state so the
+   *  trigger advertises `aria-haspopup="dialog"` + `aria-expanded`. */
   plusExpanded?: boolean;
 }) {
   const Chevron = open ? ChevronDown : ChevronRight;
@@ -1099,7 +972,7 @@ function CollapsibleSectionHeader({
         onClick={onPlus}
         title={plusTitle}
         aria-label={plusTitle}
-        aria-haspopup={plusExpanded === undefined ? undefined : "listbox"}
+        aria-haspopup={plusExpanded === undefined ? undefined : "dialog"}
         aria-expanded={plusExpanded}
         className="cursor-pointer rounded p-1 text-fg-2 transition-colors hover:bg-bg hover:text-fg"
       >

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,9 +4,10 @@
 //   - WORKSPACE: search (placeholder), runner, crew nav links.
 //   - MISSION:   collapsible header with count + `+` (Start Mission), one row
 //                per running mission. The currently-open mission is highlighted.
-//   - SESSION:   collapsible header with count + `+` (jump to runners list),
-//                one row per live direct-chat. The currently-open
-//                direct chat is highlighted.
+//   - SESSION:   collapsible header with count + `+` (opens an inline
+//                runner-picker popover that spawns a direct chat in
+//                place), one row per live direct-chat. The currently-
+//                open direct chat is highlighted.
 //
 // MISSION pulls from `mission_list_summary` (filtered to status === "running").
 // SESSION continues to consume `runner/activity` events for live direct chats.
@@ -52,7 +53,8 @@ import {
   unmarkArchivingMission,
   unmarkArchivingSession,
 } from "../lib/archivingState";
-import type { AppendedEvent, MissionSummary } from "../lib/types";
+import { readDefaultWorkingDir } from "../lib/settings";
+import type { AppendedEvent, MissionSummary, Runner } from "../lib/types";
 import { StartMissionModal } from "./StartMissionModal";
 import { SettingsModal } from "./SettingsModal";
 import { CommandPalette } from "./CommandPalette";
@@ -164,6 +166,17 @@ export function Sidebar({
   // instead of its label. Submit (Enter) → session_rename + refresh.
   // Cancel (Escape / blur with no change) → close without write.
   const [renamingId, setRenamingId] = useState<string | null>(null);
+
+  // CHAT `+` runner-picker popover. Lazy-loaded on first open; the cached
+  // list stays around so subsequent opens render immediately while a
+  // refetch runs in the background. `spawningRunnerId` gates concurrent
+  // spawns and drives the per-row "Starting…" affordance.
+  const [chatPickerOpen, setChatPickerOpen] = useState(false);
+  const [pickerRunners, setPickerRunners] = useState<Runner[] | null>(null);
+  const [pickerLoading, setPickerLoading] = useState(false);
+  const [pickerError, setPickerError] = useState<string | null>(null);
+  const [spawningRunnerId, setSpawningRunnerId] = useState<string | null>(null);
+  const chatPickerRef = useRef<HTMLDivElement | null>(null);
 
   // Identify the currently-open runtime so we can highlight the matching
   // sidebar row. `useMatch` returns null when the URL doesn't match.
@@ -478,12 +491,83 @@ export function Sidebar({
     [navigate, location.pathname],
   );
 
-  // SESSION's `+` button — direct chats are spawned from a runner, so we
-  // route to the runners list and let the user pick. A future v0.x could
-  // open an inline runner-picker popover instead.
-  const handleNewDirectChat = useCallback(() => {
-    navigate("/runners");
-  }, [navigate]);
+  // CHAT `+` button — opens an inline runner-picker popover (GH #104).
+  // Direct chats are spawned from a runner; the popover lets the user
+  // pick one without leaving the sidebar context. We also force the
+  // CHAT section open so the spawned row lands visibly. Runner list is
+  // lazy-loaded on each open (small, rare).
+  const openChatPicker = useCallback(() => {
+    setChatPickerOpen(true);
+    setPickerError(null);
+    if (!sessionsOpen) {
+      setSessionsOpen(true);
+      setStoredFlag(STORAGE_SESSION_OPEN, true);
+    }
+    setPickerLoading(true);
+    api.runner
+      .list()
+      .then((rows) => setPickerRunners(rows))
+      .catch((e) => setPickerError(String(e)))
+      .finally(() => setPickerLoading(false));
+  }, [sessionsOpen]);
+
+  const closeChatPicker = useCallback(() => {
+    setChatPickerOpen(false);
+    setPickerError(null);
+  }, []);
+
+  // Spawn a direct chat for the picked runner. Mirrors the spawn-then-
+  // navigate dance in Runners.tsx / RunnerDetail.tsx — the
+  // working_dir-vs-fallback rule is load-bearing: only override cwd
+  // when the runner has none of its own.
+  const spawnDirectChatFromPicker = useCallback(
+    async (runner: Runner) => {
+      if (spawningRunnerId) return;
+      setSpawningRunnerId(runner.id);
+      setPickerError(null);
+      try {
+        const fallbackCwd = runner.working_dir
+          ? null
+          : (readDefaultWorkingDir() || null);
+        const spawned = await api.session.startDirect(
+          runner.id,
+          fallbackCwd,
+          null,
+          null,
+        );
+        setChatPickerOpen(false);
+        navigate(`/runners/${runner.handle}/chat/${spawned.id}`, {
+          state: { sessionStatus: "running" },
+        });
+      } catch (e) {
+        setPickerError(String(e));
+      } finally {
+        setSpawningRunnerId(null);
+      }
+    },
+    [navigate, spawningRunnerId],
+  );
+
+  // Outside-click + Escape close. Mirrors the crewPickerRef pattern in
+  // StartMissionModal.tsx.
+  useEffect(() => {
+    if (!chatPickerOpen) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (!chatPickerRef.current) return;
+      if (!chatPickerRef.current.contains(e.target as Node)) {
+        setChatPickerOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setChatPickerOpen(false);
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [chatPickerOpen]);
 
   const toggleMissions = useCallback(() => {
     setMissionsOpen((prev) => {
@@ -660,14 +744,75 @@ export function Sidebar({
             <div className="h-8 shrink-0" />
 
             <section className="flex min-h-0 flex-[2] basis-0 flex-col">
-              <CollapsibleSectionHeader
-                label="CHAT"
-                count={directSessions.length}
-                open={sessionsOpen}
-                onToggle={toggleSessions}
-                onPlus={handleNewDirectChat}
-                plusTitle="Start a chat"
-              />
+              <div ref={chatPickerRef} className="relative">
+                <CollapsibleSectionHeader
+                  label="CHAT"
+                  count={directSessions.length}
+                  open={sessionsOpen}
+                  onToggle={toggleSessions}
+                  onPlus={openChatPicker}
+                  plusTitle="Start a chat"
+                  plusExpanded={chatPickerOpen}
+                />
+                {chatPickerOpen ? (
+                  <div
+                    role="listbox"
+                    aria-label="Pick a runner to chat with"
+                    className="absolute left-3 right-3 top-full z-30 mt-1 max-h-56 overflow-y-auto rounded-md border border-line bg-panel p-1 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
+                  >
+                    {pickerRunners === null && pickerLoading ? (
+                      <div className="px-2.5 py-2 text-xs text-fg-3">
+                        Loading…
+                      </div>
+                    ) : pickerError && (pickerRunners?.length ?? 0) === 0 ? (
+                      <div className="px-2.5 py-1 text-[11px] text-danger">
+                        {pickerError}
+                      </div>
+                    ) : pickerRunners && pickerRunners.length === 0 ? (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          closeChatPicker();
+                          navigate("/runners");
+                        }}
+                        className="flex w-full cursor-pointer items-center gap-1 rounded px-2.5 py-2 text-left text-xs text-fg-2 transition-colors hover:bg-raised hover:text-fg"
+                      >
+                        No runners yet · Create one →
+                      </button>
+                    ) : (
+                      <>
+                        {(pickerRunners ?? []).map((r) => {
+                          const thisSpawning = spawningRunnerId === r.id;
+                          const disabled = spawningRunnerId !== null;
+                          return (
+                            <button
+                              key={r.id}
+                              type="button"
+                              role="option"
+                              aria-selected={false}
+                              disabled={disabled}
+                              onClick={() => void spawnDirectChatFromPicker(r)}
+                              className="flex w-full cursor-pointer items-center justify-between gap-2 rounded px-2.5 py-2 text-left transition-colors hover:bg-raised disabled:cursor-default disabled:opacity-60 disabled:hover:bg-transparent"
+                            >
+                              <span className="truncate font-mono text-[13px] text-fg">
+                                @{r.handle}
+                              </span>
+                              <span className="shrink-0 rounded bg-bg px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-fg-2">
+                                {thisSpawning ? "Starting…" : r.runtime}
+                              </span>
+                            </button>
+                          );
+                        })}
+                        {pickerError ? (
+                          <p className="px-2.5 py-1 text-[11px] text-danger">
+                            {pickerError}
+                          </p>
+                        ) : null}
+                      </>
+                    )}
+                  </div>
+                ) : null}
+              </div>
               {sessionsOpen ? (
                 <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-3 pt-1">
                   {directSessions.length === 0 ? (
@@ -921,6 +1066,7 @@ function CollapsibleSectionHeader({
   onToggle,
   onPlus,
   plusTitle,
+  plusExpanded,
 }: {
   label: string;
   count: number;
@@ -928,6 +1074,9 @@ function CollapsibleSectionHeader({
   onToggle: () => void;
   onPlus: () => void;
   plusTitle: string;
+  /** When the `+` opens a popover, pass `true` while it's open so the
+   *  trigger advertises `aria-haspopup="listbox"` + `aria-expanded`. */
+  plusExpanded?: boolean;
 }) {
   const Chevron = open ? ChevronDown : ChevronRight;
   return (
@@ -950,6 +1099,8 @@ function CollapsibleSectionHeader({
         onClick={onPlus}
         title={plusTitle}
         aria-label={plusTitle}
+        aria-haspopup={plusExpanded === undefined ? undefined : "listbox"}
+        aria-expanded={plusExpanded}
         className="cursor-pointer rounded p-1 text-fg-2 transition-colors hover:bg-bg hover:text-fg"
       >
         <Plus aria-hidden className="h-3 w-3" />

--- a/src/components/StartChatModal.tsx
+++ b/src/components/StartChatModal.tsx
@@ -1,0 +1,387 @@
+// Start Chat modal — sibling of StartMissionModal for the sidebar
+// CHAT `+`. Lets the user pick a runner, optionally name the chat,
+// and override the working directory before spawning a direct PTY.
+//
+// The runner-picker dropdown mirrors StartMissionModal's CrewPicker
+// (same classes / role / outside-click ref). The Modal shell already
+// owns Escape + backdrop close; only the inner dropdown needs its
+// own dismiss handlers.
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import { ChevronDown, X } from "lucide-react";
+
+import { api } from "../lib/api";
+import { readDefaultWorkingDir } from "../lib/settings";
+import type { Runner, SpawnedSession } from "../lib/types";
+import { Button } from "./ui/Button";
+import { Modal } from "./ui/Overlay";
+
+interface StartChatModalProps {
+  open: boolean;
+  onClose: () => void;
+  /** Called after spawn (and rename if title was provided). Caller owns
+   *  navigation to the spawned chat URL. */
+  onStarted: (spawned: SpawnedSession, runnerHandle: string) => void;
+}
+
+export function StartChatModal({
+  open,
+  onClose,
+  onStarted,
+}: StartChatModalProps) {
+  const [runners, setRunners] = useState<Runner[]>([]);
+  const [runnerId, setRunnerId] = useState<string>("");
+  const [runnerPickerOpen, setRunnerPickerOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  // Tracks whether the user has typed in the title field. While false
+  // the title auto-derives from the picked runner's handle; once true
+  // their text sticks even if they change the runner.
+  const [titleEdited, setTitleEdited] = useState(false);
+  // Synchronous mirror of `titleEdited` for closures that run *between*
+  // state-set and the next render — specifically the list-load `.then()`
+  // resolution and the onChange handler. We set the ref alongside every
+  // setTitleEdited call instead of mirroring via a passive effect, so
+  // there's no one-tick lag in either direction.
+  const titleEditedRef = useRef(false);
+  const [cwd, setCwd] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const runnerPickerRef = useRef<HTMLDivElement | null>(null);
+
+  // Reset on **close**, not open — so the *first* render after `open`
+  // flips back to true already paints clean state instead of flashing
+  // the previous session's selection. The open-path effect below then
+  // only has to drive the fetch.
+  useEffect(() => {
+    if (open) return;
+    setRunners([]);
+    setRunnerId("");
+    setRunnerPickerOpen(false);
+    setTitle("");
+    setTitleEdited(false);
+    titleEditedRef.current = false;
+    setCwd("");
+    setError(null);
+    setSubmitting(false);
+  }, [open]);
+
+  // Open-path: kick off the runner-list fetch and seed runnerId / title
+  // atomically when it lands. State is already clean from the close-path
+  // reset, so we don't repeat those resets here. The `cancelled` flag
+  // closes a stale-write race: if the user opens then closes (or
+  // reopens) before the promise resolves, the late `.then()` would
+  // otherwise undo the close-path's wipe and flash prior state.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void api.runner
+      .list()
+      .then((rows) => {
+        if (cancelled) return;
+        const first = rows[0] ?? null;
+        setRunners(rows);
+        setRunnerId(first?.id ?? "");
+        // Atomic initial title fill — the ref is the authoritative
+        // signal here, since a keystroke during the pre-load window
+        // would have flipped it true synchronously.
+        if (first && !titleEditedRef.current) {
+          setTitle(defaultTitleFor(first));
+        }
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  // Inner dropdown's own dismiss handlers. The Modal shell handles
+  // Escape/backdrop for the dialog itself; this scopes to the
+  // popover only.
+  useEffect(() => {
+    if (!runnerPickerOpen) return;
+    const onPointerDown = (e: MouseEvent) => {
+      if (!runnerPickerRef.current?.contains(e.target as Node)) {
+        setRunnerPickerOpen(false);
+      }
+    };
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setRunnerPickerOpen(false);
+    };
+    window.addEventListener("mousedown", onPointerDown, true);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("mousedown", onPointerDown, true);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [runnerPickerOpen]);
+
+  const selectedRunner = useMemo(
+    () => runners.find((r) => r.id === runnerId) ?? null,
+    [runners, runnerId],
+  );
+
+  // Follow runner-picker changes: while the user hasn't typed in the
+  // title field, re-derive the title from the currently-picked runner.
+  // The *initial* fill lives in the open-effect's list-load path
+  // (atomic with picking the first runner); this effect only handles
+  // subsequent user-driven picks.
+  useEffect(() => {
+    if (!open) return;
+    if (titleEdited) return;
+    if (!selectedRunner) return;
+    setTitle(defaultTitleFor(selectedRunner));
+  }, [open, selectedRunner, titleEdited]);
+
+  const browseCwd = async () => {
+    try {
+      const picked = await openDialog({
+        directory: true,
+        multiple: false,
+        title: "Pick a working directory",
+      });
+      if (typeof picked === "string") setCwd(picked);
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const start = async () => {
+    if (!selectedRunner) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      // Effective cwd precedence (matches Runners.tsx / RunnerDetail.tsx
+      // + the explicit-override extension):
+      //   user typed value  → use as-is
+      //   else runner has its own working_dir → null (backend uses
+      //                                         the runner's dir)
+      //   else readDefaultWorkingDir() or null
+      // The input is left blank by default and the placeholder shows
+      // what blank-leave will produce, so we don't have to thread a
+      // separate "edited" flag for this field.
+      const trimmedCwd = cwd.trim();
+      const effectiveCwd =
+        trimmedCwd.length > 0
+          ? trimmedCwd
+          : selectedRunner.working_dir
+            ? null
+            : (readDefaultWorkingDir() || null);
+      const spawned = await api.session.startDirect(
+        selectedRunner.id,
+        effectiveCwd,
+        null,
+        null,
+      );
+      const trimmedTitle = title.trim();
+      if (trimmedTitle.length > 0) {
+        try {
+          await api.session.rename(spawned.id, trimmedTitle);
+        } catch (e) {
+          // The chat is already spawned; sidebar's context menu can
+          // rename it later. Don't block navigation on a rename hiccup.
+          console.error("StartChatModal: session_rename failed", e);
+        }
+      }
+      onStarted(spawned, selectedRunner.handle);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={submitting ? () => {} : onClose}
+      title={
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-base font-semibold text-fg">
+              Start a chat
+            </span>
+            <span className="text-xs font-normal text-fg-2">
+              Spawns a direct PTY with the selected runner.
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded text-fg-3 transition-colors hover:bg-raised hover:text-fg disabled:pointer-events-none disabled:opacity-50"
+            aria-label="Close start chat"
+          >
+            <X aria-hidden className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      }
+      widthClass="w-full max-w-[560px]"
+      footer={
+        <>
+          <Button onClick={onClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => void start()}
+            disabled={submitting || !runnerId || runners.length === 0}
+          >
+            {submitting ? "Starting…" : "Start chat"}
+          </Button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-5">
+        {error ? (
+          <div className="rounded border border-danger/40 bg-danger/10 px-3 py-2 text-xs text-danger">
+            {error}
+          </div>
+        ) : null}
+
+        <Field label="Runner">
+          <div ref={runnerPickerRef} className="relative">
+            <button
+              type="button"
+              disabled={submitting || runners.length === 0}
+              onClick={() => setRunnerPickerOpen((v) => !v)}
+              className="flex w-full cursor-pointer items-center gap-3 rounded-md border border-line bg-bg px-3 py-2.5 text-left transition-colors hover:border-line-strong focus:border-fg-3 focus:outline-none disabled:cursor-default disabled:opacity-60"
+              aria-haspopup="listbox"
+              aria-expanded={runnerPickerOpen}
+            >
+              <span className="min-w-0 flex-1">
+                <span className="block truncate font-mono text-[13px] font-semibold text-fg">
+                  {selectedRunner ? `@${selectedRunner.handle}` : "No runners yet"}
+                </span>
+                <span className="block truncate text-[11px] text-fg-2">
+                  {summarizeRunner(selectedRunner)}
+                </span>
+              </span>
+              <ChevronDown aria-hidden className="h-3.5 w-3.5 text-fg-3" />
+            </button>
+            {runnerPickerOpen ? (
+              <div
+                role="listbox"
+                className="absolute left-0 right-0 top-full z-30 mt-1 max-h-56 overflow-y-auto rounded-md border border-line bg-panel p-1 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
+              >
+                {runners.map((r) => (
+                  <button
+                    key={r.id}
+                    type="button"
+                    role="option"
+                    aria-selected={r.id === runnerId}
+                    onClick={() => {
+                      setRunnerId(r.id);
+                      setRunnerPickerOpen(false);
+                    }}
+                    className={`flex w-full cursor-pointer items-center justify-between gap-3 rounded px-2.5 py-2 text-left transition-colors hover:bg-raised ${
+                      r.id === runnerId ? "bg-raised" : ""
+                    }`}
+                  >
+                    <span className="min-w-0">
+                      <span className="block truncate font-mono text-[13px] font-semibold text-fg">
+                        @{r.handle}
+                      </span>
+                      <span className="block truncate text-[11px] text-fg-2">
+                        {summarizeRunner(r)}
+                      </span>
+                    </span>
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+          {runners.length === 0 ? (
+            <p className="mt-1 text-[11px] text-warn">
+              No runners yet. Create one from the runner page first.
+            </p>
+          ) : null}
+        </Field>
+
+        <Field
+          label="Chat name"
+          subtitle="Optional. Leave blank to use the runner's default label."
+        >
+          <input
+            value={title}
+            onChange={(e) => {
+              setTitle(e.target.value);
+              titleEditedRef.current = true;
+              setTitleEdited(true);
+            }}
+            placeholder="e.g. quick-debug"
+            disabled={submitting}
+            className="rounded-md border border-line bg-bg px-3 py-2 text-[13px] text-fg placeholder:text-fg-3 focus:border-fg-3 focus:outline-none"
+          />
+        </Field>
+
+        <Field label="Working directory">
+          <div className="flex items-center gap-2">
+            <input
+              value={cwd}
+              onChange={(e) => setCwd(e.target.value)}
+              placeholder={cwdPlaceholderFor(selectedRunner)}
+              disabled={submitting}
+              className="min-w-0 flex-1 rounded-md border border-line bg-bg px-3 py-2 font-mono text-xs text-fg placeholder:text-fg-3 focus:border-fg-3 focus:outline-none"
+            />
+            <Button onClick={() => void browseCwd()} disabled={submitting}>
+              Browse…
+            </Button>
+          </div>
+          <p className="text-[11px] text-fg-2">
+            Leave blank to use the runner&apos;s working directory.
+          </p>
+        </Field>
+      </div>
+    </Modal>
+  );
+}
+
+function Field({
+  label,
+  subtitle,
+  children,
+}: {
+  label: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <label className="flex flex-col gap-1.5">
+      <span className="text-xs font-semibold text-fg">{label}</span>
+      {children}
+      {subtitle ? (
+        <span className="text-[11px] text-fg-3">{subtitle}</span>
+      ) : null}
+    </label>
+  );
+}
+
+function summarizeRunner(runner: Runner | null): string {
+  if (!runner) return "Create a runner first.";
+  const wd = runner.working_dir ?? "no working dir";
+  return `${runner.runtime} · ${wd}`;
+}
+
+// Default Chat name when the user hasn't typed anything. Uses the
+// runner's `handle` (not `display_name`) so the title mirrors the URL
+// path the chat will land at.
+function defaultTitleFor(runner: Runner | null): string {
+  if (!runner) return "";
+  return `Chat with @${runner.handle}`;
+}
+
+// Dynamic placeholder for the working-directory input. Shows what
+// blank-leave will produce: the runner's own working_dir if set,
+// else the global settings default, else a parenthetical hint that
+// no directory will be passed.
+function cwdPlaceholderFor(runner: Runner | null): string {
+  if (runner?.working_dir) return runner.working_dir;
+  const fallback = readDefaultWorkingDir();
+  if (fallback) return fallback;
+  return "(no working directory)";
+}


### PR DESCRIPTION
## Summary
- Closes #104. The CHAT section's `+` opens a new `StartChatModal` (mirroring `StartMissionModal`) — picking a runner spawns a direct chat in place via `api.session.startDirect`, with no detour through `/runners`.
- Modal carries three fields: **Runner** picker (`api.runner.list()` with a CrewPicker-style two-line dropdown), optional **Chat name** (defaulted to `Chat with @<runner.handle>`, auto-updates when the runner pick changes unless the user has edited the field), and optional **Working directory** with `@tauri-apps/plugin-dialog` Browse.
- CWD precedence preserves the rule from `Runners.tsx` / `RunnerDetail.tsx`: user override > runner's own `working_dir` > `readDefaultWorkingDir()` > `null`. Blank input + runner-has-own-dir sends `null` so the runner-specific directory wins.
- Submit flow: `api.session.startDirect(runnerId, effectiveCwd, null, null)` → if title set, `api.session.rename(spawned.id, title)` (rename failures are logged and swallowed — chat is already spawned and renamable from the sidebar context menu) → navigate to `/runners/<handle>/chat/<sessionId>`.
- State is reset on **close** (not open) so a reopen never flashes prior selection; `titleEditedRef` mirrored synchronously into a ref to avoid a pre-load keystroke race; in-flight `runner.list()` guarded by a cancellation flag so a late-resolving promise can't write into a closed/reopened modal.
- `CollapsibleSectionHeader` gains an optional `plusExpanded` prop to thread `aria-haspopup="dialog"` / `aria-expanded`; MISSION call site is unaffected.

## Note on commit history
This branch's first commit (`d0ad0bd`) implemented an inline runner-picker popover; user feedback during review preferred a modal mirroring `StartMissionModal` for visual symmetry with the MISSION `+`. The second commit (`a887c5b`) is the final design — both will collapse on squash merge.

## Test plan
- [ ] Click CHAT `+` in the sidebar — modal opens; no `/runners` navigation.
- [ ] Runner picker dropdown lists runners; each row shows `@handle` + a runtime/working_dir subtitle. Outside-click and Escape close the dropdown without closing the modal.
- [ ] Chat name pre-fills to `Chat with @<handle>` for the initial runner. Switch runners in the picker — the name updates. Type into the name field — it locks; switching runners now leaves the typed value alone.
- [ ] CWD precedence walk:
  - [ ] Input filled, runner has `working_dir` → sends the typed value.
  - [ ] Input filled, runner has no `working_dir` → sends the typed value.
  - [ ] Input blank, runner has `working_dir` → sends `null` (runner's dir wins).
  - [ ] Input blank, runner has no `working_dir` → sends `readDefaultWorkingDir() || null`.
- [ ] Browse button opens the directory picker and fills the input.
- [ ] Click Start chat → new chat appears in the CHAT section and opens in the workspace; the chat row carries the typed/derived title.
- [ ] Rename failure (mock `session.rename` to reject): chat still spawns and navigates; an error is logged but not surfaced inline.
- [ ] Spawn failure (mock `session.startDirect` to reject): error renders inline (`text-danger`); modal stays open.
- [ ] Reopen-flash: open modal, close, reopen quickly — no flash of prior runner/title/cwd.
- [ ] Race: open modal, close before runners load — reopen sees a fresh fetch, not stale data.
- [ ] Zero runners: Start button stays disabled; inline warn line below the picker explains.
- [ ] MISSION `+` flow unchanged (still opens `StartMissionModal`).
- [ ] `tsc --noEmit` + lint clean (pre-existing `UpdateContext.tsx` fast-refresh warning is the only output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)