### PR TITLE
fix(terminal): alt-screen reattach for claude-code mission reopen

### DIFF
--- a/docs/impls/0009-terminal-alt-screen-reattach.md
+++ b/docs/impls/0009-terminal-alt-screen-reattach.md
@@ -1,0 +1,200 @@
+# Terminal Alt-Screen Reattach
+
+## Context
+
+Opening a previously-running mission whose lead is a claude-code (or any
+alt-screen TUI) session shows **stacked redraws** in xterm's main-screen
+scrollback. Each window resize or tab activation appends another copy of the
+agent's banner+brief+UI rather than overwriting the previous frame in place.
+Image attached to the discussion thread shows four banner stacks accumulated
+after a couple of resizes; user reports this gets worse the longer the mission
+runs.
+
+iTerm2 / Terminal.app / Warp do not show this behaviour with the same
+claude-code process. The difference is that those terminals see claude-code's
+original `ESC[?1049h` (enter alt-screen) at startup and stay on alt-screen for
+the lifetime of the process — every redraw replaces the alt-screen buffer
+in place, and main-screen scrollback is left untouched.
+
+### Why our reattach path drops the alt-screen state
+
+Two reasons stack:
+
+1. **`tmux capture-pane -p -e` emits rendered cells as text**, with SGR colour
+   escapes for styling, but **never** re-emits the mode-switching escapes
+   (`ESC[?1049h`, `ESC[?47h`, etc.) that originally put the pane into
+   alt-screen. `capture_replay_bytes` already detects alt-screen state via
+   `is_alternate_on(...)` (`src-tauri/src/session/tmux_runtime.rs:1190`) and
+   uses it to gate `-S - -E -` (full scrollback inclusion), but it doesn't
+   propagate that state to the consumer.
+
+2. **`output_buffers` is a bounded `VecDeque<OutputEvent>` of 4096 chunks**
+   (`src-tauri/src/session/manager.rs:44`). For long-running missions, the
+   original `ESC[?1049h` from claude-code's startup has long since rolled off
+   the deque. `output_snapshot()` returns chunks that *start mid-alt-screen* —
+   no enter escape anywhere in the byte stream.
+
+So on reattach:
+
+- xterm starts on main-screen (constructor default).
+- `term.reset()` in the replay path also leaves us on main-screen.
+- We write capture-pane text into main-screen.
+- The live `pipe-pane` stream resumes. claude-code's SIGWINCH redraws (one per
+  activation tab-switch via the resize dance, plus one per ResizeObserver tick
+  during a window drag) were emitted *assuming* alt-screen — they land in
+  main-screen instead, and each redraw scrolls the previous content up into
+  main-screen scrollback.
+
+### Why the SIGWINCH dance amplifies the symptom
+
+`RunnerTerminal.tsx:484-485` resizes the backend twice per activation
+(`cols-1 → cols`) to force claude-code to repaint. With xterm correctly on
+alt-screen, a single resize would already cause an in-place redraw — no
+stacking. With xterm on the wrong screen, the dance produces *two* visible
+stacked frames per activation. Switch between three runner tabs after a
+window resize and you've accumulated 6+ visible stacks.
+
+## Approach
+
+Re-emit the alt-screen entry escape from `capture_replay_bytes` when the pane
+is currently on alt-screen, so xterm enters alt-screen at attach time and the
+live byte stream lands where claude-code expects it to. Drop the SIGWINCH
+dance once the underlying state mismatch is fixed.
+
+### Trade-off
+
+Scrolling up in a claude-code pane after this change will show only the
+current alt-screen view (no "history of redraws" in scrollback). That matches
+iTerm2 / Terminal.app exactly. For conversation history, users rely on
+claude-code's own internal scroll (the same way iTerm2 users do).
+
+For non-alt-screen sessions (plain shells, codex's main-screen UI, build
+output), the path is unchanged — main-screen scrollback continues to work.
+
+---
+
+## Step 1: Prepend alt-screen-enter on reattach capture
+
+**File: `src-tauri/src/session/tmux_runtime.rs`**
+
+In `capture_replay_bytes` (line 1189), after invoking `tmux capture-pane` and
+verifying success, if `alt_on == true`, prepend `\x1b[?1049h\x1b[H` (enter
+alt-screen + cursor home) to the captured bytes before returning.
+
+The cursor-home is defensive: capture-pane's output starts at row 1 col 1 by
+default, but explicit positioning means a stale cursor state from xterm's
+reset can't drift the first cell of the replay.
+
+Do **not** modify the fresh-spawn branch (`capture_visible_region`) — fresh
+spawns capture from the pane before claude-code has had a chance to emit its
+own `ESC[?1049h`, and re-emitting it artificially would break the
+trim-leading-blank-lines path for non-TUI fresh spawns.
+
+```rust
+fn capture_replay_bytes(cmd: &Command, session: &RuntimeSession) -> RuntimeResult<Vec<u8>> {
+    let alt_on = is_alternate_on(cmd, &session.pane)?;
+    // ... existing capture-pane invocation ...
+    let mut bytes = out.stdout;
+    if alt_on {
+        // Re-emit the alt-screen entry so xterm.js enters alt-screen at
+        // attach time. capture-pane gives us rendered cells, not the
+        // mode-switching escapes the agent originally emitted; without
+        // this, subsequent live redraws from claude-code land in
+        // main-screen and stack in scrollback (see docs/impls/0009).
+        let mut with_alt = Vec::with_capacity(bytes.len() + 8);
+        with_alt.extend_from_slice(b"\x1b[?1049h\x1b[H");
+        with_alt.append(&mut bytes);
+        bytes = with_alt;
+    }
+    Ok(bytes)
+}
+```
+
+## Step 2: Drop the SIGWINCH dance in activation
+
+**File: `src/components/RunnerTerminal.tsx`**
+
+Replace the double-resize at lines 484-485:
+
+```ts
+void api.session.resize(sessionId, Math.max(2, cols - 1), rows)
+  .then(() => api.session.resize(sessionId, cols, rows))
+```
+
+with a single:
+
+```ts
+void api.session.resize(sessionId, cols, rows).catch(() => {
+  // session may have exited
+});
+```
+
+The dance existed to "wake claude-code into repainting" after an attach where
+the new cols equalled the old cols (no SIGWINCH delta to detect). With Step 1
+correctly entering alt-screen, claude-code's *one* redraw on the actual
+resize lands in alt-screen and overwrites in place — there's no scrollback
+to corrupt with the dance's extra redraw, and the visible viewport ends up
+identical either way.
+
+## Step 3: Update comments at attach_streaming
+
+**File: `src-tauri/src/session/tmux_runtime.rs`**
+
+In the `attach_streaming` block-comment (lines 805-829), add a note to Step 2
+("Reattach only: snapshot via capture-pane") that the snapshot now prepends
+`ESC[?1049h` for alt-screen panes, with a one-line rationale pointing at
+`docs/impls/0009`.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `src-tauri/src/session/tmux_runtime.rs` | Prepend `ESC[?1049h\x1b[H` in `capture_replay_bytes` when alt-screen is on. Update attach_streaming comment. |
+| `src/components/RunnerTerminal.tsx` | Replace SIGWINCH dance (two resizes) with a single resize call. |
+| `docs/impls/0009-terminal-alt-screen-reattach.md` | This document. |
+
+No backend API shape change. No DB migration. No new dependencies.
+
+## Verification
+
+### Manual (the canonical reproducer)
+
+1. Open a long-running mission with a claude-code lead. Confirm reopen works.
+2. Scroll up in the `@architect` pane after reattach. **Expected:** no banner
+   stacking — scrollback shows nothing above the current view (because
+   we're on alt-screen). **Regression signal:** stacked banners or stacked
+   conversation excerpts in scrollback.
+3. Resize the window a few times (drag the edge slowly). Scroll up again.
+   **Expected:** still no stacking.
+4. Switch tabs (`@architect` → `@impl` → `@reviewer`) several times. Scroll
+   up in each. **Expected:** alt-screen view is current, no stacked redraws.
+5. Run codex (alt-screen TUI) — same expectations.
+6. Run a plain shell command in a session (`echo hello`, `ls`). Scroll up.
+   **Expected:** main-screen scrollback works normally — this path is
+   gated on `alt_on == false`, unchanged.
+
+### Edge cases
+
+- **Fresh mission spawn.** `attach_streaming` takes the `is_fresh_spawn=true`
+  branch which uses `capture_visible_region`, not `capture_replay_bytes`.
+  Behaviour unchanged — fresh spawn captures the visible region and trims
+  leading blanks; claude-code's own `ESC[?1049h` flows through `pipe-pane`
+  naturally on first output.
+- **Agent exits while we're on alt-screen.** When the agent emits
+  `ESC[?1049l` (exit alt-screen) on shutdown, xterm returns to main-screen
+  with its prior contents — empty since we never wrote anything there.
+  Matches iTerm2 behaviour.
+- **Reattach to a session that's mid-transition from main to alt or back.**
+  `is_alternate_on` reads `#{alternate_on}` synchronously at capture time,
+  so we honour whatever state tmux thinks the pane is in at that instant. A
+  race where the agent toggles alt-screen between our `is_alternate_on`
+  check and the `capture-pane` call is theoretically possible but vanishingly
+  rare; worst case is one frame of mis-rendering that the next live byte
+  corrects.
+
+### Automated
+
+No new unit tests proposed — the bug lives in the interaction between
+tmux's capture format, xterm's mode machine, and the agent's redraw timing,
+none of which are easily testable in isolation without a full integration
+harness. Manual verification covers the regression path.

--- a/docs/impls/0010-terminal-replay-cols-alignment.md
+++ b/docs/impls/0010-terminal-replay-cols-alignment.md
@@ -1,0 +1,284 @@
+# Terminal Replay Cols Alignment
+
+> **Status: investigated, not implemented.**
+> The fix below pre-resizes xterm to the snapshot's cols/rows so the
+> *current* claude-code page paints correctly on reattach. After
+> implementing it locally, we discovered the residual symptom that
+> made us shelve it: **claude-code's previous "pages" (its own
+> internal scroll history) are still drifted**, because claude-code
+> only re-emits the current viewport on SIGWINCH — historical pages
+> are written at whatever cols was current at their original write
+> time, and no SIGWINCH from us causes the agent to re-emit them.
+> The terminal layer can't repair what the agent never re-paints.
+>
+> Keeping this plan committed as the durable record of the
+> investigation: the diagnosis (Ink absolute positioning vs.
+> codex's relative wrap, why quit+restart amplifies the cols
+> mismatch, why partial-fix the previous-page rendering is
+> impossible from our side) should save the next person from
+> re-deriving it. If someone returns to this with a strategy for
+> coaxing agents into re-emitting their full scroll history,
+> Steps 1–4 below are still the right shape for the *current*-page
+> half of the fix.
+
+## Context
+
+Follow-up to `0009-terminal-alt-screen-reattach.md`. After landing the
+alt-screen prepend + dropping the SIGWINCH dance, the *stacking* symptom
+went away — but quit-and-restart of the app still corrupts claude-code's
+terminal output. The user's example screenshot shows the architect's brief
+text rendered with progressively-shifting indentation on every line, with
+the visible right edge of the rendering box mid-screen (well inside xterm's
+actual cols) and large empty space to the right.
+
+### Why it only affects claude-code (not codex)
+
+The two TUIs differ in rendering strategy:
+
+- **claude-code** is built on Ink (React for CLI). Ink computes absolute cell
+  positions for every glyph and emits `ESC[<row>;<col>H` to place text. Its
+  layout is sized to *the cols it was rendered for*. Replaying those bytes
+  into an xterm at a different cols sends every positioning escape to the
+  wrong absolute coordinate — text scatters with the rendering-box edges
+  baked in at the wrong place. xterm cannot reflow alt-screen content (and
+  even main-screen reflow only works for `isWrapped` runs xterm emitted
+  itself, not agent-emitted absolute positions).
+- **codex** renders with relative positioning — print rows sequentially,
+  rely on terminal wrap. A cols mismatch leaves trailing space on the right
+  but the text reads correctly.
+
+So this is claude-code-specific because of Ink's absolute positioning.
+
+### Why quit+restart triggers it
+
+State at quit:
+
+- xterm at the user's current container cols (e.g. 200).
+- We pushed that cols to tmux on the last activation, so tmux pane is at 200.
+- claude-code is on alt-screen, drawing for 200.
+
+Quit + relaunch:
+
+1. `RunnerTerminal` mounts at the constructor default **cols=80, rows=24**
+   (`src/components/RunnerTerminal.tsx:142-144`).
+2. Mount effect fetches the snapshot. `attach_streaming` had already run in
+   the backend and queued a `Replay` from `capture_replay_bytes` — captured
+   at **tmux's current cols (200)**, now (post-0009) also prefixed with
+   `ESC[?1049h`.
+3. Frontend writes those 200-cols-wide bytes **into an 80-cols xterm**.
+4. Activation effect runs `fit.fit()` → xterm grows to container cols (200)
+   and we resize tmux back to 200.
+5. claude-code SIGWINCHes and does a *diff-based* redraw — only changed cells
+   are rewritten. The cells we mis-painted from step 3 stay broken.
+
+The corruption is permanent for the lifetime of the alt-screen view (until
+claude-code itself triggers a full redraw, which it rarely does).
+
+## Approach
+
+Replay the snapshot at *exactly* the cols claude-code was drawing for.
+Backend reports tmux's current pane cols/rows alongside the snapshot bytes;
+frontend resizes xterm to those dims *before* writing the bytes; only after
+the snapshot is in does `fit.fit()` resize to container cols and trigger the
+agent's clean in-alt-screen redraw at the new dims.
+
+For codex / plain shells / build output this is a no-op improvement — they
+were already rendering correctly at any cols; we're just no longer relying
+on that property.
+
+---
+
+## Step 1: Runtime accessor for pane cols/rows
+
+**File: `src-tauri/src/session/runtime.rs`**
+
+Add a method to the `SessionRuntime` trait:
+
+```rust
+/// Current cols/rows of the pane in the runtime's view. Used by
+/// the snapshot path to align xterm's grid with the bytes it's
+/// about to replay (see docs/impls/0010).
+fn pane_size(&self, session: &RuntimeSession) -> RuntimeResult<(u16, u16)>;
+```
+
+**File: `src-tauri/src/session/tmux_runtime.rs`**
+
+Implement via `tmux display-message -p -t <pane> '#{pane_width},#{pane_height}'`.
+Reuse the `clone_cmd` / status-check pattern already established by
+`is_alternate_on` (line 1218). Parse `"<cols>,<rows>\n"` defensively; map
+parse failure to `RuntimeError::TmuxFailed`.
+
+## Step 2: Bundle cols/rows into the snapshot API
+
+**File: `src-tauri/src/session/manager.rs`**
+
+New type adjacent to `OutputEvent`:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutputSnapshot {
+    pub events: Vec<OutputEvent>,
+    /// Pane dimensions at the moment of the snapshot. Frontend
+    /// resizes xterm to these *before* writing `events` so
+    /// absolute positioning escapes (claude-code/Ink) land at the
+    /// correct grid coordinates. Optional — `None` for sessions
+    /// whose runtime can't report the size.
+    pub cols: Option<u16>,
+    pub rows: Option<u16>,
+}
+```
+
+Replace `pub fn output_snapshot(&self, session_id: &str) -> Vec<OutputEvent>`
+with one that returns `OutputSnapshot`. Internally:
+
+1. Collect buffered events (current behaviour).
+2. Look up the `rt_session` for `session_id` in the live map.
+3. If present, call `runtime.pane_size(&rt_session)`. Treat any error as
+   "we don't know" → leave `cols`/`rows` as `None`.
+
+Sessions that have already terminated (no live rt_session) just get
+`cols: None, rows: None` — the events still replay; xterm just doesn't
+pre-resize. Acceptable degradation for dead sessions.
+
+**File: `src-tauri/src/commands/session.rs`**
+
+Update `session_output_snapshot` (line 138) return type from
+`Result<Vec<OutputEvent>>` to `Result<OutputSnapshot>`.
+
+## Step 3: Frontend pre-resize before replay
+
+**File: `src/lib/api.ts`**
+
+Update the `outputSnapshot` typing (line 178) to match the new struct:
+
+```ts
+interface SessionOutputSnapshot {
+  events: SessionOutputEvent[];
+  cols: number | null;
+  rows: number | null;
+}
+outputSnapshot: (sessionId: string) =>
+  invoke<SessionOutputSnapshot>("session_output_snapshot", { sessionId }),
+```
+
+**File: `src/components/RunnerTerminal.tsx`**
+
+In the mount effect, replace:
+
+```ts
+let snapshot: OutputEvent[] = [];
+try {
+  snapshot = await api.session.outputSnapshot(sessionId);
+} catch (e) { … }
+termRef.current?.reset();
+for (const ev of snapshot) { … }
+```
+
+with:
+
+```ts
+let snapshot: SessionOutputSnapshot = { events: [], cols: null, rows: null };
+try {
+  snapshot = await api.session.outputSnapshot(sessionId);
+} catch (e) { … }
+const t = termRef.current;
+t?.reset();
+if (t && snapshot.cols && snapshot.rows) {
+  // Match xterm's grid to the cols/rows the captured bytes were drawn
+  // for. claude-code/Ink emit absolute-positioning escapes (`ESC[r;cH`);
+  // replaying them into the wrong cols paints the alt-screen in the
+  // wrong cells and the agent's subsequent diff-based SIGWINCH redraw
+  // doesn't repair the miswritten regions. See docs/impls/0010.
+  try { t.resize(snapshot.cols, snapshot.rows); } catch { /* xterm guard */ }
+}
+for (const ev of snapshot.events) { … write … }
+```
+
+The activation effect's existing `fit.fit()` + `api.session.resize(cols,
+rows)` continues to run after replay — xterm grows from snapshot-cols to
+container-cols, tmux follows, claude-code SIGWINCHes and redraws once into
+the same alt-screen, in place. The redraw is diff-based so it cheaply
+updates the cells that need to change.
+
+## Step 4: Cleanup
+
+**File: `src-tauri/src/session/manager.rs`**
+
+Find any tests that assert on the shape of `output_snapshot`'s return type
+(grep for `output_snapshot`) and update to the new struct shape.
+
+Drop any now-redundant comments in the mount effect that explained the
+"replay-before-fit cols mismatch" rationale — Steps 1-3 supersede them.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `src-tauri/src/session/runtime.rs` | Add `pane_size` to `SessionRuntime` trait. |
+| `src-tauri/src/session/tmux_runtime.rs` | Implement `pane_size` via `tmux display-message`. |
+| `src-tauri/src/session/manager.rs` | New `OutputSnapshot` struct; `output_snapshot` returns it. Update tests. |
+| `src-tauri/src/commands/session.rs` | Update `session_output_snapshot` return type. |
+| `src/lib/api.ts` | Update `outputSnapshot` typing. |
+| `src/components/RunnerTerminal.tsx` | Pre-resize xterm to snapshot cols/rows before writing. |
+| `docs/impls/0010-terminal-replay-cols-alignment.md` | This document. |
+
+No DB migration. No new dependencies. One new IPC field (`cols`, `rows`)
+on the existing `session_output_snapshot` response.
+
+## Verification
+
+### Manual (the canonical reproducer)
+
+1. Open a long-running mission with claude-code lead. Confirm the *first*
+   open looks correct (this was already working post-0009).
+2. **Quit the app** (Cmd+Q). Wait until process is fully gone.
+3. **Relaunch the app.** Open the same mission.
+4. Inspect the `@architect` pane. **Expected:** brief text reads correctly,
+   no progressive indentation drift, no mid-screen "right edge" of the old
+   render visible. The view should be indistinguishable from running the
+   mission for the first time.
+5. Resize the window after restart. **Expected:** claude-code redraws
+   cleanly into alt-screen at the new cols, no stacking (0009 handles this).
+6. Same test with codex — **expected:** unchanged (codex was already fine).
+7. Same test with a plain shell session that's accumulated scrollback —
+   **expected:** scrollback reads correctly; main-screen reflow continues
+   to work for `isWrapped` runs.
+
+### Edge cases
+
+- **Session terminated between attach and frontend mount.** `pane_size`
+  errors out (pane gone). Snapshot returns `cols: None, rows: None`. Frontend
+  skips the pre-resize. xterm replays at default cols. Dead session — the
+  content is a static remnant; user can't interact further; minor visual
+  imperfection is acceptable.
+- **First-time spawn (no prior render).** `attach_streaming`'s fresh-spawn
+  branch uses `capture_visible_region`, not `capture_replay_bytes`; the
+  buffer at snapshot time is small or empty. `pane_size` returns whatever
+  size tmux is at (matches `initial_size` from spawn spec). Frontend
+  pre-resizes to that. Activation then grows to container cols. Net visual:
+  one extra resize tick on first open; should be imperceptible.
+- **Container size changed between quit and restart.** Snapshot is at the
+  cols tmux remembers (pre-quit user size). Frontend resizes xterm to that
+  → replay correct. Then `fit.fit()` grows/shrinks to the new container
+  size, tmux resizes, claude-code SIGWINCH redraw → clean final state at
+  the user's new dims. This is the primary case the fix is designed for.
+- **Two RunnerTerminals for the same session (split view).** Both call
+  `outputSnapshot` independently. Both pre-resize their xterm to the same
+  cols. After activation, each fits to its own container; the runtime
+  resize calls race but tmux is single-writer so the last one wins. No
+  worse than today.
+
+### Automated
+
+The interesting test would be: capture a known PTY byte stream with
+positioning escapes targeting cols=200, replay it into an 80-cols xterm,
+assert layout corruption; then re-run with pre-resize, assert correct
+layout. That requires a headless xterm.js harness which we don't have.
+Defer to manual verification.
+
+## Risk
+
+The IPC shape change (`Vec<OutputEvent>` → `OutputSnapshot`) is a breaking
+change for any code calling `session_output_snapshot`. Only one consumer
+exists (`api.ts:177`), so the blast radius is contained — both sides ship
+together in the same release.


### PR DESCRIPTION
## Summary
- Backend: `capture_replay_bytes` now prepends `ESC[?1049h\x1b[H` to the snapshot when the pane is on alt-screen, so xterm enters the alt-screen buffer at reattach time instead of staying on main-screen.
- Frontend: replaces the activation effect's `resize(cols-1, rows) → resize(cols, rows)` SIGWINCH dance with a single resize. With xterm on the right buffer, claude-code's one SIGWINCH redraw overwrites in place — no need to "wake it" with a fake delta resize.

## Why
Reopening a long-running mission with claude-code as the lead used to **stack 4–6 banner copies** in xterm's main-screen scrollback after a couple of resizes / tab switches. Diagnosis (full notes in `docs/impls/0009`):

- claude-code uses alt-screen — its startup `ESC[?1049h` was historically observed by direct PTY consumers (iTerm2 etc.) so they stayed on alt-screen for the agent's lifetime and every redraw replaced in place.
- `tmux capture-pane -p -e` returns rendered cells but omits the mode-switching escapes by design.
- `output_buffers` is a bounded `VecDeque<OutputEvent>` (4096 chunks). For a long-running session, the original `ESC[?1049h` has rolled off the deque before the user reopens.
- Net: xterm saw cells-without-mode-switch, stayed on main-screen, and live SIGWINCH redraws appended below the existing content instead of replacing it in alt-screen.

The fix re-emits the mode switch from the backend whenever `is_alternate_on` reports the pane is on alt-screen, restoring the iTerm2-equivalent state on reattach.

## What this is *not*
- Not a fix for the previous-page rendering drift on quit+restart with claude-code (see `docs/impls/0010` for the diagnosis and why the agent layer prevents a full fix).
- Not a fix for the "smooth scroll" framing in #141 — different problem, that PR was unrelated UX polish.

## Test plan
- [x] Reopen "Runner issue 143" mission → `@architect` tab → scroll up: no banner stacking.
- [x] Resize the window several times after reattach: no new stacked redraws.
- [x] Switch between `@architect` / `@impl` / `@reviewer`: each pane stays clean.
- [x] Plain shell session in a runner (non-alt-screen): main-screen scrollback unaffected.
- [x] `cargo test --lib session::manager` green.
- [ ] Verify in v0.1.15 packaged build once released.

## Docs included
- `docs/impls/0009-terminal-alt-screen-reattach.md` — the diagnosis + the fix that landed.
- `docs/impls/0010-terminal-replay-cols-alignment.md` — shelved follow-up; pre-resize-before-replay would fix the current-page drift on cold start but can't fix previous-page drift because claude-code never re-emits its internal scroll history on SIGWINCH. Committed as a durable record so the investigation isn't redone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)