### PR TITLE
wip(terminal): resize-aligned attach snapshot (#150)

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -20,7 +20,7 @@ use crate::{
     commands::runner,
     error::{Error, Result},
     model::{Session, SessionStatus, Timestamp},
-    session::manager::{OutputEvent, SessionEvents, SpawnedSession, TauriSessionEvents},
+    session::manager::{AttachSnapshot, OutputEvent, SessionEvents, SpawnedSession, TauriSessionEvents},
     AppState,
 };
 
@@ -140,6 +140,22 @@ pub async fn session_output_snapshot(
     session_id: String,
 ) -> Result<Vec<OutputEvent>> {
     Ok(state.sessions.output_snapshot(&session_id))
+}
+
+/// Resize the pane to xterm's container dims and return a fresh
+/// alt-screen-aware capture. Replaces `session_output_snapshot` in
+/// the frontend's mount-time attach flow — the cols-matched capture
+/// avoids the absolute-positioning misalignment claude-code's Ink
+/// renderer produces when the replay cols don't match the original
+/// draw cols (issue #150).
+#[tauri::command]
+pub async fn session_attach_snapshot(
+    state: State<'_, AppState>,
+    session_id: String,
+    cols: u16,
+    rows: u16,
+) -> Result<AttachSnapshot> {
+    state.sessions.attach_snapshot(&session_id, cols, rows)
 }
 
 /// Restore NSPasteboard for a PNG paste that came in through the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -282,6 +282,7 @@ pub fn run() {
             commands::session::session_kill,
             commands::session::session_resize,
             commands::session::session_output_snapshot,
+            commands::session::session_attach_snapshot,
             commands::session::session_paste_image,
             commands::session::session_start_direct,
         ])

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -256,6 +256,23 @@ pub struct OutputEvent {
     pub data: String,
 }
 
+/// Resize-aligned attach snapshot returned by `attach_snapshot`. The
+/// frontend writes `data` into an xterm sized to the cols/rows it asked
+/// for, then dedups buffered live events against `as_of_seq` (drop
+/// `seq <= as_of_seq`, replay `seq > as_of_seq`). Implements the fix
+/// for issue #150 (cold-restart cols-mismatch drift).
+#[derive(Debug, Clone, Serialize)]
+pub struct AttachSnapshot {
+    /// Base64-encoded capture-pane bytes at the requested dims, with
+    /// alt-screen-enter prepended when applicable (see
+    /// `capture_replay_bytes` and docs/impls/0009).
+    pub data: String,
+    /// `output_seq` value at the moment of capture. Live events with
+    /// `seq <= as_of_seq` are already reflected in `data` and should
+    /// not be replayed by the consumer.
+    pub as_of_seq: u64,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct ExitEvent {
     pub session_id: String,
@@ -1728,6 +1745,54 @@ impl SessionManager {
             .unwrap_or_default()
     }
 
+    /// Resize the runtime pane to `(cols, rows)` and return a fresh
+    /// alt-screen-aware capture of the resulting cells, plus the
+    /// `output_seq` high-water-mark at capture time. The frontend
+    /// writes the bytes into an xterm sized to `(cols, rows)` (matched
+    /// to its container), then drops any buffered live events with
+    /// `seq <= as_of_seq` because those are already baked into the
+    /// capture; events with `seq > as_of_seq` are post-capture and get
+    /// applied as deltas. Fixes the cold-restart cols-mismatch path
+    /// (issue #150).
+    ///
+    /// `as_of_seq` is read *after* `capture-pane` returns, on the
+    /// theory that tmux processes incoming PTY bytes before pipe-pane
+    /// forwards them — so any event the forwarder has recorded with
+    /// `seq <= as_of_seq` is necessarily reflected in the capture's
+    /// cells. The narrow race between `capture-pane` returning and us
+    /// reading the seq map is on the order of microseconds and would
+    /// at worst double-paint a single live chunk — visually
+    /// indistinguishable from a normal redraw.
+    pub fn attach_snapshot(
+        &self,
+        session_id: &str,
+        cols: u16,
+        rows: u16,
+    ) -> Result<AttachSnapshot> {
+        let rt_session = self
+            .sessions
+            .lock()
+            .unwrap()
+            .get(session_id)
+            .map(|h| h.runtime_session.clone())
+            .ok_or_else(|| Error::Msg(format!("session {session_id} is not live")))?;
+        let bytes = self
+            .runtime
+            .resize_and_capture(&rt_session, cols, rows)
+            .map_err(|e| Error::Msg(format!("resize_and_capture failed: {e}")))?;
+        let as_of_seq = self
+            .output_seq
+            .lock()
+            .unwrap()
+            .get(session_id)
+            .copied()
+            .unwrap_or(0);
+        Ok(AttachSnapshot {
+            data: BASE64.encode(&bytes),
+            as_of_seq,
+        })
+    }
+
     /// Kill the child and wait for the reader thread to reap it.
     ///
     /// Sequence:
@@ -2665,6 +2730,16 @@ mod tests {
                 "InertRuntime: capture_visible unsupported".into(),
             ))
         }
+        fn resize_and_capture(
+            &self,
+            _: &RuntimeSession,
+            _: u16,
+            _: u16,
+        ) -> RuntimeResult<Vec<u8>> {
+            Err(RuntimeError::Msg(
+                "InertRuntime: resize_and_capture unsupported".into(),
+            ))
+        }
     }
 
     fn inert_runtime() -> Arc<dyn SessionRuntime> {
@@ -2977,6 +3052,19 @@ mod tests {
             } else {
                 Ok(self.pane_pre_paste.lock().unwrap().clone())
             }
+        }
+
+        fn resize_and_capture(
+            &self,
+            _: &RuntimeSession,
+            _: u16,
+            _: u16,
+        ) -> RuntimeResult<Vec<u8>> {
+            // Tests don't model resize+capture; integration coverage
+            // lives in `session::tmux_runtime::tests`. Synthesizes an
+            // empty buffer so any manager-level test that lands here
+            // gets a deterministic noop.
+            Ok(Vec::new())
         }
     }
 

--- a/src-tauri/src/session/runtime.rs
+++ b/src-tauri/src/session/runtime.rs
@@ -363,4 +363,21 @@ pub trait SessionRuntime: Send + Sync {
     /// readback is the only reliable signal absent a runtime-level
     /// "input bound" event.
     fn capture_visible(&self, session: &RuntimeSession) -> RuntimeResult<Vec<u8>>;
+
+    /// Atomically resize the pane to the requested dims and return a
+    /// fresh alt-screen-aware snapshot of the resulting cells. Used
+    /// by frontend attach to align the captured bytes with xterm's
+    /// container cols before painting, avoiding the absolute-
+    /// positioning misalignment claude-code's Ink renderer produces
+    /// when the replay cols don't match the original draw cols
+    /// (issue #150). The runtime is expected to wait long enough
+    /// after the resize for the agent's SIGWINCH-triggered redraw to
+    /// land in its cell buffer; tmux's capture-pane reads the
+    /// post-redraw state so the bytes match the requested dims.
+    fn resize_and_capture(
+        &self,
+        session: &RuntimeSession,
+        cols: u16,
+        rows: u16,
+    ) -> RuntimeResult<Vec<u8>>;
 }

--- a/src-tauri/src/session/tmux_runtime.rs
+++ b/src-tauri/src/session/tmux_runtime.rs
@@ -674,6 +674,34 @@ impl SessionRuntime for TmuxRuntime {
         capture_visible_region(&self.cmd(), session)
     }
 
+    fn resize_and_capture(
+        &self,
+        session: &RuntimeSession,
+        cols: u16,
+        rows: u16,
+    ) -> RuntimeResult<Vec<u8>> {
+        // Resize first so the agent's SIGWINCH redraw lands at the
+        // dims the caller wants the snapshot for. `capture_replay_bytes`
+        // returns whatever cells are in tmux's buffer at the moment of
+        // the call, so we briefly yield to let claude-code's redraw
+        // bytes flow through the master PTY into tmux's grid before
+        // capturing. 200 ms is enough for Ink's diff render in the
+        // pessimistic case observed on macOS aarch64 (issue #150 repro).
+        run_tmux_check(
+            self.cmd()
+                .arg("resize-window")
+                .arg("-t")
+                .arg(window_target(&session.session_name, &session.window))
+                .arg("-x")
+                .arg(cols.to_string())
+                .arg("-y")
+                .arg(rows.to_string()),
+            "resize-window",
+        )?;
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        capture_replay_bytes(&self.cmd(), session)
+    }
+
     fn status(&self, session: &RuntimeSession) -> RuntimeResult<Option<SessionStatus>> {
         // First gate: has-session. tmux exits non-zero if the
         // target session is gone — that's our terminal-unavailable

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -101,6 +101,19 @@ export function RunnerTerminal({
   // closures don't capture a stale value across the long-lived
   // terminal effect.
   const disabledRef = useRef<boolean>(disabled ?? false);
+  // Snapshot replay is deferred from mount to activation. The mount effect
+  // only subscribes + buffers live events; the activation effect calls
+  // `attach_snapshot` with the *post-fit* container cols, so the backend
+  // resizes tmux + captures fresh bytes at the right size in one round
+  // trip. That keeps absolute-positioning escapes from claude-code's Ink
+  // renderer aligned with xterm's actual grid on cold restart (issue
+  // #150). `as_of_seq` is the high-water-mark in the live event stream at
+  // capture time — buffered events with `seq <= as_of_seq` are already
+  // baked into the snapshot bytes and must be dropped to avoid
+  // double-painting.
+  const replayDoneRef = useRef(false);
+  const lastWrittenSeqRef = useRef(0);
+  const pendingLiveRef = useRef<OutputEvent[]>([]);
 
   // Keep the latest sessionId visible to the data/resize callbacks without
   // re-creating the terminal on prop change. The session listener below
@@ -118,11 +131,18 @@ export function RunnerTerminal({
   // render's value is the initial — we don't want to reset on mount,
   // only on subsequent bumps. We achieve that by skipping the very
   // first effect run via a ref.
+  //
+  // Clear semantics: parent wants a clean slate before driving a resume,
+  // so drop any buffered pre-clear live events and mark replay as already
+  // done — future live events should land on the empty xterm without us
+  // later overwriting them with a (now-stale) `attach_snapshot`.
   const lastClearVersionRef = useRef<number | undefined>(clearVersion);
   useEffect(() => {
     if (lastClearVersionRef.current === clearVersion) return;
     lastClearVersionRef.current = clearVersion;
     termRef.current?.reset();
+    replayDoneRef.current = true;
+    pendingLiveRef.current = [];
   }, [clearVersion]);
 
   useEffect(() => {
@@ -383,32 +403,31 @@ export function RunnerTerminal({
     };
   }, []);
 
-  // Subscribe to the bound session's output + exit. The listener is registered
-  // before snapshot replay so live chunks that arrive during the command round
-  // trip are buffered and merged by seq.
+  // Subscribe to the bound session's output + exit. Live chunks go into
+  // `pendingLiveRef` until the activation effect lands the snapshot; after
+  // that, the listener writes directly into xterm.
   useEffect(() => {
     let unlistenOutput: (() => void) | null = null;
     let unlistenExit: (() => void) | null = null;
     let cancelled = false;
-    let replayDone = false;
-    let lastWrittenSeq = 0;
-    const pendingLive: OutputEvent[] = [];
 
-    const writeOutput = (ev: OutputEvent) => {
-      termRef.current?.write(decodeBase64Chunk(ev.data));
-    };
+    // Reset per-session replay state. Re-binding to a different sessionId
+    // means the next activation owns refetching the snapshot for the new id.
+    replayDoneRef.current = false;
+    lastWrittenSeqRef.current = 0;
+    pendingLiveRef.current = [];
 
     void (async () => {
       const [fnOut, fnExit] = await Promise.all([
         listen<OutputEvent>("session/output", (event) => {
           if (event.payload.session_id !== sessionId) return;
-          if (!replayDone) {
-            pendingLive.push(event.payload);
+          if (!replayDoneRef.current) {
+            pendingLiveRef.current.push(event.payload);
             return;
           }
-          if (event.payload.seq <= lastWrittenSeq) return;
-          writeOutput(event.payload);
-          lastWrittenSeq = event.payload.seq;
+          if (event.payload.seq <= lastWrittenSeqRef.current) return;
+          termRef.current?.write(decodeBase64Chunk(event.payload.data));
+          lastWrittenSeqRef.current = event.payload.seq;
         }),
         listen<ExitEvent>("session/exit", (event) => {
           if (event.payload.session_id !== sessionId) return;
@@ -422,32 +441,6 @@ export function RunnerTerminal({
       }
       unlistenOutput = fnOut;
       unlistenExit = fnExit;
-
-      let snapshot: OutputEvent[] = [];
-      try {
-        snapshot = await api.session.outputSnapshot(sessionId);
-      } catch (e) {
-        onErrorRef.current?.(String(e));
-      }
-      if (cancelled) return;
-
-      termRef.current?.reset();
-      for (const ev of snapshot) {
-        writeOutput(ev);
-        lastWrittenSeq = Math.max(lastWrittenSeq, ev.seq);
-      }
-      replayDone = true;
-      for (const ev of pendingLive) {
-        if (ev.seq <= lastWrittenSeq) continue;
-        writeOutput(ev);
-        lastWrittenSeq = ev.seq;
-      }
-      pendingLive.length = 0;
-
-      // Do not resize here: hidden terminal panes mount before they are
-      // measurable, and sending that hidden geometry to TUIs makes them paint
-      // their startup screen into a tiny grid. The activation effect below
-      // owns the SIGWINCH dance once the pane is visible.
     })();
 
     return () => {
@@ -458,16 +451,17 @@ export function RunnerTerminal({
   }, [sessionId]);
 
   // Activation effect: when this tab moves to the front, wait for the pane
-  // to become measurable, fit to its container, repaint the WebGL/canvas
-  // renderer with the current scrollback, and grab focus so keystrokes flow
-  // into the expected PTY.
+  // to become measurable, fit to its container, then (first activation only)
+  // resize + capture + replay so the snapshot bytes line up with xterm's
+  // grid. Subsequent activations skip the snapshot — xterm already holds the
+  // right content; we just refit + refocus.
   useEffect(() => {
     if (!active) return;
     let cancelled = false;
     let raf1 = 0;
     let raf2 = 0;
 
-    const activate = () => {
+    const activate = async () => {
       if (cancelled) return;
       const t = termRef.current;
       const fit = fitRef.current;
@@ -477,25 +471,61 @@ export function RunnerTerminal({
       if (rect.width <= 0 || rect.height <= 0) return;
       try {
         fit.fit();
+
+        if (!replayDoneRef.current) {
+          const cols = t.cols;
+          const rows = t.rows;
+          let snapshot: { data: string; as_of_seq: number } | null = null;
+          try {
+            snapshot = await api.session.attachSnapshot(sessionId, cols, rows);
+          } catch (e) {
+            onErrorRef.current?.(String(e));
+          }
+          if (cancelled) return;
+          t.reset();
+          if (snapshot && snapshot.data) {
+            t.write(decodeBase64Chunk(snapshot.data));
+          }
+          const asOf = snapshot?.as_of_seq ?? 0;
+          lastWrittenSeqRef.current = asOf;
+          // Drain any live events that arrived during the resize+capture
+          // round trip. Those with `seq <= as_of_seq` are already inside
+          // the snapshot's cells (tmux processes PTY bytes before pipe-pane
+          // forwards them, so any event the forwarder recorded by capture
+          // time is reflected in the capture); the rest are post-capture
+          // deltas that need to be applied.
+          for (const ev of pendingLiveRef.current) {
+            if (ev.seq <= lastWrittenSeqRef.current) continue;
+            t.write(decodeBase64Chunk(ev.data));
+            lastWrittenSeqRef.current = ev.seq;
+          }
+          pendingLiveRef.current = [];
+          replayDoneRef.current = true;
+        }
+
         t.refresh(0, t.rows - 1);
         t.focus();
-        const cols = t.cols;
-        const rows = t.rows;
-        // Single resize is enough once xterm enters alt-screen at attach
-        // time (see docs/impls/0009). The earlier cols-1 → cols dance was
-        // there to coax claude-code into a repaint that would land where
-        // the user could see it; with the alt-screen state correct, the
-        // agent's single SIGWINCH redraw lands in the right buffer.
-        void api.session.resize(sessionId, cols, rows).catch(() => {
-          // session may have exited
-        });
+        // `attachSnapshot` already resized tmux to (cols, rows). On a
+        // subsequent activation (tab-switch back) the dims may have
+        // changed; a single resize keeps tmux in sync — claude-code's
+        // in-place alt-screen redraw lands cleanly since 0009 routed us
+        // into alt-screen at the first attach.
+        if (replayDoneRef.current) {
+          const cols = t.cols;
+          const rows = t.rows;
+          void api.session.resize(sessionId, cols, rows).catch(() => {
+            // session may have exited
+          });
+        }
       } catch {
         // Layout not ready yet — the next activation / resize will drive it.
       }
     };
 
     raf1 = window.requestAnimationFrame(() => {
-      raf2 = window.requestAnimationFrame(activate);
+      raf2 = window.requestAnimationFrame(() => {
+        void activate();
+      });
     });
 
     return () => {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -23,6 +23,7 @@ import type {
   RunnerActivity,
   RunnerWithActivity,
   Session,
+  SessionAttachSnapshot,
   SessionOutputEvent,
   SlotWithRunner,
   SpawnedSession,
@@ -176,6 +177,12 @@ export const api = {
       invoke<void>("session_resize", { sessionId, cols, rows }),
     outputSnapshot: (sessionId: string) =>
       invoke<SessionOutputEvent[]>("session_output_snapshot", { sessionId }),
+    attachSnapshot: (sessionId: string, cols: number, rows: number) =>
+      invoke<SessionAttachSnapshot>("session_attach_snapshot", {
+        sessionId,
+        cols,
+        rows,
+      }),
     pasteImage: (bytes: Uint8Array) =>
       invoke<void>("session_paste_image", {
         bytes: Array.from(bytes),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -128,6 +128,17 @@ export interface SessionOutputEvent {
   data: string;
 }
 
+/** Returned by `session_attach_snapshot`. `data` is the base64-encoded
+ *  capture-pane bytes at the cols/rows the frontend asked for; xterm should
+ *  be sized to those dims before writing. `as_of_seq` is the high-water-mark
+ *  in the live event stream at capture time — buffered events with
+ *  `seq <= as_of_seq` are already reflected in `data` and must be dropped to
+ *  avoid double-painting. Implements the fix for issue #150. */
+export interface SessionAttachSnapshot {
+  data: string;
+  as_of_seq: number;
+}
+
 export type MissionStatus = "running" | "completed" | "aborted";
 
 export interface Mission {


### PR DESCRIPTION
> **Draft / WIP.** Improves the cold-restart symptom but doesn't fully fix #150. Opening for visibility on the work-in-progress shape; not ready to merge.

## Summary

Implements the resize-then-capture attach flow proposed in #150:

- Frontend tells the backend its post-\`fit.fit()\` container cols/rows.
- Backend resizes tmux → waits 200 ms for the agent's SIGWINCH redraw to flow through pipe-pane → \`capture-pane\` returns fresh cells at the matched dims (with the 0009 alt-screen prepend).
- Backend reads \`output_seq\` immediately after the capture as a high-water-mark.
- Frontend writes the bytes into an xterm sized to the same cols/rows, then dedups buffered live events against \`as_of_seq\` to avoid double-painting.

## Backend

- New \`SessionRuntime::resize_and_capture\` trait method; tmux impl runs \`resize-window\` → 200 ms sleep → \`capture_replay_bytes\`.
- \`SessionManager::attach_snapshot\` orchestrates the call and reads the high-water-mark.
- \`AttachSnapshot { data, as_of_seq }\` struct + \`session_attach_snapshot\` Tauri command.
- \`InertRuntime\` / \`FakeRuntime\` test stubs.

## Frontend

- Mount effect now only subscribes + buffers live events into \`pendingLiveRef\`; the snapshot fetch moves to the activation effect so it runs *after* \`fit.fit()\` and we know the container cols.
- Activation effect (first-activation-only) calls \`attachSnapshot(cols, rows)\`, writes the returned bytes, sets \`lastWrittenSeqRef = as_of_seq\`, and drains \`pendingLiveRef\` skipping seqs already baked into the capture.
- \`clearVersion\` now also marks replay-done + drops buffered live so the resume flow's clean-slate intent isn't clobbered.

## Status

Manual smoke shows noticeable improvement on the cold-restart + window-resize reproducer but **doesn't fully eliminate** the misalignment. Suspect candidates for the residual gap:

- 200 ms post-resize wait may be insufficient when claude-code is mid-render; capture sees a half-redrawn frame and bakes the wrong cells. → try FIFO-quiet detection instead of a fixed sleep, or extend the wait window.
- claude-code's diff-based redraw might leave pre-resize cells untouched in rows it doesn't consider "dirty" → may need a \`clear + SIGWINCH\` to force a full repaint before capture.
- 0009's \`ESC[?1049h\` prepend may interact with state already on alt-screen unexpectedly.

Holding the branch as draft while we investigate.

## Checks

- [x] \`cargo check --all-targets\` clean
- [x] \`cargo test --lib session::manager\` (28 passing)
- [x] \`pnpm exec tsc --noEmit\` clean
- [x] \`pnpm lint\` no new warnings
- [ ] Manual cold-restart verification — residual misalignment, needs more iteration

🤖 Generated with [Claude Code](https://claude.com/claude-code)