### PR TITLE
fix(terminal): route OSC 8 hyperlinks through plugin-opener

### DIFF
--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -151,6 +151,17 @@ export function RunnerTerminal({
       allowProposedApi: true,
       scrollSensitivity: 3,
       fastScrollSensitivity: 8,
+      // OSC 8 hyperlinks (emitted by claude-code and other modern CLIs) are
+      // handled by xterm natively, not by WebLinksAddon. The default activator
+      // calls window.open() which is a silent no-op in WKWebView/Tauri, so we
+      // route them through the same plugin-opener path as regex-detected URLs.
+      linkHandler: {
+        activate: (_event, uri) => {
+          void openUrl(uri).catch((err) => {
+            console.error("[terminal] OSC 8 openUrl failed:", err);
+          });
+        },
+      },
     });
     const fit = new FitAddon();
     term.loadAddon(fit);


### PR DESCRIPTION
## Summary
- Set `linkHandler` on the xterm `Terminal` options so OSC 8 hyperlink activations go through the same `plugin-opener` `openUrl()` path as `WebLinksAddon`. xterm handles OSC 8 escape sequences natively; its default activator calls `window.open()`, which silently no-ops in Tauri/WKWebView.
- Symptom this fixes: Claude Code (and other modern CLIs that emit OSC 8 hyperlinks — `gh`, `docker`, `git`'s newer versions) renders URLs as underlined-on-hover but plain-click and Cmd+click both did nothing in the packaged build. Plain regex-matched URLs (caught by `WebLinksAddon`) were unaffected, which made the bug look prod-only and link-source-specific instead of being a global OSC 8 routing miss.

## Test plan
- [x] `pnpm tauri build` locally (signed + notarized release config).
- [x] In the packaged app, ask Claude Code to print a URL; click the underlined URL → opens system browser.
- [x] Plain `echo "https://example.com"` in a shell pane is still clickable (regression check for `WebLinksAddon` path).
- [ ] After release, confirm the same in v0.1.14 from the GitHub release.

## Notes
- Diff is one option on the `Terminal` constructor. No new deps, no capability changes, no Rust changes.
- Earlier in the investigation the `tauri/devtools` Cargo feature appeared to fix this, which was a misread — the build where it "worked" coincidentally clicked a non-OSC-8 URL. Feature flag is intentionally **not** included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)