### PR TITLE
feat: in-process PTY terminal runtime (0011 umbrella)

### DIFF
--- a/docs/impls/0011-pty-host-terminal-runtime.md
+++ b/docs/impls/0011-pty-host-terminal-runtime.md
@@ -1,305 +1,309 @@
-# PTY Host Terminal Runtime
+# In-Process PTY Terminal Runtime
 
 ## Context
 
 The current terminal runtime uses tmux as both the process-survival
-layer **and** the replay/snapshot source for xterm.js. The replay role
-is the problem: `tmux capture-pane` gives a rendered text approximation
+layer and the replay/snapshot source for xterm.js. The replay role is
+the problem: `tmux capture-pane` returns a rendered text approximation
 of the pane, and modern TUIs (claude-code especially) redraw on resize
-in ways `capture-pane` can't faithfully reproduce. The latest stacking
-screenshot (issue #150) is the visible symptom.
+in ways `capture-pane` can't faithfully reproduce. The stacking
+screenshot on issue #150 is the visible symptom.
 
 Two earlier design attempts went further:
 
 - **PR #154** — route every resize through `capture-pane` + reset +
   replay. Didn't fix the stacking; closed.
-- **PR #157** — host-side headless emulator
-  (`alacritty_terminal::Term`) + `screen_to_ansi` serializer + bracketed-
-  paste handling + key-name translation. Compiled and passed tests, but
-  the first review pass surfaced a seq race, an incomplete protocol
-  contract for `Key` / `Paste`, and missing terminal-mode restoration in
-  the snapshot. The pattern of "every architectural layer we add must
-  be correct across all of xterm's protocol surface" was the fragility
-  signal. Closed.
+- **PR #157** — host-side PTY sidecar with a headless emulator
+  (`alacritty_terminal::Term` + `screen_to_ansi` + key translation +
+  bracketed-paste handling). Compiled and passed tests, but the first
+  review pass surfaced a seq race, an incomplete protocol contract,
+  and missing mode restoration in the snapshot. The pattern of "every
+  architectural layer must be correct across all of xterm's protocol
+  surface" was the fragility signal. Closed.
 
-This rewrite picks a different point on the trade-off curve:
+This rewrite picks the smallest design that fixes the original
+problem:
 
-> The PTY host owns the agent process and forwards raw bytes.
-> xterm.js is the terminal model. **We do not try to restore visible
-> state across app restart or webview reload.**
+> Replace tmux with `portable-pty` in the **same** Tauri process.
+> xterm.js is the terminal model. Agents die with Tauri; a manual
+> Resume button respawns them via the existing `agent_session_key`
+> flow.
+
+There is no sidecar, no headless emulator, no IPC protocol, no host
+serialization layer.
 
 ## Persistence guarantees
 
-What survives what, after the migration:
+| Event                                  | Agent process | Tauri app | Webview | Conversation recoverable |
+|----------------------------------------|---------------|-----------|---------|--------------------------|
+| Webview reload (Cmd+R)                 | ✅            | ✅        | ❌      | ✅ (live stream resumes) |
+| Tauri quit (graceful / crash / kill)   | ❌            | ❌        | ❌      | ✅ (`agent_session_key` resume) |
 
-| Event                          | Agent CLI | PTY host | Tauri app | Webview |
-|--------------------------------|-----------|----------|-----------|---------|
-| Webview reload (Cmd+R)         | ✅        | ✅       | ✅        | ❌      |
-| Tauri app crash / force-quit   | ✅        | ✅       | ❌        | ❌      |
-| PTY host process death         | ❌        | ❌       | (n/a)     | (n/a)   |
+Cmd+R remounts the webview but keeps the Tauri main process and every
+PTY it owns. The frontend resubscribes, raw bytes flow again from the
+agent's next emit forward — xterm starts blank until the agent
+repaints (which TUIs do on the next user interaction).
 
-Process-survival guarantees match what tmux gives us today (and what
-PR #157 promised). **Visible state on reattach is explicitly NOT a goal
-in v1.** After a webview reload or app restart, xterm starts blank; the
-agent is still running and bytes will appear once it next emits. TUIs
-that redraw on user interaction (claude-code, codex, vim) repaint
-quickly. Plain shells stay blank until the user hits Enter.
+Every other "app went away" event kills the agents. Recovery is via
+the existing `session_resume` flow — `--resume <uuid>` for
+claude-code, `codex resume <uuid>` for codex once the key-capture
+path lands. See `src-tauri/src/commands/session.rs:556` and
+`src-tauri/src/session/codex_capture.rs`. Sessions surface as
+`stopped` in the sidebar, the user clicks **Resume**, the backend
+respawns the agent CLI with its prior conversation key, and xterm
+renders the freshly-redrawn UI from the agent's own re-render.
 
-The agents-survive-app-crash guarantee requires the sidecar to be
-**detached** from the Tauri main process at boot, not a managed child.
-See Step 2.
+**No auto-resume on app start.** Sessions surface as `stopped`; the
+user decides which (if any) to resume. Matches the existing
+`DirectSessionEntry` click contract
+(`src-tauri/src/commands/session.rs:230`) and avoids surprise
+wakeups firing N agents' worth of LLM context loads.
 
 ## Approach
 
 ```text
 Runner UI (xterm.js)
-  <-> Tauri session manager
-  <-> runner-pty-host sidecar over local IPC
-  <-> portable-pty (PTY allocation + child spawn)
+  <-> Tauri SessionManager (existing)
+  <-> PtyRuntime (in-process, this PR)
+  <-> portable-pty
   <-> agent CLI
 ```
 
-The PTY host **owns**:
+Same shape as today's `TmuxRuntime`: a `SessionRuntime` impl that
+lives in the Tauri main process. The only thing changing is the
+backend (`portable-pty` instead of tmux) and the contract
+(`Replay` snapshots on `resume` go away).
 
-- agent process and PTY master fd,
-- stdin / paste / key forwarding — verbatim from xterm.js, no host-side
-  translation,
-- resize forwarding — `MasterPty::resize` ioctl, nothing else,
-- live raw-byte broadcast to subscribed clients,
-- session status (alive / exit code).
+PtyRuntime **owns**:
 
-The PTY host **does not own**:
+- agent process + PTY master fd (one per session, in
+  `HashMap<session_id, SessionHandle>`),
+- the reader thread that pumps raw PTY bytes into the existing
+  `RuntimeOutput::Stream` channel,
+- writer mutex for `send_bytes` / `paste`,
+- resize ioctl,
+- child kill on `stop`.
 
-- any terminal-state mirror (no headless emulator, no `Term`,
-  no `Processor`),
+PtyRuntime **does not own**:
+
+- any terminal-state mirror (no headless emulator, no `Term`, no
+  `Processor`),
 - any serialized snapshot (no `screen_to_ansi`),
-- any key-name translation table — xterm.js converts
-  `KeyboardEvent.key` to bytes before sending,
-- any bracketed-paste wrapping — xterm.js wraps client-side based on
-  its own mode tracking.
+- bracketed-paste wrapping for the user-input path — xterm.js wraps
+  client-side based on its own mode tracking before calling
+  `send_bytes`.
 
-The rule:
-
-> Bytes in from agent → bytes out to xterm. Bytes in from xterm →
-> bytes out to agent. The host does not interpret either direction.
-
-### Why no reattach-state
+### Why no headless emulator
 
 PR #157 tried to give the user visible state after reattach by
 mirroring the agent's terminal in `alacritty_terminal::Term` and
-re-serializing it on `Attach`. That introduced a class of correctness
-problems:
+re-serializing it on `Attach`. That introduced four correctness
+problems in one review pass:
 
 1. Two parsers had to agree (host's alacritty + frontend's xterm.js).
-   Any mismatch in protocol coverage produced visible drift.
 2. The serializer had to round-trip the screen *and* every user-facing
-   mode (`APP_CURSOR`, `BRACKETED_PASTE`, mouse modes, focus reporting,
-   alt-screen, line-wrap, …).
-3. The seq numbering had to be race-free across the term-lock + atomic
-   + subscriber-list boundaries.
+   mode (`APP_CURSOR`, `BRACKETED_PASTE`, mouse modes, focus, alt-
+   screen, line-wrap, …).
+3. The seq numbering had to be race-free across term-lock + atomic +
+   subscriber-list boundaries.
 4. `Key` + `Paste` had to be host-side translated to honor the agent's
    current mode bits.
 
-Each layer needed to be correct individually *and* in composition with
-the others. The first review pass produced findings on three of them.
-The fourth was probably next.
+Accepting "no reattach-state" deletes all four. The Cmd+R UX cost is
+real (blank xterm until the agent's next emit) and we accept it. If
+real usage shows the blank-xterm window is too jarring, v2 can add a
+tiny ring buffer of recent raw bytes — pure UX patch, no emulator.
 
-Accepting "no reattach state" deletes all four problems. The trade is
-real (a webview reload leaves the user staring at a blank xterm for a
-moment until the agent next emits) and we accept it. If real usage
-shows the blank-xterm window is too jarring, v2 can add a tiny ring
-buffer of the last few KB of raw bytes — *purely a UX patch*, no
-emulator, no serializer.
+### Why no sidecar
 
-## Step 1: Define the PTY Host Protocol
+The sidecar in PR #157's design was justified by "agents survive
+Tauri quit/crash". Once we trade that away in favor of manual resume,
+the sidecar buys nothing:
 
-**File:** `crates/runner-core/src/pty_host.rs`
+- Cmd+R doesn't kill the Tauri main process — in-process PTYs survive
+  Cmd+R fine.
+- All the IPC machinery (Unix socket, framed JSON, protocol crate,
+  bundle externalBin, stage script) would exist purely to cross a
+  process boundary that no behavior depends on.
 
-Requests:
+In-process is also cheaper to debug, drops a build target, and
+eliminates the seq / subscriber race surface entirely (the manager
+holds the `OutputStream` directly, no IPC fan-out).
 
-| Op | Payload | Response |
-|---|---|---|
-| `Spawn` | `SpawnSpecWire` | `Spawned { session_id, pid }` |
-| `Attach` | `session_id` | `Ack` (registers subscription; **no snapshot**) |
-| `Input` | `session_id, data_base64` | `Ack` |
-| `Resize` | `session_id, cols, rows` | `Ack` |
-| `Stop` | `session_id` | `Ack` |
-| `Status` | `session_id` | `SessionStatus` |
-| `List` | (none) | `Sessions` |
+## Step 1: `PtyRuntime`
 
-Push events:
+**File:** `src-tauri/src/session/pty_runtime.rs`
 
-| Kind | Payload |
-|---|---|
-| `Output` | `session_id, seq, data_base64` — raw PTY bytes |
-| `Exit` | `session_id, seq, exit_code` |
-
-`HostMessage { type: response | event }` envelope at the top level so
-the Tauri side routes without inspecting inner tags.
-
-`seq` is per-session monotonic. The frontend uses it for ordering;
-receive-out-of-order isn't expected on a single socket, but the seq
-makes the contract explicit and gives the Tauri side a knob for
-duplicate detection during a brief reconnect window.
-
-**Explicitly dropped from PR #157's protocol:** `Paste`, `Key`,
-`HostSnapshot`, `TerminalReplayEvent`, `RunnerStatus`. xterm.js
-owns the user-input translation surface; the host doesn't see
-keys or pastes as anything other than `Input` bytes.
-
-## Step 2: Sidecar Daemon + Sessions
-
-**File:** `src-tauri/src/bin/runner-pty-host.rs`
-
-Daemon scaffold (mostly inherited from PR #157's design, which got
-that piece right):
-
-- `--detach`: setsid + double-fork before bind; macOS hardened
-  runtime may force a swap to `posix_spawn` +
-  `POSIX_SPAWN_SETSID` — validate in the bundling pass.
-- `--socket-dir <PATH>`: directory for the lockfile + Unix socket.
-- `fs2::FileExt::try_lock_exclusive` on `pty-host.lock` — second
-  invocation exits cleanly so the Tauri startup connects to the
-  existing host.
-- 0o700 dir / 0o600 socket perms.
-- Stale-socket liveness probe before unlink.
-- 4-byte big-endian length-prefixed JSON frames, capped at 16 MiB.
-
-Per-session ownership:
-
-- `portable_pty::native_pty_system()` for PTY allocation.
-- `MasterPty` (the master fd) wrapped in `Mutex` for the resize
-  ioctl.
-- `Child` handle (`Box<dyn Child + Send + Sync>`) from
-  `slave.spawn_command(CommandBuilder)`. The slave is dropped
-  immediately after spawn to release our side of the pair.
-- Reader thread per session: `try_clone_reader()` → blocking read
-  into an 8 KiB buffer → base64-encode → broadcast
-  `HostEvent::Output` to subscribers.
-- Writer: `take_writer()` → `Mutex<Box<dyn Write + Send>>` for input.
-- Resize: `master.resize(PtySize { rows, cols, .. })`.
-- Stop: `child.clone_killer()` returns a `Send`-able `ChildKiller`;
-  call `kill()` on that from the dispatch thread.
-
-There is **no `Term`, no `Processor`, no `FairMutex` around
-terminal state**. The reader thread's only state is the master fd
-and a seq counter.
-
-`SpawnSpecWire` keys the host trusts verbatim:
+A `SessionRuntime` impl backed by `portable-pty`. Per session:
 
 ```rust
-struct SpawnSpecWire {
-    command: String,
-    args: Vec<String>,
-    cwd: Option<String>,
-    env: BTreeMap<String, String>,
-    cols: u16,
-    rows: u16,
+struct SessionHandle {
+    runtime_id: RuntimeSession,         // existing identifier shape
+    master: Mutex<Box<dyn MasterPty + Send>>,
+    writer: Mutex<Box<dyn Write + Send>>,
+    killer: Mutex<Box<dyn ChildKiller + Send>>,
+    cols: AtomicU16,
+    rows: AtomicU16,
+    exit_code: Mutex<Option<i32>>,
+    alive: AtomicBool,
+    output_tx: mpsc::Sender<RuntimeOutput>,   // same channel SessionManager listens on
 }
 ```
 
-Env / cwd filtering is the Tauri side's job (`session::launch`).
-The host doesn't second-guess it.
+Trait method mapping:
 
-## Step 3: `PtyHostRuntime`
-
-**Files:**
-
-- `src-tauri/src/session/pty_host_runtime.rs`
-- `src-tauri/src/session/runtime.rs` (existing trait; lightly
-  re-document for the no-snapshot contract)
-- `src-tauri/src/session/manager.rs`
-
-`SessionRuntime` impl that talks to the sidecar over the local socket:
-
-| Method | Host op |
+| Method | PtyRuntime behavior |
 |---|---|
-| `spawn` | `Spawn` |
-| `resume` | `Attach` — subscribes to live `Output` stream, no snapshot returned |
-| `send_bytes` | `Input` — verbatim |
-| `paste` | `Input` — xterm.js sends bracketed-paste-wrapped bytes when its mode is set, the host doesn't care |
-| `send_key` | `Input` — frontend translates `KeyboardEvent` → bytes; the host stays neutral |
-| `resize` | `Resize` |
-| `status` | `Status` |
-| `stop` | `Stop` |
-| `capture_visible` | Paste verification's legacy contract. v1 scope: argv-only delivery; this method returns empty and paste verification falls back to argv. Revisit if a real need surfaces. |
+| `spawn(spec)` | `native_pty_system().openpty(PtySize)` → `slave.spawn_command(CommandBuilder)`. Drop the slave immediately. Spawn the reader thread. Return the `(RuntimeSession, OutputStream)` pair. |
+| `resume(session)` | The runtime is in-process and the session is already in the manager's registry → no work needed at the runtime layer. The contract changes here: we **do not** emit a `RuntimeOutput::Replay` first. The frontend already accepts the no-snapshot trade. |
+| `send_bytes(session, bytes)` | `writer.lock().write_all(bytes)` |
+| `paste(session, payload)` | Same as `send_bytes` — xterm.js wraps in `\x1b[200~`/`\x1b[201~` client-side based on its own mode bit. Rust-side callers that want bracketed paste prefix it themselves. |
+| `send_key(session, key)` | Translate via a small Rust-side name table: `"Enter"` → `\r`, `"Escape"` → `\x1b`, `"C-c"` → `\x03`, `"C-d"` → `\x04`, `"Tab"` → `\t`, plus the arrows/Home/End/Function keys for completeness. Only names Rust callers (e.g., the first-prompt `paste`-then-Enter machinery) actually use need to land in v1; unknown names error. **Not** the full xterm.js `KeyboardEvent.key` space — xterm.js routes user typing through `send_bytes`. |
+| `resize(session, cols, rows)` | `master.resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })` |
+| `status(session)` | Read atomic `alive` + `exit_code`. |
+| `stop(session)` | `killer.kill()`. SIGTERM-style; the reader thread observes EOF, marks `alive = false`, and emits the final `RuntimeOutput::Stream` empty + `RuntimeOutput::Exit` if/as the manager expects. |
+| `capture_visible(session)` | v1 scope: return empty bytes. The paste-verification path (`inject_paste_with_verify` in `manager.rs`) currently uses this to readback the visible pane. With no host-side terminal state, we can't readback. Drop the verify-then-Enter chain in favor of always-argv-or-paste-then-Enter at the manager level. |
 
-Fallback flag: `RUNNER_SESSION_RUNTIME=tmux` keeps the tmux path
-alive during cutover. Default becomes `pty-host` once the
-manual-test pass in Step 4 succeeds.
+Reader thread, per session:
 
-## Step 4: Wire Startup + Reattach Policy
+```rust
+let mut buf = [0u8; 8192];
+loop {
+    match reader.read(&mut buf) {
+        Ok(0) => break,                 // EOF
+        Ok(n) => {
+            if output_tx.send(RuntimeOutput::Stream(buf[..n].to_vec())).is_err() {
+                break;                  // manager dropped the receiver
+            }
+        }
+        Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+        Err(_) => break,
+    }
+}
+// Mark alive=false, try_wait for exit code, emit Exit, drop.
+```
 
-**Files:**
+Dependencies added to `src-tauri/Cargo.toml` (cfg(unix)-gated to
+match the existing tmux runtime; Windows keeps the tmux fallback
+until a separate effort lands):
 
-- `src-tauri/src/lib.rs`
-- `src-tauri/src/session/manager.rs`
-- `src-tauri/tauri.conf.json` (register sidecar in `bundle.externalBin`)
-- `scripts/stage-runner-pty-host.mjs` (mirrors `stage-runner-cli.mjs`)
-- `package.json` (wire stage script into `tauri:before:dev` and
-  `tauri:before:build`)
+```toml
+portable-pty = "0.9"
+```
 
-At Tauri startup:
-
-1. Locate sidecar via
-   `app.path().resolve("runner-pty-host", BaseDirectory::Resource)?`
-   — **not** `std::env::current_exe()`.
-2. Launch with `--detach --socket-dir <app_data>/pty-host`.
-3. Connect to the resulting socket, build `PtyHostRuntime`.
-4. `reattach_running_sessions`:
-   - **Direct chats:** send `Attach` per known session, subscribe to
-     the live `Output` stream. xterm renders blank; the agent's next
-     emit fills it.
-   - **Mission sessions:** keep the conservative policy until the
-     router/event-bus also moves host-side. Don't pretend the
-     mission stayed fully coordinated while the router was down.
-
-Webview reload (Cmd+R):
-- Tauri main process and sidecar both stay alive.
-- Frontend remounts, calls `Attach` per session.
-- xterm starts blank, live bytes flow.
-
-Tauri app restart (force-quit + relaunch):
-- Sidecar stays alive (detached at boot).
-- New Tauri process discovers the existing host via the lockfile.
-- Same reattach flow as above.
-
-## Step 5: Remove tmux
+## Step 2: Lifecycle wiring
 
 **Files:**
 
-- `src-tauri/src/session/tmux_runtime.rs` — delete
+- `src-tauri/src/lib.rs` (startup hook, quit hook)
+- `src-tauri/src/session/manager.rs` (startup DB cleanup)
+
+### Tauri startup
+
+1. **DB cleanup first.** Before mounting the UI:
+   ```sql
+   UPDATE sessions
+       SET status = 'stopped', stopped_at = COALESCE(stopped_at, ?1)
+       WHERE status = 'running';
+   ```
+   Defensive — covers the force-quit / crash path where the on-quit
+   hook didn't run. Resumable rows surface in the sidebar with the
+   existing `DirectSessionEntry.resumable` flag.
+2. Build `SessionManager` with `PtyRuntime`. No reattach pass — the
+   DB has zero `running` rows at this point.
+
+### Tauri on-quit hook
+
+`tauri::Builder::on_window_event` + `RunEvent::ExitRequested` /
+`RunEvent::Exit`:
+
+1. Walk the DB for `status = 'running'` direct-chat sessions.
+2. For each, call `SessionManager::stop` (which routes to
+   `PtyRuntime::stop` → `ChildKiller::kill()`).
+3. Brief wait (~500ms total budget) for reader threads to observe
+   EOF and emit `Exit`.
+4. Mark rows `status = 'stopped'`, `stopped_at = now()`.
+5. Let Tauri continue exit.
+
+If the user force-quits before this hook runs, step 1 of the
+**startup** cleanup catches it on next launch.
+
+### Webview reload (Cmd+R)
+
+- Tauri main process, PtyRuntime, every PTY all stay alive.
+- Frontend remounts. For rows still marked `running`, the existing
+  `DirectSessionEntry.status === "running"` branch calls
+  `session_attach` → manager rewires its existing `OutputStream` to
+  the new frontend listener.
+- xterm starts blank; live bytes flow on the next agent emit.
+- This is the **only** path where Attach actually has a live
+  session to attach to.
+
+### User clicks Resume
+
+- Frontend calls `session_resume(session_id, cols, rows)`
+  (`src-tauri/src/commands/session.rs:556`) — already implemented.
+- `SessionManager::resume` reads `agent_session_key` off the row,
+  builds the resume command (`--resume <key>` etc.), and calls
+  `PtyRuntime::spawn` with the resulting `SpawnSpec`.
+- The agent CLI re-renders its UI from its own conversation store.
+  xterm receives the freshly-rendered frame as the first batch of
+  bytes.
+- Status flips back to `running`, `started_at` updates.
+
+### Mission sessions
+
+Out of scope for this PR. Mission coordination still depends on the
+app-side router/event-bus; moving it host-side is a separate effort.
+Mission rows behave like direct-chat rows for the lifecycle paths
+above (stopped at quit, resumed by user click), but the router
+doesn't auto-rewire for resumed mission sessions.
+
+### Fallback flag
+
+`RUNNER_SESSION_RUNTIME=tmux` keeps the tmux path alive during
+cutover. Default flips to `pty` once the manual-test pass below
+succeeds.
+
+## Step 3: Remove tmux
+
+**Files:**
+
+- `src-tauri/src/session/tmux_runtime.rs` — delete (~1850 lines)
 - `src-tauri/src/session/tmux.rs` — delete
-- `src-tauri/src/session/mod.rs` — drop the tmux mod
-- `src-tauri/Cargo.toml` — drop tmux-only deps
-- `docs/impls/0004-tmux-session-runtime.md` — mark superseded
+- `src-tauri/src/session/mod.rs` — drop the tmux mods
+- `src-tauri/Cargo.toml` — drop tmux-only deps if any
+- `docs/impls/0004-tmux-session-runtime.md` — mark superseded by 0011
 - `docs/impls/0009-terminal-alt-screen-reattach.md` — mark superseded
+- `docs/impls/0010-terminal-replay-cols-alignment.md` — already
+  shelved; delete in this step's landing commit if still present
 
-After PtyHostRuntime parity for spawn / resume / input / resize /
-kill / archive / app restart:
+After PtyRuntime parity for spawn / send_bytes / paste / resize /
+stop / status / resume on direct chats:
 
 - Stop constructing `TmuxRuntime` by default.
-- Remove `capture-pane` from any attach path.
-- Delete tmux session-management code.
-- Update superseded-by markers on the older impls.
+- Delete the tmux runtime module and its capture-pane / pipe-pane /
+  send-keys plumbing.
+- Update older docs to mark them superseded.
 
 ## Verification
 
 ### Unit tests
 
-- Protocol round-trips for every request / response / event.
-- `PtyHostRuntime` method-to-op mapping.
-- Subscriber retain-on-broadcast-failure correctly garbage-collects
-  closed connections.
+- `PtyRuntime::spawn` + `send_bytes` round-trip via `/bin/cat`.
+- `PtyRuntime::resize` updates `MasterPty::get_size()`.
+- `PtyRuntime::stop` causes child to exit and reader thread to
+  observe EOF.
+- Key-name translation table covers the names Rust callers use;
+  unknown names error.
 
 ### Integration tests
 
-- Spawn `/bin/cat`, inject bytes via `Input`, observe matching
-  `Output` event.
-- Spawn `/usr/bin/false` (or `sh -c "exit 7"`); verify `Exit` event
-  with `exit_code: Some(7)` and DB row transition to `stopped`.
-- Restart Tauri-side manager while host stays alive; verify each
-  direct-chat session `Attach` succeeds and live stream resumes.
+- Spawn a `sh -c "exit 7"` session; verify `RuntimeOutput::Exit`
+  with `exit_code: Some(7)` and DB transition to `stopped`.
+- Two concurrent sessions don't cross output streams.
+- Webview reload simulation (drop + reconstruct the frontend-side
+  listener) preserves live `RuntimeOutput::Stream` delivery.
 
 ### Manual tests
 
@@ -312,8 +316,10 @@ kill / archive / app restart:
 4. Cmd+R reload. xterm goes blank.
 5. Type "hi" — claude-code receives, responds, output flows.
 6. Force-quit the Tauri app. Relaunch.
-7. Open the same direct chat — xterm blank, agent still alive.
-8. Type again — agent responds. ✓
+7. Sidebar shows the prior session as `stopped` with a Resume
+   affordance.
+8. Click Resume. Agent re-spawns, re-renders the prior conversation.
+   ✓
 
 ### Regression checks
 
@@ -323,15 +329,12 @@ kill / archive / app restart:
 
 ## Non-Goals
 
-- **Visible state on reattach.** Deliberate. See "Why no reattach-state".
-- **Mission router / event-bus host-side migration.** Mission
-  coordination still depends on the app-side router today; moving
-  it into the sidecar is a separate effort.
-- **Windows support.** Defer until a named-pipe + child-spawn
-  equivalent of the detach mechanism lands.
+- **Visible state on Cmd+R reload.** Deliberate. Blank xterm until
+  next emit; ring buffer is a possible v2 patch.
+- **Cross-Tauri-process agent survival.** Deliberately removed in
+  favor of manual resume.
+- **Mission router / event-bus migration.** Separate effort.
+- **Windows support.** Defer until a portable-pty + child-spawn pass
+  on Windows lands.
 - **Persistent terminal scrollback across reattach.** xterm.js's
-  in-memory scrollback during a single mount is enough; agents that
-  need history paint it themselves on user interaction.
-- **Recovering visible state via a ring buffer of recent bytes.**
-  Not in v1; if usage feedback demands it, that's a small v2 patch
-  (bounded `Vec<u8>` per session, replay-on-Attach).
+  in-memory scrollback during a single mount is enough.

--- a/docs/impls/0011-pty-host-terminal-runtime.md
+++ b/docs/impls/0011-pty-host-terminal-runtime.md
@@ -2,46 +2,35 @@
 
 ## Context
 
-The current terminal runtime uses tmux as both:
+The current terminal runtime uses tmux as both the process-survival
+layer **and** the replay/snapshot source for xterm.js. The replay role
+is the problem: `tmux capture-pane` gives a rendered text approximation
+of the pane, and modern TUIs (claude-code especially) redraw on resize
+in ways `capture-pane` can't faithfully reproduce. The latest stacking
+screenshot (issue #150) is the visible symptom.
 
-1. the process-survival layer, and
-2. the replay/snapshot source for xterm.js.
+Two earlier design attempts went further:
 
-That second role is the problem. The latest Claude Code stacking screenshot
-shows repeated banners and duplicated prompt panels after reopen. This is not a
-frontend paint bug; it is a source-of-truth bug. `tmux capture-pane` gives
-Runner a rendered cell approximation of a pane, not the original terminal event
-stream. For modern TUIs that redraw on resize, especially Claude Code,
-`capture-pane` can include prior redraws, resize artifacts, and main-screen
-history that was never meant to be replayed as fresh terminal input.
+- **PR #154** — route every resize through `capture-pane` + reset +
+  replay. Didn't fix the stacking; closed.
+- **PR #157** — host-side headless emulator
+  (`alacritty_terminal::Term`) + `screen_to_ansi` serializer + bracketed-
+  paste handling + key-name translation. Compiled and passed tests, but
+  the first review pass surfaced a seq race, an incomplete protocol
+  contract for `Key` / `Paste`, and missing terminal-mode restoration in
+  the snapshot. The pattern of "every architectural layer we add must
+  be correct across all of xterm's protocol surface" was the fragility
+  signal. Closed.
 
-Relevant current code:
+This rewrite picks a different point on the trade-off curve:
 
-- `src-tauri/src/session/tmux_runtime.rs:816` wires `pipe-pane`,
-  `capture-pane`, and live FIFO streaming into one `OutputStream`.
-- `src-tauri/src/session/tmux_runtime.rs:872` uses full scrollback
-  `capture-pane` on reattach for main-screen panes.
-- `src/components/RunnerTerminal.tsx:489` fetches the backend output snapshot,
-  resets xterm, then writes the returned bytes.
-- `src-tauri/src/session/manager.rs:1715` stores only a bounded in-memory
-  output snapshot, so app restart relies on the runtime reattach path.
-
-The most recent attempt to patch the existing architecture
-(branch `fix/terminal-attach-resize-replay`, PR #154 — closed) routed every
-resize through a tmux `capture-pane` + `term.reset()` + replay round trip.
-It did not fix the stacking. Main-screen claude-code's SIGWINCH redraws
-land at the current cursor position, and `capture-pane`'s text dump can't
-distinguish "live frame" from "previous frame in scrollback". The dropped
-PR is the final piece of evidence that the tmux-as-replay-source model is
-unrepairable for modern TUIs — we have to own the byte stream end-to-end.
-
-VS Code's integrated terminal architecture is closer to what Runner needs:
-the app owns a PTY host process and the terminal byte stream. The display is
-xterm.js, but tmux is not the replay source.
+> The PTY host owns the agent process and forwards raw bytes.
+> xterm.js is the terminal model. **We do not try to restore visible
+> state across app restart or webview reload.**
 
 ## Persistence guarantees
 
-This is what survives what after the migration:
+What survives what, after the migration:
 
 | Event                          | Agent CLI | PTY host | Tauri app | Webview |
 |--------------------------------|-----------|----------|-----------|---------|
@@ -49,661 +38,300 @@ This is what survives what after the migration:
 | Tauri app crash / force-quit   | ✅        | ✅       | ❌        | ❌      |
 | PTY host process death         | ❌        | ❌       | (n/a)     | (n/a)   |
 
-The first two rows are the goal — they're what tmux gives us today; losing
-either would be a regression. The third row is "agents die when their PTY
-owner dies"; the host owns the master fd, so this is by construction.
+Process-survival guarantees match what tmux gives us today (and what
+PR #157 promised). **Visible state on reattach is explicitly NOT a goal
+in v1.** After a webview reload or app restart, xterm starts blank; the
+agent is still running and bytes will appear once it next emits. TUIs
+that redraw on user interaction (claude-code, codex, vim) repaint
+quickly. Plain shells stay blank until the user hits Enter.
 
 The agents-survive-app-crash guarantee requires the sidecar to be
-**detached** from the Tauri main process at boot, not a managed child. See
-Step 2 for the mechanism.
-
-## Resize-stack fix mechanism
-
-Owning the byte stream is *necessary but not sufficient* for the
-resize-stack fix. If the host just streams every raw byte to xterm and
-faithfully replays the byte tape on attach, claude-code's repeated
-SIGWINCH redraws still stack in xterm scrollback — the host has merely
-preserved the original problem with higher fidelity.
-
-The first draft of this doc proposed a "live-path scrollback clear" —
-the host emits `ESC[3J ESC[H ESC[2J` to subscribers on every Resize
-before forwarding SIGWINCH. That approach is rejected: plain shells
-are also main-screen sessions with meaningful scrollback (e.g. the
-output of an earlier `ls` or `cargo test`), and clearing it on every
-window-edge drag is a real regression that no heuristic distinguishes
-from claude-code's case at the wire level.
-
-The fix lives in the **snapshot**, not the live byte stream:
-
-- The host parses every PTY byte through a headless terminal emulator
-  (`wezterm-term` — the embeddable parser inside the WezTerm terminal
-  emulator; production-tested, designed-for-library use, broad and
-  aggressively-updated escape-sequence coverage). The host wraps it
-  with a small screen → ANSI walker that emits cursor positioning +
-  SGR state + cell content per row, capturing the exact bytes needed
-  to recreate the current visible state.
-- The live `Output` events are still raw PTY bytes; xterm's behaviour
-  on the live path matches Terminal.app / iTerm2 / any other PTY
-  viewer. Claude-code's redraw-on-SIGWINCH still stacks in xterm
-  scrollback during a live session — same as it does in any other
-  terminal — and we deliberately do not fight that.
-- `Attach` returns the headless emulator's serialized state, *not* the
-  raw event tape. After an app restart or webview reload (the actual
-  reported bug), xterm receives "exactly the visible region claude-code
-  is rendering right now" instead of "the entire history of every
-  frame claude-code has ever painted, including the stale ones".
-
-This means the headless emulator is **v1 infrastructure, not a
-deferred optimization**. The raw event tape is still kept on disk for
-durability and post-mortem debugging, but the wire-level snapshot is
-the parser's output. See Steps 3 and 5 for the parser integration and
-the snapshot contract.
-
-For alt-screen TUIs (codex), the parser tracks state correctly across
-the `?1049h` / `?1049l` toggle and the snapshot covers the active
-alt-screen frame — which is the entire visible UI for an alt-screen
-app, so nothing meaningful is lost.
-
-For plain shells, the v1 snapshot is the **visible region only** —
-`screen_to_ansi` walks the cells the user can currently see, not the
-scrollback rows above the viewport. That means a webview reload or
-host-side reattach to a plain shell session loses pre-reload
-scrollback (e.g. the output of an earlier `ls` that has since scrolled
-out of view). This is a real fidelity trade vs. tmux's
-`capture-pane -S - -E -` and is the one v1 regression in the migration.
-
-The trade is deliberate. The naive fix — have `screen_to_ansi` walk the
-scrollback grid too — would re-stack every historical SIGWINCH redraw
-frame for main-screen TUIs like claude-code (the v2.1.143 case that
-motivated this whole migration), and there's no wire-level signal that
-distinguishes meaningful shell scrollback from stale TUI redraws.
-Phase 2 work can revisit with a per-runtime flag or an OSC-based
-annotation scheme; v1 ships with the visible-region-only contract and
-documents it in release notes.
+**detached** from the Tauri main process at boot, not a managed child.
+See Step 2.
 
 ## Approach
-
-Introduce a Runner-owned PTY host process:
 
 ```text
 Runner UI (xterm.js)
   <-> Tauri session manager
   <-> runner-pty-host sidecar over local IPC
-  <-> portable-pty
+  <-> portable-pty (PTY allocation + child spawn)
   <-> agent CLI
 ```
 
-The PTY host becomes the source of truth for:
+The PTY host **owns**:
 
-- spawning and stopping agent processes,
-- stdin, paste, key, and resize delivery,
-- live output events,
-- durable raw terminal event logs,
-- session status and exit codes.
+- agent process and PTY master fd,
+- stdin / paste / key forwarding — verbatim from xterm.js, no host-side
+  translation,
+- resize forwarding — `MasterPty::resize` ioctl, nothing else,
+- live raw-byte broadcast to subscribed clients,
+- session status (alive / exit code).
 
-The rule for this migration:
+The PTY host **does not own**:
 
-> Do not use `tmux capture-pane` as terminal replay again.
+- any terminal-state mirror (no headless emulator, no `Term`,
+  no `Processor`),
+- any serialized snapshot (no `screen_to_ansi`),
+- any key-name translation table — xterm.js converts
+  `KeyboardEvent.key` to bytes before sending,
+- any bracketed-paste wrapping — xterm.js wraps client-side based on
+  its own mode tracking.
 
-v1 ships a headless terminal model in the host (`wezterm-term` —
-see "Resize-stack fix mechanism" above and Step 5's snapshot
-semantics). On `Attach`, the host returns the headless model's
-serialized current state via `screen_to_ansi`, not a replay of the
-raw event tape. Frontend writes those bytes into a pre-sized xterm
-and starts processing live events from `last_seq + 1`.
+The rule:
 
-The raw event tape (`terminal.ndjson` — see Step 7) is kept on disk
-for durability, debugging, and post-mortem audit, but it is **not**
-on the attach replay path. Earlier drafts of this plan considered
-raw-tape replay as the v1 approach with headless-model snapshots
-deferred; that design is rejected because faithful tape replay would
-re-stack every historical SIGWINCH redraw frame just like the failed
-PR #154 did with `tmux capture-pane`.
+> Bytes in from agent → bytes out to xterm. Bytes in from xterm →
+> bytes out to agent. The host does not interpret either direction.
 
----
+### Why no reattach-state
+
+PR #157 tried to give the user visible state after reattach by
+mirroring the agent's terminal in `alacritty_terminal::Term` and
+re-serializing it on `Attach`. That introduced a class of correctness
+problems:
+
+1. Two parsers had to agree (host's alacritty + frontend's xterm.js).
+   Any mismatch in protocol coverage produced visible drift.
+2. The serializer had to round-trip the screen *and* every user-facing
+   mode (`APP_CURSOR`, `BRACKETED_PASTE`, mouse modes, focus reporting,
+   alt-screen, line-wrap, …).
+3. The seq numbering had to be race-free across the term-lock + atomic
+   + subscriber-list boundaries.
+4. `Key` + `Paste` had to be host-side translated to honor the agent's
+   current mode bits.
+
+Each layer needed to be correct individually *and* in composition with
+the others. The first review pass produced findings on three of them.
+The fourth was probably next.
+
+Accepting "no reattach state" deletes all four problems. The trade is
+real (a webview reload leaves the user staring at a blank xterm for a
+moment until the agent next emits) and we accept it. If real usage
+shows the blank-xterm window is too jarring, v2 can add a tiny ring
+buffer of the last few KB of raw bytes — *purely a UX patch*, no
+emulator, no serializer.
 
 ## Step 1: Define the PTY Host Protocol
 
-**File: `crates/runner-core/src/pty_host.rs`**
+**File:** `crates/runner-core/src/pty_host.rs`
 
-Add shared serde types for app <-> host IPC.
+Requests:
 
-Core request types:
+| Op | Payload | Response |
+|---|---|---|
+| `Spawn` | `SpawnSpecWire` | `Spawned { session_id, pid }` |
+| `Attach` | `session_id` | `Ack` (registers subscription; **no snapshot**) |
+| `Input` | `session_id, data_base64` | `Ack` |
+| `Resize` | `session_id, cols, rows` | `Ack` |
+| `Stop` | `session_id` | `Ack` |
+| `Status` | `session_id` | `SessionStatus` |
+| `List` | (none) | `Sessions` |
 
-- `Spawn { spec: SpawnSpecWire }`
-- `Attach { session_id }`
-- `Input { session_id, data_base64 }`
-- `Paste { session_id, data_base64 }`
-- `Key { session_id, key }`
-- `Resize { session_id, cols, rows }`
-- `Stop { session_id }`
-- `Status { session_id }`
-- `List`
+Push events:
 
-Core response/event types:
+| Kind | Payload |
+|---|---|
+| `Output` | `session_id, seq, data_base64` — raw PTY bytes |
+| `Exit` | `session_id, seq, exit_code` |
 
-- `HostAck`
-- `HostError { message }`
-- `HostSessionStatus { alive, exit_code, pid, command }`
-- `HostSnapshot { events, last_seq, cols, rows }`
-- `HostEvent::Output`
-- `HostEvent::Resize`
-- `HostEvent::Exit`
-- `HostEvent::RunnerStatus`
+`HostMessage { type: response | event }` envelope at the top level so
+the Tauri side routes without inspecting inner tags.
 
-Terminal replay events should be explicit:
+`seq` is per-session monotonic. The frontend uses it for ordering;
+receive-out-of-order isn't expected on a single socket, but the seq
+makes the contract explicit and gives the Tauri side a knob for
+duplicate detection during a brief reconnect window.
+
+**Explicitly dropped from PR #157's protocol:** `Paste`, `Key`,
+`HostSnapshot`, `TerminalReplayEvent`, `RunnerStatus`. xterm.js
+owns the user-input translation surface; the host doesn't see
+keys or pastes as anything other than `Input` bytes.
+
+## Step 2: Sidecar Daemon + Sessions
+
+**File:** `src-tauri/src/bin/runner-pty-host.rs`
+
+Daemon scaffold (mostly inherited from PR #157's design, which got
+that piece right):
+
+- `--detach`: setsid + double-fork before bind; macOS hardened
+  runtime may force a swap to `posix_spawn` +
+  `POSIX_SPAWN_SETSID` — validate in the bundling pass.
+- `--socket-dir <PATH>`: directory for the lockfile + Unix socket.
+- `fs2::FileExt::try_lock_exclusive` on `pty-host.lock` — second
+  invocation exits cleanly so the Tauri startup connects to the
+  existing host.
+- 0o700 dir / 0o600 socket perms.
+- Stale-socket liveness probe before unlink.
+- 4-byte big-endian length-prefixed JSON frames, capped at 16 MiB.
+
+Per-session ownership:
+
+- `portable_pty::native_pty_system()` for PTY allocation.
+- `MasterPty` (the master fd) wrapped in `Mutex` for the resize
+  ioctl.
+- `Child` handle (`Box<dyn Child + Send + Sync>`) from
+  `slave.spawn_command(CommandBuilder)`. The slave is dropped
+  immediately after spawn to release our side of the pair.
+- Reader thread per session: `try_clone_reader()` → blocking read
+  into an 8 KiB buffer → base64-encode → broadcast
+  `HostEvent::Output` to subscribers.
+- Writer: `take_writer()` → `Mutex<Box<dyn Write + Send>>` for input.
+- Resize: `master.resize(PtySize { rows, cols, .. })`.
+- Stop: `child.clone_killer()` returns a `Send`-able `ChildKiller`;
+  call `kill()` on that from the dispatch thread.
+
+There is **no `Term`, no `Processor`, no `FairMutex` around
+terminal state**. The reader thread's only state is the master fd
+and a seq counter.
+
+`SpawnSpecWire` keys the host trusts verbatim:
 
 ```rust
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "snake_case")]
-pub enum TerminalReplayEvent {
-    Output {
-        seq: u64,
-        // base64 of a terminal byte stream the frontend should write
-        // verbatim into xterm. Origin varies by carrier:
-        //   - on `HostEvent::Output` (live path): raw PTY bytes
-        //     forwarded from the child;
-        //   - on `HostSnapshot.events[0]` (attach path): synthetic
-        //     bytes produced by the host's `screen_to_ansi`
-        //     serializer over the headless `Terminal`'s current
-        //     screen. See Step 5's snapshot semantics.
-        data: String,
-    },
-    Resize {
-        seq: u64,
-        cols: u16,
-        rows: u16,
-    },
+struct SpawnSpecWire {
+    command: String,
+    args: Vec<String>,
+    cwd: Option<String>,
+    env: BTreeMap<String, String>,
+    cols: u16,
+    rows: u16,
 }
 ```
 
-Why resize belongs in the replay tape: raw terminal output only replays
-correctly if xterm sees the same geometry transitions the agent saw. Without
-resize events, historical wrapping and absolute-positioned TUI redraws can
-still drift.
+Env / cwd filtering is the Tauri side's job (`session::launch`).
+The host doesn't second-guess it.
 
-Add protocol round-trip tests in `runner-core`.
-
-## Step 2: Add the PTY Host Sidecar
-
-**Files:**
-
-- `src-tauri/src/bin/runner-pty-host.rs`
-- `src-tauri/Cargo.toml`
-- `src-tauri/tauri.conf.json`
-
-Add a sidecar binary that runs independently of both the webview and the
-Tauri main process. It should listen on a private Unix socket under app
-data, for example:
-
-```text
-<app_data>/pty-host/runner-pty-host.sock
-```
-
-On startup:
-
-- if invoked with `--detach`, the entry point performs a `setsid` +
-  double-fork before any other work so its parent (the Tauri main
-  process) reaping it does not propagate SIGHUP to the agent children;
-- create the socket directory with owner-only permissions,
-- acquire a lock file (`pty-host.lock` with `fs2::FileExt::try_lock_exclusive`)
-  so only one host owns the socket,
-- remove stale sockets only after proving no live host responds,
-- load known session metadata/log directories,
-- begin accepting one or more app connections.
-
-The Tauri side resolves the bundled sidecar path explicitly — *not*
-`std::env::current_exe()`, which would point at the main app binary
-rather than the bundled sidecar binary. The sidecar is registered in
-`tauri.conf.json` under `bundle.externalBin` with target-triple
-suffixing (e.g. `runner-pty-host-aarch64-apple-darwin`), and Tauri's
-`PathResolver` exposes it at runtime:
-
-```rust
-let sidecar_path = app
-    .path()
-    .resolve("runner-pty-host", BaseDirectory::Resource)?;
-```
-
-In dev (`cargo tauri dev`), Tauri's path resolver returns the path
-under `src-tauri/target/debug/`; in a packaged bundle, it returns the
-path inside `Runner.app/Contents/Resources/`. Invoke that path with
-`--detach`; the app does not retain the child handle. The sidecar is
-single-instance and discoverable by socket path. On subsequent app
-launches, the existing host is reused if its lockfile proves liveness.
-
-Initial platform scope: macOS/Linux. Windows can use named pipes later
-and the `setsid` trick has no direct equivalent — defer until needed.
-
-A note on macOS hardened runtime: the entitled production bundle may
-restrict double-forking. If `posix_spawn` + `POSIX_SPAWN_SETSID` is the
-only path that survives notarization review, swap the detach
-implementation. Validate this during phase 2 before bundling.
-
-Add dependencies:
-
-- `portable-pty` for PTY creation,
-- `wezterm-term` for the host-side headless terminal model
-  (see "Resize-stack fix mechanism" and Step 5's snapshot semantics),
-- `fs2` for the single-instance lockfile,
-- no tmux dependency in the new path.
-
-## Step 3: Implement Host-Owned Sessions
-
-**Files:**
-
-- `src-tauri/src/bin/runner-pty-host.rs`
-- `src-tauri/src/session/launch.rs`
-
-Each host session owns:
-
-- `portable_pty::MasterPty`,
-- child process handle,
-- writer handle for stdin,
-- reader thread for stdout/stderr PTY bytes,
-- `wezterm_term::Terminal` (mirror of the agent's terminal state —
-  see the resize-stack mechanism section above) with a
-  `screen_to_ansi` serializer adjacent to it (see Step 5),
-- current `cols` / `rows`,
-- monotonic `seq`,
-- raw terminal replay log file (for durability; not used on the
-  attach replay path),
-- subscriber list for connected app clients.
-
-Reuse the existing launch-script machinery from `src-tauri/src/session/launch.rs`
-so PATH, cwd, runner shims, and environment filtering stay consistent with the
-current tmux runtime.
-
-The host reader thread should:
-
-1. read raw PTY bytes,
-2. feed them through `wezterm_term::Terminal::advance_bytes(bytes)`
-   to update the headless terminal state,
-3. append `TerminalReplayEvent::Output` to the session log,
-4. broadcast a live `Output` event to connected app clients (raw
-   bytes, same as today's `pipe-pane` stream — frontend xterm
-   behavior on the live path is unchanged),
-5. feed the existing busy/idle detector logic currently in
-   `src-tauri/src/session/tmux_runtime.rs`.
-
-On resize:
-
-1. resize the headless model first: `terminal.resize(TerminalSize { rows, cols, pixel_width, pixel_height })`
-   (the `pixel_*` fields can be zero — wezterm only consults them
-   for pixel-addressable escape sequences we don't emit) so the
-   parser grid is ready to absorb the agent's SIGWINCH redraw at the
-   new geometry. Snapshot fidelity depends on the headless model
-   staying in lockstep with the child PTY — resizing only the master
-   would leave the parser stuck at the old size and the next
-   snapshot would be wrong;
-2. then resize the PTY master: `master.resize(PtySize { rows, cols, ... })`
-   so the child receives SIGWINCH;
-3. append `TerminalReplayEvent::Resize` to the replay log;
-4. broadcast resize if the frontend needs to mirror it.
-
-On stop:
-
-- terminate the child,
-- close PTY handles,
-- append/emit exit status,
-- keep the replay log until explicit archive/delete.
-
-## Step 4: Add a `PtyHostRuntime`
+## Step 3: `PtyHostRuntime`
 
 **Files:**
 
 - `src-tauri/src/session/pty_host_runtime.rs`
-- `src-tauri/src/session/mod.rs`
-- `src-tauri/src/session/runtime.rs`
-- `src-tauri/src/lib.rs`
-
-Implement `SessionRuntime` by talking to the sidecar instead of tmux.
-
-Mapping:
-
-| `SessionRuntime` method | PTY host behavior |
-|---|---|
-| `spawn` | send `Spawn`, receive runtime handle, subscribe to live events |
-| `resume` | send `Attach`, receive replay snapshot + live stream |
-| `send_bytes` | send `Input` |
-| `paste` | send `Paste` with bracketed-paste semantics in host |
-| `send_key` | send `Key` |
-| `resize` | send `Resize` |
-| `status` | send `Status` |
-| `stop` | send `Stop` |
-| `capture_visible` | temporary compatibility path for paste verification; implement via host terminal model or a host-visible-screen readback in Step 8 |
-
-For the first cut, store PTY host metadata in the existing runtime columns:
-
-- `runtime = 'pty-host'`
-- `runtime_socket = <socket path>`
-- `runtime_session = <session_id>`
-- `runtime_window = 'main'`
-- `runtime_pane = <session_id>`
-
-This avoids a migration during the initial cutover. A cleanup migration can
-replace the tmux-shaped fields with a runtime JSON blob later.
-
-Keep `TmuxRuntime` behind a fallback flag until the PTY host path proves out:
-
-```text
-RUNNER_SESSION_RUNTIME=tmux
-```
-
-Default should become `pty-host`.
-
-## Step 5: Replace Snapshot Replay Semantics
-
-**Files:**
-
+- `src-tauri/src/session/runtime.rs` (existing trait; lightly
+  re-document for the no-snapshot contract)
 - `src-tauri/src/session/manager.rs`
-- `src-tauri/src/commands/session.rs`
-- `src/lib/types.ts`
-- `src/lib/api.ts`
-- `src/components/RunnerTerminal.tsx`
 
-Replace `session_output_snapshot -> Vec<OutputEvent>` with a structured
-terminal snapshot:
+`SessionRuntime` impl that talks to the sidecar over the local socket:
 
-```ts
-interface SessionTerminalSnapshot {
-  events: TerminalReplayEvent[];
-  last_seq: number;
-  cols: number;
-  rows: number;
-}
+| Method | Host op |
+|---|---|
+| `spawn` | `Spawn` |
+| `resume` | `Attach` — subscribes to live `Output` stream, no snapshot returned |
+| `send_bytes` | `Input` — verbatim |
+| `paste` | `Input` — xterm.js sends bracketed-paste-wrapped bytes when its mode is set, the host doesn't care |
+| `send_key` | `Input` — frontend translates `KeyboardEvent` → bytes; the host stays neutral |
+| `resize` | `Resize` |
+| `status` | `Status` |
+| `stop` | `Stop` |
+| `capture_visible` | Paste verification's legacy contract. v1 scope: argv-only delivery; this method returns empty and paste verification falls back to argv. Revisit if a real need surfaces. |
 
-type TerminalReplayEvent =
-  | { kind: "resize"; seq: number; cols: number; rows: number }
-  | { kind: "output"; seq: number; data: string };
-```
+Fallback flag: `RUNNER_SESSION_RUNTIME=tmux` keeps the tmux path
+alive during cutover. Default becomes `pty-host` once the
+manual-test pass in Step 4 succeeds.
 
-Frontend replay algorithm:
-
-1. Register live listeners first.
-2. Fetch `session_output_snapshot`.
-3. Reset xterm.
-4. **Resize xterm to `snapshot.cols` / `snapshot.rows` before writing
-   any output.** The serialized bytes from the host's `screen_to_ansi`
-   walker are positioned for the headless terminal's screen, which is
-   the agent's view. Writing into a different grid (e.g. xterm's
-   default 80×24) corrupts the replay with the same cols-mismatch
-   that the failed PR #154 demonstrated. The top-level
-   `cols`/`rows` fields on `SessionTerminalSnapshot` exist for this
-   step; do not rely on per-event resize entries to land first
-   (the v1 snapshot returns a single Output event).
-5. For each replay event:
-   - `resize`: call `term.resize(cols, rows)`;
-   - `output`: decode base64 and `term.write(bytes)`.
-6. Mark `last_seq`.
-7. Flush pending live events with `seq > last_seq`.
-8. Fit to the visible container and push one resize to the host
-   (host updates `Terminal` + PTY master + appends `Resize` event).
-
-This preserves the original terminal stream without asking tmux to
-reconstruct it.
-
-### Snapshot semantics (v1)
-
-The snapshot returned by `Attach` is **the host's `screen_to_ansi`
-serialization of the headless emulator's current state**, not the raw
-event tape. See "Resize-stack fix mechanism" above for why — this is
-the load-bearing choice that makes the reattach view correct at the
-current geometry. It intentionally does not promise full shell scrollback
-for plain-shell sessions in v1; only the visible terminal state is
-reattached.
-
-Concretely the host wraps the serialized bytes in a single synthetic
-`TerminalReplayEvent::Output { seq: last_seq, data: <base64> }` and
-returns it as the only entry in `HostSnapshot.events`, with
-`HostSnapshot.cols` / `rows` set to the current `Term` geometry so the
-frontend can pre-size xterm before writing the bytes (see Step 5's
-replay algorithm, line 4). The frontend then writes the bytes, marks
-`last_seq`, and flushes pending live events with `seq > last_seq`.
-
-The raw event tape (`terminal.ndjson` — see Step 7) is still kept on
-disk for durability, debugging, and post-mortem audit, but it is not
-on the attach replay path.
-
-#### Why `wezterm-term` for v1
-
-- It's the embeddable parser inside [WezTerm](https://github.com/wezterm/wezterm)
-  — production-tested in a major terminal emulator, and unlike
-  `alacritty_terminal`, **designed as a reusable library from the
-  start**. WezTerm's whole architecture is modular: `termwiz`
-  (rendering primitives), `wezterm-term` (the terminal model),
-  `wezterm-mux` (session multiplexing). The mux server uses
-  `wezterm-term` exactly the way our pty-host will — that's the
-  upstream reference design for this exact use case.
-- Aggressive modern-protocol coverage: synchronized updates
-  (`?2026h`), kitty keyboard / graphics protocol, OSC 8 hyperlinks
-  (which claude-code already emits and our existing
-  `RunnerTerminal.tsx` routes through `plugin-opener`),
-  bracketed-paste, mouse reporting, application keypad / cursor.
-  Wez Furlong tracks the modern spec aggressively; gaps close in
-  weeks, not Alacritty's quarters.
-- The whole point of this architecture migration is fidelity (the
-  failed PR #154 was a fidelity failure). Picking the parser with
-  the broader and more aggressively-updated protocol footprint
-  upfront avoids discovering gaps in production after agents adopt
-  new sequences.
-- Cost: heavier transitive dep tree (`termwiz`, `wezterm-bidi`, etc.)
-  than `alacritty_terminal`. The dep weight is contained inside the
-  sidecar binary — the main Tauri app doesn't pull it. We accept the
-  ~10 MB binary delta for a parser with first-class library posture.
-
-The one shared cost with the alacritty alternative is that
-`wezterm-term` does not ship a built-in "serialize the grid as ANSI"
-helper (unlike `vt100`'s `Screen::contents_formatted()`). We write
-that ourselves in a `screen_to_ansi(terminal: &Terminal) -> Vec<u8>`
-adjacent to the parser: iterate `terminal.screen().lines()` row by
-row, emit `\x1b[<r>;1H` to position the cursor, then for each
-contiguous run of cells sharing the same SGR state emit one SGR
-escape + the cell glyphs, finally restore alt-screen state and
-cursor position from `terminal.get_mode()` and
-`terminal.cursor_pos()`. Expect ~150 lines plus a focused unit test
-that round-trips constructed screens through the serializer.
-
-Keep the host's parser behind a small trait (`HeadlessTerminal` with
-`process_bytes`, `resize`, `snapshot_ansi`) so the binding point is
-mechanical if we ever need to swap.
-
-## Step 6: Wire App Startup to the Host
+## Step 4: Wire Startup + Reattach Policy
 
 **Files:**
 
 - `src-tauri/src/lib.rs`
 - `src-tauri/src/session/manager.rs`
-- `src-tauri/src/session/pty_host_runtime.rs`
+- `src-tauri/tauri.conf.json` (register sidecar in `bundle.externalBin`)
+- `scripts/stage-runner-pty-host.mjs` (mirrors `stage-runner-cli.mjs`)
+- `package.json` (wire stage script into `tauri:before:dev` and
+  `tauri:before:build`)
 
-During Tauri startup:
+At Tauri startup:
 
-1. connect to an existing host, or launch one if none responds;
-2. construct `PtyHostRuntime`;
-3. call `SessionManager::reattach_running_sessions`.
+1. Locate sidecar via
+   `app.path().resolve("runner-pty-host", BaseDirectory::Resource)?`
+   — **not** `std::env::current_exe()`.
+2. Launch with `--detach --socket-dir <app_data>/pty-host`.
+3. Connect to the resulting socket, build `PtyHostRuntime`.
+4. `reattach_running_sessions`:
+   - **Direct chats:** send `Attach` per known session, subscribe to
+     the live `Output` stream. xterm renders blank; the agent's next
+     emit fills it.
+   - **Mission sessions:** keep the conservative policy until the
+     router/event-bus also moves host-side. Don't pretend the
+     mission stayed fully coordinated while the router was down.
 
-Reattach policy:
+Webview reload (Cmd+R):
+- Tauri main process and sidecar both stay alive.
+- Frontend remounts, calls `Attach` per session.
+- xterm starts blank, live bytes flow.
 
-- Direct chats: attach to the host session and keep them running.
-- Mission sessions: keep the current conservative policy at first unless the
-  mission router/event-bus is also moved into the host. The terminal host can
-  keep the PTY alive, but mission coordination still depends on the app-side
-  router. Do not silently pretend a mission remained fully coordinated while
-  the router was down.
+Tauri app restart (force-quit + relaunch):
+- Sidecar stays alive (detached at boot).
+- New Tauri process discovers the existing host via the lockfile.
+- Same reattach flow as above.
 
-This means direct-chat restart survivability lands first. Full mission
-survivability is a separate follow-up: move mission router/event-bus ownership
-into the host process or add a host-side router worker.
-
-## Step 7: Disk Layout and Cleanup
-
-**Files:**
-
-- `src-tauri/src/bin/runner-pty-host.rs`
-- `src-tauri/src/session/manager.rs`
-- `src-tauri/src/commands/session.rs`
-
-Use a per-session directory:
-
-```text
-<app_data>/pty-host/sessions/<session_id>/
-  meta.json
-  terminal.ndjson
-```
-
-`terminal.ndjson` contains `TerminalReplayEvent` rows. `meta.json` contains:
-
-- session id,
-- runner id,
-- mission id,
-- cwd,
-- command/args summary,
-- current cols/rows,
-- started/stopped timestamps,
-- last seq,
-- exit status.
-
-Cleanup rules:
-
-- archive direct chat: stop host session if live, remove replay directory;
-- runner delete: remove associated replay directories;
-- mission archive/reset: remove associated replay directories;
-- host startup: remove directories for sessions no longer present in DB.
-
-## Step 8: Restore Paste Verification Without tmux
+## Step 5: Remove tmux
 
 **Files:**
 
-- `src-tauri/src/session/manager.rs`
-- `src-tauri/src/session/pty_host_runtime.rs`
-- `src-tauri/src/bin/runner-pty-host.rs`
+- `src-tauri/src/session/tmux_runtime.rs` — delete
+- `src-tauri/src/session/tmux.rs` — delete
+- `src-tauri/src/session/mod.rs` — drop the tmux mod
+- `src-tauri/Cargo.toml` — drop tmux-only deps
+- `docs/impls/0004-tmux-session-runtime.md` — mark superseded
+- `docs/impls/0009-terminal-alt-screen-reattach.md` — mark superseded
 
-Current first-prompt delivery uses `capture_visible` for paste verification
-(`src-tauri/src/session/runtime.rs:356`). The tmux implementation reads the
-visible pane with `capture-pane`.
+After PtyHostRuntime parity for spawn / resume / input / resize /
+kill / archive / app restart:
 
-For PTY host, implement one of these, in order:
-
-1. Preferred: host maintains a lightweight terminal parser and exposes
-   `VisibleText { rows }`.
-2. Acceptable first cut: host records recent raw output and verifies paste
-   placeholders from the event tape when the agent emits them.
-3. Fallback: keep argv delivery as the dominant path and reduce paste
-   verification scope, but do not call tmux.
-
-If a parser crate is added, use it only inside the host. The frontend remains
-xterm.js.
-
-## Step 9: Remove tmux From the Default Path
-
-**Files:**
-
-- `src-tauri/src/session/tmux_runtime.rs`
-- `src-tauri/src/session/tmux.rs`
-- `src-tauri/src/session/mod.rs`
-- `src-tauri/Cargo.toml`
-- `docs/impls/0004-tmux-session-runtime.md`
-- `docs/impls/0009-terminal-alt-screen-reattach.md`
-
-(`docs/impls/0010-terminal-replay-cols-alignment.md` is deleted as part
-of this plan's landing commit — its diagnosis is preserved here in
-"Resize-stack fix mechanism" above.)
-
-After PTY host validation:
-
-- stop constructing `TmuxRuntime` by default,
-- remove `capture-pane` replay from any app-start attach path,
-- keep tmux fallback only if we still need a short migration window,
-- update older docs to mark tmux replay as superseded by this plan.
-
-Do this after, not before, the PTY host has parity for direct chat spawn,
-resume, paste, resize, kill, archive, and app restart.
-
-## Files to Modify
-
-| File | Change |
-|---|---|
-| `crates/runner-core/src/pty_host.rs` | Shared host protocol and replay event types. |
-| `src-tauri/src/bin/runner-pty-host.rs` | New sidecar daemon owning PTYs and replay logs. |
-| `src-tauri/Cargo.toml` | Add sidecar binary and `portable-pty` dependency. |
-| `src-tauri/tauri.conf.json` | Bundle or locate the sidecar. |
-| `src-tauri/src/session/pty_host_runtime.rs` | New `SessionRuntime` implementation backed by the sidecar. |
-| `src-tauri/src/session/runtime.rs` | Keep trait; adjust docs and snapshot/readback contracts. |
-| `src-tauri/src/session/manager.rs` | Use PTY host runtime, structured snapshots, and host reattach policy. |
-| `src-tauri/src/commands/session.rs` | Return structured terminal snapshots. |
-| `src/lib/types.ts` | Add `SessionTerminalSnapshot` and `TerminalReplayEvent`. |
-| `src/lib/api.ts` | Update `outputSnapshot` typing. |
-| `src/components/RunnerTerminal.tsx` | Pre-size xterm to snapshot dims, then write the host's `screen_to_ansi` bytes; resume live events from `last_seq + 1`. |
-| `src-tauri/src/session/tmux_runtime.rs` | Keep fallback initially; later remove from default path. |
-| `src-tauri/src/session/tmux.rs` | Keep fallback initially; later remove from default path. |
+- Stop constructing `TmuxRuntime` by default.
+- Remove `capture-pane` from any attach path.
+- Delete tmux session-management code.
+- Update superseded-by markers on the older impls.
 
 ## Verification
 
-### Unit Tests
+### Unit tests
 
-- Protocol serde round-trips for every request/response/event.
-- Host replay log preserves monotonic seq across output and resize events.
-- `Attach` snapshot bytes round-trip: feed a known PTY byte sequence
-  into `wezterm_term::Terminal`, snapshot via `screen_to_ansi`, then
-  feed those bytes into a second fresh `Terminal` and confirm both
-  terminals' grid contents and modes match. Catches serializer
-  regressions early.
-- Snapshot bytes pre-sized correctly: `HostSnapshot.cols`/`rows`
-  match the host `Terminal`'s current geometry at capture time.
-- Snapshot plus pending live event merge never duplicates or drops
-  events when the snapshot is followed by live events with seq
-  > snapshot's `last_seq`.
-- Host cleanup removes replay logs on archive/delete/reset.
-- `PtyHostRuntime` maps `SessionRuntime` methods to host requests.
+- Protocol round-trips for every request / response / event.
+- `PtyHostRuntime` method-to-op mapping.
+- Subscriber retain-on-broadcast-failure correctly garbage-collects
+  closed connections.
 
-### Integration Tests
+### Integration tests
 
-- Spawn `/bin/cat`, inject bytes, verify output event.
-- Spawn shell command that exits, verify exit status and DB row transition.
-- Resize session, then immediately `Attach`; verify
-  `HostSnapshot.cols` / `rows` match the post-resize geometry and the
-  serialized bytes in `events[0]` reflect the redrawn screen at the
-  new dims. (v1 returns a single synthetic Output event plus
-  top-level dims; there is no intra-snapshot Resize event to assert
-  on.)
-- Kill session, verify child exits and host forgets live handle.
-- Restart Tauri-side manager while host remains alive; verify direct session
-  reattaches without tmux.
+- Spawn `/bin/cat`, inject bytes via `Input`, observe matching
+  `Output` event.
+- Spawn `/usr/bin/false` (or `sh -c "exit 7"`); verify `Exit` event
+  with `exit_code: Some(7)` and DB row transition to `stopped`.
+- Restart Tauri-side manager while host stays alive; verify each
+  direct-chat session `Attach` succeeds and live stream resumes.
 
-### Manual Tests
+### Manual tests
 
-1. Start a direct Claude Code chat.
-2. Let the initial banner and prompt render.
-3. Resize the window several times.
-4. Quit the Runner UI and relaunch.
-5. Reopen the chat.
-6. Expected: no stacked Claude banners, no duplicated prompt panels, no
-   staircase indentation.
-7. Type into the chat after reopen.
-8. Expected: input lands in the same live agent process.
-9. Open two direct chats, switch between them while both remain mounted,
-   and verify each visible terminal state stays correct without relying on
-   hidden xterm panes.
-10. Kill the host process manually.
-11. Expected: Runner marks affected sessions stopped/crashed and does not
-    show stale "running" state.
+1. Start a direct claude-code chat, let the banner render.
+2. Type a prompt, get a response — confirm input + output flow.
+3. Resize the window several times. Claude-code's SIGWINCH redraw
+   lands in xterm; expect the same stacking-during-live-session
+   behavior as Terminal.app / iTerm2 (we deliberately do not fight
+   this).
+4. Cmd+R reload. xterm goes blank.
+5. Type "hi" — claude-code receives, responds, output flows.
+6. Force-quit the Tauri app. Relaunch.
+7. Open the same direct chat — xterm blank, agent still alive.
+8. Type again — agent responds. ✓
 
-### Regression Checks
+### Regression checks
 
 - `pnpm exec tsc --noEmit`
 - `pnpm run lint`
-- `cargo test -p runner --lib`
-- Host integration tests, gated if they spawn real PTYs.
-- Manual Claude Code restart repro from issue #150.
+- `cargo test --workspace`
 
 ## Non-Goals
 
-- Do not build full mission survivability in the first terminal-host PR.
-  Mission coordination still needs router/event-bus ownership outside the UI
-  process.
-- Do not replay the raw event tape on `Attach` — the v1 snapshot path
-  is the headless terminal's `screen_to_ansi` output. The tape exists
-  for durability and debugging only.
-- Do not use tmux control mode as a halfway solution; it still keeps tmux as
-  the terminal owner.
-- Do not add a UI redesign. This is runtime architecture, not product surface.
+- **Visible state on reattach.** Deliberate. See "Why no reattach-state".
+- **Mission router / event-bus host-side migration.** Mission
+  coordination still depends on the app-side router today; moving
+  it into the sidecar is a separate effort.
+- **Windows support.** Defer until a named-pipe + child-spawn
+  equivalent of the detach mechanism lands.
+- **Persistent terminal scrollback across reattach.** xterm.js's
+  in-memory scrollback during a single mount is enough; agents that
+  need history paint it themselves on user interaction.
+- **Recovering visible state via a ring buffer of recent bytes.**
+  Not in v1; if usage feedback demands it, that's a small v2 patch
+  (bounded `Vec<u8>` per session, replay-on-Attach).


### PR DESCRIPTION
Umbrella PR for the 0011 migration. Sub-PRs target `feat/pty-host-runtime`; this PR merges to `main` when all 3 steps are in.

**The first two commits on this branch are the plan-doc evolution.** The design has gone through two pivots since the original plan landed on main:

- Original (merged as PR #155): headless emulator on host + screen_to_ansi snapshot
- Pivot 1 ([88f9382](../commit/88f9382)): drop the headless emulator, accept "no visible state on reattach"
- Pivot 2 ([e269891](../commit/e269891)): drop the sidecar entirely, run `PtyRuntime` in-process

See the latest [docs/impls/0011-pty-host-terminal-runtime.md](../blob/feat/pty-host-runtime/docs/impls/0011-pty-host-terminal-runtime.md) for the final design.

## Pivot summary

| Was (PR #157) | Was (rewrite 1) | Now |
|---|---|---|
| Host-side `alacritty_terminal::Term` | No host-side terminal model | No host-side terminal model |
| `screen_to_ansi` serializer on `Attach` | No snapshot | No snapshot |
| Detached sidecar (setsid + lockfile) | Managed-child sidecar | **No sidecar — in-process runtime** |
| IPC: Unix socket + framed JSON | IPC: Unix socket + framed JSON | **No IPC** — direct method calls |
| `runner-pty-host` external bin in bundle | `runner-pty-host` external bin | **No external bin** |
| Tries to restore visible state on reattach | Auto-attach + spawn-with-resume tree | **Manual Resume button only** |

## Step checklist

- [ ] **Step 1** — `PtyRuntime` (`src-tauri/src/session/pty_runtime.rs`) — `SessionRuntime` impl over `portable-pty`, in-process
- [ ] **Step 2** — Lifecycle wiring — startup DB cleanup + on-quit hook + Cmd+R re-attach + Resume button (existing `session_resume`)
- [ ] **Step 3** — Remove tmux — delete `TmuxRuntime`, `session/tmux.rs`

## What's dropped vs the original plan

- Sidecar binary (`runner-pty-host`) and `[[bin]]` registration
- Detach machinery (setsid, double-fork, lockfile, stale-socket probe)
- Protocol crate (`crates/runner-core/src/pty_host.rs`)
- IPC framing, `HostMessage` envelope
- `HostSnapshot`, `TerminalReplayEvent`, `screen_to_ansi`
- Host-side key translation, host-side bracketed-paste wrapping
- `bundle.externalBin` registration for the sidecar
- `scripts/stage-runner-pty-host.mjs` build-time script

The "drop the headless emulator" trade was visible state on reattach.
The "drop the sidecar" trade was agent survival across Tauri quit/crash.
Both are accepted; together they collapse the implementation surface to
~300 lines of Rust plus a handful of lifecycle wiring changes.

## Earlier attempts

- PR #155 — original plan doc, merged to main. Now stale; this umbrella's commits replace it.
- PR #154 — closed. Tmux capture-pane patching, didn't fix the bug.
- PR #157 — closed. Headless emulator path; hit a correctness finding cascade and was retired.

## Merge plan

Squash-merge to `main` after Step 3 lands and the manual repro from issue #150 passes (no stacking; blank-xterm-on-Cmd+R is the expected behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)