### PR TITLE
feat: app logging + crash reporting (#138)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,17 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -42,6 +53,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
+]
+
+[[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
 ]
 
 [[package]]
@@ -117,6 +145,12 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-broadcast"
@@ -327,6 +361,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,6 +404,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +453,40 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "schemars 1.2.1",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -514,6 +618,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -1037,6 +1147,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,6 +1229,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1220,6 +1349,12 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -1634,6 +1769,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1641,7 +1779,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -2298,6 +2436,9 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "mac"
@@ -2524,6 +2665,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -3163,6 +3313,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3213,6 +3383,12 @@ dependencies = [
  "rusqlite",
  "uuid",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -3426,6 +3602,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3503,6 +3688,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "runner"
 version = "0.1.12"
 dependencies = [
@@ -3510,6 +3724,7 @@ dependencies = [
  "chrono",
  "fs2",
  "libc",
+ "log",
  "notify",
  "r2d2",
  "r2d2_sqlite",
@@ -3521,6 +3736,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-shell",
@@ -3571,6 +3787,23 @@ dependencies = [
  "libsqlite3-sys",
  "serde_json",
  "smallvec",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.6",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3763,6 +3996,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -4067,6 +4306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4331,6 +4576,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tar"
 version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4518,6 +4769,28 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-log"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7545bd67f070a4500432c826e2e0682146a1d6712aee22a2786490156b574d93"
+dependencies = [
+ "android_logger",
+ "byte-unit",
+ "fern",
+ "log",
+ "objc2",
+ "objc2-foundation",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]
@@ -4788,7 +5061,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -4820,6 +5095,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
@@ -5212,6 +5502,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5235,6 +5531,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -6225,6 +6527,15 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,9 +18,11 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+tauri-plugin-log = "2"
 tauri-plugin-process = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-updater = "2"
+log = "0.4"
 serde = { workspace = true }
 serde_json = { workspace = true }
 base64 = "0.22"

--- a/src-tauri/src/cli_install.rs
+++ b/src-tauri/src/cli_install.rs
@@ -49,8 +49,8 @@ const DEST_BIN_NAME: &str = if cfg!(windows) {
 
 pub fn install_runner_cli(app_data_dir: &Path) -> Result<()> {
     let Some(source) = locate_source()? else {
-        eprintln!(
-            "runner: bundled CLI ({SOURCE_BIN_NAME}) not found next to current_exe; \
+        log::warn!(
+            "bundled CLI ({SOURCE_BIN_NAME}) not found next to current_exe; \
              skipping install. Sessions that invoke `runner` will error until the \
              binary is on PATH. Build the CLI with `cargo build -p runner-cli` and \
              relaunch."

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -1,4 +1,5 @@
 use tauri::{AppHandle, Manager};
+use tauri_plugin_opener::OpenerExt;
 
 use crate::error::Error;
 
@@ -12,5 +13,35 @@ pub fn app_ready(app: AppHandle) -> crate::error::Result<()> {
         .ok_or_else(|| Error::msg("main window not found"))?;
     window.show().map_err(|e| Error::msg(e.to_string()))?;
     window.set_focus().map_err(|e| Error::msg(e.to_string()))?;
+    Ok(())
+}
+
+/// Reveal the app log directory in the system file browser.
+///
+/// On macOS this is `~/Library/Logs/com.wycstudios.runner/`, where
+/// `tauri-plugin-log` writes `runner.log` (+ rotations). Surfaced via
+/// the Help → "Reveal logs in Finder" menu and the Settings →
+/// Diagnostics pane; both routes call this same command.
+#[tauri::command]
+pub fn runner_logs_reveal(app: AppHandle) -> crate::error::Result<()> {
+    reveal_logs_dir(&app)
+}
+
+/// Shared backend for both menu and Settings-pane entry points.
+pub(crate) fn reveal_logs_dir(app: &AppHandle) -> crate::error::Result<()> {
+    let dir = app
+        .path()
+        .app_log_dir()
+        .map_err(|e| Error::msg(format!("resolve log dir: {e}")))?;
+    // `tauri-plugin-log` lazily creates the dir on first write. If
+    // the user clicks "Reveal" before any log line has been emitted
+    // (race-y but possible during very early startup), create it
+    // ourselves so the opener has something to point at.
+    if !dir.exists() {
+        std::fs::create_dir_all(&dir).map_err(|e| Error::msg(format!("create log dir: {e}")))?;
+    }
+    app.opener()
+        .open_path(dir.to_string_lossy().to_string(), None::<String>)
+        .map_err(|e| Error::msg(format!("open log dir: {e}")))?;
     Ok(())
 }

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -517,6 +517,12 @@ pub async fn mission_start(
         let mut conn = state.db.get()?;
         start(&mut conn, &state.app_data_dir, input)?
     };
+    log::info!(
+        "mission starting: id={} crew={} title={:?}",
+        out.mission.id,
+        out.mission.crew_id,
+        out.mission.title,
+    );
 
     // Mission row + opening events are durable. Now spawn one PTY per
     // slot. This loop is **all-or-nothing**: if any spawn fails we kill
@@ -735,6 +741,11 @@ pub async fn mission_start(
     }
 
     state.routers.register(out.mission.id.clone(), router);
+    log::info!(
+        "mission started: id={} sessions={}",
+        out.mission.id,
+        spawned_pairs.len(),
+    );
     Ok(out)
 }
 
@@ -761,6 +772,7 @@ pub async fn mission_attach(
     app: tauri::AppHandle,
     mission_id: String,
 ) -> Result<Mission> {
+    log::info!("mission attach: id={mission_id}");
     ensure_mission_router_mounted(&state, &app, &mission_id).await?;
     let conn = state.db.get()?;
     get(&conn, &mission_id)
@@ -903,20 +915,26 @@ pub(crate) async fn reattach_all_running_missions(
 ) -> HashSet<String> {
     let mission_ids = match state.db.get() {
         Ok(conn) => list_running_mission_ids(&conn).unwrap_or_else(|e| {
-            eprintln!("runner: reattach_all_running_missions query failed: {e}");
+            log::error!("reattach_all_running_missions query failed: {e}");
             Vec::new()
         }),
         Err(e) => {
-            eprintln!("runner: reattach_all_running_missions db pool unavailable: {e}");
+            log::error!("reattach_all_running_missions db pool unavailable: {e}");
             Vec::new()
         }
     };
 
     let mut failed = HashSet::new();
     for mission_id in mission_ids {
-        if let Err(e) = ensure_mission_router_mounted(state, app, &mission_id).await {
-            eprintln!("runner: mission {mission_id} reattach failed: {e}");
-            failed.insert(mission_id);
+        match ensure_mission_router_mounted(state, app, &mission_id).await {
+            Ok(()) => {
+                log::info!("mission reattach: id={mission_id} action=mounted");
+            }
+            Err(e) => {
+                log::info!("mission reattach: id={mission_id} action=mount_failed → stop");
+                log::warn!("mission {mission_id} mount-failed reattach: {e}");
+                failed.insert(mission_id);
+            }
         }
     }
     failed
@@ -948,6 +966,7 @@ fn list_running_mission_ids(conn: &Connection) -> rusqlite::Result<Vec<String>> 
 /// For end-of-mission, see `mission_archive`.
 #[tauri::command]
 pub async fn mission_stop(state: State<'_, AppState>, id: String) -> Result<Mission> {
+    log::info!("mission stop: id={id}");
     state.sessions.kill_all_for_mission(&id)?;
     let conn = state.db.get()?;
     get(&conn, &id)

--- a/src-tauri/src/event_bus/mod.rs
+++ b/src-tauri/src/event_bus/mod.rs
@@ -185,7 +185,7 @@ impl EventBus {
                 // can rehydrate after a reopen and so any backlog the writer
                 // produced before the watcher attached is delivered.
                 if let Err(e) = state.tick(&log, emitter_for_thread.as_ref()) {
-                    eprintln!("event_bus[{mission_id_for_thread}]: initial tick failed: {e}");
+                    log::error!("initial tick failed for mission {mission_id_for_thread}: {e}");
                 }
                 loop {
                     // recv_timeout lets us notice shutdown without a notify
@@ -201,7 +201,7 @@ impl EventBus {
                     // shutdown flag and exit before notify delivered the
                     // terminal write, dropping the event silently.
                     if let Err(e) = state.tick(&log, emitter_for_thread.as_ref()) {
-                        eprintln!("event_bus[{mission_id_for_thread}]: tick failed: {e}");
+                        log::error!("tick failed for mission {mission_id_for_thread}: {e}");
                     }
                     if shutting {
                         return;
@@ -295,9 +295,11 @@ impl BusState {
     fn tick(&mut self, log: &EventLog, emitter: &dyn BusEmitter) -> Result<()> {
         let (entries, skipped) = log.read_from_lossy(self.next_offset)?;
         for skip in &skipped {
-            eprintln!(
-                "event_bus[{}]: skipping malformed line at offset {} ({})",
-                self.mission_id, skip.offset, skip.error
+            log::warn!(
+                "skipping malformed line for mission {} at offset {} ({})",
+                self.mission_id,
+                skip.offset,
+                skip.error
             );
         }
         // Compute the new `next_offset` from the max of every line seen this
@@ -373,9 +375,10 @@ impl BusState {
         // entry as read and hide every future entry whose ULID came before
         // "zzzz" — which, given Crockford's alphabet, is all of them.
         if up_to.parse::<ulid::Ulid>().is_err() {
-            eprintln!(
-                "event_bus[{}]: dropping inbox_read with non-ULID up_to {:?}",
-                self.mission_id, up_to
+            log::warn!(
+                "dropping inbox_read with non-ULID up_to {:?} for mission {}",
+                up_to,
+                self.mission_id
             );
             return;
         }
@@ -457,6 +460,7 @@ impl BusRegistry {
             return Ok(Arc::clone(existing));
         }
         let bus = EventBus::for_mission(mission_id.clone(), mission_dir, roster, emitter)?;
+        log::info!("bus mounted: mission={mission_id}");
         buses.insert(mission_id, Arc::clone(&bus));
         Ok(bus)
     }
@@ -465,6 +469,7 @@ impl BusRegistry {
         let bus = self.buses.lock().unwrap().remove(mission_id);
         if let Some(bus) = bus {
             bus.stop();
+            log::info!("bus unmounted: mission={mission_id}");
         }
     }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -370,9 +370,9 @@ fn build_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
             .close_window()
             .build()?;
 
-        return MenuBuilder::new(app)
+        MenuBuilder::new(app)
             .items(&[&app_menu, &edit_menu, &view_menu, &window_menu, &help_menu])
-            .build();
+            .build()
     }
     #[cfg(not(target_os = "macos"))]
     {
@@ -399,10 +399,9 @@ fn default_log_path() -> PathBuf {
         let home = std::env::var_os("HOME")
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from("/"));
-        return home
-            .join("Library/Logs")
+        home.join("Library/Logs")
             .join(APP_IDENTIFIER)
-            .join("runner.log");
+            .join("runner.log")
     }
     #[cfg(target_os = "linux")]
     {
@@ -410,14 +409,14 @@ fn default_log_path() -> PathBuf {
             .map(PathBuf::from)
             .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")))
             .unwrap_or_else(|| PathBuf::from("/tmp"));
-        return base.join(APP_IDENTIFIER).join("logs").join("runner.log");
+        base.join(APP_IDENTIFIER).join("logs").join("runner.log")
     }
     #[cfg(target_os = "windows")]
     {
         let base = std::env::var_os("LOCALAPPDATA")
             .map(PathBuf::from)
             .unwrap_or_else(|| PathBuf::from("."));
-        return base.join(APP_IDENTIFIER).join("logs").join("runner.log");
+        base.join(APP_IDENTIFIER).join("logs").join("runner.log")
     }
     #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
     PathBuf::from("runner.log")

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,14 +4,29 @@ mod db;
 mod error;
 mod event_bus;
 mod model;
+mod panic_hook;
 mod router;
 mod session;
 mod shell_path;
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use tauri::Manager;
+#[cfg(target_os = "macos")]
+use tauri::menu::{AboutMetadataBuilder, PredefinedMenuItem};
+use tauri::menu::{Menu, MenuBuilder, MenuItemBuilder, SubmenuBuilder};
+use tauri::{AppHandle, Manager, Wry};
+use tauri_plugin_log::{Builder as LogBuilder, RotationStrategy, Target, TargetKind};
+
+/// Bundle identifier as declared in `tauri.conf.json`. Used by:
+///
+/// 1. The pre-builder fallback panic-log path (so panics that fire
+///    before `tauri-plugin-log`'s setup callback runs still land in
+///    the same dir the plugin itself will write to once it boots).
+/// 2. The `identifier_matches_tauri_conf` test, which string-asserts
+///    `tauri.conf.json` against this constant — catches a silent
+///    rename in either direction.
+pub const APP_IDENTIFIER: &str = "com.wycstudios.runner";
 
 pub struct AppState {
     pub db: Arc<db::DbPool>,
@@ -35,7 +50,42 @@ pub struct AppState {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    // Install the panic hook BEFORE the Tauri builder. The fallback
+    // path mirrors the dir `tauri-plugin-log` will resolve from the
+    // bundle identifier; both writes (the `log::error!` line and the
+    // direct-file append from the hook) end up next to each other.
+    panic_hook::install(default_log_path());
+
+    let default_level = if cfg!(debug_assertions) {
+        log::LevelFilter::Debug
+    } else {
+        log::LevelFilter::Info
+    };
+    let log_levels = std::env::var("RUST_LOG")
+        .ok()
+        .map(|raw| parse_rust_log(&raw, default_level))
+        .unwrap_or(LogLevels {
+            global: default_level,
+            per_target: Vec::new(),
+        });
+
+    let mut log_builder = LogBuilder::new()
+        .targets([
+            Target::new(TargetKind::LogDir {
+                file_name: Some("runner".into()),
+            }),
+            #[cfg(debug_assertions)]
+            Target::new(TargetKind::Stdout),
+        ])
+        .level(log_levels.global)
+        .max_file_size(10 * 1024 * 1024)
+        .rotation_strategy(RotationStrategy::KeepSome(3));
+    for (target, level) in log_levels.applied_targets() {
+        log_builder = log_builder.level_for(target, level);
+    }
+
     tauri::Builder::default()
+        .plugin(log_builder.build())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
@@ -61,6 +111,10 @@ pub fn run() {
                 }
             };
             std::fs::create_dir_all(&app_data_dir)?;
+
+            // First line of every app start. Triage-from-log starts here.
+            log_startup_banner(app.handle(), &app_data_dir);
+
             let db_path = app_data_dir.join("runner.db");
             let pool = Arc::new(db::open_pool(&db_path)?);
             // Session reconciliation now happens AFTER the
@@ -78,7 +132,7 @@ pub fn run() {
             // try to invoke `runner` — surfaced as a runtime stderr from
             // the agent rather than a startup hang.
             if let Err(e) = cli_install::install_runner_cli(&app_data_dir) {
-                eprintln!("runner: failed to install bundled CLI: {e}");
+                log::error!("failed to install bundled CLI: {e}");
             }
 
             // Resolve the user's login-shell PATH once at startup so
@@ -164,10 +218,27 @@ pub fn run() {
             );
 
             app.manage(state);
+
+            // Build the app menu and wire the `runner_logs_reveal`
+            // menu item to the same handler the Settings →
+            // Diagnostics button calls. Done in `setup` (not at the
+            // builder level) so we get a real `AppHandle` for the
+            // menu's child item builders.
+            let menu = build_menu(app.handle())?;
+            app.set_menu(menu)?;
+            app.on_menu_event(|app, ev| {
+                if ev.id() == "runner_logs_reveal" {
+                    if let Err(e) = commands::app::reveal_logs_dir(app) {
+                        log::error!("reveal logs failed: {e}");
+                    }
+                }
+            });
+
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
             commands::app::app_ready,
+            commands::app::runner_logs_reveal,
             commands::crew::crew_list,
             commands::crew::crew_get,
             commands::crew::crew_create,
@@ -216,4 +287,301 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+/// First log line on every app start. Captures the four things
+/// triage usually wants up front: version, app_data_dir, OS/arch,
+/// and tmux version.
+fn log_startup_banner(app: &AppHandle, app_data_dir: &Path) {
+    let pkg = app.package_info();
+    let tmux = std::process::Command::new("tmux")
+        .arg("-V")
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_else(|| "(unavailable)".to_string());
+    log::info!(
+        "starting {} v{} on {}-{}; app_data_dir={}; {}",
+        pkg.name,
+        pkg.version,
+        std::env::consts::OS,
+        std::env::consts::ARCH,
+        app_data_dir.display(),
+        tmux,
+    );
+}
+
+/// Build the application menu. On macOS we recreate the full
+/// standard menu (App / Edit / View / Window / Help) so the system
+/// shortcuts (Cmd+C/V/X, Cmd+W, Cmd+Q, fullscreen, …) stay wired up
+/// — calling `set_menu` with a smaller menu would strip them. On
+/// other platforms we only attach Help; standard shortcuts there
+/// flow through the webview without a menu bar.
+fn build_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
+    let reveal_logs =
+        MenuItemBuilder::with_id("runner_logs_reveal", "Reveal logs in Finder").build(app)?;
+    let help_menu = SubmenuBuilder::new(app, "Help")
+        .item(&reveal_logs)
+        .build()?;
+
+    #[cfg(target_os = "macos")]
+    {
+        let pkg = app.package_info();
+        let about_meta = AboutMetadataBuilder::new()
+            .name(Some(pkg.name.clone()))
+            .version(Some(pkg.version.to_string()))
+            .build();
+        let about = PredefinedMenuItem::about(app, Some("About Runner"), Some(about_meta))?;
+
+        let app_menu = SubmenuBuilder::new(app, "Runner")
+            .item(&about)
+            .separator()
+            .services()
+            .separator()
+            .hide()
+            .hide_others()
+            .show_all()
+            .separator()
+            .quit()
+            .build()?;
+
+        let edit_menu = SubmenuBuilder::new(app, "Edit")
+            .undo()
+            .redo()
+            .separator()
+            .cut()
+            .copy()
+            .paste()
+            .select_all()
+            .build()?;
+
+        let view_menu = SubmenuBuilder::new(app, "View").fullscreen().build()?;
+
+        let window_menu = SubmenuBuilder::new(app, "Window")
+            .minimize()
+            .maximize()
+            .separator()
+            .close_window()
+            .build()?;
+
+        return MenuBuilder::new(app)
+            .items(&[&app_menu, &edit_menu, &view_menu, &window_menu, &help_menu])
+            .build();
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        MenuBuilder::new(app).items(&[&help_menu]).build()
+    }
+}
+
+/// Compute the path `tauri-plugin-log` would resolve for the LogDir
+/// target, BEFORE any Tauri runtime exists. Used by the pre-builder
+/// panic hook as a fallback sink so a panic during plugin init still
+/// lands next to the eventual `runner.log`.
+///
+/// Mirrors the plugin's platform conventions:
+///
+/// - macOS:   `$HOME/Library/Logs/<identifier>/runner.log`
+/// - Linux:   `$XDG_DATA_HOME` (or `$HOME/.local/share`) `/<identifier>/logs/runner.log`
+/// - Windows: `$LOCALAPPDATA/<identifier>/logs/runner.log`
+///
+/// Best-effort env lookups with sane fallbacks — we'd rather write
+/// a panic line into `./runner.log` than lose it.
+fn default_log_path() -> PathBuf {
+    #[cfg(target_os = "macos")]
+    {
+        let home = std::env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("/"));
+        return home
+            .join("Library/Logs")
+            .join(APP_IDENTIFIER)
+            .join("runner.log");
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let base = std::env::var_os("XDG_DATA_HOME")
+            .map(PathBuf::from)
+            .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".local/share")))
+            .unwrap_or_else(|| PathBuf::from("/tmp"));
+        return base.join(APP_IDENTIFIER).join("logs").join("runner.log");
+    }
+    #[cfg(target_os = "windows")]
+    {
+        let base = std::env::var_os("LOCALAPPDATA")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("."));
+        return base.join(APP_IDENTIFIER).join("logs").join("runner.log");
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    PathBuf::from("runner.log")
+}
+
+/// Parsed `RUST_LOG` directives. `global` always carries a value
+/// (the caller's default if the env var is unset / unparseable);
+/// `per_target` is empty unless one or more `target=level` pairs
+/// were present.
+struct LogLevels {
+    global: log::LevelFilter,
+    per_target: Vec<(String, log::LevelFilter)>,
+}
+
+impl LogLevels {
+    /// Expand parsed pairs into the final list handed to
+    /// `Builder::level_for`. Aliases `runner` → also `runner_lib`, the
+    /// real crate name (set by `[lib] name` in `src-tauri/Cargo.toml`).
+    ///
+    /// Spec §Phase 2 documents `RUST_LOG=runner=debug` as the dev
+    /// escape hatch, so we honor that exact form. Without the alias
+    /// the directive would silently no-op against
+    /// `runner_lib::*` targets, which is where every `log::` macro in
+    /// this crate actually emits from.
+    ///
+    /// A user-supplied `runner_lib=…` directive is preserved as-is —
+    /// `level_for` is idempotent per target, so a duplicate from
+    /// `runner` aliasing on top would only re-assert the same level.
+    fn applied_targets(&self) -> Vec<(String, log::LevelFilter)> {
+        let mut out = Vec::with_capacity(self.per_target.len());
+        for (target, level) in &self.per_target {
+            out.push((target.clone(), *level));
+            if target == "runner" {
+                out.push(("runner_lib".to_string(), *level));
+            }
+        }
+        out
+    }
+}
+
+/// Tiny `RUST_LOG` parser. Supports the two forms the spec calls
+/// out:
+///
+/// ```text
+/// RUST_LOG=debug                 → global = Debug
+/// RUST_LOG=runner=debug,info     → per-target runner=Debug, global = Info
+/// ```
+///
+/// More-elaborate `env_logger` grammar (regex filters, span scopes,
+/// etc.) is intentionally out of scope. Unrecognized fragments are
+/// silently skipped — they fall back to the caller-supplied default
+/// instead of taking the whole filter down with them.
+fn parse_rust_log(input: &str, default_global: log::LevelFilter) -> LogLevels {
+    let mut global = default_global;
+    let mut per_target = Vec::new();
+    for part in input.split(',') {
+        let part = part.trim();
+        if part.is_empty() {
+            continue;
+        }
+        match part.split_once('=') {
+            Some((target, level)) => {
+                if let Some(lf) = parse_level(level) {
+                    per_target.push((target.trim().to_string(), lf));
+                }
+            }
+            None => {
+                if let Some(lf) = parse_level(part) {
+                    global = lf;
+                }
+            }
+        }
+    }
+    LogLevels { global, per_target }
+}
+
+fn parse_level(s: &str) -> Option<log::LevelFilter> {
+    match s.trim().to_ascii_lowercase().as_str() {
+        "off" => Some(log::LevelFilter::Off),
+        "error" => Some(log::LevelFilter::Error),
+        "warn" => Some(log::LevelFilter::Warn),
+        "info" => Some(log::LevelFilter::Info),
+        "debug" => Some(log::LevelFilter::Debug),
+        "trace" => Some(log::LevelFilter::Trace),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Identifier ↔ log-path safety net: `tauri-plugin-log` resolves
+    // `LogDir` via the bundle identifier in tauri.conf.json, and our
+    // pre-builder fallback log path uses the same constant. A rename
+    // that touches only one side would silently send logs to a
+    // different dir than the panic-hook fallback — this test wedges
+    // both sides against `APP_IDENTIFIER`.
+    #[test]
+    fn identifier_matches_tauri_conf() {
+        let raw = include_str!("../tauri.conf.json");
+        let v: serde_json::Value = serde_json::from_str(raw).expect("parse tauri.conf.json");
+        let ident = v
+            .get("identifier")
+            .and_then(|s| s.as_str())
+            .expect("identifier field");
+        assert_eq!(ident, APP_IDENTIFIER);
+    }
+
+    #[test]
+    fn parse_rust_log_global_only() {
+        let l = parse_rust_log("debug", log::LevelFilter::Info);
+        assert_eq!(l.global, log::LevelFilter::Debug);
+        assert!(l.per_target.is_empty());
+    }
+
+    #[test]
+    fn parse_rust_log_per_target_with_default() {
+        let l = parse_rust_log("runner=debug,info", log::LevelFilter::Warn);
+        assert_eq!(l.global, log::LevelFilter::Info);
+        assert_eq!(
+            l.per_target,
+            vec![("runner".to_string(), log::LevelFilter::Debug)]
+        );
+    }
+
+    #[test]
+    fn parse_rust_log_invalid_falls_back_to_default() {
+        let l = parse_rust_log("garbage,also-garbage=nope", log::LevelFilter::Info);
+        assert_eq!(l.global, log::LevelFilter::Info);
+        assert!(l.per_target.is_empty());
+    }
+
+    // Spec phase-2 escape hatch: `RUST_LOG=runner=debug` must actually
+    // bind to the `runner_lib::*` targets every `log::` macro in this
+    // crate emits from. The `[lib] name = "runner"` in Cargo.toml is
+    // "runner" on the dependency-graph side but the resulting crate
+    // module path is `runner_lib`. Alias both so the documented
+    // directive works without the user having to know the lib rename.
+    #[test]
+    fn runner_alias_expands_to_runner_lib() {
+        let l = parse_rust_log("runner=debug", log::LevelFilter::Info);
+        let applied = l.applied_targets();
+        assert!(
+            applied.contains(&("runner".to_string(), log::LevelFilter::Debug)),
+            "applied set must contain runner; got {applied:?}",
+        );
+        assert!(
+            applied.contains(&("runner_lib".to_string(), log::LevelFilter::Debug)),
+            "applied set must contain runner_lib alias; got {applied:?}",
+        );
+    }
+
+    #[test]
+    fn runner_lib_directive_does_not_double_apply() {
+        // If a user writes `runner_lib=debug` directly, we don't add a
+        // synthetic `runner` entry — only the alias goes the other
+        // direction. (`level_for` is idempotent per target anyway, but
+        // keeping the applied set tight makes the test cheap to read.)
+        let l = parse_rust_log("runner_lib=debug", log::LevelFilter::Info);
+        let applied = l.applied_targets();
+        assert_eq!(
+            applied,
+            vec![("runner_lib".to_string(), log::LevelFilter::Debug)]
+        );
+    }
 }

--- a/src-tauri/src/panic_hook.rs
+++ b/src-tauri/src/panic_hook.rs
@@ -1,0 +1,91 @@
+//! Panic hook that writes the panic body + a captured backtrace to
+//! the same `log::error!` sink as the rest of the app, then chains
+//! to the previously-installed hook.
+//!
+//! Chaining is deliberate: the default hook prints to stderr and is
+//! what the OS CrashReporter keys on. Replacing it outright would
+//! suppress that stderr line; we only want to *add* a persistent log
+//! line in front of the existing abort/unwind path.
+//!
+//! Two writes happen per panic:
+//!
+//!  1. `log::error!(...)` — picked up by `tauri-plugin-log` once its
+//!     setup callback has installed the global `log` subscriber. The
+//!     usual path for any panic after Tauri's plugins have come up.
+//!
+//!  2. A direct best-effort append to `fallback_path`. Covers the
+//!     window between `install()` and the plugin's setup running —
+//!     panics during builder construction, plugin construction, or
+//!     another plugin's setup land somewhere persistent even though
+//!     no `log` subscriber has attached yet. This is the "next
+//!     user-reported crash is unrecoverable" case spec #18 exists to
+//!     fix.
+//!
+//! The two writes are independent — the file target uses a separate
+//! fd, so we don't try to dedupe. Two log lines per crash is fine.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::PathBuf;
+
+pub fn install(fallback_path: PathBuf) {
+    let prev = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let bt = std::backtrace::Backtrace::force_capture();
+        log::error!("panic: {info}\n{bt}");
+        // Direct-file fallback: append to fallback_path so a panic
+        // that fires before the log plugin's setup callback runs
+        // still has a persistent home. Best-effort: we're already
+        // panicking, so swallow every error here.
+        let _ = write_fallback(&fallback_path, info, &bt);
+        prev(info);
+    }));
+}
+
+fn write_fallback(
+    path: &PathBuf,
+    info: &std::panic::PanicHookInfo<'_>,
+    bt: &std::backtrace::Backtrace,
+) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut f = OpenOptions::new().create(true).append(true).open(path)?;
+    let ts = chrono::Utc::now().to_rfc3339();
+    writeln!(f, "[{ts}] panic: {info}\n{bt}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Combined smoke test: installing the hook must (a) not break
+    // the test harness — libtest's panic capture still gets called
+    // via the prev() chain so the panicking thread still produces
+    // `Err` on join — and (b) write the panic body to the fallback
+    // file even when no `log` subscriber is attached (the case the
+    // direct-file write exists for).
+    //
+    // Kept as a single test so the global `set_hook` only fires
+    // once per test process; chained installs across multiple tests
+    // would otherwise leak panics from unrelated tests into our
+    // fallback file.
+    #[test]
+    fn install_writes_fallback_and_preserves_harness() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("runner.log");
+        install(path.clone());
+        let h = std::thread::spawn(|| panic!("intentional-marker-xyz"));
+        let res = h.join();
+        assert!(res.is_err(), "panic must still propagate to join");
+        let contents = std::fs::read_to_string(&path).expect("fallback file written");
+        assert!(
+            contents.contains("panic:"),
+            "fallback file must contain panic header; got: {contents}",
+        );
+        assert!(
+            contents.contains("intentional-marker-xyz"),
+            "fallback file must contain panic body; got: {contents}",
+        );
+    }
+}

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -237,9 +237,11 @@ impl Router {
         // tolerate at least the same set of histories the bus does.
         let (entries, skipped) = self.log.read_from_lossy(0)?;
         for skip in &skipped {
-            eprintln!(
-                "router[{}]: reconstruct skipping malformed line at offset {} ({})",
-                self.mission_id, skip.offset, skip.error,
+            log::warn!(
+                "reconstruct skipping malformed line for mission {} at offset {} ({})",
+                self.mission_id,
+                skip.offset,
+                skip.error,
             );
         }
 
@@ -400,8 +402,8 @@ impl Router {
             serde_json::json!({ "state": "busy" }),
         );
         if let Err(e) = self.log.append(draft) {
-            eprintln!(
-                "router[{}]: failed to append synthetic runner_status busy for @{handle}: {e}",
+            log::error!(
+                "failed to append synthetic runner_status busy for @{handle} on mission {}: {e}",
                 self.mission_id,
             );
             return;
@@ -490,7 +492,7 @@ impl Router {
         // assertions still observe one body push.
         if delay.is_zero() {
             if let Err(e) = self.injector.inject_paste_with_verify(&session_id, &body) {
-                eprintln!("router: inline verified-paste to {session_id} failed: {e}");
+                log::error!("inline verified-paste to {session_id} failed: {e}");
             }
             return;
         }
@@ -501,7 +503,7 @@ impl Router {
             // `delay` here would push the lead launch prompt past
             // 4s before the first paste even tries.
             if let Err(e) = injector.inject_paste_with_verify(&session_id, &body) {
-                eprintln!("router: delayed verified-paste to {session_id} failed: {e}");
+                log::error!("delayed verified-paste to {session_id} failed: {e}");
             }
         });
     }
@@ -629,9 +631,10 @@ impl Router {
             serde_json::json!({ "message": message }),
         );
         if let Err(e) = self.log.append(draft) {
-            eprintln!(
-                "router[{}]: failed to append mission_warning ({}): {e}",
-                self.mission_id, message,
+            log::error!(
+                "failed to append mission_warning for mission {} ({}): {e}",
+                self.mission_id,
+                message,
             );
         }
     }
@@ -677,8 +680,8 @@ impl Router {
         match self.log.append(draft) {
             Ok(ev) => Some(ev.id),
             Err(e) => {
-                eprintln!(
-                    "router[{}]: failed to append human_question: {e}",
+                log::error!(
+                    "failed to append human_question for mission {}: {e}",
                     self.mission_id
                 );
                 None
@@ -784,11 +787,14 @@ impl RouterRegistry {
     }
 
     pub fn register(&self, mission_id: String, router: Arc<Router>) {
+        log::info!("router mounted: mission={mission_id}");
         self.routers.lock().unwrap().insert(mission_id, router);
     }
 
     pub fn unregister(&self, mission_id: &str) {
-        self.routers.lock().unwrap().remove(mission_id);
+        if self.routers.lock().unwrap().remove(mission_id).is_some() {
+            log::info!("router unmounted: mission={mission_id}");
+        }
     }
 
     #[allow(dead_code)] // Exposed for the future workspace UI bridge.

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -95,8 +95,8 @@ fn open_mission_event_log(
     match EventLog::open(&mission_dir) {
         Ok(log) => Some(Arc::new(log)),
         Err(e) => {
-            eprintln!(
-                "runner: open event log for mission {mission_id} ({}): {e}",
+            log::error!(
+                "open event log for mission {mission_id} ({}): {e}",
                 mission_dir.display(),
             );
             None
@@ -656,6 +656,7 @@ impl SessionManager {
         }
 
         let stop = output.stop_flag();
+        let pane_for_log = rt_session.pane.clone();
         self.sessions.lock().unwrap().insert(
             session_id.clone(),
             SessionHandle {
@@ -697,6 +698,14 @@ impl SessionManager {
             runner,
             &plan,
             first_turn_delivered_via_argv,
+        );
+
+        log::info!(
+            "session spawn: mission={} session={} runner={} pane={}",
+            mission.id,
+            session_id,
+            slot.slot_handle,
+            pane_for_log,
         );
 
         Ok(SpawnedSession {
@@ -1390,9 +1399,9 @@ impl SessionManager {
                             match outcome {
                                 AppendOutcome::Ok => {
                                     if drop_streak > 0 {
-                                        eprintln!(
-                                            "forwarder[{session_id}]: runner_status emit \
-                                             recovered after {drop_streak} dropped events \
+                                        log::info!(
+                                            "runner_status emit recovered for {session_id} \
+                                             after {drop_streak} dropped events \
                                              ({drop_total} total this session)",
                                         );
                                     }
@@ -1402,9 +1411,9 @@ impl SessionManager {
                                     drop_streak += 1;
                                     drop_total += 1;
                                     if drop_streak_is_loggable(drop_streak) {
-                                        eprintln!(
-                                            "forwarder[{session_id}]: runner_status emit \
-                                             failing; {drop_streak} events dropped in a row \
+                                        log::error!(
+                                            "runner_status emit failing for {session_id}; \
+                                             {drop_streak} events dropped in a row \
                                              ({drop_total} total this session)",
                                         );
                                     }
@@ -1588,8 +1597,8 @@ impl SessionManager {
             .runtime
             .capture_visible(&rt_session)
             .unwrap_or_else(|e| {
-                eprintln!(
-                    "runner: first-prompt baseline capture for {session_id} failed: {e} \
+                log::warn!(
+                    "first-prompt baseline capture for {session_id} failed: {e} \
                      (proceeding with zero baselines)"
                 );
                 Vec::new()
@@ -1619,8 +1628,8 @@ impl SessionManager {
             let after = match self.runtime.capture_visible(&rt_session) {
                 Ok(b) => b,
                 Err(e) => {
-                    eprintln!(
-                        "runner: first-prompt capture for {session_id} attempt {attempt} failed: {e}"
+                    log::warn!(
+                        "first-prompt capture for {session_id} attempt {attempt} failed: {e}"
                     );
                     if !config.between_attempts.is_zero() {
                         std::thread::sleep(config.between_attempts);
@@ -1848,7 +1857,7 @@ impl SessionManager {
         let rows: Vec<RowSnap> = match collect_running_rows(&pool) {
             Ok(rows) => rows,
             Err(e) => {
-                eprintln!("runner: reattach query failed: {e}");
+                log::warn!("reattach query failed: {e}");
                 return;
             }
         };
@@ -1901,14 +1910,22 @@ impl SessionManager {
                     // it via the existing reconcile path. Marking
                     // it stopped here would create a UI/DB-vs-tmux
                     // mismatch.
-                    eprintln!(
-                        "runner: reattach failed to stop mission session {} \
+                    log::warn!(
+                        "reattach failed to stop mission session {} \
                          after mount failure: {e}",
                         row_dbg(&row.id)
                     );
                     return;
                 }
                 mark_session_stopped(pool, &row.id, now);
+                // Decision INFO fires only on the happy path —
+                // stop succeeded AND the row was actually marked.
+                // The Err branch above already returns without
+                // marking; a top-of-branch INFO would have lied.
+                log::info!(
+                    "session reattach: id={} action=stopped reason=mission_mount_failed",
+                    row_dbg(&row.id)
+                );
             }
             Ok(Some(s)) if s.alive => {
                 // Mission and direct rows take the same alive-pane
@@ -1923,17 +1940,24 @@ impl SessionManager {
                 // is still running and lying in the DB would strand
                 // it.
                 let id = row.id.clone();
+                let pane_for_log = rt_session.pane.clone();
                 let rt_for_cleanup = rt_session.clone();
                 if let Err(e) = self.attach_existing(row, rt_session, pool, events, app_data_dir) {
-                    eprintln!("runner: reattach session {} failed: {e}", row_dbg(&id));
+                    log::warn!("reattach session {} failed: {e}", row_dbg(&id));
                     match self.runtime.stop(&rt_for_cleanup) {
                         Ok(()) => mark_session_stopped(pool, &id, now),
-                        Err(e) => eprintln!(
-                            "runner: reattach orphan-stop for {} failed: {e}; \
+                        Err(e) => log::warn!(
+                            "reattach orphan-stop for {} failed: {e}; \
                              leaving row as running",
                             row_dbg(&id)
                         ),
                     }
+                } else {
+                    log::info!(
+                        "session reattach: id={} action=resumed pane={}",
+                        row_dbg(&id),
+                        pane_for_log,
+                    );
                 }
             }
             Ok(Some(status)) => {
@@ -1945,6 +1969,7 @@ impl SessionManager {
                 } else {
                     "crashed"
                 };
+                let exit_code = status.exit_code;
                 let _ = self.runtime.stop(&rt_session);
                 if let Ok(conn) = pool.get() {
                     let _ = conn.execute(
@@ -1955,10 +1980,19 @@ impl SessionManager {
                         params![row.id, final_status, now],
                     );
                 }
+                log::info!(
+                    "session reattach: id={} action=stopped reason=pane_exited code={:?}",
+                    row_dbg(&row.id),
+                    exit_code,
+                );
             }
             Ok(None) | Err(_) => {
                 // tmux can't find the pane — terminal-unavailable.
                 mark_session_stopped(pool, &row.id, now);
+                log::info!(
+                    "session reattach: id={} action=stopped reason=pane_gone",
+                    row_dbg(&row.id)
+                );
             }
         }
     }
@@ -2268,8 +2302,8 @@ fn schedule_mission_first_prompt(
     // rather than re-introducing the paste race the plan got rid
     // of.
     if !delivered_via_argv {
-        eprintln!(
-            "runner: first-turn argv not delivered for {session_id} (runtime {}); skipping post-spawn injection",
+        log::warn!(
+            "first-turn argv not delivered for {session_id} (runtime {}); skipping post-spawn injection",
             runner.runtime,
         );
     }
@@ -2305,8 +2339,8 @@ fn schedule_direct_first_prompt(
         return;
     }
     if !delivered_via_argv {
-        eprintln!(
-            "runner: first-turn argv not delivered for direct chat {session_id} (runtime {}); skipping post-spawn injection",
+        log::warn!(
+            "first-turn argv not delivered for direct chat {session_id} (runtime {}); skipping post-spawn injection",
             runner.runtime,
         );
     }
@@ -2379,13 +2413,11 @@ fn schedule_continue_on_resume(
         // Inline path under `cfg(test)` so synchronous output
         // assertions can observe the injection.
         if let Err(e) = mgr.inject_paste_with_verify(&session_id, b"continue", config) {
-            eprintln!(
-                "runner: continue-on-resume verify failed for {session_id}: {e}; sending fallback Enter"
+            log::warn!(
+                "continue-on-resume verify failed for {session_id}: {e}; sending fallback Enter"
             );
             if let Err(ee) = mgr.send_enter(&session_id) {
-                eprintln!(
-                    "runner: continue-on-resume fallback Enter for {session_id} failed: {ee}"
-                );
+                log::error!("continue-on-resume fallback Enter for {session_id} failed: {ee}");
             }
         }
         return;
@@ -2393,13 +2425,11 @@ fn schedule_continue_on_resume(
     let mgr = Arc::clone(mgr);
     std::thread::spawn(move || {
         if let Err(e) = mgr.inject_paste_with_verify(&session_id, b"continue", config) {
-            eprintln!(
-                "runner: continue-on-resume verify failed for {session_id}: {e}; sending fallback Enter"
+            log::warn!(
+                "continue-on-resume verify failed for {session_id}: {e}; sending fallback Enter"
             );
             if let Err(ee) = mgr.send_enter(&session_id) {
-                eprintln!(
-                    "runner: continue-on-resume fallback Enter for {session_id} failed: {ee}"
-                );
+                log::error!("continue-on-resume fallback Enter for {session_id} failed: {ee}");
             }
         }
     });

--- a/src-tauri/src/session/tmux_runtime.rs
+++ b/src-tauri/src/session/tmux_runtime.rs
@@ -1639,7 +1639,7 @@ mod tests {
     #[ignore]
     fn integration_spawn_and_observe() {
         let Some(rt) = test_runtime("spawn-and-observe") else {
-            eprintln!("tmux not available — skipping");
+            log::warn!("tmux not available — skipping");
             return;
         };
         let (session, rx) = spawn_echo(&rt, "spawnobs01", "hello-from-tmux").unwrap();

--- a/src-tauri/src/shell_path.rs
+++ b/src-tauri/src/shell_path.rs
@@ -61,8 +61,8 @@ pub fn resolve_login_shell_path() -> Option<String> {
     {
         Ok(c) => c,
         Err(e) => {
-            eprintln!(
-                "runner: shell PATH resolution via `{shell}` failed to spawn ({e}); falling back to launchd PATH"
+            log::warn!(
+                "shell PATH resolution via `{shell}` failed to spawn ({e}); falling back to launchd PATH"
             );
             return None;
         }
@@ -76,7 +76,7 @@ pub fn resolve_login_shell_path() -> Option<String> {
         None => {
             let _ = child.kill();
             let _ = child.wait();
-            eprintln!("runner: shell PATH resolution lost stdout pipe; falling back");
+            log::warn!("shell PATH resolution lost stdout pipe; falling back");
             return None;
         }
     };
@@ -99,8 +99,8 @@ pub fn resolve_login_shell_path() -> Option<String> {
                 if Instant::now() >= deadline {
                     let _ = child.kill();
                     let _ = child.wait();
-                    eprintln!(
-                        "runner: shell PATH resolution via `{shell}` timed out after {}s; killed shell; falling back to launchd PATH",
+                    log::warn!(
+                        "shell PATH resolution via `{shell}` timed out after {}s; killed shell; falling back to launchd PATH",
                         RESOLVE_TIMEOUT.as_secs()
                     );
                     return None;
@@ -110,8 +110,8 @@ pub fn resolve_login_shell_path() -> Option<String> {
             Err(e) => {
                 let _ = child.kill();
                 let _ = child.wait();
-                eprintln!(
-                    "runner: shell PATH resolution via `{shell}` failed waiting ({e}); falling back to launchd PATH"
+                log::warn!(
+                    "shell PATH resolution via `{shell}` failed waiting ({e}); falling back to launchd PATH"
                 );
                 return None;
             }
@@ -119,8 +119,8 @@ pub fn resolve_login_shell_path() -> Option<String> {
     };
 
     if !status.success() {
-        eprintln!(
-            "runner: shell PATH resolution via `{shell}` exited non-zero (status={:?}); falling back to launchd PATH",
+        log::warn!(
+            "shell PATH resolution via `{shell}` exited non-zero (status={:?}); falling back to launchd PATH",
             status.code()
         );
         return None;
@@ -129,8 +129,8 @@ pub fn resolve_login_shell_path() -> Option<String> {
     let stdout_bytes = match rx.recv_timeout(STDOUT_DRAIN_GRACE) {
         Ok(b) => b,
         Err(_) => {
-            eprintln!(
-                "runner: shell PATH resolution via `{shell}` produced no stdout in time; falling back"
+            log::warn!(
+                "shell PATH resolution via `{shell}` produced no stdout in time; falling back"
             );
             return None;
         }
@@ -138,8 +138,8 @@ pub fn resolve_login_shell_path() -> Option<String> {
     let stdout_str = String::from_utf8_lossy(&stdout_bytes);
     let parsed = extract_path_between_markers(&stdout_str);
     if parsed.is_none() {
-        eprintln!(
-            "runner: shell PATH resolution via `{shell}` returned no PATH between markers; falling back to launchd PATH"
+        log::warn!(
+            "shell PATH resolution via `{shell}` returned no PATH between markers; falling back to launchd PATH"
         );
     }
     parsed

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -17,6 +17,8 @@ import {
   BookText,
   Download,
   ExternalLink,
+  FileText,
+  FolderOpen,
   Info,
   Loader2,
   Minus,
@@ -29,6 +31,7 @@ import {
   X,
 } from "lucide-react";
 
+import { invoke } from "@tauri-apps/api/core";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { getVersion } from "@tauri-apps/api/app";
@@ -80,7 +83,7 @@ interface SettingsModalProps {
   onClose: () => void;
 }
 
-type Pane = "general" | "terminal" | "updates" | "about";
+type Pane = "general" | "terminal" | "diagnostics" | "updates" | "about";
 
 const PANES: { key: Pane; label: string; subtitle: string; icon: typeof SettingsIcon }[] = [
   {
@@ -94,6 +97,12 @@ const PANES: { key: Pane; label: string; subtitle: string; icon: typeof Settings
     label: "Terminal",
     subtitle: "xterm appearance",
     icon: Terminal,
+  },
+  {
+    key: "diagnostics",
+    label: "Diagnostics",
+    subtitle: "Logs & troubleshooting",
+    icon: FileText,
   },
   {
     key: "updates",
@@ -190,6 +199,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
           </button>
           {pane === "general" ? <GeneralPane /> : null}
           {pane === "terminal" ? <TerminalPane /> : null}
+          {pane === "diagnostics" ? <DiagnosticsPane /> : null}
           {pane === "updates" ? <UpdatesPane /> : null}
           {pane === "about" ? <AboutPane /> : null}
         </div>
@@ -551,6 +561,52 @@ function FontSizeStepper({
         <span className="font-mono text-[10px] text-fg-3">px</span>
       </span>
     </Stepper>
+  );
+}
+
+function DiagnosticsPane() {
+  // Mirrors the Help → "Reveal logs in Finder" menu item. Both routes
+  // invoke `runner_logs_reveal`, which resolves
+  // `~/Library/Logs/com.wycstudios.runner/` and hands it to the
+  // opener plugin. Dedicated pane (not buried in About) so #10/#13/#14
+  // diagnostic affordances have a home to grow into.
+  const [busy, setBusy] = useState(false);
+  const reveal = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await invoke("runner_logs_reveal");
+    } catch (e) {
+      // Best-effort: the only failure path is opener refusing the
+      // path or the log dir not yet existing. The backend creates
+      // the dir on demand, so a swallow here keeps the modal quiet —
+      // a follow-up could surface a toast.
+      console.error("reveal logs failed", e);
+    } finally {
+      setBusy(false);
+    }
+  };
+  return (
+    <>
+      <PaneHeader
+        title="Diagnostics"
+        subtitle="Logs and troubleshooting tools."
+      />
+      <Row
+        label="Application logs"
+        sub="Open the folder containing runner.log so you can attach it to a bug report."
+      >
+        <button
+          type="button"
+          onClick={() => void reveal()}
+          disabled={busy}
+          className="flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md border border-line bg-panel px-3 py-1.5 text-[12px] font-medium text-fg-2 transition-colors hover:border-line-strong hover:text-fg disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          <FolderOpen aria-hidden className="h-3 w-3" />
+          Reveal logs in Finder
+        </button>
+      </Row>
+    </>
   );
 }
 


### PR DESCRIPTION
Closes #138.

Implements [spec 18](docs/features/18-app-logging-and-crash-reporting.md): `tauri-plugin-log` with file rotation, panic hook with pre-logger fallback, `eprintln!` → `log::` sweep, Reveal Logs menu + Settings affordance.

## Summary

- `tauri-plugin-log` initialized at the OS log dir (`~/Library/Logs/com.wycstudios.runner/runner.log` on macOS) with 10MB rotation, keep last 3. Stdout target gated to debug builds.
- All 38 `eprintln!` sites in `src-tauri/src/` converted to `log::` at spec-rubric levels (error/warn/info/debug).
- Panic hook installed as the first line of `runner_lib::run()` — chains the previous hook, writes via `log::error!` AND a direct-file fallback so pre-logger panics (Tauri builder construction, plugin setup ordering) still land on disk.
- `RUST_LOG` is honored, with `runner` → `runner_lib` aliasing so the documented `RUST_LOG=runner=debug` form actually binds to this crate's targets.
- New INFO-level lifecycle markers on mission start/stop/attach, bus/router mount/unmount, session spawn, and the reattach decision branches.
- Help → Reveal Logs in Finder + Settings → Diagnostics → Reveal Logs button, both routing through `runner_logs_reveal`.
- Startup banner logs version, OS-arch, `app_data_dir`, and tmux version (best-effort, `(unavailable)` fallback).

## Tests

- New: `panic_hook::tests::install_writes_fallback_and_preserves_harness`.
- New: 5 tests in `lib.rs` covering `RUST_LOG` parser (global, per-target+default, all-garbage fallback) and the alias applier (`runner=` expands to both, `runner_lib=` does not double-apply).
- New: `tests::identifier_matches_tauri_conf` guards against an identifier rename silently breaking the log path.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test --workspace` (250 in `runner`, +5 new)
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run lint`
- [x] Manual smoke: banner appears in `runner.log` on fresh dev launch
- [x] Manual smoke: mission start emits `mission starting` → `session spawn`× N → `bus mounted` → `router mounted` → `mission started`
- [x] Manual smoke: app restart with live missions emits per-mission and per-session reattach decision INFO lines
- [x] Manual smoke: Help → Reveal Logs and Settings → Diagnostics → Reveal Logs both open the log dir
- [ ] Manual smoke: forced panic landing in log (skipped — covered by unit test asserting fallback writes the panic body)
- [ ] Manual smoke: rotation overflow (skipped — trust the plugin)

## Out of scope

Remote crash reporting, in-app log viewer, JSON formatter, per-mission app logs, log scrubbing — all explicitly deferred by spec §Out of scope.