### PR TITLE
fix: stabilize terminal attach and resize replay

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -20,7 +20,7 @@ use crate::{
     commands::runner,
     error::{Error, Result},
     model::{Session, SessionStatus, Timestamp},
-    session::manager::{OutputEvent, SessionEvents, SpawnedSession, TauriSessionEvents},
+    session::manager::{OutputSnapshot, SessionEvents, SpawnedSession, TauriSessionEvents},
     AppState,
 };
 
@@ -138,8 +138,18 @@ pub async fn session_resize(
 pub async fn session_output_snapshot(
     state: State<'_, AppState>,
     session_id: String,
-) -> Result<Vec<OutputEvent>> {
+) -> Result<OutputSnapshot> {
     Ok(state.sessions.output_snapshot(&session_id))
+}
+
+#[tauri::command]
+pub async fn session_attach_snapshot(
+    state: State<'_, AppState>,
+    session_id: String,
+    cols: u16,
+    rows: u16,
+) -> Result<OutputSnapshot> {
+    state.sessions.attach_snapshot(&session_id, cols, rows)
 }
 
 /// Restore NSPasteboard for a PNG paste that came in through the

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -289,6 +289,7 @@ pub fn run() {
             commands::session::session_kill,
             commands::session::session_resize,
             commands::session::session_output_snapshot,
+            commands::session::session_attach_snapshot,
             commands::session::session_paste_image,
             commands::session::session_start_direct,
         ])

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -42,6 +42,7 @@ use crate::session::runtime::{
 };
 
 const MAX_OUTPUT_BUFFER_CHUNKS: usize = 4096;
+const ATTACH_SNAPSHOT_REDRAW_GRACE: Duration = Duration::from_millis(120);
 
 /// Inputs the forwarder consumer needs to translate a
 /// `RuntimeOutput::StatusTransition` into a real `runner_status`
@@ -254,6 +255,16 @@ pub struct OutputEvent {
     pub seq: u64,
     /// Base64-encoded raw bytes read from the PTY.
     pub data: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OutputSnapshot {
+    pub events: Vec<OutputEvent>,
+    /// Highest per-session output seq the frontend should consider
+    /// covered by this snapshot. Live events with seq <= this value
+    /// were already recorded before snapshot capture began and can be
+    /// dropped after the replay bytes are written.
+    pub last_seq: u64,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -1719,13 +1730,75 @@ impl SessionManager {
     /// The snapshot is intentionally process-local and bounded: it covers
     /// webview reloads / chat switching for live sessions without turning the
     /// sessions table into a PTY transcript store.
-    pub fn output_snapshot(&self, session_id: &str) -> Vec<OutputEvent> {
-        self.output_buffers
+    pub fn output_snapshot(&self, session_id: &str) -> OutputSnapshot {
+        let events = self
+            .output_buffers
             .lock()
             .unwrap()
             .get(session_id)
             .map(|chunks| chunks.iter().cloned().collect())
-            .unwrap_or_default()
+            .unwrap_or_default();
+        let last_seq = self
+            .output_seq
+            .lock()
+            .unwrap()
+            .get(session_id)
+            .copied()
+            .unwrap_or(0);
+        OutputSnapshot { events, last_seq }
+    }
+
+    /// Capture a fresh attach-time snapshot after the frontend has
+    /// fitted xterm to a visible container. This is the cold-restart
+    /// path for TUI panes: stale replay bytes captured during backend
+    /// startup may have been sized for tmux's old grid and must not be
+    /// written into a hidden/default 80-col xterm. The capture itself
+    /// is stored back into the bounded buffer so later remounts have a
+    /// sane baseline.
+    pub fn attach_snapshot(
+        &self,
+        session_id: &str,
+        cols: u16,
+        rows: u16,
+    ) -> Result<OutputSnapshot> {
+        let (rt_session, mission_id) = self
+            .sessions
+            .lock()
+            .unwrap()
+            .get(session_id)
+            .map(|h| (h.runtime_session.clone(), h.mission_id.clone()))
+            .ok_or_else(|| Error::msg(format!("session not found: {session_id}")))?;
+
+        self.runtime.resize(&rt_session, cols, rows)?;
+        thread::sleep(ATTACH_SNAPSHOT_REDRAW_GRACE);
+        let covered_seq = self
+            .output_seq
+            .lock()
+            .unwrap()
+            .get(session_id)
+            .copied()
+            .unwrap_or(0);
+        let bytes = self.runtime.capture_replay(&rt_session)?;
+
+        // The fresh capture supersedes startup reattach replay and any
+        // resize-diff chunks already recorded before capture-pane ran.
+        // Keep the seq counter monotonic so pending live events can be
+        // filtered by the returned watermark; the stored snapshot gets a
+        // later seq but should not hide bytes that race after capture starts.
+        self.purge_output_buffer(session_id);
+
+        if bytes.is_empty() {
+            return Ok(OutputSnapshot {
+                events: Vec::new(),
+                last_seq: covered_seq,
+            });
+        }
+
+        let ev = self.record_output(session_id, mission_id.as_deref(), BASE64.encode(&bytes));
+        Ok(OutputSnapshot {
+            last_seq: covered_seq,
+            events: vec![ev],
+        })
     }
 
     /// Kill the child and wait for the reader thread to reap it.
@@ -2665,6 +2738,11 @@ mod tests {
                 "InertRuntime: capture_visible unsupported".into(),
             ))
         }
+        fn capture_replay(&self, _: &RuntimeSession) -> RuntimeResult<Vec<u8>> {
+            Err(RuntimeError::Msg(
+                "InertRuntime: capture_replay unsupported".into(),
+            ))
+        }
     }
 
     fn inert_runtime() -> Arc<dyn SessionRuntime> {
@@ -2977,6 +3055,10 @@ mod tests {
             } else {
                 Ok(self.pane_pre_paste.lock().unwrap().clone())
             }
+        }
+
+        fn capture_replay(&self, session: &RuntimeSession) -> RuntimeResult<Vec<u8>> {
+            self.capture_visible(session)
         }
     }
 
@@ -4038,7 +4120,7 @@ mod tests {
         let deadline = Instant::now() + Duration::from_secs(2);
         let snapshot = loop {
             let snapshot = mgr.output_snapshot(&spawned.id);
-            if !snapshot.is_empty() {
+            if !snapshot.events.is_empty() {
                 break snapshot;
             }
             if Instant::now() > deadline {
@@ -4047,9 +4129,10 @@ mod tests {
             std::thread::sleep(Duration::from_millis(20));
         };
 
-        assert_eq!(snapshot[0].seq, 1);
+        assert_eq!(snapshot.events[0].seq, 1);
+        assert_eq!(snapshot.last_seq, 1);
         assert!(
-            snapshot.iter().all(|ev| ev.session_id == spawned.id),
+            snapshot.events.iter().all(|ev| ev.session_id == spawned.id),
             "snapshot must only include chunks for the requested session"
         );
 
@@ -4058,14 +4141,99 @@ mod tests {
         // remount can replay the dead session's scrollback. Explicit
         // cleanup is via `purge_session_buffers`.
         assert!(
-            !mgr.output_snapshot(&spawned.id).is_empty(),
+            !mgr.output_snapshot(&spawned.id).events.is_empty(),
             "kill must keep the output buffer for snapshot replay"
         );
         mgr.purge_session_buffers(&spawned.id);
         assert!(
-            mgr.output_snapshot(&spawned.id).is_empty(),
+            mgr.output_snapshot(&spawned.id).events.is_empty(),
             "purge_session_buffers must drop the buffer"
         );
+    }
+
+    #[test]
+    fn attach_snapshot_resizes_captures_and_replaces_stale_buffer() {
+        let pool = pool_with_schema();
+        let now = Utc::now().to_rfc3339();
+        let runner_id = ulid::Ulid::new().to_string();
+        {
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'attachsnap', 'Attach Snapshot', 'shell', '/bin/cat',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+                params![runner_id, now],
+            )
+            .unwrap();
+        }
+
+        let mut runner = runner("/bin/cat", &[]);
+        runner.id = runner_id;
+        runner.handle = "attachsnap".into();
+
+        let fake = fake_runtime();
+        let mgr = mgr_with_fake(None, Arc::clone(&fake));
+        let spawned = mgr
+            .spawn_direct(
+                &runner,
+                Some("/tmp"),
+                None,
+                None,
+                std::path::Path::new("/tmp"),
+                Arc::clone(&pool),
+                capture(),
+                None,
+            )
+            .unwrap();
+
+        fake.push_output(0, b"stale startup replay");
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if !mgr.output_snapshot(&spawned.id).events.is_empty() {
+                break;
+            }
+            if Instant::now() > deadline {
+                panic!("stale output never reached snapshot buffer");
+            }
+            std::thread::sleep(Duration::from_millis(20));
+        }
+
+        fake.set_pane_post_paste(b"fresh visible capture");
+        let snapshot = mgr.attach_snapshot(&spawned.id, 120, 40).unwrap();
+
+        assert_eq!(
+            fake.resizes.lock().unwrap().clone(),
+            vec![(format!("runner-{}", spawned.id), 120, 40)]
+        );
+        assert_eq!(snapshot.events.len(), 1);
+        assert_eq!(
+            snapshot.events[0].data,
+            BASE64.encode(b"fresh visible capture")
+        );
+        assert_eq!(
+            snapshot.last_seq, 1,
+            "watermark should cover stale output captured before attach, not the synthetic snapshot event"
+        );
+        assert!(
+            snapshot.events[0].seq > snapshot.last_seq,
+            "synthetic snapshot event is stored for future remounts but must not hide live race events"
+        );
+
+        let buffered = mgr.output_snapshot(&spawned.id);
+        assert_eq!(
+            buffered
+                .events
+                .iter()
+                .map(|ev| ev.data.as_str())
+                .collect::<Vec<_>>(),
+            vec![snapshot.events[0].data.as_str()],
+            "attach snapshot should replace stale startup replay in the buffer"
+        );
+
+        mgr.kill(&spawned.id).unwrap();
     }
 
     #[test]

--- a/src-tauri/src/session/runtime.rs
+++ b/src-tauri/src/session/runtime.rs
@@ -363,4 +363,11 @@ pub trait SessionRuntime: Send + Sync {
     /// readback is the only reliable signal absent a runtime-level
     /// "input bound" event.
     fn capture_visible(&self, session: &RuntimeSession) -> RuntimeResult<Vec<u8>>;
+
+    /// Attach-time snapshot of the pane's current screen. The frontend
+    /// calls this after it has a visible xterm grid; the runtime may
+    /// restore mode-switch escapes needed for replay, but it should not
+    /// include historical scrollback from TUI panes because resize redraws
+    /// there are size-dependent.
+    fn capture_replay(&self, session: &RuntimeSession) -> RuntimeResult<Vec<u8>>;
 }

--- a/src-tauri/src/session/tmux_runtime.rs
+++ b/src-tauri/src/session/tmux_runtime.rs
@@ -656,6 +656,15 @@ impl SessionRuntime for TmuxRuntime {
     }
 
     fn resize(&self, session: &RuntimeSession, cols: u16, rows: u16) -> RuntimeResult<()> {
+        if pane_size(&self.cmd(), &session.pane)? == Some((cols, rows)) {
+            log::debug!(
+                "session_resize noop pane={} cols={} rows={}",
+                session.pane,
+                cols,
+                rows,
+            );
+            return Ok(());
+        }
         // Trace at debug so a `tauri dev` run can correlate the
         // frontend `pushSize` → backend resize-window → agent
         // SIGWINCH → live Stream burst chain when investigating
@@ -683,6 +692,10 @@ impl SessionRuntime for TmuxRuntime {
 
     fn capture_visible(&self, session: &RuntimeSession) -> RuntimeResult<Vec<u8>> {
         capture_visible_region(&self.cmd(), session)
+    }
+
+    fn capture_replay(&self, session: &RuntimeSession) -> RuntimeResult<Vec<u8>> {
+        capture_attach_bytes(&self.cmd(), session)
     }
 
     fn status(&self, session: &RuntimeSession) -> RuntimeResult<Option<SessionStatus>> {
@@ -876,7 +889,7 @@ fn attach_streaming(
     //   shouldn't be edited.
     let snapshot = if is_fresh_spawn {
         let raw = capture_visible_region(cmd, session)?;
-        trim_leading_blank_lines(raw)
+        normalize_capture_line_endings(trim_leading_blank_lines(raw))
     } else {
         capture_replay_bytes(cmd, session)?
     };
@@ -1203,6 +1216,42 @@ fn is_visually_blank(line: &[u8]) -> bool {
     true
 }
 
+/// `tmux capture-pane -p` serializes rows with bare LF. PTY streams
+/// normally use CRLF for line transitions; writing LF-only captures
+/// into xterm leaves the cursor in its current column and makes replayed
+/// rows staircase sideways.
+fn normalize_capture_line_endings(snapshot: Vec<u8>) -> Vec<u8> {
+    let extra_crs = snapshot
+        .iter()
+        .enumerate()
+        .filter(|(idx, b)| **b == b'\n' && (*idx == 0 || snapshot[*idx - 1] != b'\r'))
+        .count();
+    if extra_crs == 0 {
+        return snapshot;
+    }
+
+    let mut out = Vec::with_capacity(snapshot.len() + extra_crs);
+    for (idx, b) in snapshot.iter().enumerate() {
+        if *b == b'\n' && (idx == 0 || snapshot[idx - 1] != b'\r') {
+            out.push(b'\r');
+        }
+        out.push(*b);
+    }
+    out
+}
+
+fn capture_attach_bytes(cmd: &Command, session: &RuntimeSession) -> RuntimeResult<Vec<u8>> {
+    let alt_on = is_alternate_on(cmd, &session.pane)?;
+    let mut bytes = normalize_capture_line_endings(capture_visible_region(cmd, session)?);
+    if alt_on {
+        let mut with_alt = Vec::with_capacity(bytes.len() + 11);
+        with_alt.extend_from_slice(b"\x1b[?1049h\x1b[H");
+        with_alt.append(&mut bytes);
+        bytes = with_alt;
+    }
+    Ok(bytes)
+}
+
 fn capture_replay_bytes(cmd: &Command, session: &RuntimeSession) -> RuntimeResult<Vec<u8>> {
     let alt_on = is_alternate_on(cmd, &session.pane)?;
     let mut capture = clone_cmd(cmd);
@@ -1233,14 +1282,40 @@ fn capture_replay_bytes(cmd: &Command, session: &RuntimeSession) -> RuntimeResul
     // one in main-screen scrollback (see docs/impls/0009). Cursor home
     // after the mode switch is defensive — it pins the first replayed cell
     // to (1,1) regardless of stale cursor state from `term.reset()`.
-    let mut bytes = out.stdout;
+    let mut bytes = normalize_capture_line_endings(out.stdout);
     if alt_on {
-        let mut with_alt = Vec::with_capacity(bytes.len() + 8);
+        let mut with_alt = Vec::with_capacity(bytes.len() + 11);
         with_alt.extend_from_slice(b"\x1b[?1049h\x1b[H");
         with_alt.append(&mut bytes);
         bytes = with_alt;
     }
     Ok(bytes)
+}
+
+fn pane_size(cmd: &Command, pane: &str) -> RuntimeResult<Option<(u16, u16)>> {
+    let out = clone_cmd(cmd)
+        .arg("display-message")
+        .arg("-p")
+        .arg("-t")
+        .arg(pane)
+        .arg("#{pane_width} #{pane_height}")
+        .output()?;
+    if !out.status.success() {
+        return Err(RuntimeError::TmuxFailed {
+            command: "display-message".into(),
+            status: out.status.code().unwrap_or(-1),
+            stderr: String::from_utf8_lossy(&out.stderr).to_string(),
+        });
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    let mut parts = text.split_whitespace();
+    let Some(cols) = parts.next().and_then(|s| s.parse::<u16>().ok()) else {
+        return Ok(None);
+    };
+    let Some(rows) = parts.next().and_then(|s| s.parse::<u16>().ok()) else {
+        return Ok(None);
+    };
+    Ok(Some((cols, rows)))
 }
 
 /// `display-message -p -t=<pane> '#{alternate_on}'` returns
@@ -1424,6 +1499,13 @@ mod tests {
         assert!(is_visually_blank(b"\x1b[2J"));
         assert!(!is_visually_blank(b" hi "));
         assert!(!is_visually_blank(b"\x1b[31mhello\x1b[0m"));
+    }
+
+    #[test]
+    fn normalize_capture_line_endings_converts_lf_rows_for_xterm_replay() {
+        let input = b"one\ntwo\r\nthree\n".to_vec();
+        let out = normalize_capture_line_endings(input);
+        assert_eq!(out, b"one\r\ntwo\r\nthree\r\n");
     }
 
     /// Build a detector with tiny debounce + threshold so the

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -8,7 +8,7 @@
 // raw bytes, backend snapshot replay for late attach, and SIGWINCH dance on
 // attach so claude-code/codex repaint onto a fresh grid.
 
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 
 import { listen } from "@tauri-apps/api/event";
 import { debug as logDebug } from "@tauri-apps/plugin-log";
@@ -20,6 +20,7 @@ import { WebglAddon } from "@xterm/addon-webgl";
 import "@xterm/xterm/css/xterm.css";
 
 import { api } from "../lib/api";
+import type { SessionOutputSnapshot } from "../lib/types";
 import {
   readTerminalCursorStyle,
   readTerminalFontFamily,
@@ -132,6 +133,15 @@ export function RunnerTerminal({
   // lengthen the redraw window the user perceives.
   const lastPushedColsRef = useRef(0);
   const lastPushedRowsRef = useRef(0);
+  const replayDoneRef = useRef(false);
+  const replayInFlightRef = useRef(false);
+  const pendingLiveRef = useRef<OutputEvent[]>([]);
+  const lastWrittenSeqRef = useRef(0);
+  const outputListenerReadyRef = useRef<Promise<void>>(Promise.resolve());
+
+  const writeOutputEvent = useCallback((ev: OutputEvent) => {
+    termRef.current?.write(decodeBase64Chunk(ev.data));
+  }, []);
 
   // Keep the latest sessionId visible to the data/resize callbacks without
   // re-creating the terminal on prop change. The session listener below
@@ -187,6 +197,7 @@ export function RunnerTerminal({
       allowProposedApi: true,
       scrollSensitivity: 3,
       fastScrollSensitivity: 8,
+      smoothScrollDuration: 125,
       // OSC 8 hyperlinks (emitted by claude-code and other modern CLIs) are
       // handled by xterm natively, not by WebLinksAddon. The default activator
       // calls window.open() which is a silent no-op in WKWebView/Tauri, so we
@@ -331,11 +342,14 @@ export function RunnerTerminal({
     const textarea = term.textarea;
     textarea?.addEventListener("paste", onPaste, { capture: true });
 
+    let resizeTimer: number | null = null;
+
     // Dedupe by last-pushed dims. See `lastPushedColsRef` comment for why.
     const pushSize = () => {
       const t = termRef.current;
       const sid = sessionIdRef.current;
       if (!t || !sid || disabledRef.current) return;
+      if (!replayDoneRef.current) return;
       if (
         t.cols === lastPushedColsRef.current &&
         t.rows === lastPushedRowsRef.current
@@ -354,16 +368,23 @@ export function RunnerTerminal({
         // session may have exited
       });
     };
-    // Refit + push backend geometry when the pane is active and
-    // measurable. Hidden panes don't refit/push — the activation
-    // effect picks up the new metrics when they come to the front.
+    const schedulePushSize = () => {
+      if (resizeTimer !== null) window.clearTimeout(resizeTimer);
+      resizeTimer = window.setTimeout(() => {
+        resizeTimer = null;
+        pushSize();
+      }, 140);
+    };
+    // Refit immediately, but coalesce backend geometry pushes. Claude Code's
+    // main-screen redraws on SIGWINCH are expensive and can leave stale
+    // intermediate frames in scrollback if we forward every drag tick.
     const refitAndPush = () => {
-      if (!activeRef.current || !containerRef.current) return;
+      if (!containerRef.current) return;
       const rect = containerRef.current.getBoundingClientRect();
       if (rect.width <= 0 || rect.height <= 0) return;
       try {
         fit.fit();
-        pushSize();
+        schedulePushSize();
       } catch {
         // teardown
       }
@@ -373,9 +394,8 @@ export function RunnerTerminal({
     // container's width without firing window-resize, so the xterm
     // grid and backend PTY geometry stay stale until the user nudges
     // the OS window (#108). Observing the container catches those
-    // CSS-driven size changes; refitAndPush's activeRef + measurable-
-    // rect guards keep hidden panes from pushing stale geometry to
-    // the backend.
+    // CSS-driven size changes; measurable-rect guards keep truly hidden
+    // panes from pushing stale geometry to the backend.
     const ro = new ResizeObserver(() => refitAndPush());
     ro.observe(containerRef.current);
 
@@ -433,6 +453,7 @@ export function RunnerTerminal({
     fitRef.current = fit;
 
     return () => {
+      if (resizeTimer !== null) window.clearTimeout(resizeTimer);
       ro.disconnect();
       window.removeEventListener("resize", refitAndPush);
       window.removeEventListener("focus", refreshTerm);
@@ -447,31 +468,36 @@ export function RunnerTerminal({
   }, []);
 
   // Subscribe to the bound session's output + exit. The listener is registered
-  // before snapshot replay so live chunks that arrive during the command round
-  // trip are buffered and merged by seq.
+  // before snapshot replay. We intentionally do NOT fetch the snapshot here:
+  // mission panes mount while hidden on the Feed tab, and replaying tmux's
+  // visible grid into xterm's default 80-col hidden buffer bakes in the drift
+  // that #150 is about. The activation effect below fetches the first replay
+  // once the pane is measurable.
   useEffect(() => {
     let unlistenOutput: (() => void) | null = null;
     let unlistenExit: (() => void) | null = null;
     let cancelled = false;
-    let replayDone = false;
-    let lastWrittenSeq = 0;
-    const pendingLive: OutputEvent[] = [];
+    let markReady: () => void = () => {};
+    outputListenerReadyRef.current = new Promise((resolve) => {
+      markReady = resolve;
+    });
 
-    const writeOutput = (ev: OutputEvent) => {
-      termRef.current?.write(decodeBase64Chunk(ev.data));
-    };
+    replayDoneRef.current = false;
+    replayInFlightRef.current = false;
+    pendingLiveRef.current = [];
+    lastWrittenSeqRef.current = 0;
 
     void (async () => {
       const [fnOut, fnExit] = await Promise.all([
         listen<OutputEvent>("session/output", (event) => {
           if (event.payload.session_id !== sessionId) return;
-          if (!replayDone) {
-            pendingLive.push(event.payload);
+          if (!replayDoneRef.current) {
+            pendingLiveRef.current.push(event.payload);
             return;
           }
-          if (event.payload.seq <= lastWrittenSeq) return;
-          writeOutput(event.payload);
-          lastWrittenSeq = event.payload.seq;
+          if (event.payload.seq <= lastWrittenSeqRef.current) return;
+          writeOutputEvent(event.payload);
+          lastWrittenSeqRef.current = event.payload.seq;
         }),
         listen<ExitEvent>("session/exit", (event) => {
           if (event.payload.session_id !== sessionId) return;
@@ -481,54 +507,91 @@ export function RunnerTerminal({
       if (cancelled) {
         fnOut();
         fnExit();
+        markReady();
         return;
       }
       unlistenOutput = fnOut;
       unlistenExit = fnExit;
-
-      let snapshot: OutputEvent[] = [];
-      try {
-        snapshot = await api.session.outputSnapshot(sessionId);
-      } catch (e) {
-        onErrorRef.current?.(String(e));
-      }
-      if (cancelled) return;
-
-      termRef.current?.reset();
-      for (const ev of snapshot) {
-        writeOutput(ev);
-        lastWrittenSeq = Math.max(lastWrittenSeq, ev.seq);
-      }
-      replayDone = true;
-      for (const ev of pendingLive) {
-        if (ev.seq <= lastWrittenSeq) continue;
-        writeOutput(ev);
-        lastWrittenSeq = ev.seq;
-      }
-      pendingLive.length = 0;
-
-      // Do not resize here: hidden terminal panes mount before they are
-      // measurable, and sending that hidden geometry to TUIs makes them paint
-      // their startup screen into a tiny grid. The activation effect below
-      // owns the SIGWINCH dance once the pane is visible.
+      markReady();
     })();
 
     return () => {
       cancelled = true;
+      markReady();
       unlistenOutput?.();
       unlistenExit?.();
     };
-  }, [sessionId]);
+  }, [sessionId, writeOutputEvent]);
 
   // Activation effect: when this tab moves to the front, wait for the pane
-  // to become measurable, fit to its container, repaint the WebGL/canvas
-  // renderer with the current scrollback, and grab focus so keystrokes flow
-  // into the expected PTY.
+  // to become measurable, fit to its container, replay the first snapshot at
+  // that exact grid, repaint the renderer, and grab focus for live panes.
   useEffect(() => {
-    if (!active) return;
     let cancelled = false;
     let raf1 = 0;
     let raf2 = 0;
+
+    const flushPendingLive = () => {
+      const pending = pendingLiveRef.current;
+      pendingLiveRef.current = [];
+      for (const ev of pending) {
+        if (ev.seq <= lastWrittenSeqRef.current) continue;
+        writeOutputEvent(ev);
+        lastWrittenSeqRef.current = ev.seq;
+      }
+    };
+
+    const replayAtSize = async (cols: number, rows: number) => {
+      if (replayDoneRef.current || replayInFlightRef.current) return;
+      replayInFlightRef.current = true;
+      try {
+        await outputListenerReadyRef.current;
+        if (cancelled || sessionIdRef.current !== sessionId) return;
+        const live = !disabledRef.current;
+        let snapshot: SessionOutputSnapshot;
+        try {
+          snapshot = live
+            ? await api.session.attachSnapshot(sessionId, cols, rows)
+            : await api.session.outputSnapshot(sessionId);
+        } catch (err) {
+          if (!live) throw err;
+          // If the pane exited between render and activation, fall back
+          // to the bounded in-memory buffer so the terminal still shows
+          // whatever scrollback the manager retained.
+          snapshot = await api.session.outputSnapshot(sessionId);
+        }
+        if (cancelled || sessionIdRef.current !== sessionId) return;
+
+        const t = termRef.current;
+        if (!t) return;
+        t.reset();
+        t.clear();
+        const lastSeq = snapshot.last_seq;
+        for (const ev of snapshot.events) {
+          writeOutputEvent(ev);
+        }
+        lastWrittenSeqRef.current = Math.max(
+          lastWrittenSeqRef.current,
+          lastSeq,
+        );
+        replayDoneRef.current = true;
+        if (live) {
+          lastPushedColsRef.current = cols;
+          lastPushedRowsRef.current = rows;
+        }
+        flushPendingLive();
+        try {
+          t.refresh(0, t.rows - 1);
+        } catch {
+          // teardown
+        }
+        if (live && activeRef.current) t.focus();
+      } catch (e) {
+        if (!cancelled) onErrorRef.current?.(String(e));
+      } finally {
+        replayInFlightRef.current = false;
+      }
+    };
 
     const activate = () => {
       if (cancelled) return;
@@ -541,9 +604,15 @@ export function RunnerTerminal({
       try {
         fit.fit();
         t.refresh(0, t.rows - 1);
-        t.focus();
         const cols = t.cols;
         const rows = t.rows;
+        if (!replayDoneRef.current) {
+          void replayAtSize(cols, rows);
+          return;
+        }
+        if (!activeRef.current) return;
+        if (disabledRef.current) return;
+        t.focus();
         // Single resize is enough once xterm enters alt-screen at attach
         // time (see docs/impls/0009). The earlier cols-1 → cols dance was
         // there to coax claude-code into a repaint that would land where
@@ -576,7 +645,7 @@ export function RunnerTerminal({
       window.cancelAnimationFrame(raf1);
       window.cancelAnimationFrame(raf2);
     };
-  }, [active, sessionId]);
+  }, [active, sessionId, writeOutputEvent]);
 
   return (
     <div className="h-full w-full overflow-hidden">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -23,7 +23,7 @@ import type {
   RunnerActivity,
   RunnerWithActivity,
   Session,
-  SessionOutputEvent,
+  SessionOutputSnapshot,
   SlotWithRunner,
   SpawnedSession,
   StartMissionInput,
@@ -175,7 +175,13 @@ export const api = {
     resize: (sessionId: string, cols: number, rows: number) =>
       invoke<void>("session_resize", { sessionId, cols, rows }),
     outputSnapshot: (sessionId: string) =>
-      invoke<SessionOutputEvent[]>("session_output_snapshot", { sessionId }),
+      invoke<SessionOutputSnapshot>("session_output_snapshot", { sessionId }),
+    attachSnapshot: (sessionId: string, cols: number, rows: number) =>
+      invoke<SessionOutputSnapshot>("session_attach_snapshot", {
+        sessionId,
+        cols,
+        rows,
+      }),
     pasteImage: (bytes: Uint8Array) =>
       invoke<void>("session_paste_image", {
         bytes: Array.from(bytes),

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -128,6 +128,11 @@ export interface SessionOutputEvent {
   data: string;
 }
 
+export interface SessionOutputSnapshot {
+  events: SessionOutputEvent[];
+  last_seq: number;
+}
+
 export type MissionStatus = "running" | "completed" | "aborted";
 
 export interface Mission {

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -669,10 +669,9 @@ export default function MissionWorkspace() {
 
           <div className="relative flex flex-1 min-h-0 flex-col">
             {/* All panes stay mounted so xterm's in-memory scrollback
-                survives tab switches. Inactive panes use display:none:
-                that keeps the React/xterm instances alive while making
-                the visible session unambiguous. The terminal activation
-                effect refits + repaints after the pane is shown. */}
+                survives tab switches. Inactive panes stay layout-visible
+                but transparent, so xterm can attach at real dimensions
+                and keep streaming scrollback while hidden. */}
             <Pane active={activeTab === "feed"}>
               <EventFeed
                 missionId={mission.id}
@@ -861,7 +860,7 @@ function SlotPtyPane({
         <RunnerTerminal
           sessionId={session.id}
           onError={onError}
-          active={active && !dead && !resuming}
+          active={active && !resuming}
           disabled={dead || resuming}
         />
       </div>
@@ -893,8 +892,10 @@ function Pane({
 }) {
   return (
     <div
-      className={`absolute inset-0 flex-col bg-bg ${
-        active ? "flex" : "hidden"
+      className={`absolute inset-0 flex flex-col bg-bg transition-opacity ${
+        active
+          ? "z-10 opacity-100"
+          : "pointer-events-none z-0 opacity-0"
       }`}
     >
       {children}

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -766,9 +766,10 @@ export default function RunnerChat() {
         </div>
       ) : null}
 
-      {/* Keep one xterm mounted per direct session. Hidden panes still receive
-          PTY output into their buffers, so switching sessions preserves the
-          real terminal state. When the active pane's session has exited the
+      {/* Keep one xterm mounted per direct session. Inactive panes remain
+          layout-visible but transparent so they still receive PTY output at
+          real dimensions, preserving scrollback across session switches.
+          When the active pane's session has exited the
           xterm dims and a "Session ended" card overlays the center —
           mirrors Pencil node `vS5ce`.
           Archived rows render a static placeholder instead — no xterm,
@@ -812,10 +813,13 @@ export default function RunnerChat() {
                   ? "opacity-45"
                   : ""
               : "";
+            const visibilityClass = active
+              ? `z-10 ${paneOpacity || "opacity-100"}`
+              : "pointer-events-none z-0 opacity-0";
             return (
               <div
                 key={s.id}
-                className={`absolute inset-4 ${active ? "block" : "hidden"} ${paneOpacity} transition-opacity`}
+                className={`absolute inset-4 ${visibilityClass} transition-opacity`}
               >
                 <RunnerTerminal
                   sessionId={s.id}


### PR DESCRIPTION
## Summary
- Replay attach snapshots after the frontend fits xterm to a real visible grid.
- Normalize tmux capture output from LF to CRLF before writing it into xterm.
- Keep inactive terminal panes layout-visible so they stream scrollback at real dimensions.
- Debounce/no-op resize pushes to avoid accumulating intermediate Claude redraws.

## Root Cause
- Claude Code 2.1.143 uses tmux main-screen mode, so full `capture-pane` history contains resize redraw artifacts. Replaying that polluted history caused stacked output after restart/resize.
- `tmux capture-pane -p` emits bare LF rows; xterm replay needs CRLF-style row transitions, otherwise lines staircase sideways.
- Hidden panes mounted without measurable layout, so early replay/input geometry could bake in an 80-col or stale grid.

## Validation
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm exec tsc --noEmit`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm run lint`
- `COREPACK_ENABLE_AUTO_PIN=0 pnpm run build`
- `cargo test -p runner --lib`
- `git diff --check`

Notes: frontend checks pass with the existing Node engine warning in this shell (`18.20.8` vs project `>=22.12.0`), the existing Fast Refresh lint warning in `src/contexts/UpdateContext.tsx`, and the existing Vite chunk-size warning.

Fixes #150
Fixes #141