### PR TITLE
fix(session): codex resume parity — capture on spawn + auto-continue (#137)

### DIFF
--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -2379,9 +2379,8 @@ fn schedule_direct_first_prompt(
 /// having to manually nudge it. Only fires when the resume actually
 /// reloaded a prior conversation (`plan.resuming == true` AND we
 /// have an `agent_session_key` to point claude-code at). For
-/// runtimes that don't have a real "resume" semantic (shell, or
-/// codex pre-capture), no-op — there's no conversation thread to
-/// continue.
+/// runtimes that don't have a real "resume" semantic (shell),
+/// no-op — there's no conversation thread to continue.
 ///
 /// Same readback-verified primitive as `inject_first_turn`. The
 /// resume case carries an extra subtlety: a resumed pane may
@@ -2416,7 +2415,7 @@ fn schedule_continue_on_resume(
     runner: &Runner,
     plan: &router::runtime::ResumePlan,
 ) {
-    if runner.runtime != "claude-code" {
+    if runner.runtime != "claude-code" && runner.runtime != "codex" {
         return;
     }
     if !plan.resuming {

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -602,7 +602,8 @@ impl SessionManager {
         // metadata yet) so a fast-failing runtime spawn doesn't leave
         // a half-row. We update with runtime metadata once the
         // runtime hands them back.
-        let started_at = Utc::now().to_rfc3339();
+        let started_at_dt = Utc::now();
+        let started_at = started_at_dt.to_rfc3339();
         {
             let conn = pool.get()?;
             conn.execute(
@@ -689,6 +690,19 @@ impl SessionManager {
         );
         if let Some(h) = self.sessions.lock().unwrap().get_mut(&session_id) {
             h.forwarder = Some(forwarder);
+        }
+
+        // Mirror the codex rollout capture from spawn_direct / resume so
+        // mission-slot spawns also populate agent_session_key for restart.
+        if runner.runtime == "codex" && plan.assigned_key.is_none() {
+            if let Some(cwd) = capture_cwd(resolved_cwd.clone()) {
+                crate::session::codex_capture::spawn_capture(
+                    session_id.clone(),
+                    cwd,
+                    started_at_dt,
+                    Arc::clone(&pool),
+                );
+            }
         }
 
         emit_runner_activity(&pool, runner, events.as_ref());

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1317,8 +1317,8 @@ impl SessionManager {
         // On a real resume (not a fresh-with-known-uuid spawn), nudge
         // the agent with "continue" so it picks up where it left off
         // without the user having to type. Skipped for fresh spawns
-        // — the first-prompt path covers those — and for non-claude-
-        // code runtimes that don't have a real resume semantic.
+        // — the first-prompt path covers those — and for runtimes
+        // without a real resume semantic (shell).
         schedule_continue_on_resume(self, session_id.to_string(), &runner, &plan);
 
         // Return the slot's in-mission identity for mission rows so the
@@ -2378,7 +2378,7 @@ fn schedule_direct_first_prompt(
 /// resume so the agent picks up where it left off without the user
 /// having to manually nudge it. Only fires when the resume actually
 /// reloaded a prior conversation (`plan.resuming == true` AND we
-/// have an `agent_session_key` to point claude-code at). For
+/// have an `agent_session_key` for the agent CLI to bind to). For
 /// runtimes that don't have a real "resume" semantic (shell),
 /// no-op — there's no conversation thread to continue.
 ///
@@ -4968,7 +4968,7 @@ mod tests {
 
     #[test]
     fn continue_resume_skips_for_non_claude_runtime() {
-        // codex / shell don't have a real "continue" semantic — the
+        // shell doesn't have a real "continue" semantic — the
         // function must no-op (no paste, no Enter) regardless of
         // `plan.resuming`.
         let fake = fake_runtime();


### PR DESCRIPTION
## Summary
Two related fixes for codex resume parity, both flowing from #137:

1. **Capture `agent_session_key` on mission spawn** — `SessionManager::spawn` (mission-slot path) now fires the codex rollout-capture watcher, matching `spawn_direct` and `resume`. Without this, the first restart after a fresh codex-backed mission found `agent_session_key = NULL`, codex re-spawned fresh, and the prior rollout under `~/.codex/sessions/` was orphaned.
2. **Auto-send "continue" on codex resume** — `schedule_continue_on_resume` was hardcoded claude-code-only. That was correct-by-accident before fix (1): every codex "resume" used to degrade to fresh spawn, so there was no thread to continue. Now that capture is wired and codex resumes drive `codex resume <uuid>` against a real prior rollout, the auto-continue nudge should fire there too.

Fixes #137.

## Approach
- **Commit 1** (`manager.rs:605`, `:692`): hoist `started_at` to `DateTime<Utc>` (single source for the DB string and the watcher), then mirror the codex-capture block from the two sibling sites after the forwarder install. Same guard (`runtime == "codex" && plan.assigned_key.is_none()`), same args.
- **Commit 2** (`manager.rs:2418`, docstring): expand the `schedule_continue_on_resume` guard from `runtime != "claude-code"` to also admit `"codex"`. Shell and future runtimes still excluded.

Total diff: 18+/5- in `src-tauri/src/session/manager.rs` only.

## Test plan
- [x] `cargo fmt --check`, `cargo check`, `cargo clippy -- -D warnings` — clean
- [x] `cargo test --lib session::manager` — 28/28 pass
- [ ] Manual: start a codex mission, take one turn, confirm `sessions.agent_session_key` is non-NULL. Quit + restart the app, resume the mission, confirm `codex resume <uuid>` is invoked AND the auto-"continue" nudge fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)