### PR TITLE
feat: add crew system_prompt_addendum (Layer 2)

### DIFF
--- a/src-tauri/migrations/0005_crew_system_prompt_addendum.sql
+++ b/src-tauri/migrations/0005_crew_system_prompt_addendum.sql
@@ -1,0 +1,11 @@
+-- Adds `system_prompt_addendum` to crews — Layer 2 of the
+-- system-prompt stack (see issue #54). The platform preamble
+-- (Layer 1, code) and the runner persona (Layer 3, data) bracket
+-- this column; spawned mission workers see all three in order,
+-- direct chats see only the persona.
+--
+-- Nullable / default NULL. Empty / NULL = no addendum, no splice
+-- (current behavior). Seeded Build squad rows stay NULL — the
+-- seeded persona content is already enough; no backfill.
+
+ALTER TABLE crews ADD COLUMN system_prompt_addendum TEXT;

--- a/src-tauri/src/commands/crew.rs
+++ b/src-tauri/src/commands/crew.rs
@@ -16,11 +16,16 @@ use crate::{
     AppState,
 };
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct CreateCrewInput {
     pub name: String,
     pub purpose: Option<String>,
     pub goal: Option<String>,
+    /// Optional team-conventions text. Empty after trim → stored as NULL.
+    /// Plain Option (not Option<Option>) because create has no "leave
+    /// existing" semantic. See #54.
+    #[serde(default)]
+    pub system_prompt_addendum: Option<String>,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -30,6 +35,10 @@ pub struct UpdateCrewInput {
     pub goal: Option<Option<String>>,
     pub orchestrator_policy: Option<Option<serde_json::Value>>,
     pub signal_types: Option<Vec<SignalType>>,
+    /// Outer None = leave existing untouched; outer Some(inner) =
+    /// write inner. Inner Some("") / whitespace-only collapses to
+    /// NULL.
+    pub system_prompt_addendum: Option<Option<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -84,6 +93,7 @@ fn row_to_crew(row: &Row<'_>) -> rusqlite::Result<Crew> {
         signal_types: serde_json::from_str(&signal_types_raw).map_err(|e| {
             rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
         })?,
+        system_prompt_addendum: row.get("system_prompt_addendum")?,
         created_at: created_at.parse().map_err(|e: chrono::ParseError| {
             rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
         })?,
@@ -96,7 +106,8 @@ fn row_to_crew(row: &Row<'_>) -> rusqlite::Result<Crew> {
 pub fn list(conn: &Connection) -> Result<Vec<CrewListItem>> {
     let mut stmt = conn.prepare(
         "SELECT c.id, c.name, c.purpose, c.goal, c.orchestrator_policy,
-                c.signal_types, c.created_at, c.updated_at,
+                c.signal_types, c.system_prompt_addendum,
+                c.created_at, c.updated_at,
                 (SELECT COUNT(*) FROM slots s WHERE s.crew_id = c.id) AS runner_count
            FROM crews c
          ORDER BY c.created_at ASC",
@@ -158,7 +169,8 @@ pub fn list(conn: &Connection) -> Result<Vec<CrewListItem>> {
 pub fn get(conn: &Connection, id: &str) -> Result<Crew> {
     conn.query_row(
         "SELECT id, name, purpose, goal, orchestrator_policy,
-                signal_types, created_at, updated_at
+                signal_types, system_prompt_addendum,
+                created_at, updated_at
            FROM crews WHERE id = ?1",
         params![id],
         row_to_crew,
@@ -188,6 +200,15 @@ fn validate_crew_goal(goal: Option<&str>) -> Result<()> {
     Ok(())
 }
 
+/// Trim a text-with-default-NULL field. `None`, all-whitespace, or
+/// the empty string all collapse to `None` so the column never
+/// stores a degenerate "" value. Used for `system_prompt_addendum`;
+/// other text fields (purpose / goal) predate this helper and keep
+/// their raw-pass-through semantics for now.
+fn normalize_addendum(raw: Option<String>) -> Option<String> {
+    raw.map(|s| s.trim().to_string()).filter(|s| !s.is_empty())
+}
+
 pub fn create(conn: &Connection, input: CreateCrewInput) -> Result<Crew> {
     let name = input.name.trim();
     if name.is_empty() {
@@ -196,10 +217,12 @@ pub fn create(conn: &Connection, input: CreateCrewInput) -> Result<Crew> {
     validate_crew_goal(input.goal.as_deref())?;
     let id = new_id();
     let ts = now().to_rfc3339();
+    let addendum = normalize_addendum(input.system_prompt_addendum);
     conn.execute(
-        "INSERT INTO crews (id, name, purpose, goal, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?5)",
-        params![id, name, input.purpose, input.goal, ts],
+        "INSERT INTO crews (id, name, purpose, goal,
+                            system_prompt_addendum, created_at, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)",
+        params![id, name, input.purpose, input.goal, addendum, ts],
     )?;
     get(conn, &id)
 }
@@ -224,6 +247,10 @@ pub fn update(conn: &Connection, id: &str, input: UpdateCrewInput) -> Result<Cre
         .orchestrator_policy
         .unwrap_or(existing.orchestrator_policy);
     let signal_types = input.signal_types.unwrap_or(existing.signal_types);
+    let system_prompt_addendum = match input.system_prompt_addendum {
+        Some(inner) => normalize_addendum(inner),
+        None => existing.system_prompt_addendum,
+    };
 
     let policy_raw = match orchestrator_policy.as_ref() {
         Some(v) => Some(serde_json::to_string(v)?),
@@ -239,9 +266,19 @@ pub fn update(conn: &Connection, id: &str, input: UpdateCrewInput) -> Result<Cre
                 goal = ?3,
                 orchestrator_policy = ?4,
                 signal_types = ?5,
-                updated_at = ?6
-          WHERE id = ?7",
-        params![name, purpose, goal, policy_raw, signals_raw, ts, id],
+                system_prompt_addendum = ?6,
+                updated_at = ?7
+          WHERE id = ?8",
+        params![
+            name,
+            purpose,
+            goal,
+            policy_raw,
+            signals_raw,
+            system_prompt_addendum,
+            ts,
+            id,
+        ],
     )?;
     get(conn, id)
 }
@@ -311,8 +348,8 @@ mod tests {
             &conn,
             CreateCrewInput {
                 name: "Big".into(),
-                purpose: None,
                 goal: Some(oversized),
+                ..Default::default()
             },
         )
         .expect_err("oversize crew.goal must be rejected");
@@ -327,8 +364,7 @@ mod tests {
             &conn,
             CreateCrewInput {
                 name: "Victim".into(),
-                purpose: None,
-                goal: None,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -337,11 +373,8 @@ mod tests {
             &conn,
             &crew.id,
             UpdateCrewInput {
-                name: None,
-                purpose: None,
                 goal: Some(Some(oversized)),
-                orchestrator_policy: None,
-                signal_types: None,
+                ..Default::default()
             },
         )
         .expect_err("oversize crew.goal must be rejected on update");
@@ -356,8 +389,7 @@ mod tests {
             &conn,
             CreateCrewInput {
                 name: "Alpha".into(),
-                purpose: None,
-                goal: None,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -378,8 +410,7 @@ mod tests {
             &conn,
             CreateCrewInput {
                 name: "A".into(),
-                purpose: None,
-                goal: None,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -387,8 +418,7 @@ mod tests {
             &conn,
             CreateCrewInput {
                 name: "B".into(),
-                purpose: None,
-                goal: None,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -425,7 +455,7 @@ mod tests {
             CreateCrewInput {
                 name: "Original".into(),
                 purpose: Some("keep me".into()),
-                goal: None,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -454,8 +484,7 @@ mod tests {
             &conn,
             CreateCrewInput {
                 name: "Doomed".into(),
-                purpose: None,
-                goal: None,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -500,11 +529,106 @@ mod tests {
             &conn,
             CreateCrewInput {
                 name: "   ".into(),
-                purpose: None,
-                goal: None,
+                ..Default::default()
             },
         )
         .unwrap_err();
         assert!(err.to_string().contains("empty"));
+    }
+
+    #[test]
+    fn create_and_get_roundtrips_system_prompt_addendum() {
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let crew = create(
+            &conn,
+            CreateCrewInput {
+                name: "Conventional".into(),
+                system_prompt_addendum: Some("squash PRs against main".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            crew.system_prompt_addendum.as_deref(),
+            Some("squash PRs against main"),
+        );
+        let reread = get(&conn, &crew.id).unwrap();
+        assert_eq!(
+            reread.system_prompt_addendum.as_deref(),
+            Some("squash PRs against main"),
+        );
+    }
+
+    #[test]
+    fn create_collapses_empty_addendum_to_null() {
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let crew = create(
+            &conn,
+            CreateCrewInput {
+                name: "Blank".into(),
+                system_prompt_addendum: Some("   \n  ".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(crew.system_prompt_addendum, None);
+    }
+
+    #[test]
+    fn update_some_some_empty_string_clears_addendum_to_null() {
+        // Wire contract for the CrewEditor "Save" action: when the
+        // operator clears the field, the frontend sends `null`. But
+        // an older or alternate caller sending `Some("")` must also
+        // collapse to NULL so the column never stores a degenerate
+        // empty string. Issue #54 spelled this out explicitly.
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let crew = create(
+            &conn,
+            CreateCrewInput {
+                name: "Pre-filled".into(),
+                system_prompt_addendum: Some("convention".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let updated = update(
+            &conn,
+            &crew.id,
+            UpdateCrewInput {
+                system_prompt_addendum: Some(Some(String::new())),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.system_prompt_addendum, None);
+    }
+
+    #[test]
+    fn update_outer_none_preserves_existing_addendum() {
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let crew = create(
+            &conn,
+            CreateCrewInput {
+                name: "Keeper".into(),
+                system_prompt_addendum: Some("keep this".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let updated = update(
+            &conn,
+            &crew.id,
+            UpdateCrewInput {
+                name: Some("Renamed Keeper".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(updated.name, "Renamed Keeper");
+        assert_eq!(updated.system_prompt_addendum.as_deref(), Some("keep this"));
     }
 }

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -535,10 +535,15 @@ pub async fn mission_start(
     // each slot references. Mission spawn iterates per slot — two
     // slots referencing the same runner template both produce
     // distinct PTYs identifying as their respective slot_handles.
-    let (crew_name, allowed_signals, crew_default_goal) = {
+    let (crew_name, allowed_signals, crew_default_goal, crew_addendum) = {
         let conn = state.db.get()?;
         let crew = crew::get(&conn, &out.mission.crew_id)?;
-        (crew.name, crew.signal_types, crew.goal)
+        (
+            crew.name,
+            crew.signal_types,
+            crew.goal,
+            crew.system_prompt_addendum,
+        )
     };
     let roster = {
         let conn = state.db.get()?;
@@ -593,12 +598,14 @@ pub async fn mission_start(
                                 mission_goal: goal_text.as_str(),
                                 roster: &roster_entries,
                                 allowed_signals: &allowed_signals,
+                                crew_addendum: crew_addendum.as_deref(),
                             },
                         )
                     })
                 } else {
                     Some(crate::router::prompt::compose_worker_first_turn(
                         m.runner.system_prompt.as_deref(),
+                        crew_addendum.as_deref(),
                     ))
                 }
             })
@@ -633,6 +640,7 @@ pub async fn mission_start(
         crew_name,
         &roster,
         allowed_signals,
+        crew_addendum.clone(),
         Arc::clone(&log_arc),
         injector,
     ) {
@@ -822,10 +830,10 @@ pub(crate) async fn ensure_mission_router_mounted(
         return Ok(());
     }
 
-    let (crew_name, allowed_signals) = {
+    let (crew_name, allowed_signals, crew_addendum) = {
         let conn = state.db.get()?;
         let crew = crew::get(&conn, &mission.crew_id)?;
-        (crew.name, crew.signal_types)
+        (crew.name, crew.signal_types, crew.system_prompt_addendum)
     };
     let roster = {
         let conn = state.db.get()?;
@@ -868,6 +876,7 @@ pub(crate) async fn ensure_mission_router_mounted(
         crew_name,
         &roster,
         allowed_signals,
+        crew_addendum,
         Arc::clone(&log_arc),
         injector,
     )?;
@@ -1041,10 +1050,15 @@ pub async fn mission_reset(
         let conn = state.db.get()?;
         get(&conn, &id)?
     };
-    let (crew_name, crew_signal_types, crew_goal) = {
+    let (crew_name, crew_signal_types, crew_goal, crew_addendum) = {
         let conn = state.db.get()?;
         let crew = crew::get(&conn, &mission_snap.crew_id)?;
-        (crew.name, crew.signal_types, crew.goal)
+        (
+            crew.name,
+            crew.signal_types,
+            crew.goal,
+            crew.system_prompt_addendum,
+        )
     };
     let roster = {
         let conn = state.db.get()?;
@@ -1195,12 +1209,14 @@ pub async fn mission_reset(
                                 mission_goal: goal_text.as_str(),
                                 roster: &roster_entries,
                                 allowed_signals: &crew_signal_types,
+                                crew_addendum: crew_addendum.as_deref(),
                             },
                         )
                     })
                 } else {
                     Some(crate::router::prompt::compose_worker_first_turn(
                         m.runner.system_prompt.as_deref(),
+                        crew_addendum.as_deref(),
                     ))
                 }
             })
@@ -1220,6 +1236,7 @@ pub async fn mission_reset(
         crew_name,
         &roster,
         crew_signal_types,
+        crew_addendum.clone(),
         Arc::clone(&log_arc),
         injector,
     )?;
@@ -1444,8 +1461,8 @@ mod tests {
             conn,
             CreateCrewInput {
                 name: name.into(),
-                purpose: None,
                 goal: goal.map(String::from),
+                ..Default::default()
             },
         )
         .unwrap();

--- a/src-tauri/src/commands/slot.rs
+++ b/src-tauri/src/commands/slot.rs
@@ -508,8 +508,7 @@ mod tests {
             conn,
             crew::CreateCrewInput {
                 name: name.into(),
-                purpose: None,
-                goal: None,
+                ..Default::default()
             },
         )
         .unwrap()

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -82,6 +82,10 @@ fn init_connection(conn: &mut Connection) -> rusqlite::Result<()> {
 // archived missions out of search/list surfaces without conflating
 // them with `status = 'completed'`. Backfills existing completed
 // rows so their archived_at = stopped_at.
+// 0005: adds `system_prompt_addendum` (TEXT, nullable) to crews —
+// Layer 2 of the system-prompt stack (#54). Spliced between
+// platform preamble and runner persona on mission spawns only.
+// No backfill; seeded Build squad rows stay NULL.
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, include_str!("../migrations/0001_init.sql")),
     (2, include_str!("../migrations/0002_persona_only_seeds.sql")),
@@ -89,6 +93,10 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (
         4,
         include_str!("../migrations/0004_mission_archived_at.sql"),
+    ),
+    (
+        5,
+        include_str!("../migrations/0005_crew_system_prompt_addendum.sql"),
     ),
 ];
 

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -25,6 +25,11 @@ pub struct Crew {
     pub goal: Option<String>,
     pub orchestrator_policy: Option<serde_json::Value>,
     pub signal_types: Vec<SignalType>,
+    /// Layer-2 team conventions text. Spliced between the platform
+    /// preamble and the runner persona on mission spawns only;
+    /// direct chats ignore it. NULL / empty = no splice. See #54.
+    #[serde(default)]
+    pub system_prompt_addendum: Option<String>,
     pub created_at: Timestamp,
     pub updated_at: Timestamp,
 }

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -147,6 +147,7 @@ pub struct Router {
 impl Router {
     /// Build a router from the crew's roster and lead. `roster` is the same
     /// slice `mission_start` already loaded for the spawn loop.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         mission_id: String,
         crew_id: String,

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -81,6 +81,12 @@ pub(crate) struct LaunchInputs {
     lead: LeadRow,
     roster: Vec<RosterRow>,
     allowed_signals: Vec<SignalType>,
+    /// `crew.system_prompt_addendum` snapshot at mount/resume time
+    /// (Layer 2 of the system-prompt stack, #54). Used by
+    /// `fire_lead_launch_prompt` on the resume fresh-fallback so the
+    /// relaunched lead sees the same composed prompt the first spawn
+    /// got. `None` / empty → no splice.
+    crew_addendum: Option<String>,
 }
 
 pub(crate) struct LeadRow {
@@ -147,6 +153,7 @@ impl Router {
         crew_name: String,
         roster: &[SlotWithRunner],
         allowed_signals: Vec<SignalType>,
+        crew_addendum: Option<String>,
         log: Arc<EventLog>,
         injector: Arc<dyn StdinInjector>,
     ) -> Result<Arc<Self>> {
@@ -180,6 +187,7 @@ impl Router {
                 lead,
                 roster: roster_rows,
                 allowed_signals,
+                crew_addendum,
             },
             state: Mutex::new(RouterState::default()),
         }))
@@ -574,6 +582,7 @@ impl Router {
                 mission_goal: &goal,
                 roster: &roster_entries,
                 allowed_signals: self.launch.allowed_signals(),
+                crew_addendum: self.launch.crew_addendum(),
             },
         );
         let body = prompt.trim_end_matches(['\n', '\r']).as_bytes().to_vec();
@@ -695,6 +704,9 @@ impl LaunchInputs {
     }
     pub(crate) fn allowed_signals(&self) -> &[SignalType] {
         &self.allowed_signals
+    }
+    pub(crate) fn crew_addendum(&self) -> Option<&str> {
+        self.crew_addendum.as_deref()
     }
 }
 

--- a/src-tauri/src/router/prompt.rs
+++ b/src-tauri/src/router/prompt.rs
@@ -42,19 +42,20 @@ pub struct LaunchPromptInput<'a> {
     pub roster: &'a [RosterEntry<'a>],
     pub allowed_signals: &'a [SignalType],
     /// Layer-2 team conventions text (`crew.system_prompt_addendum`).
-    /// Spliced as raw, unlabeled text between the "You are X, lead
-    /// runner in crew Y" intro and the `== Your brief ==` section.
-    /// Empty / whitespace-only → no splice. See #54.
+    /// Spliced under a `== Team conventions ==` section between the
+    /// "You are X, lead runner in crew Y" intro and the `== Your
+    /// brief ==` section. Empty / whitespace-only → no splice. See #54.
     pub crew_addendum: Option<&'a str>,
 }
 
 /// First-user-turn body for a non-lead mission worker. Combines the
 /// platform-injected coordination preamble (Layer 1 — verbs the
 /// worker needs to participate in the bus + reply to the human),
-/// the optional crew-level addendum (Layer 2 — team conventions),
-/// and the worker's per-runner system_prompt as a "brief" section
-/// (Layer 3 — persona). Returns the full composed body, never
-/// empty (preamble is always present).
+/// the optional crew-level addendum spliced under a `== Team
+/// conventions ==` section (Layer 2), and the worker's per-runner
+/// system_prompt as a `== Your brief ==` section (Layer 3 —
+/// persona). Returns the full composed body, never empty (preamble
+/// is always present).
 ///
 /// Delivered as the trailing positional `[PROMPT]` argv at spawn time
 /// when the runtime accepts it (see `router::runtime::first_turn_argv`);
@@ -76,7 +77,7 @@ pub fn compose_worker_first_turn(
     let mut out = String::new();
     out.push_str(WORKER_COORDINATION_PREAMBLE);
     if let Some(addendum) = addendum {
-        out.push_str("\n\n");
+        out.push_str("\n\n== Team conventions ==\n");
         out.push_str(&addendum);
     }
     if let Some(brief) = user_brief {
@@ -130,6 +131,7 @@ pub fn compose_launch_prompt(input: &LaunchPromptInput<'_>) -> String {
     if let Some(addendum) = input.crew_addendum {
         let addendum = addendum.trim();
         if !addendum.is_empty() {
+            out.push_str("== Team conventions ==\n");
             out.push_str(addendum);
             out.push_str("\n\n");
         }
@@ -314,14 +316,23 @@ mod tests {
     fn worker_first_turn_splices_addendum_between_preamble_and_brief() {
         let body = compose_worker_first_turn(Some("WORKER_BRIEF"), Some("TEAM_TEXT"));
         assert!(body.contains(WORKER_COORDINATION_PREAMBLE));
+        assert!(
+            body.contains("== Team conventions =="),
+            "addendum must be wrapped in a `== Team conventions ==` section; got: {body}",
+        );
         assert!(body.contains("TEAM_TEXT"));
         assert!(body.contains("== Your brief =="));
         let preamble_pos = body.find("Coordination ==").unwrap();
+        let header_pos = body.find("== Team conventions ==").unwrap();
         let addendum_pos = body.find("TEAM_TEXT").unwrap();
         let brief_pos = body.find("== Your brief ==").unwrap();
         assert!(
-            preamble_pos < addendum_pos,
-            "preamble must come before addendum; got body: {body}",
+            preamble_pos < header_pos,
+            "preamble must come before the team-conventions header; got body: {body}",
+        );
+        assert!(
+            header_pos < addendum_pos,
+            "team-conventions header must come before the addendum text; got body: {body}",
         );
         assert!(
             addendum_pos < brief_pos,
@@ -350,10 +361,16 @@ mod tests {
             allowed_signals: &allowed,
             crew_addendum: Some("TEAM_TEXT"),
         });
+        assert!(
+            with_addendum.contains("== Team conventions =="),
+            "addendum must be wrapped in a `== Team conventions ==` section; got: {with_addendum}",
+        );
         let intro_pos = with_addendum.find("lead runner in crew").unwrap();
+        let header_pos = with_addendum.find("== Team conventions ==").unwrap();
         let addendum_pos = with_addendum.find("TEAM_TEXT").unwrap();
         let brief_pos = with_addendum.find("== Your brief ==").unwrap();
-        assert!(intro_pos < addendum_pos);
+        assert!(intro_pos < header_pos);
+        assert!(header_pos < addendum_pos);
         assert!(addendum_pos < brief_pos);
 
         // None addendum is byte-identical to the no-addendum baseline.

--- a/src-tauri/src/router/prompt.rs
+++ b/src-tauri/src/router/prompt.rs
@@ -41,26 +41,44 @@ pub struct LaunchPromptInput<'a> {
     pub mission_goal: &'a str,
     pub roster: &'a [RosterEntry<'a>],
     pub allowed_signals: &'a [SignalType],
+    /// Layer-2 team conventions text (`crew.system_prompt_addendum`).
+    /// Spliced as raw, unlabeled text between the "You are X, lead
+    /// runner in crew Y" intro and the `== Your brief ==` section.
+    /// Empty / whitespace-only → no splice. See #54.
+    pub crew_addendum: Option<&'a str>,
 }
 
 /// First-user-turn body for a non-lead mission worker. Combines the
-/// platform-injected coordination preamble (verbs the worker needs to
-/// participate in the bus + reply to the human) with the worker's
-/// per-runner system_prompt as a "brief" section. Returns the full
-/// composed body, never empty (preamble is always present).
+/// platform-injected coordination preamble (Layer 1 — verbs the
+/// worker needs to participate in the bus + reply to the human),
+/// the optional crew-level addendum (Layer 2 — team conventions),
+/// and the worker's per-runner system_prompt as a "brief" section
+/// (Layer 3 — persona). Returns the full composed body, never
+/// empty (preamble is always present).
 ///
 /// Delivered as the trailing positional `[PROMPT]` argv at spawn time
 /// when the runtime accepts it (see `router::runtime::first_turn_argv`);
 /// callers that can't use argv inject the same body via stdin paste.
 /// Source of truth lives here so both delivery paths use byte-identical
 /// content.
-pub fn compose_worker_first_turn(system_prompt: Option<&str>) -> String {
+pub fn compose_worker_first_turn(
+    system_prompt: Option<&str>,
+    crew_addendum: Option<&str>,
+) -> String {
+    let addendum = crew_addendum
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
     let user_brief = system_prompt
         .map(str::trim)
         .filter(|s| !s.is_empty())
         .map(str::to_string);
     let mut out = String::new();
     out.push_str(WORKER_COORDINATION_PREAMBLE);
+    if let Some(addendum) = addendum {
+        out.push_str("\n\n");
+        out.push_str(&addendum);
+    }
     if let Some(brief) = user_brief {
         out.push_str("\n\n== Your brief ==\n");
         out.push_str(&brief);
@@ -108,6 +126,14 @@ pub fn compose_launch_prompt(input: &LaunchPromptInput<'_>) -> String {
         "You are `{}` ({}), lead runner in crew \"{}\".\n\n",
         input.lead.handle, input.lead.display_name, input.crew_name,
     ));
+
+    if let Some(addendum) = input.crew_addendum {
+        let addendum = addendum.trim();
+        if !addendum.is_empty() {
+            out.push_str(addendum);
+            out.push_str("\n\n");
+        }
+    }
 
     if let Some(brief) = input.lead.system_prompt {
         let brief = brief.trim();
@@ -192,6 +218,7 @@ mod tests {
             mission_goal: "ship v0",
             roster: &[],
             allowed_signals: &allowed,
+            crew_addendum: None,
         });
         assert!(prompt.contains("== Your brief =="));
         assert!(prompt.contains("Drive coordination."));
@@ -204,6 +231,7 @@ mod tests {
             mission_goal: "ship v0",
             roster: &[],
             allowed_signals: &allowed,
+            crew_addendum: None,
         });
         assert!(!prompt2.contains("== Your brief =="));
     }
@@ -216,6 +244,7 @@ mod tests {
             mission_goal: "",
             roster: &[],
             allowed_signals: &[],
+            crew_addendum: None,
         });
         assert!(prompt.contains("(no goal set"));
     }
@@ -226,7 +255,7 @@ mod tests {
         // section must explicitly say silence is fine for passing
         // remarks, so agents stop posting "got it"/"noted" on every
         // human_said.
-        let body = compose_worker_first_turn(None);
+        let body = compose_worker_first_turn(None, None);
         assert!(
             body.contains("silence is fine"),
             "preamble should tell workers silence is acceptable for passing remarks; got: {body}",
@@ -256,10 +285,95 @@ mod tests {
                 },
             ],
             allowed_signals: &[],
+            crew_addendum: None,
         });
         assert!(prompt.contains("`impl`"));
         // Self-row must not appear under crewmates.
         let crewmates_section = prompt.split("== Your crewmates ==").nth(1).unwrap();
         assert!(!crewmates_section.contains("`lead`"));
+    }
+
+    #[test]
+    fn worker_first_turn_with_none_addendum_matches_no_addendum_baseline() {
+        // Regression guard for #54: existing mission spawns (no crew
+        // addendum set) must produce byte-identical output to the
+        // pre-#54 composer, so seeded Build squad rows / any crew that
+        // leaves the addendum NULL keep the exact prompt they had.
+        let with_brief = compose_worker_first_turn(Some("WORKER_BRIEF"), None);
+        let without_brief = compose_worker_first_turn(None, None);
+
+        assert!(with_brief.starts_with(WORKER_COORDINATION_PREAMBLE));
+        assert!(with_brief.contains("== Your brief =="));
+        assert!(with_brief.contains("WORKER_BRIEF"));
+
+        // No addendum → preamble is the entire body when brief is None.
+        assert_eq!(without_brief, WORKER_COORDINATION_PREAMBLE);
+    }
+
+    #[test]
+    fn worker_first_turn_splices_addendum_between_preamble_and_brief() {
+        let body = compose_worker_first_turn(Some("WORKER_BRIEF"), Some("TEAM_TEXT"));
+        assert!(body.contains(WORKER_COORDINATION_PREAMBLE));
+        assert!(body.contains("TEAM_TEXT"));
+        assert!(body.contains("== Your brief =="));
+        let preamble_pos = body.find("Coordination ==").unwrap();
+        let addendum_pos = body.find("TEAM_TEXT").unwrap();
+        let brief_pos = body.find("== Your brief ==").unwrap();
+        assert!(
+            preamble_pos < addendum_pos,
+            "preamble must come before addendum; got body: {body}",
+        );
+        assert!(
+            addendum_pos < brief_pos,
+            "addendum must come before brief; got body: {body}",
+        );
+    }
+
+    #[test]
+    fn worker_first_turn_whitespace_only_addendum_collapses_to_none() {
+        let with_blanks = compose_worker_first_turn(Some("BRIEF"), Some("   \n\t  "));
+        let baseline = compose_worker_first_turn(Some("BRIEF"), None);
+        assert_eq!(
+            with_blanks, baseline,
+            "whitespace-only addendum must be treated as None",
+        );
+    }
+
+    #[test]
+    fn launch_prompt_splices_addendum_between_intro_and_brief() {
+        let allowed = [SignalType::new("mission_goal")];
+        let with_addendum = compose_launch_prompt(&LaunchPromptInput {
+            lead: lead("lead", Some("LEAD_BRIEF")),
+            crew_name: "Alpha",
+            mission_goal: "ship v0",
+            roster: &[],
+            allowed_signals: &allowed,
+            crew_addendum: Some("TEAM_TEXT"),
+        });
+        let intro_pos = with_addendum.find("lead runner in crew").unwrap();
+        let addendum_pos = with_addendum.find("TEAM_TEXT").unwrap();
+        let brief_pos = with_addendum.find("== Your brief ==").unwrap();
+        assert!(intro_pos < addendum_pos);
+        assert!(addendum_pos < brief_pos);
+
+        // None addendum is byte-identical to the no-addendum baseline.
+        let baseline = compose_launch_prompt(&LaunchPromptInput {
+            lead: lead("lead", Some("LEAD_BRIEF")),
+            crew_name: "Alpha",
+            mission_goal: "ship v0",
+            roster: &[],
+            allowed_signals: &allowed,
+            crew_addendum: None,
+        });
+        let whitespace = compose_launch_prompt(&LaunchPromptInput {
+            lead: lead("lead", Some("LEAD_BRIEF")),
+            crew_name: "Alpha",
+            mission_goal: "ship v0",
+            roster: &[],
+            allowed_signals: &allowed,
+            crew_addendum: Some("   \n  "),
+        });
+        assert_eq!(whitespace, baseline);
+        assert!(!baseline.contains("TEAM_TEXT"));
     }
 }

--- a/src-tauri/src/router/tests.rs
+++ b/src-tauri/src/router/tests.rs
@@ -177,6 +177,7 @@ fn fixture(
         "Crew One".into(),
         &roster,
         vec![SignalType::new("mission_goal"), SignalType::new("ask_lead")],
+        None,
         log.clone(),
         injector_dyn,
     )
@@ -680,6 +681,7 @@ fn pending_ask_map_reconstructs_from_log_on_reopen() {
             "Crew One".into(),
             &roster,
             vec![],
+            None,
             log.clone(),
             injector_dyn,
         )
@@ -713,6 +715,7 @@ fn pending_ask_map_reconstructs_from_log_on_reopen() {
         "Crew One".into(),
         &roster,
         vec![],
+        None,
         log.clone(),
         injector_dyn,
     )
@@ -818,6 +821,7 @@ fn reconstruct_recovers_latest_runner_status_only() {
         "Crew One".into(),
         &roster,
         vec![],
+        None,
         log.clone(),
         injector_dyn,
     )
@@ -906,6 +910,7 @@ fn fresh_mission_start_does_not_call_reconstruct() {
         "Crew One".into(),
         &roster,
         vec![],
+        None,
         log.clone(),
         injector_dyn,
     )
@@ -1002,6 +1007,7 @@ fn reconstruct_tolerates_malformed_lines_like_the_bus() {
             "Crew One".into(),
             &roster,
             vec![],
+            None,
             log.clone(),
             injector_dyn,
         )
@@ -1029,6 +1035,7 @@ fn reconstruct_tolerates_malformed_lines_like_the_bus() {
         "Crew One".into(),
         &roster,
         vec![],
+        None,
         log.clone(),
         injector_dyn,
     )
@@ -1165,6 +1172,7 @@ fn synthetic_busy_replays_through_existing_runner_status_projection() {
             "Crew One".into(),
             &roster,
             vec![],
+            None,
             log.clone(),
             injector_dyn,
         )
@@ -1186,6 +1194,7 @@ fn synthetic_busy_replays_through_existing_runner_status_projection() {
         "Crew One".into(),
         &roster,
         vec![],
+        None,
         log.clone(),
         injector_dyn,
     )

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -3219,7 +3219,7 @@ mod tests {
         slot.id = slot_id;
         slot.lead = false;
 
-        let body = compose_worker_first_turn(runner.system_prompt.as_deref());
+        let body = compose_worker_first_turn(runner.system_prompt.as_deref(), None);
         // Composer ships the on-bus preamble + the brief.
         assert!(body.contains("in a crew coordinated by the bundled"));
         assert!(body.contains("WORKER_BRIEF"));

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,6 +16,10 @@ export interface Crew {
   goal: string | null;
   orchestrator_policy: unknown | null;
   signal_types: SignalType[];
+  /** Layer-2 team conventions text. Spliced between the platform
+   *  preamble and the runner persona on mission spawns only;
+   *  direct chats ignore it. NULL / empty = no splice. See #54. */
+  system_prompt_addendum: string | null;
   created_at: Timestamp;
   updated_at: Timestamp;
 }
@@ -202,6 +206,9 @@ export interface CreateCrewInput {
   name: string;
   purpose?: string | null;
   goal?: string | null;
+  /** Team-conventions text. Empty after trim collapses to NULL on
+   *  the backend. */
+  system_prompt_addendum?: string | null;
 }
 
 export interface UpdateCrewInput {
@@ -210,6 +217,9 @@ export interface UpdateCrewInput {
   goal?: string | null;
   orchestrator_policy?: unknown | null;
   signal_types?: SignalType[];
+  /** Omit to leave existing untouched; pass null to clear; pass a
+   *  non-empty string to set. */
+  system_prompt_addendum?: string | null;
 }
 
 /// Permission mode the runner-edit form's dropdown writes onto the

--- a/src/pages/CrewEditor.tsx
+++ b/src/pages/CrewEditor.tsx
@@ -33,6 +33,9 @@ export default function CrewEditor() {
   const [editing, setEditing] = useState<Runner | null>(null);
   const [nameDraft, setNameDraft] = useState("");
   const [savingName, setSavingName] = useState(false);
+  const [addendumEditing, setAddendumEditing] = useState(false);
+  const [addendumDraft, setAddendumDraft] = useState("");
+  const [savingAddendum, setSavingAddendum] = useState(false);
   const [reordering, setReordering] = useState(false);
   const reorderInFlight = useRef(false);
   const navigate = useNavigate();
@@ -72,6 +75,34 @@ export default function CrewEditor() {
       setError(String(e));
     } finally {
       setSavingName(false);
+    }
+  };
+
+  const onStartAddendumEdit = () => {
+    setAddendumDraft(crew?.system_prompt_addendum ?? "");
+    setAddendumEditing(true);
+  };
+
+  const onCancelAddendumEdit = () => {
+    setAddendumEditing(false);
+    setAddendumDraft("");
+  };
+
+  const onSaveAddendum = async () => {
+    if (!crewId) return;
+    const trimmed = addendumDraft.trim();
+    setSavingAddendum(true);
+    try {
+      await api.crew.update(crewId, {
+        system_prompt_addendum: trimmed.length > 0 ? trimmed : null,
+      });
+      setAddendumEditing(false);
+      setAddendumDraft("");
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSavingAddendum(false);
     }
   };
 
@@ -227,6 +258,64 @@ export default function CrewEditor() {
                 <p className="text-sm text-fg">{crew.purpose}</p>
               ) : (
                 <p className="text-sm italic text-fg-3">No purpose set.</p>
+              )}
+            </section>
+
+            <section className="flex flex-col gap-1.5">
+              <div className="flex items-center justify-between gap-3">
+                <div className="text-[10px] font-semibold uppercase tracking-[0.15em] text-fg-3">
+                  Team conventions
+                </div>
+                {!addendumEditing && crew.system_prompt_addendum ? (
+                  <button
+                    type="button"
+                    onClick={onStartAddendumEdit}
+                    className="text-xs text-fg-2 transition-colors hover:text-fg"
+                  >
+                    Edit
+                  </button>
+                ) : null}
+              </div>
+              {addendumEditing ? (
+                <div className="flex flex-col gap-2">
+                  <textarea
+                    value={addendumDraft}
+                    onChange={(e) => setAddendumDraft(e.target.value)}
+                    placeholder="Optional team-level guidance applied to all mission spawns."
+                    rows={6}
+                    className="w-full rounded border border-line bg-bg px-3 py-2 font-mono text-sm text-fg focus:border-fg-3 focus:outline-none"
+                  />
+                  <div className="flex items-center gap-2">
+                    <Button onClick={onSaveAddendum} disabled={savingAddendum}>
+                      {savingAddendum ? "Saving..." : "Save"}
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      onClick={onCancelAddendumEdit}
+                      disabled={savingAddendum}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : crew.system_prompt_addendum ? (
+                <p className="whitespace-pre-wrap text-sm text-fg">
+                  {crew.system_prompt_addendum}
+                </p>
+              ) : (
+                <div className="flex flex-col gap-1">
+                  <button
+                    type="button"
+                    onClick={onStartAddendumEdit}
+                    className="self-start text-sm text-fg-2 transition-colors hover:text-fg"
+                  >
+                    + Add team conventions
+                  </button>
+                  <p className="text-xs text-fg-3">
+                    Optional team-level guidance applied to all mission spawns.
+                    Leave blank for crews that need no team-level layer.
+                  </p>
+                </div>
               )}
             </section>
 


### PR DESCRIPTION
## Summary

Adds a nullable `crew.system_prompt_addendum` text column — Layer 2 of the system-prompt stack. On mission spawns, it splices between `WORKER_COORDINATION_PREAMBLE` (Layer 1, platform) and the runner's persona (Layer 3, data). Direct chat is untouched and continues to deliver just the persona.

- Migration `0005_crew_system_prompt_addendum.sql` — `ALTER TABLE crews ADD COLUMN system_prompt_addendum TEXT;` Nullable, default NULL, no backfill.
- `compose_worker_first_turn(brief, crew_addendum)` and `LaunchPromptInput.crew_addendum` splice the addendum between platform preamble and persona; whitespace / empty collapses to no-splice. Lead and workers both pick it up.
- `mission_start`, `mission_reset`, and the resume fresh-fallback (`fire_lead_launch_prompt`) all plumb the addendum through. Resumed leads don't silently drop Layer 2.
- Crew CRUD wire contract: `Some(Some(""))` normalizes to NULL so the column never stores a degenerate empty string. Outer `None` preserves existing.
- New "Team conventions" section in `CrewEditor` (render-only when set, edit-on-click textarea + Save/Cancel, "+ Add team conventions" button + caption when null). `CreateCrewModal` deliberately untouched per the issue's "hidden by default" intent.
- 8 new Rust tests: baseline byte-identical regression guards for both composers, splice-order + whitespace-collapse checks, CRUD roundtrip + clear-to-NULL + preserve-on-outer-None.

Closes #54

## Test plan

- [x] `cargo test --workspace` — 275 passed / 0 failed
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] GUI smoke (`pnpm tauri dev`):
  - [ ] Crew Detail → **+ Add team conventions** → paste text → Save → reload → text re-renders
  - [ ] Edit → clear → Save → reload → falls back to **+ Add team conventions** button (empty string normalized to NULL)
  - [ ] Start mission with a non-empty addendum → worker's first turn renders `WORKER_COORDINATION_PREAMBLE` → addendum → `== Your brief ==` → persona, in order
  - [ ] Lead's first turn renders intro line → addendum → `== Your brief ==` → mission → crewmates → coordination
  - [ ] Direct chat (Chat now on Runner Detail) does NOT include the addendum — persona only
  - [ ] Stop and Resume the lead → addendum still present on relaunch (fresh-fallback path)