### PR TITLE
fix(mission-tabs): truncate long runner handles with hover tooltip

### DIFF
--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -1019,14 +1019,15 @@ function PtyTabButton({
     <button
       type="button"
       onClick={onClick}
+      title={`@${handle}`}
       className={`-mb-px flex items-center gap-2 border-b-2 px-3.5 py-2.5 text-[13px] transition-colors ${
         active
           ? "border-accent font-medium text-fg"
           : "border-transparent text-fg-2 hover:text-fg"
       }`}
     >
-      <Terminal aria-hidden className="h-3 w-3" />
-      <span className="font-mono">@{handle}</span>
+      <Terminal aria-hidden className="h-3 w-3 shrink-0" />
+      <span className="max-w-[140px] truncate font-mono">@{handle}</span>
       <span
         role="button"
         aria-label={`Close @${handle} tab`}
@@ -1034,7 +1035,7 @@ function PtyTabButton({
           e.stopPropagation();
           onClose();
         }}
-        className="inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded text-fg-3 hover:bg-raised hover:text-fg"
+        className="inline-flex h-4 w-4 shrink-0 cursor-pointer items-center justify-center rounded text-fg-3 hover:bg-raised hover:text-fg"
       >
         <X aria-hidden className="h-3 w-3" />
       </span>


### PR DESCRIPTION
## Summary

Long runner handles (e.g. `@tomb-raid-player-2`) were wrapping inside the mission tab strip, making each tab 3 lines tall and pushing the whole strip out of shape. `PtyTabButton` now:

- Constrains the label span to `max-w-[140px]` with `truncate` (CSS ellipsis on overflow).
- Adds `shrink-0` to the terminal icon and `×` so only the label gives way, not the chrome.
- Adds `title={\`@\${handle}\`}` to the button so hovering shows the full handle via the native browser tooltip.

Result: tabs are single-line, long names show `…`, hover reveals the full name.

## Test plan

- [x] Smoke-tested locally in `tauri dev` (per author).
- [x] `tsc --noEmit` clean.
- [x] `eslint src/pages/MissionWorkspace.tsx` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)