### PR TITLE
Propagate login-shell proxy env to PTY children

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -142,14 +142,16 @@ pub fn run() {
                 log::error!("failed to install bundled CLI: {e}");
             }
 
-            // Resolve the user's login-shell PATH once at startup so
-            // child PTYs can find tools that live outside launchd's
-            // stripped default PATH (Homebrew, mise/asdf/fnm, npm-global,
-            // etc.). Best-effort: a failure or timeout just leaves
-            // shell_path = None and we fall back to the inherited
-            // launchd PATH. See `shell_path` module docs for the
-            // launchd-strips-PATH problem this fixes.
-            let shell_path = shell_path::resolve_login_shell_path();
+            // Snapshot the user's login-shell env once at startup so
+            // child PTYs see the same PATH + proxy vars that
+            // Terminal.app's children would. Covers both the
+            // GUI-launch shim-discovery problem (Homebrew /
+            // mise / asdf / fnm / npm-global on a launchd-stripped
+            // PATH) and the claude/codex-login-behind-VPN problem
+            // (HTTPS_PROXY / NO_PROXY etc. set in rc files).
+            // Best-effort: a failure or timeout just leaves the
+            // snapshot empty and we fall back to launchd's env.
+            let login_shell_env = shell_path::resolve_login_shell_env();
 
             // Construct the in-process PTY runtime
             // (docs/impls/0011). v1 is unix-only — Windows fails at
@@ -169,7 +171,7 @@ pub fn run() {
                 }
             };
 
-            let sessions = session::SessionManager::new(shell_path, runtime);
+            let sessions = session::SessionManager::new(login_shell_env, runtime);
 
             // Build the AppState up front so the mission-side
             // reattach (next block) has access to the bus + router

--- a/src-tauri/src/session/launch.rs
+++ b/src-tauri/src/session/launch.rs
@@ -69,7 +69,7 @@ pub struct LaunchScript {
 ///    that the shim execs into; direct chats omit both to enforce
 ///    the off-bus invariant from PR #51).
 /// 3. `shell_path` (best-effort login-shell PATH from
-///    `shell_path::resolve_login_shell_path`, possibly None).
+///    `shell_path::resolve_login_shell_env`, possibly None).
 /// 4. Fallback CLI dirs (`~/.local/bin` etc.). Always included so
 ///    spawn correctness doesn't depend on the shell resolver
 ///    succeeding before a fixed timer.

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -358,13 +358,17 @@ pub struct SessionManager {
     /// SIGTERM produces a non-zero exit code. Entries are cleared by
     /// the reader after the DB row is updated.
     killed: Mutex<HashSet<String>>,
-    /// User's login-shell PATH, captured once at app start by
-    /// `shell_path::resolve_login_shell_path`. None when the resolve
+    /// User's login-shell env snapshot, captured once at app start by
+    /// `shell_path::resolve_login_shell_env`. Empty when the resolve
     /// failed/timed out, when running on Windows, or in tests.
-    /// Merged into every child PTY's PATH so GUI-launched apps can
-    /// find tools (claude, codex, mise, etc.) that aren't on
-    /// launchd's stripped default PATH.
-    shell_path: Option<String>,
+    ///
+    /// `path` is composed into every child PTY's PATH (so GUI-launched
+    /// apps can find tools like claude / codex / mise that aren't on
+    /// launchd's stripped default PATH — issue #65); `vars` (the
+    /// proxy quartet in both cases) is layered into every spawn's env
+    /// under `runner.env` so the child can reach the network the same
+    /// way Terminal.app's children would (issues #109 / #152).
+    shell_env: crate::shell_path::LoginShellEnv,
     /// Underlying terminal runtime (Step 9 of
     /// docs/impls/0004-tmux-session-runtime.md). v1 is `TmuxRuntime`
     /// on macOS + Linux; Windows fails at runtime construction in
@@ -395,14 +399,17 @@ impl Drop for ResumeClaim {
 }
 
 impl SessionManager {
-    pub fn new(shell_path: Option<String>, runtime: Arc<dyn SessionRuntime>) -> Arc<Self> {
+    pub fn new(
+        shell_env: crate::shell_path::LoginShellEnv,
+        runtime: Arc<dyn SessionRuntime>,
+    ) -> Arc<Self> {
         Arc::new(Self {
             sessions: Mutex::new(HashMap::new()),
             killed: Mutex::new(HashSet::new()),
             output_buffers: Mutex::new(HashMap::new()),
             output_seq: Mutex::new(HashMap::new()),
             resuming_claims: Mutex::new(HashSet::new()),
-            shell_path,
+            shell_env,
             runtime,
         })
     }
@@ -433,11 +440,14 @@ impl SessionManager {
         initial_size: Option<(u16, u16)>,
         extra_env: BTreeMap<String, String>,
     ) -> SpawnSpec {
-        let mut env: BTreeMap<String, String> = runner
-            .env
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
+        // Bottom layer: login-shell vars (proxy quartet, both cases)
+        // captured at app start. A runner row can override any of these
+        // by setting the same name in its own env map — the runner row
+        // is the most specific configuration surface.
+        let mut env: BTreeMap<String, String> = self.shell_env.vars.clone();
+        for (k, v) in &runner.env {
+            env.insert(k.clone(), v.clone());
+        }
         // System vars layer on top so the user can't accidentally
         // shadow them. PATH is set by the launch script from the
         // composed path; a runner.env PATH would be filtered by
@@ -457,7 +467,7 @@ impl SessionManager {
             mission,
             shim_dir,
             bundled_bin_dir,
-            shell_path: self.shell_path.clone(),
+            shell_path: self.shell_env.path.clone(),
             initial_size,
         }
     }
@@ -2608,7 +2618,13 @@ mod tests {
     /// Build a manager backed by the supplied FakeRuntime. Returns
     /// the Arc so tests can introspect the captured calls.
     fn mgr_with_fake(shell: Option<String>, fake: Arc<FakeRuntime>) -> Arc<SessionManager> {
-        SessionManager::new(shell, fake)
+        SessionManager::new(
+            crate::shell_path::LoginShellEnv {
+                path: shell,
+                vars: Default::default(),
+            },
+            fake,
+        )
     }
 
     /// Test emitter that just records every event. Replaces the Tauri
@@ -3058,7 +3074,7 @@ mod tests {
 
     #[test]
     fn inject_stdin_on_unknown_session_errors_cleanly() {
-        let mgr = SessionManager::new(None, inert_runtime());
+        let mgr = SessionManager::new(crate::shell_path::LoginShellEnv::default(), inert_runtime());
         let err = mgr.inject_stdin("nope", b"x").unwrap_err();
         assert!(format!("{err}").contains("session not found"));
     }
@@ -3431,7 +3447,7 @@ mod tests {
             .execute("DROP TABLE sessions", [])
             .unwrap();
 
-        let mgr = SessionManager::new(None, inert_runtime());
+        let mgr = SessionManager::new(crate::shell_path::LoginShellEnv::default(), inert_runtime());
         let slot = slot_for(&runner);
         let err = mgr
             .spawn(
@@ -3611,6 +3627,91 @@ mod tests {
         assert_eq!(
             last.active_sessions, 0,
             "after reap, active_sessions for this runner must be 0"
+        );
+    }
+
+    #[test]
+    fn login_shell_proxy_env_reaches_spawn_with_runner_env_taking_precedence() {
+        // Issue #152: GUI-launched Runner.app inherits launchd's
+        // stripped env, so HTTPS_PROXY / NO_PROXY from the user's
+        // shell rc files never reaches PTY children and claude /
+        // codex login fails behind a corporate VPN / ClashX.
+        //
+        // The captured login-shell env on `SessionManager` should:
+        //   - land in every spawn's env so children see the same
+        //     proxy vars Terminal.app's children see;
+        //   - lose to an explicit runner.env override on the same
+        //     key, because the runner row is the more specific
+        //     configuration surface.
+        let pool = pool_with_schema();
+        let now = Utc::now().to_rfc3339();
+        let runner_id = ulid::Ulid::new().to_string();
+        {
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'proxied', 'P', 'shell', '/bin/sh',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+                params![runner_id, now],
+            )
+            .unwrap();
+        }
+
+        let mut runner = runner("/bin/sh", &["-c", "true"]);
+        runner.id = runner_id;
+        runner.handle = "proxied".into();
+        // The runner row overrides HTTPS_PROXY but leaves
+        // NO_PROXY / lowercase variants untouched, so we expect
+        // those to come straight from the login-shell snapshot.
+        runner
+            .env
+            .insert("HTTPS_PROXY".into(), "http://runner-override:9999".into());
+
+        let fake = fake_runtime();
+        let mut vars = std::collections::BTreeMap::new();
+        vars.insert("HTTPS_PROXY".into(), "http://login-shell:7890".into());
+        vars.insert("https_proxy".into(), "http://login-shell:7890".into());
+        vars.insert(
+            "NO_PROXY".into(),
+            "localhost,127.0.0.1,*.byted.org".into(),
+        );
+        let mgr = SessionManager::new(
+            crate::shell_path::LoginShellEnv {
+                path: None,
+                vars,
+            },
+            Arc::clone(&fake) as Arc<dyn SessionRuntime>,
+        );
+        mgr.spawn_direct(
+            &runner,
+            Some("/tmp"),
+            None,
+            None,
+            std::path::Path::new("/tmp"),
+            Arc::clone(&pool),
+            capture(),
+            None,
+        )
+        .unwrap();
+
+        let spec = fake.last_spawn_spec().expect("spawn was called");
+        assert_eq!(
+            spec.env.get("HTTPS_PROXY").map(String::as_str),
+            Some("http://runner-override:9999"),
+            "runner.env must override the login-shell capture",
+        );
+        assert_eq!(
+            spec.env.get("https_proxy").map(String::as_str),
+            Some("http://login-shell:7890"),
+            "lowercase variant must flow through unchanged",
+        );
+        assert_eq!(
+            spec.env.get("NO_PROXY").map(String::as_str),
+            Some("localhost,127.0.0.1,*.byted.org"),
+            "NO_PROXY (with wildcard) must flow through unchanged",
         );
     }
 
@@ -3857,7 +3958,7 @@ mod tests {
             )
             .unwrap();
         }
-        let mgr = SessionManager::new(None, inert_runtime());
+        let mgr = SessionManager::new(crate::shell_path::LoginShellEnv::default(), inert_runtime());
         for (sid, needle) in [
             ("running-sid", "already running"),
             ("archived-sid", "archived"),

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -3674,15 +3674,9 @@ mod tests {
         let mut vars = std::collections::BTreeMap::new();
         vars.insert("HTTPS_PROXY".into(), "http://login-shell:7890".into());
         vars.insert("https_proxy".into(), "http://login-shell:7890".into());
-        vars.insert(
-            "NO_PROXY".into(),
-            "localhost,127.0.0.1,*.byted.org".into(),
-        );
+        vars.insert("NO_PROXY".into(), "localhost,127.0.0.1,*.byted.org".into());
         let mgr = SessionManager::new(
-            crate::shell_path::LoginShellEnv {
-                path: None,
-                vars,
-            },
+            crate::shell_path::LoginShellEnv { path: None, vars },
             Arc::clone(&fake) as Arc<dyn SessionRuntime>,
         );
         mgr.spawn_direct(

--- a/src-tauri/src/session/runtime.rs
+++ b/src-tauri/src/session/runtime.rs
@@ -51,7 +51,7 @@ pub struct SpawnSpec {
     /// not have the bundled CLI on PATH).
     pub bundled_bin_dir: Option<PathBuf>,
     /// Best-effort login-shell PATH from
-    /// `shell_path::resolve_login_shell_path`, captured once by the
+    /// `shell_path::resolve_login_shell_env`, captured once by the
     /// manager at app start. `None` if the resolver
     /// failed/timed out — the launch script's fallback CLI dirs
     /// (`~/.local/bin`, `/opt/homebrew/bin`, etc.) cover the common

--- a/src-tauri/src/shell_path.rs
+++ b/src-tauri/src/shell_path.rs
@@ -1,33 +1,37 @@
-//! Resolves the user's login-shell PATH so child PTYs spawned by a
-//! GUI-launched app can find tools that live outside launchd's stripped
-//! default PATH (Homebrew, npm-global, mise / asdf / fnm shims, etc.).
+//! Resolves env vars from the user's login shell so child PTYs spawned by a
+//! GUI-launched app see the same values they would inside Terminal.app.
 //!
-//! On macOS, launchd hands GUI apps a default PATH of
-//! `/usr/bin:/bin:/usr/sbin:/sbin`. The user's shell rc files extend PATH
-//! with toolchains, but they're sourced by the shell — not by launchd. So a
-//! GUI-launched Runner inherits a stripped PATH and `claude`, `codex`,
-//! `mise` etc. don't resolve. `pnpm tauri dev` from a terminal hides this
-//! because the terminal-spawned process already has the shell PATH.
+//! On macOS, launchd hands GUI apps a stripped env: a default PATH of
+//! `/usr/bin:/bin:/usr/sbin:/sbin`, no `HTTPS_PROXY` / `HTTP_PROXY` / etc.
+//! The user's shell rc files set those, but they're sourced by the shell —
+//! not by launchd. So a GUI-launched Runner inherits a stripped env and
+//! tools that need either the user's PATH (Homebrew, mise/asdf/fnm,
+//! npm-global) OR the user's HTTP proxy (claude / codex login behind a
+//! corporate VPN or ClashX-style local proxy) fail in ways that don't
+//! reproduce under `pnpm tauri dev` from a terminal.
 //!
-//! Workaround: at startup, spawn `$SHELL -ilc '<marker>; printenv PATH;
-//! <marker>'` once, parse the marker-delimited PATH out of stdout, and
-//! prepend it onto every child PTY's PATH alongside our bundled-bin dir.
+//! Workaround: at startup, spawn `$SHELL -ilc '<probe>'` once and parse
+//! marker-delimited values out of its stdout. We capture a fixed set of
+//! var names (`PATH` + the standard proxy quartet, both upper- and
+//! lower-case) — names that are dot-files-set rather than launchd-set
+//! and that downstream tools universally respect. Values stay whatever
+//! the user's rc files happen to export.
 //!
 //! Capture choices:
-//!   - `printenv PATH` instead of `printf '%s' "$PATH"` — `$PATH`
-//!     expansion is shell-specific (fish renders it space-separated),
-//!     while `printenv` reads the exported env var which is always
-//!     colon-delimited on Unix regardless of the parent shell.
-//!   - Sentinel markers around the value — rc files often print banners
-//!     or tool noise (`nvm` warnings, `direnv` notices, etc.) on
-//!     interactive startup; the markers let us extract the real PATH out
-//!     of an arbitrarily noisy stdout.
+//!   - `printenv NAME` per var, wrapped in per-var `__RUNNER_KV_NAME_…__`
+//!     markers — rc files often print banners or tool noise (`nvm`
+//!     warnings, `direnv` notices, etc.) on interactive startup; the
+//!     markers let us pluck each value out of an arbitrarily noisy
+//!     stdout, and a missing var (`printenv` exits non-zero) just leaves
+//!     an empty marker pair.
 //!   - try_wait poll with deadline + `kill + wait` on timeout — a hung
 //!     rc would otherwise leave a dangling login shell behind every app
 //!     launch.
 //!
-//! On Windows the problem doesn't arise (no launchd) and this returns None.
+//! On Windows the problem doesn't arise (no launchd) and this returns an
+//! empty `LoginShellEnv`.
 
+use std::collections::BTreeMap;
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::thread;
@@ -36,20 +40,74 @@ use std::time::{Duration, Instant};
 const RESOLVE_TIMEOUT: Duration = Duration::from_secs(2);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 const STDOUT_DRAIN_GRACE: Duration = Duration::from_millis(500);
-const MARKER_BEGIN: &str = "__RUNNER_PATH_BEGIN__";
-const MARKER_END: &str = "__RUNNER_PATH_END__";
+
+/// Var names captured from the login shell. PATH covers the original
+/// GUI-launch shim-discovery problem (issue #65); the proxy quartet
+/// (both cases) covers the claude / codex login-behind-VPN problem
+/// (issue #152). Lowercase variants are standard across curl /
+/// reqwest / Python requests / Node's undici / Go's `http.ProxyFromEnvironment`
+/// and many users only export the lowercase form.
+///
+/// This list is intentionally narrow: capturing arbitrary login-shell
+/// env would propagate every prompt customization and tool warning a
+/// user has in their rc files. Adding a name here is an explicit
+/// decision that the var (a) is typically rc-file-set, (b) affects
+/// behavior of CLIs the user expects to "just work."
+const CAPTURED_VARS: &[&str] = &[
+    "PATH",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "NO_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+    "no_proxy",
+];
+
+/// Snapshot of the login shell's env captured at app start.
+///
+/// `path` is split out because PATH composition (shim_dir →
+/// bundled_bin_dir → login_shell_path → launchd inherited) has its
+/// own precedence rules in `launch::compose_path` and isn't a
+/// straight env-var passthrough. `vars` holds everything else we
+/// capture (today: the proxy quartet, both cases) and is layered
+/// into every child PTY's env under `runner.env`, so a runner row's
+/// explicit override still wins.
+#[derive(Debug, Clone, Default)]
+pub struct LoginShellEnv {
+    pub path: Option<String>,
+    pub vars: BTreeMap<String, String>,
+}
 
 #[cfg(unix)]
-pub fn resolve_login_shell_path() -> Option<String> {
+pub fn resolve_login_shell_env() -> LoginShellEnv {
     let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
 
     // -i (interactive) sources `.zshrc` / `.bashrc`; -l (login) sources
     // `.zprofile` / `.bash_profile`. Both are needed: Homebrew
     // `shellenv` typically lives in `.zprofile` on Apple Silicon while
-    // mise / fnm / asdf inject from `.zshrc`. The single-quoted `printf`
-    // forms work in zsh / bash / fish; `printenv` is in coreutils on
-    // every Unix we target.
-    let inner = format!("printf '%s' '{MARKER_BEGIN}'; printenv PATH; printf '%s' '{MARKER_END}'");
+    // mise / fnm / asdf inject from `.zshrc`. `printenv` is in
+    // coreutils on every Unix we target and reads the exported env var
+    // straight from the process env (no shell-specific `$var`
+    // expansion).
+    //
+    // For each captured var: print BEGIN marker → printenv (stderr to
+    // /dev/null so a missing var doesn't pollute stdout) → END marker
+    // on its own line. The trailing newline keeps banner text on
+    // subsequent lines from running into the END marker. Missing vars
+    // produce `BEGIN__END__\n` (empty value) which the parser skips.
+    let mut inner = String::new();
+    for v in CAPTURED_VARS {
+        // The shell sees the script as a single -c arg — using
+        // double-quoted markers inside single-quoted printf args
+        // means we don't have to escape anything. var names are
+        // ASCII identifiers (no shell metachars) so direct
+        // interpolation is safe here.
+        inner.push_str(&format!(
+            "printf '%s' '__RUNNER_KV_{v}_BEGIN__'; printenv {v} 2>/dev/null; printf '%s\\n' '__RUNNER_KV_{v}_END__'; "
+        ));
+    }
 
     let mut child = match Command::new(&shell)
         .arg("-ilc")
@@ -62,9 +120,10 @@ pub fn resolve_login_shell_path() -> Option<String> {
         Ok(c) => c,
         Err(e) => {
             log::warn!(
-                "shell PATH resolution via `{shell}` failed to spawn ({e}); falling back to launchd PATH"
+                "login-shell env resolution via `{shell}` failed to spawn ({e}); \
+                 falling back to launchd env"
             );
-            return None;
+            return LoginShellEnv::default();
         }
     };
 
@@ -76,8 +135,8 @@ pub fn resolve_login_shell_path() -> Option<String> {
         None => {
             let _ = child.kill();
             let _ = child.wait();
-            log::warn!("shell PATH resolution lost stdout pipe; falling back");
-            return None;
+            log::warn!("login-shell env resolution lost stdout pipe; falling back");
+            return LoginShellEnv::default();
         }
     };
     let (tx, rx) = mpsc::channel();
@@ -100,10 +159,11 @@ pub fn resolve_login_shell_path() -> Option<String> {
                     let _ = child.kill();
                     let _ = child.wait();
                     log::warn!(
-                        "shell PATH resolution via `{shell}` timed out after {}s; killed shell; falling back to launchd PATH",
+                        "login-shell env resolution via `{shell}` timed out after {}s; \
+                         killed shell; falling back to launchd env",
                         RESOLVE_TIMEOUT.as_secs()
                     );
-                    return None;
+                    return LoginShellEnv::default();
                 }
                 thread::sleep(POLL_INTERVAL);
             }
@@ -111,108 +171,145 @@ pub fn resolve_login_shell_path() -> Option<String> {
                 let _ = child.kill();
                 let _ = child.wait();
                 log::warn!(
-                    "shell PATH resolution via `{shell}` failed waiting ({e}); falling back to launchd PATH"
+                    "login-shell env resolution via `{shell}` failed waiting ({e}); \
+                     falling back to launchd env"
                 );
-                return None;
+                return LoginShellEnv::default();
             }
         }
     };
 
     if !status.success() {
         log::warn!(
-            "shell PATH resolution via `{shell}` exited non-zero (status={:?}); falling back to launchd PATH",
+            "login-shell env resolution via `{shell}` exited non-zero (status={:?}); \
+             falling back to launchd env",
             status.code()
         );
-        return None;
+        return LoginShellEnv::default();
     }
 
     let stdout_bytes = match rx.recv_timeout(STDOUT_DRAIN_GRACE) {
         Ok(b) => b,
         Err(_) => {
             log::warn!(
-                "shell PATH resolution via `{shell}` produced no stdout in time; falling back"
+                "login-shell env resolution via `{shell}` produced no stdout in time; \
+                 falling back"
             );
-            return None;
+            return LoginShellEnv::default();
         }
     };
     let stdout_str = String::from_utf8_lossy(&stdout_bytes);
-    let parsed = extract_path_between_markers(&stdout_str);
-    if parsed.is_none() {
+    let parsed = parse_login_shell_env(&stdout_str);
+    if parsed.path.is_none() && parsed.vars.is_empty() {
         log::warn!(
-            "shell PATH resolution via `{shell}` returned no PATH between markers; falling back to launchd PATH"
+            "login-shell env resolution via `{shell}` returned no captured vars; \
+             falling back to launchd env"
         );
     }
     parsed
 }
 
 #[cfg(not(unix))]
-pub fn resolve_login_shell_path() -> Option<String> {
-    None
+pub fn resolve_login_shell_env() -> LoginShellEnv {
+    LoginShellEnv::default()
 }
 
-/// Pull the marker-delimited PATH value out of arbitrary shell stdout.
-/// Tolerates rc-file banners and tool warnings printed before / after
-/// our markers; uses `rfind` for the begin marker so a marker mention
-/// in a banner can't shadow the real one.
-fn extract_path_between_markers(stdout: &str) -> Option<String> {
-    let begin_idx = stdout.rfind(MARKER_BEGIN)?;
-    let after_begin = &stdout[begin_idx + MARKER_BEGIN.len()..];
-    let end_idx = after_begin.find(MARKER_END)?;
-    let path = after_begin[..end_idx].trim();
-    if path.is_empty() {
-        None
-    } else {
-        Some(path.to_string())
+/// Pull each `__RUNNER_KV_<NAME>_BEGIN__…__RUNNER_KV_<NAME>_END__`
+/// block out of arbitrary shell stdout. Tolerates rc-file banners
+/// before / between / after blocks. Uses `rfind` for each begin
+/// marker so a marker mention in a banner can't shadow the real one.
+/// An empty value (missing var) is dropped — distinct from "var set
+/// to empty string", which we'd represent the same way and which has
+/// no useful effect on a child anyway.
+fn parse_login_shell_env(stdout: &str) -> LoginShellEnv {
+    let mut env = LoginShellEnv::default();
+    for v in CAPTURED_VARS {
+        let begin = format!("__RUNNER_KV_{v}_BEGIN__");
+        let end = format!("__RUNNER_KV_{v}_END__");
+        let Some(begin_idx) = stdout.rfind(&begin) else {
+            continue;
+        };
+        let after_begin = &stdout[begin_idx + begin.len()..];
+        let Some(end_idx) = after_begin.find(&end) else {
+            continue;
+        };
+        let value = after_begin[..end_idx].trim();
+        if value.is_empty() {
+            continue;
+        }
+        if *v == "PATH" {
+            env.path = Some(value.to_string());
+        } else {
+            env.vars.insert(v.to_string(), value.to_string());
+        }
     }
+    env
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn extracts_path_between_markers_ignoring_rc_banner() {
-        // Typical noisy interactive startup: rc banner before our begin
-        // marker, then the real PATH (with `printenv`'s trailing
-        // newline), then end marker.
-        let stdout = "Welcome to zsh!\nnvm: using node v20\n__RUNNER_PATH_BEGIN__/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin\n__RUNNER_PATH_END__";
-        assert_eq!(
-            extract_path_between_markers(stdout).as_deref(),
-            Some("/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin")
-        );
+    fn block(name: &str, value: &str) -> String {
+        format!("__RUNNER_KV_{name}_BEGIN__{value}__RUNNER_KV_{name}_END__\n")
     }
 
     #[test]
-    fn extracts_path_when_banner_mentions_marker_substring() {
-        // A rogue banner that prints something containing the begin
-        // marker shouldn't shadow the real one — we use `rfind` so the
-        // last begin-marker before our end-marker wins.
-        let stdout = "echo: __RUNNER_PATH_BEGIN__ (this is a banner)\n__RUNNER_PATH_BEGIN__/usr/bin:/bin\n__RUNNER_PATH_END__";
+    fn parses_path_and_proxy_quartet_ignoring_rc_banner() {
+        let mut stdout = String::from("Welcome to zsh!\nnvm: using node v20\n");
+        stdout.push_str(&block("PATH", "/opt/homebrew/bin:/usr/bin:/bin"));
+        stdout.push_str(&block("HTTPS_PROXY", "http://127.0.0.1:7890"));
+        stdout.push_str(&block("https_proxy", "http://127.0.0.1:7890"));
+        stdout.push_str(&block("NO_PROXY", "localhost,127.0.0.1,*.byted.org"));
+        stdout.push_str(&block("HTTP_PROXY", ""));
+        let parsed = parse_login_shell_env(&stdout);
+        assert_eq!(parsed.path.as_deref(), Some("/opt/homebrew/bin:/usr/bin:/bin"));
         assert_eq!(
-            extract_path_between_markers(stdout).as_deref(),
-            Some("/usr/bin:/bin")
+            parsed.vars.get("HTTPS_PROXY").map(String::as_str),
+            Some("http://127.0.0.1:7890"),
         );
+        assert_eq!(
+            parsed.vars.get("https_proxy").map(String::as_str),
+            Some("http://127.0.0.1:7890"),
+        );
+        assert_eq!(
+            parsed.vars.get("NO_PROXY").map(String::as_str),
+            Some("localhost,127.0.0.1,*.byted.org"),
+        );
+        // Empty value (var was unset) is dropped — distinct from a
+        // set-but-empty value, which we'd skip anyway since exporting
+        // an empty proxy var has no useful effect on a child.
+        assert!(!parsed.vars.contains_key("HTTP_PROXY"));
     }
 
     #[test]
-    fn missing_markers_returns_none() {
-        assert_eq!(extract_path_between_markers("just a banner"), None);
-        assert_eq!(
-            extract_path_between_markers("__RUNNER_PATH_BEGIN__only"),
-            None
-        );
-        assert_eq!(extract_path_between_markers(""), None);
+    fn banner_mentioning_marker_substring_doesnt_shadow_real_block() {
+        let mut stdout = String::from("echo: __RUNNER_KV_PATH_BEGIN__ (banner)\n");
+        stdout.push_str(&block("PATH", "/usr/bin:/bin"));
+        let parsed = parse_login_shell_env(&stdout);
+        assert_eq!(parsed.path.as_deref(), Some("/usr/bin:/bin"));
     }
 
     #[test]
-    fn empty_path_between_markers_returns_none() {
-        assert_eq!(
-            extract_path_between_markers("__RUNNER_PATH_BEGIN____RUNNER_PATH_END__"),
-            None
-        );
-        assert_eq!(
-            extract_path_between_markers("__RUNNER_PATH_BEGIN__\n  \n__RUNNER_PATH_END__"),
-            None
-        );
+    fn missing_blocks_returns_default() {
+        let parsed = parse_login_shell_env("just a banner");
+        assert!(parsed.path.is_none());
+        assert!(parsed.vars.is_empty());
+
+        let parsed = parse_login_shell_env("__RUNNER_KV_PATH_BEGIN__only");
+        assert!(parsed.path.is_none());
+        assert!(parsed.vars.is_empty());
+
+        let parsed = parse_login_shell_env("");
+        assert!(parsed.path.is_none());
+        assert!(parsed.vars.is_empty());
+    }
+
+    #[test]
+    fn empty_value_between_markers_is_dropped() {
+        let stdout = block("PATH", "") + &block("HTTPS_PROXY", "  \n  ");
+        let parsed = parse_login_shell_env(&stdout);
+        assert!(parsed.path.is_none());
+        assert!(parsed.vars.is_empty());
     }
 }

--- a/src-tauri/src/shell_path.rs
+++ b/src-tauri/src/shell_path.rs
@@ -263,7 +263,10 @@ mod tests {
         stdout.push_str(&block("NO_PROXY", "localhost,127.0.0.1,*.byted.org"));
         stdout.push_str(&block("HTTP_PROXY", ""));
         let parsed = parse_login_shell_env(&stdout);
-        assert_eq!(parsed.path.as_deref(), Some("/opt/homebrew/bin:/usr/bin:/bin"));
+        assert_eq!(
+            parsed.path.as_deref(),
+            Some("/opt/homebrew/bin:/usr/bin:/bin")
+        );
         assert_eq!(
             parsed.vars.get("HTTPS_PROXY").map(String::as_str),
             Some("http://127.0.0.1:7890"),

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -110,6 +110,17 @@ export function RunnerTerminal({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<Terminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
+  // Live WebglAddon handle so the visibility / focus / font-change
+  // listeners below can call `clearTextureAtlas()` on it. The WebGL
+  // renderer caches every distinct (codepoint, fg, bg, style) cell
+  // into a GPU texture atlas; in dev (Vite HMR re-mounts) and on
+  // long-lived sessions with bold + italic + many ANSI colors the
+  // atlas occasionally desyncs and ASCII codepoints render with the
+  // wrong glyph until a resize triggers a refit. Rebuilding the
+  // atlas on the same lifecycle hooks where we already refresh /
+  // refit makes the corruption window a few hundred milliseconds at
+  // worst instead of "until the user touches the window edge."
+  const webglRef = useRef<WebglAddon | null>(null);
   const sessionIdRef = useRef<string>(sessionId);
   const onExitRef = useRef(onExit);
   const onErrorRef = useRef(onError);
@@ -200,9 +211,20 @@ export function RunnerTerminal({
     });
     term.loadAddon(webLinks);
     term.open(containerRef.current);
+    // WebGL renderer + context-loss recovery. Without the
+    // onContextLoss hook, a single GPU reset / driver hiccup / dev
+    // HMR remount would leave xterm rendering against a dead context
+    // and the canvas freezes mid-frame. Disposing the addon on loss
+    // lets xterm fall back to the DOM renderer for the rest of this
+    // mount — degraded but functional, no more frozen panes.
     try {
       const webgl = new WebglAddon();
+      webgl.onContextLoss(() => {
+        webgl.dispose();
+        webglRef.current = null;
+      });
       term.loadAddon(webgl);
+      webglRef.current = webgl;
     } catch {
       // No WebGL — fall through to canvas. RunnerChat does the same.
     }
@@ -370,6 +392,15 @@ export function RunnerTerminal({
       const t = termRef.current;
       if (!t) return;
       try {
+        // Rebuild the WebGL glyph atlas before the redraw. The atlas
+        // occasionally desyncs while the app is backgrounded (other
+        // GL apps stealing the GPU, OS compositor recycling, dev HMR
+        // re-running effects), and the symptom is plain ASCII
+        // codepoints rendering with the wrong glyph until a resize
+        // forces a refit. Clearing the atlas here costs one frame's
+        // worth of glyph re-rasterization on focus / tab-visible /
+        // font-change and eliminates the "resize-to-fix" workaround.
+        webglRef.current?.clearTextureAtlas();
         t.refresh(0, t.rows - 1);
       } catch {
         // teardown
@@ -393,14 +424,18 @@ export function RunnerTerminal({
       try {
         if (e.key === STORAGE_TERMINAL_FONT_SIZE) {
           t.options.fontSize = readTerminalFontSize();
-          // Cell metrics changed — refit and push the new PTY geometry
-          // so an active streaming TUI doesn't keep writing against
-          // stale cols/rows until the next window resize.
+          // Cell metrics changed — refit, push the new PTY geometry,
+          // and drop the atlas. The atlas indexes cells by their
+          // rendered pixel dimensions; a stale cache after a font
+          // change can leave a band of pre-change glyphs at the new
+          // size until something else evicts them.
+          webglRef.current?.clearTextureAtlas();
           refitAndPush();
         } else if (e.key === STORAGE_TERMINAL_FONT_FAMILY) {
           t.options.fontFamily = resolveTerminalFontStack(
             readTerminalFontFamily(),
           );
+          webglRef.current?.clearTextureAtlas();
           refitAndPush();
         } else if (e.key === STORAGE_TERMINAL_CURSOR_STYLE) {
           t.options.cursorStyle = readTerminalCursorStyle();

--- a/src/components/SessionEndedOverlay.tsx
+++ b/src/components/SessionEndedOverlay.tsx
@@ -161,6 +161,24 @@ export function StartingOverlay({
   );
 }
 
+/// True iff `startedAt` is within the last few seconds — the only
+/// case where the StartingOverlay pill should fire. Switching tabs
+/// to a chat that's been running for an hour, or reopening a mission
+/// the day after `mission_start`, must NOT replay the boot pill; the
+/// agent CLI inside the PTY is already painted and the user just
+/// wants the live terminal.
+///
+/// Window is intentionally short (a couple of seconds): spawn → IPC
+/// round-trip → React Router navigation is well under a second in
+/// practice, and any session older than that has already had a
+/// chance to paint its first frame.
+export function isFreshSpawn(startedAt: string | null | undefined): boolean {
+  if (!startedAt) return false;
+  const ts = Date.parse(startedAt);
+  if (!Number.isFinite(ts)) return false;
+  return Date.now() - ts < 3_000;
+}
+
 function LoadingPill({ label }: { label: string }) {
   return (
     <div className="pointer-events-auto flex items-center gap-2.5 rounded-full border border-[#1F3D4D] bg-[#0F1E26] px-4 py-2 text-[13px] font-medium text-[#39E5FF] shadow-[0_8px_30px_rgba(0,0,0,0.5)]">

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -235,8 +235,27 @@ const DEFAULT_TERMINAL_SCROLLBACK = 10000;
 // as the fallback chain so that even when a user picks a specific face
 // (JetBrains Mono, Fira Code) we still degrade gracefully on machines
 // where that font isn't installed.
+//
+// Head — Nerd Font fallbacks for the Private Use Area glyphs that
+// claude-code and other modern TUIs emit on their status line (PR /
+// branch / lock / cursor icons live in U+E000–U+F8FF). CSS font
+// stacks fall through per-codepoint, so the Latin / digit codepoints
+// keep coming from Menlo / SF Mono — the symbols fonts only win on
+// the PUA codepoints they cover, and they no-op if the user hasn't
+// installed any of these patches. Without this, macOS's automatic
+// PUA fallback lands on Apple SD Gothic Neo / Hiragino and the
+// glyph renders as a Hangul-looking character (#152 follow-up).
+//
+// Tail — `Apple Symbols` catches non-Nerd-Font symbol codepoints
+// (extra math, arrows, miscellaneous technical) before the generic
+// `monospace` fallback so the browser doesn't fall back to a CJK
+// face for those either.
 const SYSTEM_FONT_STACK =
-  'Menlo, "SF Mono", Monaco, Consolas, "Liberation Mono", monospace';
+  '"Symbols Nerd Font Mono", "Symbols Nerd Font", ' +
+  '"JetBrainsMono Nerd Font", "FiraCode Nerd Font", ' +
+  '"Hack Nerd Font Mono", ' +
+  'Menlo, "SF Mono", Monaco, Consolas, "Liberation Mono", ' +
+  '"Apple Symbols", monospace';
 
 export function readStoredBool(key: string, defaultValue: boolean): boolean {
   try {

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -47,6 +47,7 @@ import {
   ResumingOverlay,
   SessionEndedOverlay,
   StartingOverlay,
+  isFreshSpawn,
 } from "../components/SessionEndedOverlay";
 import {
   markArchivingMission,
@@ -846,12 +847,21 @@ function SlotPtyPane({
   const resuming = !!forcedResuming;
   const dead = session.status !== "running";
   // Per-slot "warming up" overlay: when the pane first mounts for a
-  // live slot, the agent CLI (claude-code / codex) takes a beat to
-  // paint its banner. Show the cyan pill over the otherwise-blank
-  // xterm canvas for at least 1s so the user doesn't stare at an
-  // empty pane wondering whether the spawn succeeded. Mirrors the
-  // resume dismissal dance (first-output + idle + min-visible).
-  const [starting, setStarting] = useState<boolean>(() => !dead);
+  // genuinely fresh slot, the agent CLI (claude-code / codex) takes
+  // a beat to paint its banner. Show the cyan pill over the
+  // otherwise-blank xterm canvas for at least 1s so the user doesn't
+  // stare at an empty pane wondering whether the spawn succeeded.
+  // Mirrors the resume dismissal dance (first-output + idle +
+  // min-visible).
+  //
+  // Gated on `isFreshSpawn(session.started_at)` so that
+  // navigating into an old mission — slot PTYs running for hours,
+  // agent long-since painted — drops straight into the live
+  // terminal instead of flashing the pill over already-rendered
+  // content.
+  const [starting, setStarting] = useState<boolean>(
+    () => !dead && isFreshSpawn(session.started_at),
+  );
   useEffect(() => {
     if (!starting) return;
     const STARTING_MIN_VISIBLE_MS = 1000;

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -33,6 +33,7 @@ import {
   ResumingOverlay,
   SessionEndedOverlay,
   StartingOverlay,
+  isFreshSpawn,
 } from "../components/SessionEndedOverlay";
 import { api, type DirectSessionEntry } from "../lib/api";
 import {
@@ -183,7 +184,12 @@ export default function RunnerChat() {
   }, []);
 
   const attach = useCallback(
-    (id: string, sessionHandle: string, status: SessionStatus = "running") => {
+    (
+      id: string,
+      sessionHandle: string,
+      status: SessionStatus = "running",
+      freshSpawn = false,
+    ) => {
       setErr(null);
       upsertSession({
         id,
@@ -192,10 +198,13 @@ export default function RunnerChat() {
         exitCode: null,
       });
       // Show the Starting pill over the freshly-mounted terminal
-      // until the agent CLI paints. Only for live sessions — landing
-      // on a stopped/crashed row from the sidebar should drop straight
-      // into the Session ended card.
-      if (status === "running") setStarting(true);
+      // until the agent CLI paints. Two gates: status === "running"
+      // (no pill over a stopped/crashed row — that surface is the
+      // Session ended card), and `freshSpawn` (no pill when the
+      // user is just switching tabs to a chat that's been running
+      // for an hour — the terminal is already painted and the user
+      // wants the live canvas, not a 1s flash).
+      if (status === "running" && freshSpawn) setStarting(true);
     },
     [upsertSession],
   );
@@ -487,9 +496,27 @@ export default function RunnerChat() {
     // so mounting RunnerTerminal would spawn a PTY listener for a row
     // that's terminal by definition.
     if (sessionId && handle && !isArchived) {
-      attach(sessionId, handle, state?.sessionStatus ?? "stopped");
+      // `freshSpawn` is the only signal that distinguishes "user just
+      // clicked Chat now and we're navigating into the spawn" from
+      // "user clicked an existing chat row in the sidebar." We key
+      // off chatMeta.started_at (loaded by the gate above) so the
+      // pill only fires on rows whose PTY was born seconds ago.
+      attach(
+        sessionId,
+        handle,
+        state?.sessionStatus ?? "stopped",
+        isFreshSpawn(chatMeta?.started_at),
+      );
     }
-  }, [attach, handle, sessionId, state?.sessionStatus, isArchived, metaLoaded]);
+  }, [
+    attach,
+    handle,
+    sessionId,
+    state?.sessionStatus,
+    isArchived,
+    metaLoaded,
+    chatMeta?.started_at,
+  ]);
 
   async function endChat() {
     if (!sessionId || !handle) return;


### PR DESCRIPTION
## Summary

Closes #152 (supersedes #109).

GUI-launched Runner.app inherits launchd's stripped env, so `HTTPS_PROXY` / `HTTP_PROXY` / `ALL_PROXY` / `NO_PROXY` (and lowercase variants) from the user's shell rc files never reach PTY children. `claude` / `codex` login flows that hit `api.anthropic.com` over the user's local proxy (ClashX / corporate VPN) silently fail, while the same binaries work from Terminal.app because that's a login shell that sourced the rc files.

## Fix

- **Generalize `shell_path.rs`.** One `$SHELL -ilc` probe at app start now sweeps a fixed list of var names — `PATH` plus the proxy quartet in both cases — instead of just `PATH`. Per-var `__RUNNER_KV_<NAME>_BEGIN__…__END__` marker pairs let us pluck each value out of noisy rc-file output; a missing var produces an empty block the parser drops. Returns `LoginShellEnv { path, vars }`. The var-name list is the only hardcoded part — values stay whatever the user's rc files export.
- **Layer it into `base_spawn_spec`.** `SessionManager` now owns the snapshot. Env composition order: login-shell `vars` (bottom) → `runner.env` → system vars (`TERM`, `COLORTERM`, top). So login-shell proxy reaches every spawn by default, a per-runner-row env override still wins, and system vars can't be shadowed.

## Tests

Five new tests, all green:

- `shell_path::tests::parses_path_and_proxy_quartet_ignoring_rc_banner` — parser handles the realistic config shape (lowercase variants, `NO_PROXY=localhost,127.0.0.1,*.byted.org`, missing var, banner noise).
- `shell_path::tests::banner_mentioning_marker_substring_doesnt_shadow_real_block` — `rfind` so a rogue banner can't spoof a value.
- `shell_path::tests::missing_blocks_returns_default` — graceful empty result.
- `shell_path::tests::empty_value_between_markers_is_dropped` — set-but-empty values are skipped (they'd be no-ops on the child anyway).
- `session::manager::tests::login_shell_proxy_env_reaches_spawn_with_runner_env_taking_precedence` — locks in layering: runner.env override beats the login-shell capture for `HTTPS_PROXY`, but lowercase variant + `NO_PROXY` flow through unchanged.

`cargo test -p runner --lib`: 222/222 pass.

## Test plan

- [x] `cargo test -p runner --lib`
- [ ] Manual on a machine with shell-level proxy (`export HTTPS_PROXY=http://127.0.0.1:7890` in `~/.zshrc`): launch Runner.app from Finder, start a fresh `claude` direct chat, run `/login` → OAuth round-trip completes.
- [ ] Manual: set the same key on a runner row's env to a deliberately wrong URL → the runner-row override wins, login flow fails (proves per-runner precedence).