### PR TITLE
fix(terminal): apply 0009 alt-screen reattach code

### DIFF
--- a/src-tauri/src/session/tmux_runtime.rs
+++ b/src-tauri/src/session/tmux_runtime.rs
@@ -814,12 +814,18 @@ fn drain_fifo_nonblocking(reader: &mut std::fs::File) -> Vec<u8> {
 ///    and step 3 land in the FIFO buffer (kernel-managed).
 /// 2. **Reattach only**: snapshot via `capture-pane` (with
 ///    alternate-screen branching) so the new xterm.js render
-///    starts with the existing pane state. Skipped on fresh
-///    spawn — there's nothing meaningful to replay (the agent
-///    just started), and including the snapshot writes the
-///    pane's empty top rows into xterm.js's buffer ahead of any
-///    live output, leaving a big blank region above the agent's
-///    actual content.
+///    starts with the existing pane state. When the pane is on
+///    alt-screen, `capture_replay_bytes` prepends `ESC[?1049h`
+///    so xterm.js enters alt-screen before consuming the cells —
+///    `capture-pane` omits mode-switching escapes by design, and
+///    without this xterm stays on main-screen and subsequent live
+///    redraws from the agent stack in scrollback (see
+///    `docs/impls/0009-terminal-alt-screen-reattach.md`).
+///    Skipped on fresh spawn — there's nothing meaningful to
+///    replay (the agent just started), and including the
+///    snapshot writes the pane's empty top rows into xterm.js's
+///    buffer ahead of any live output, leaving a big blank
+///    region above the agent's actual content.
 /// 3. Drain the FIFO buffer non-blockingly into a `Vec<u8>`.
 ///    Picks up any bytes that arrived between pipe-pane install
 ///    and now.
@@ -1208,7 +1214,22 @@ fn capture_replay_bytes(cmd: &Command, session: &RuntimeSession) -> RuntimeResul
             stderr: String::from_utf8_lossy(&out.stderr).to_string(),
         });
     }
-    Ok(out.stdout)
+    // For alt-screen panes (claude-code / codex while running), `capture-pane`
+    // gives us the rendered cell content as text but never re-emits the
+    // mode-switching escapes the agent originally sent at startup. Without
+    // ESC[?1049h here, xterm.js stays on main-screen at reattach time and
+    // every subsequent live redraw from the agent stacks below the previous
+    // one in main-screen scrollback (see docs/impls/0009). Cursor home
+    // after the mode switch is defensive — it pins the first replayed cell
+    // to (1,1) regardless of stale cursor state from `term.reset()`.
+    let mut bytes = out.stdout;
+    if alt_on {
+        let mut with_alt = Vec::with_capacity(bytes.len() + 8);
+        with_alt.extend_from_slice(b"\x1b[?1049h\x1b[H");
+        with_alt.append(&mut bytes);
+        bytes = with_alt;
+    }
+    Ok(bytes)
 }
 
 /// `display-message -p -t=<pane> '#{alternate_on}'` returns

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -481,11 +481,14 @@ export function RunnerTerminal({
         t.focus();
         const cols = t.cols;
         const rows = t.rows;
-        void api.session.resize(sessionId, Math.max(2, cols - 1), rows)
-          .then(() => api.session.resize(sessionId, cols, rows))
-          .catch(() => {
-            // session may have exited
-          });
+        // Single resize is enough once xterm enters alt-screen at attach
+        // time (see docs/impls/0009). The earlier cols-1 → cols dance was
+        // there to coax claude-code into a repaint that would land where
+        // the user could see it; with the alt-screen state correct, the
+        // agent's single SIGWINCH redraw lands in the right buffer.
+        void api.session.resize(sessionId, cols, rows).catch(() => {
+          // session may have exited
+        });
       } catch {
         // Layout not ready yet — the next activation / resize will drive it.
       }


### PR DESCRIPTION
## Summary
- Re-applies the behaviour changes that `docs/impls/0009-terminal-alt-screen-reattach.md` describes — the previous PR #148 squash-merged only the plan file and the code never landed.
- Backend: `capture_replay_bytes` prepends `ESC[?1049h\x1b[H` when the pane is on alt-screen, so xterm enters alt-screen at reattach.
- Frontend: replaces the `resize(cols-1, rows) → resize(cols, rows)` SIGWINCH dance in the activation effect with a single resize.

## Why a second PR
My `git checkout --` to revert the experimental 0010 implementation also wiped the 0009 code changes — they had been built + tested but never committed. PR #148 was therefore docs-only by accident. Apologies for the mess.

## Scope
This is the **live-session** half of the terminal-history work. The cold-restart + mid-session-resize symptom (the screenshot with line-position drift) is **not** addressed by this PR. Will be filed as a separate issue with 0010's diagnosis attached.

## Test plan
- [x] `cargo check --all-targets` clean.
- [x] `pnpm exec tsc --noEmit` clean.
- [x] `pnpm lint` no new warnings.
- [ ] Smoke-test on a running mission: switch tabs + resize window → no stacked banners (verified previously on the local build before the revert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)