### PR TITLE
Resume PTY without auto-continue; loading pill on fresh terminals; preserve scrollback on resize

### DIFF
--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1314,13 +1314,6 @@ impl SessionManager {
             schedule_direct_first_prompt(self, session_id.to_string(), &runner, &plan, false);
         }
 
-        // On a real resume (not a fresh-with-known-uuid spawn), nudge
-        // the agent with "continue" so it picks up where it left off
-        // without the user having to type. Skipped for fresh spawns
-        // — the first-prompt path covers those — and for runtimes
-        // without a real resume semantic (shell).
-        schedule_continue_on_resume(self, session_id.to_string(), &runner, &plan);
-
         // Return the slot's in-mission identity for mission rows so the
         // frontend (and the router, which keys on slot_handle) sees the
         // identity the resumed PTY actually stamps onto its events.
@@ -2112,10 +2105,10 @@ fn capture_cwd(explicit: Option<String>) -> Option<String> {
 
 // The first-prompt readback machinery (FirstPromptConfig,
 // FIRST_PROMPT_CONFIG, PLACEHOLDER_MIN_BODY_LEN) lived here under the
-// tmux runtime. docs/impls/0011 retired the verify-and-retry loop
-// it tuned; `inject_paste` is now a single paste-then-Enter and the
-// surviving "schedule continue on resume" path uses a fixed 1500ms
-// initial wait baked into `schedule_continue_on_resume`.
+// tmux runtime. docs/impls/0011 retired the verify-and-retry loop it
+// tuned; `inject_paste` is now a single paste-then-Enter and the
+// previous "schedule continue on resume" auto-nudge has been removed —
+// Resume now just respawns the PTY and lets the user drive the agent.
 
 /// Mission-flavored first-turn injection. Composes the platform
 /// coordination preamble (bus mechanics, --to human convention,
@@ -2211,9 +2204,8 @@ fn schedule_direct_first_prompt(
 
 // Pre-#88 `inject_first_turn` (the paste-fallback orchestrator) was
 // removed when first-turn delivery moved to spawn-time argv. The
-// only remaining paste-based path is `schedule_continue_on_resume`,
-// which calls `inject_paste_with_verify` directly with the 8-byte
-// "continue" body.
+// post-spawn auto-paste of "continue" on resume has also been removed
+// — Resume now just respawns the PTY without injecting any stdin.
 
 // `WORKER_COORDINATION_PREAMBLE` and the per-runtime first-turn
 // composition helpers (`compose_worker_first_turn`,
@@ -2221,74 +2213,6 @@ fn schedule_direct_first_prompt(
 // spawn-time argv path (here) and any post-spawn paste fallback
 // pull from the same composers so the delivered body is byte-
 // identical regardless of route.
-
-/// Auto-send "continue" as a first user turn after a successful
-/// resume so the agent picks up where it left off without the user
-/// having to manually nudge it. Only fires when the resume actually
-/// reloaded a prior conversation (`plan.resuming == true` AND we
-/// have an `agent_session_key` for the agent CLI to bind to). For
-/// runtimes that don't have a real "resume" semantic (shell),
-/// no-op — there's no conversation thread to continue.
-///
-/// Same readback-verified primitive as `inject_first_turn`. The
-/// resume case carries an extra subtlety: a resumed pane may
-/// already display old `[Pasted text #N ...]` placeholders from
-/// prior turns, which a naive "Pasted text appears" check would
-/// false-ack. `inject_paste_with_verify`'s count-delta check
-/// handles this — `before_placeholder_count` and
-/// `after_placeholder_count` see the same stale placeholder, delta
-/// is 0, and the body length (`continue` is 8 bytes < 64) skips
-/// the placeholder gate entirely; only the head/tail-marker delta
-/// for "continue" can accept.
-///
-/// Caller-side recovery policy: when `inject_paste_with_verify`
-/// returns Err for this caller, we still send one fallback Enter
-/// keystroke. Two paths land us in that Err. (1) The paste body
-/// landed in the composer but readback never observed the
-/// head/tail marker (capture race, TUI line-wrap, or prior
-/// transcript content matching the marker) — Enter submits the
-/// visible "continue" and the agent resumes, exactly the user's
-/// intent. (2) The paste truly didn't land — Enter on an empty
-/// claude-code composer is a no-op.
-///
-/// Both paths beat the alternative of giving up silently and
-/// leaving the user stuck with no auto-continue. This is a
-/// caller-policy decision; `inject_paste_with_verify` keeps its
-/// strict "only Enter on verified paste" contract for callers like
-/// `inject_first_turn` that paste long mission prompts where a
-/// stray Enter on a partial body would be destructive.
-fn schedule_continue_on_resume(
-    mgr: &Arc<SessionManager>,
-    session_id: String,
-    runner: &Runner,
-    plan: &router::runtime::ResumePlan,
-) {
-    if runner.runtime != "claude-code" && runner.runtime != "codex" {
-        return;
-    }
-    if !plan.resuming {
-        return;
-    }
-    // Under `cfg(test)` the inline path keeps assertions
-    // synchronous; under release a background thread drains the
-    // initial-wait + paste round-trip so the calling Tauri command
-    // returns promptly.
-    let inline = cfg!(test);
-    let do_inject = move |mgr: Arc<SessionManager>, session_id: String| {
-        if !inline {
-            std::thread::sleep(std::time::Duration::from_millis(1500));
-        }
-        if let Err(e) = mgr.inject_paste(&session_id, b"continue") {
-            log::warn!("continue-on-resume inject_paste failed for {session_id}: {e}");
-        }
-    };
-    if inline {
-        do_inject(Arc::clone(mgr), session_id);
-    } else {
-        let mgr = Arc::clone(mgr);
-        std::thread::spawn(move || do_inject(mgr, session_id));
-    }
-}
 
 fn emit_runner_activity(pool: &DbPool, runner: &Runner, events: &dyn SessionEvents) {
     let Ok(conn) = pool.get() else { return };
@@ -4409,138 +4333,15 @@ mod tests {
         assert_eq!(status, "stopped");
     }
 
-    // ──────────────────────────────────────────────────────────
-    // First-prompt readback verification (impl plan 0005).
-    //
-    // These exercise `inject_paste_with_verify` directly against
-    // a registered FakeRuntime session. They bypass the
-    // `inject_first_turn` wrapper so test setup stays minimal —
-    // the wrapper itself just selects between inline and threaded
-    // dispatch and is exercised via the existing
-    // `*_direct_chat_injects_persona_*` tests.
-    // ──────────────────────────────────────────────────────────
-
-    /// Register a FakeRuntime spawn under `session_id` so
-    /// `inject_paste_with_verify` can resolve the runtime session
-    /// without going through the full `spawn_direct` machinery.
-    /// Uses the FakeRuntime's own `spawn` to populate the
-    /// `spawns` Vec and synthesizes a SessionHandle entry on the
-    /// manager so `self.sessions.get(session_id)` returns Some.
-    fn register_fake_session(mgr: &Arc<SessionManager>, fake: &Arc<FakeRuntime>, session_id: &str) {
-        let spec = SpawnSpec {
-            session_id: session_id.into(),
-            command: "/bin/true".into(),
-            ..Default::default()
-        };
-        let (rt_session, stream) = SessionRuntime::spawn(fake.as_ref(), spec).unwrap();
-        // We don't need a forwarder thread for these tests — the
-        // verify loop only touches
-        // `self.runtime.{paste,capture_visible,send_key}`, all of
-        // which the FakeRuntime services without needing the
-        // OutputStream. Just drop the stream so its Sender goes
-        // away cleanly.
-        drop(stream);
-        let handle = SessionHandle {
-            id: session_id.to_string(),
-            mission_id: None,
-            runner_id: format!("rid-{session_id}"),
-            runtime_session: rt_session,
-            forwarder: None,
-            stop: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-        };
-        mgr.sessions
-            .lock()
-            .unwrap()
-            .insert(session_id.to_string(), handle);
-    }
-
     // The verify-and-retry first-prompt readback tests
     // (`first_prompt_landed_first_try`, `*_after_retry`,
     // `*_gives_up_after_max_attempts`,
     // `continue_resume_rejects_stale_placeholder`) lived here
     // before docs/impls/0011 retired tmux's capture-pane verify
-    // path. Under the in-process PtyRuntime there is no host-side
-    // terminal model to capture against, so `inject_paste` is a
-    // straight paste-then-Enter and the verify/retry surface those
-    // tests exercised is gone. The surviving resume-continue
-    // semantics are covered by `continue_resume_*` below.
-
-    /// Helper: build a claude-code Runner for the resume-continue
-    /// flow tests. The shared `runner()` helper hardcodes
-    /// `runtime: "shell"`, which `schedule_continue_on_resume`
-    /// short-circuits on.
-    fn claude_runner() -> Runner {
-        let mut r = runner("/bin/true", &[]);
-        r.runtime = "claude-code".into();
-        r
-    }
-
-    fn resume_plan_resuming() -> router::runtime::ResumePlan {
-        router::runtime::ResumePlan {
-            args: Vec::new(),
-            prepend: false,
-            assigned_key: Some("k".into()),
-            resuming: true,
-        }
-    }
-
-    #[test]
-    fn continue_resume_pastes_and_submits_once() {
-        // Under the in-process PtyRuntime (docs/impls/0011),
-        // `schedule_continue_on_resume` calls `inject_paste` for
-        // claude-code/codex on a resuming plan. `inject_paste` is a
-        // single paste-then-Enter — no verify, no retry, no
-        // fallback Enter. Exactly one paste + one Enter is the
-        // contract regardless of what the fake pane content looks
-        // like, because there's no host-side capture to consult.
-        let fake = fake_runtime();
-        let mgr = mgr_with_fake(None, Arc::clone(&fake));
-        register_fake_session(&mgr, &fake, "S-CONT-OK");
-
-        let r = claude_runner();
-        let plan = resume_plan_resuming();
-        super::schedule_continue_on_resume(&mgr, "S-CONT-OK".into(), &r, &plan);
-
-        let pastes = fake.pastes();
-        assert_eq!(pastes.len(), 1, "expected one paste; got {pastes:?}");
-        assert_eq!(pastes[0].1, b"continue");
-        let enters: Vec<_> = fake
-            .keys()
-            .into_iter()
-            .filter(|(_, k)| k == "Enter")
-            .collect();
-        assert_eq!(
-            enters.len(),
-            1,
-            "expected exactly one Enter; got {enters:?}",
-        );
-    }
-
-    #[test]
-    fn continue_resume_skips_for_non_claude_runtime() {
-        // shell doesn't have a real "continue" semantic — the
-        // function must no-op (no paste, no Enter) regardless of
-        // `plan.resuming`.
-        let fake = fake_runtime();
-        let mgr = mgr_with_fake(None, Arc::clone(&fake));
-        register_fake_session(&mgr, &fake, "S-CONT-SHELL");
-
-        let mut r = runner("/bin/true", &[]);
-        r.runtime = "shell".into();
-        let plan = resume_plan_resuming();
-        super::schedule_continue_on_resume(&mgr, "S-CONT-SHELL".into(), &r, &plan);
-
-        assert!(
-            fake.pastes().is_empty(),
-            "no paste for non-claude runtime; got {:?}",
-            fake.pastes()
-        );
-        assert!(
-            fake.keys().is_empty(),
-            "no key events for non-claude runtime; got {:?}",
-            fake.keys()
-        );
-    }
+    // path. The post-spawn "continue" auto-paste on resume that
+    // also lived here has been removed — Resume just respawns the
+    // PTY with no stdin injection, so the helper that synthesized
+    // a FakeRuntime SessionHandle for those tests is gone too.
 
     #[test]
     fn forwarder_status_emit_does_not_block_under_event_log_contention() {

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -319,20 +319,23 @@ export function RunnerTerminal({
       }
       lastPushedColsRef.current = t.cols;
       lastPushedRowsRef.current = t.rows;
-      // Clear scrollback before the SIGWINCH-driven redraw lands for
-      // full-screen TUI agents. Without this, claude-code / codex
-      // repaint at the new dims and the prior frame stays visible in
-      // scrollback — the "stacking" UX bug. We selectively clear only
-      // for TUI runtimes whose repaint policy means inter-frame
-      // scrollback isn't meaningful; plain shells keep their history.
-      // See docs/impls/0011-pty-host-terminal-runtime.md
+      // Clear the visible region before the SIGWINCH-driven redraw
+      // lands for full-screen TUI agents. Without this, claude-code /
+      // codex repaint at the new dims and the prior frame's visible
+      // rows get pushed into scrollback as the new paint arrives —
+      // the "stacking" UX bug. We deliberately do NOT also write
+      // `\x1b[3J` (erase saved lines): wiping the scrollback on every
+      // resize made it impossible to scroll up to older conversation
+      // history after touching the window edge. The visible-region
+      // wipe alone is enough to prevent the duplicated-frame artifact,
+      // and any older scrollback the user had accumulated stays
+      // intact. Plain shells skip the wipe entirely and keep their
+      // history. See docs/impls/0011-pty-host-terminal-runtime.md
       // §"Per-runtime clear-on-resize".
       if (runtimeClearsOnResize(runnerRuntimeRef.current)) {
-        // ESC[3J — erase saved lines (scrollback)
         // ESC[2J — erase visible region
         // ESC[H  — cursor home
-        // Same wire sequence xterm emits for a hard clear.
-        t.write("\x1b[3J\x1b[2J\x1b[H");
+        t.write("\x1b[2J\x1b[H");
       }
       void api.session.resize(sid, t.cols, t.rows).catch(() => {
         // session may have exited

--- a/src/components/SessionEndedOverlay.tsx
+++ b/src/components/SessionEndedOverlay.tsx
@@ -129,10 +129,43 @@ export function SessionEndedOverlay({
 export function ResumingOverlay() {
   return (
     <div className="pointer-events-none absolute inset-4 flex items-center justify-center">
-      <div className="pointer-events-auto flex items-center gap-2.5 rounded-full border border-[#1F3D4D] bg-[#0F1E26] px-4 py-2 text-[13px] font-medium text-[#39E5FF] shadow-[0_8px_30px_rgba(0,0,0,0.5)]">
-        <Loader2 aria-hidden className="h-4 w-4 animate-spin" />
-        Resuming…
+      <LoadingPill label="Resuming…" />
+    </div>
+  );
+}
+
+/// Centered transitional pill while a fresh session is spawning —
+/// the moment between the spawn RPC returning and xterm's first paint
+/// over the PTY. Same cyan visual as `ResumingOverlay` so "in-flight"
+/// session transitions read consistently. Pass `inline` to drop the
+/// absolute positioning when the caller is already a flex container
+/// (e.g. MissionWorkspace's loading branch).
+export function StartingOverlay({
+  label = "Starting…",
+  inline = false,
+}: {
+  label?: string;
+  inline?: boolean;
+} = {}) {
+  if (inline) {
+    return (
+      <div className="flex flex-1 items-center justify-center p-6">
+        <LoadingPill label={label} />
       </div>
+    );
+  }
+  return (
+    <div className="pointer-events-none absolute inset-4 flex items-center justify-center">
+      <LoadingPill label={label} />
+    </div>
+  );
+}
+
+function LoadingPill({ label }: { label: string }) {
+  return (
+    <div className="pointer-events-auto flex items-center gap-2.5 rounded-full border border-[#1F3D4D] bg-[#0F1E26] px-4 py-2 text-[13px] font-medium text-[#39E5FF] shadow-[0_8px_30px_rgba(0,0,0,0.5)]">
+      <Loader2 aria-hidden className="h-4 w-4 animate-spin" />
+      {label}
     </div>
   );
 }

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -46,6 +46,7 @@ import {
   ArchivingOverlay,
   ResumingOverlay,
   SessionEndedOverlay,
+  StartingOverlay,
 } from "../components/SessionEndedOverlay";
 import {
   markArchivingMission,
@@ -638,7 +639,12 @@ export default function MissionWorkspace() {
       ) : null}
 
       {loading || !mission ? (
-        <div className="px-8 py-8 text-sm text-fg-2">Loading mission…</div>
+        // Centered cyan pill while the mission's sessions/events/state
+        // are being fetched (and slot PTYs are still warming up after a
+        // fresh `mission_start`). Same visual vocabulary as the resume
+        // transition so every "session is coming up" moment reads
+        // consistently.
+        <StartingOverlay label="Starting mission…" inline />
       ) : (
         <div className="flex flex-1 min-h-0 flex-col">
           <div className="flex h-[38px] items-end gap-1 border-b border-line bg-panel px-6">
@@ -839,6 +845,60 @@ function SlotPtyPane({
 }) {
   const resuming = !!forcedResuming;
   const dead = session.status !== "running";
+  // Per-slot "warming up" overlay: when the pane first mounts for a
+  // live slot, the agent CLI (claude-code / codex) takes a beat to
+  // paint its banner. Show the cyan pill over the otherwise-blank
+  // xterm canvas for at least 1s so the user doesn't stare at an
+  // empty pane wondering whether the spawn succeeded. Mirrors the
+  // resume dismissal dance (first-output + idle + min-visible).
+  const [starting, setStarting] = useState<boolean>(() => !dead);
+  useEffect(() => {
+    if (!starting) return;
+    const STARTING_MIN_VISIBLE_MS = 1000;
+    const STARTING_IDLE_DEBOUNCE_MS = 400;
+    const STARTING_HARD_TIMEOUT_MS = 10_000;
+    const startTs = performance.now();
+    const targetId = session.id;
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    let idleTimer: number | null = null;
+    const finish = () => {
+      if (!cancelled) setStarting(false);
+    };
+    const scheduleIdleTimer = () => {
+      if (idleTimer !== null) window.clearTimeout(idleTimer);
+      const elapsed = performance.now() - startTs;
+      const delay = Math.max(
+        STARTING_IDLE_DEBOUNCE_MS,
+        STARTING_MIN_VISIBLE_MS - elapsed,
+      );
+      idleTimer = window.setTimeout(finish, delay);
+    };
+    scheduleIdleTimer();
+    const hardTimeout = window.setTimeout(finish, STARTING_HARD_TIMEOUT_MS);
+    void listen<{ session_id: string }>("session/output", (event) => {
+      if (event.payload.session_id !== targetId) return;
+      scheduleIdleTimer();
+    }).then((fn) => {
+      if (cancelled) {
+        fn();
+        return;
+      }
+      unlisten = fn;
+    });
+    return () => {
+      cancelled = true;
+      if (idleTimer !== null) window.clearTimeout(idleTimer);
+      window.clearTimeout(hardTimeout);
+      unlisten?.();
+    };
+  }, [starting, session.id]);
+  // If the slot dies before the pill clears, drop the pill so the
+  // Session ended card takes over without fighting the pill for the
+  // overlay slot.
+  useEffect(() => {
+    if (dead && starting) setStarting(false);
+  }, [dead, starting]);
 
   // Mission slot pane omits the Archive option — archiving a slot's
   // session row would orphan the slot in the workspace. Mission-level
@@ -849,10 +909,11 @@ function SlotPtyPane({
   // copy than reality.
   //
   // Pane opacity:
-  //   - resuming: 0 (canvas wiped, the pill carries the visual)
+  //   - resuming/starting: 0 (canvas hidden, the pill carries the visual)
   //   - dead but not resuming: 45% (the user can read scrollback)
   //   - running: 100%
-  const paneOpacity = resuming ? "opacity-0" : dead ? "opacity-45" : "";
+  const paneOpacity =
+    resuming || starting ? "opacity-0" : dead ? "opacity-45" : "";
   return (
     <div className="relative flex flex-1 min-h-0 flex-col">
       <div
@@ -862,12 +923,14 @@ function SlotPtyPane({
           sessionId={session.id}
           runnerRuntime={session.runtime}
           onError={onError}
-          active={active && !dead && !resuming}
-          disabled={dead || resuming}
+          active={active && !dead && !resuming && !starting}
+          disabled={dead || resuming || starting}
         />
       </div>
       {resuming ? (
         <ResumingOverlay />
+      ) : starting ? (
+        <StartingOverlay label="Starting chat…" />
       ) : dead ? (
         <SessionEndedOverlay
           status={session.status}

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -32,6 +32,7 @@ import {
   ArchivingOverlay,
   ResumingOverlay,
   SessionEndedOverlay,
+  StartingOverlay,
 } from "../components/SessionEndedOverlay";
 import { api, type DirectSessionEntry } from "../lib/api";
 import {
@@ -115,6 +116,14 @@ export default function RunnerChat() {
   // header "Resuming…" affordance, and the centered Resuming pill
   // overlay on the cleared terminal canvas.
   const [resuming, setResuming] = useState<boolean>(false);
+  // True while a freshly-attached session is still warming up — the
+  // terminal has mounted but the agent CLI (claude-code / codex)
+  // hasn't painted its first frame yet. Overlays the StartingOverlay
+  // pill on top of the otherwise-blank xterm canvas so the user sees
+  // a clear "we're booting your chat" state instead of staring at an
+  // empty pane for a couple of seconds. Cleared by the same
+  // first-output + idle-debounce + min-visible dance as `resuming`.
+  const [starting, setStarting] = useState<boolean>(false);
   // True while either this chat's own archiveChat or the sidebar's
   // session-archive flow has marked this session id as archiving.
   // Drives the centered amber pill + scrim over the chat body so the
@@ -182,6 +191,11 @@ export default function RunnerChat() {
         status,
         exitCode: null,
       });
+      // Show the Starting pill over the freshly-mounted terminal
+      // until the agent CLI paints. Only for live sessions — landing
+      // on a stopped/crashed row from the sidebar should drop straight
+      // into the Session ended card.
+      if (status === "running") setStarting(true);
     },
     [upsertSession],
   );
@@ -360,6 +374,66 @@ export default function RunnerChat() {
       unlisten?.();
     };
   }, [resuming, sessionId]);
+
+  // Mirror of the resume dismissal dance for fresh-attach. The
+  // agent CLI takes a beat after spawn to print its banner, so
+  // overlay the pill until: (1) we've seen output AND it's gone idle
+  // for ~400ms, AND (2) the pill has been visible for at least 1s
+  // (no flash on instant paints). 10s hard timeout for silent
+  // runtimes (e.g. shell prompts that never emit a banner). We don't
+  // require a first chunk to start the idle timer here — even an
+  // entirely silent runtime should clear the pill after the
+  // min-visible window, otherwise a shell session would sit behind
+  // the pill until the user typed.
+  useEffect(() => {
+    if (!starting || !sessionId) return;
+    const STARTING_MIN_VISIBLE_MS = 1000;
+    const STARTING_IDLE_DEBOUNCE_MS = 400;
+    const STARTING_HARD_TIMEOUT_MS = 10_000;
+    const startTs = performance.now();
+    const targetId = sessionId;
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    let idleTimer: number | null = null;
+
+    const finish = () => {
+      if (!cancelled) setStarting(false);
+    };
+
+    const scheduleIdleTimer = () => {
+      if (idleTimer !== null) window.clearTimeout(idleTimer);
+      const elapsed = performance.now() - startTs;
+      const delay = Math.max(
+        STARTING_IDLE_DEBOUNCE_MS,
+        STARTING_MIN_VISIBLE_MS - elapsed,
+      );
+      idleTimer = window.setTimeout(finish, delay);
+    };
+
+    // Seed the idle timer immediately so a silent agent still clears
+    // after the min-visible window.
+    scheduleIdleTimer();
+
+    const hardTimeout = window.setTimeout(finish, STARTING_HARD_TIMEOUT_MS);
+
+    void listen<{ session_id: string }>("session/output", (event) => {
+      if (event.payload.session_id !== targetId) return;
+      scheduleIdleTimer();
+    }).then((fn) => {
+      if (cancelled) {
+        fn();
+        return;
+      }
+      unlisten = fn;
+    });
+
+    return () => {
+      cancelled = true;
+      if (idleTimer !== null) window.clearTimeout(idleTimer);
+      window.clearTimeout(hardTimeout);
+      unlisten?.();
+    };
+  }, [starting, sessionId]);
 
   // Surface non-fatal session warnings (today: agent-resume fallback).
   // Mounted once per page — only one direct chat is in view at a time,
@@ -776,7 +850,9 @@ export default function RunnerChat() {
           // fire a session/output subscribe + outputSnapshot call
           // before the read-only branch takes over. The flash is short
           // but visible and contradicts the 'no PTY listener' goal.
-          <div className="text-sm text-fg-3">Loading chat…</div>
+          // Centered cyan pill mirrors the resume transitional state
+          // so any "session is coming up" moment reads consistently.
+          <StartingOverlay label="Starting chat…" />
         ) : isArchived ? (
           <div className="flex h-full items-center justify-center">
             <div className="flex max-w-md flex-col items-center gap-2 rounded border border-line bg-raised px-6 py-5 text-center">
@@ -790,18 +866,17 @@ export default function RunnerChat() {
             </div>
           </div>
         ) : directSessions.length === 0 ? (
-          <div className="text-sm text-fg-3">Starting…</div>
+          <StartingOverlay label="Starting chat…" />
         ) : (
           directSessions.map((s) => {
             const active = s.id === sessionId;
             const dead = s.status !== "running";
-            // Pane visual state: while resuming the active pane is
-            // fully blank (we already wiped it via clearVersion); the
-            // centered Resuming pill below reads on a pristine
-            // canvas. When stopped, the pane dims to 45% and the
-            // Session ended card overlays it.
+            // Pane visual state: while resuming/starting the active
+            // pane is fully blank so the centered cyan pill below
+            // reads on a pristine canvas. When stopped, the pane
+            // dims to 45% and the Session ended card overlays it.
             const paneOpacity = active
-              ? resuming
+              ? resuming || starting
                 ? "opacity-0"
                 : dead
                   ? "opacity-45"
@@ -817,13 +892,14 @@ export default function RunnerChat() {
                   runnerRuntime={runner?.runtime ?? ""}
                   // While the loader is up the canvas is hidden, so
                   // we want xterm to behave as inactive (no resize
-                  // pushes, no focus). When `resuming` flips off,
-                  // `active && !resuming` flips true, which triggers
-                  // RunnerTerminal's activation effect — fit() +
-                  // refresh() + focus + winsize push — and clears the
-                  // half-painted canvas frame the user otherwise sees.
-                  active={active && !resuming}
-                  disabled={dead || resuming}
+                  // pushes, no focus). When `resuming`/`starting`
+                  // flips off, `active && !resuming && !starting`
+                  // flips true, which triggers RunnerTerminal's
+                  // activation effect — fit() + refresh() + focus +
+                  // winsize push — and clears the half-painted
+                  // canvas frame the user otherwise sees.
+                  active={active && !resuming && !starting}
+                  disabled={dead || resuming || starting}
                   onExit={onTerminalExit}
                   onError={setErr}
                 />
@@ -832,12 +908,18 @@ export default function RunnerChat() {
           })
         )}
         {archiving ? (
-          // Archiving wins over the resume + ended overlays — the
-          // session is on its way out, so reading "Resuming…" or
-          // "Session ended" mid-flight would be misleading.
+          // Archiving wins over the resume + start + ended overlays
+          // — the session is on its way out, so reading "Resuming…"
+          // / "Starting…" / "Session ended" mid-flight would be
+          // misleading.
           <ArchivingOverlay withScrim />
         ) : chatState === "resuming" ? (
           <ResumingOverlay />
+        ) : starting && activeSession ? (
+          // Min-1s overlay while the freshly-attached agent CLI
+          // boots. The terminal underneath is hidden via
+          // `opacity-0` above so the pill reads on a clean canvas.
+          <StartingOverlay label="Starting chat…" />
         ) : activeSession && chatState !== "running" ? (
           <SessionEndedOverlay
             status={status}


### PR DESCRIPTION
## Summary

- **Resume just respawns the PTY.** The post-spawn auto-paste of `continue` was nudging claude-code / codex through a turn the user didn't ask for, and the 1.5s sleep + paste round-trip routinely landed mid-frame. Removed `schedule_continue_on_resume`, its call site, the `continue_resume_*` tests, and the FakeRuntime registration helper that only those tests used.
- **"Starting…" loading pill held for ≥1s over fresh terminals.** A direct chat or mission slot would mount its xterm instantly but the agent CLI inside took a couple of seconds to paint its banner. New `StartingOverlay` (shares a `LoadingPill` with `ResumingOverlay`) sits over the freshly-mounted pane until the agent's first output goes idle, with a 1s min-visible window and 10s hard-timeout fallback. Mirrors the resume dismissal dance in both `RunnerChat` and per-slot in `SlotPtyPane`.
- **Preserve scrollback on window resize for TUI panes.** Resizing was wiping the entire xterm scrollback because the SIGWINCH push wrote `\x1b[3J\x1b[2J\x1b[H` and `\x1b[3J` erases saved lines. Dropped the `\x1b[3J` — the visible-region wipe alone keeps the impl 0011 stacking fix intact, but older content stays scrollable.

## Test plan

- [x] `cargo test -p runner` (221 tests pass)
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run lint`
- [ ] Manual: click Resume on a stopped chat → PTY respawns without an auto-`continue` turn.
- [ ] Manual: start a fresh claude-code / codex chat → cyan "Starting chat…" pill visible for ≥1s before the agent's banner appears.
- [ ] Manual: start a fresh mission → each slot pane shows the pill until its agent paints.
- [ ] Manual: scroll up in a claude-code session, drag the window edge → scrollback survives the resize, no stacking duplicate frame on the visible region.