### PR TITLE
fix(mission): suppress Starting mission pill flash on workspace nav

### DIFF
--- a/src/lib/useDelayedFlag.ts
+++ b/src/lib/useDelayedFlag.ts
@@ -1,0 +1,71 @@
+// Render-gate companion: returns true only after `active` has held
+// true for `delayMs`. Used to suppress transitional "Starting…" /
+// "Loading…" pills on the common fast-IPC path — the underlying
+// render gate (metaLoaded, mission loading, etc.) still blocks
+// content so we keep correctness; we only delay the *visible* pill
+// so chat-to-chat and mission-to-mission nav doesn't flash cyan.
+//
+// Each fresh (active=true, resetKey) window gets its own
+// monotonically increasing generation. The timer captures the gen
+// at schedule time; the return value compares it against the
+// *current* gen at render time. Keying on a per-window gen (not the
+// raw resetKey value) matters for A→B→A: the same id can start a
+// new window after active toggled off-and-on or after resetKey
+// changed away and back, and we don't want a stale fire from the
+// first A window to match the second A window's resetKey.
+//
+// Prev-value tracking lives in `useState` rather than `useRef`
+// because reading a ref during render is forbidden by our React
+// rules — state's documented "store info from prev renders"
+// pattern (setState during render → React replays the render with
+// new state) gives us the same behavior cleanly.
+//
+// First introduced in #179 for direct-chat navigation; lifted out
+// of `RunnerChat.tsx` so `MissionWorkspace.tsx` can use the same
+// gate for its "Starting mission…" pill.
+
+import { useEffect, useState } from "react";
+
+export function useDelayedFlag(
+  active: boolean,
+  delayMs: number,
+  resetKey?: unknown,
+): boolean {
+  const [state, setState] = useState<{
+    gen: number;
+    prevActive: boolean;
+    prevResetKey: unknown;
+    // -1 sentinel for "no timer has fired" — gen starts at 0 and
+    // only increments, so it can't collide.
+    shownGen: number;
+  }>({ gen: 0, prevActive: false, prevResetKey: undefined, shownGen: -1 });
+
+  // Detect a window transition during this render. Bumping gen
+  // synchronously is what makes a repeated resetKey value (A→B→A)
+  // get a distinct window, so a stale fire from the first A window
+  // can't match the second.
+  let currentGen = state.gen;
+  if (state.prevActive !== active || state.prevResetKey !== resetKey) {
+    if (active && (!state.prevActive || state.prevResetKey !== resetKey)) {
+      currentGen = state.gen + 1;
+    }
+    setState({
+      gen: currentGen,
+      prevActive: active,
+      prevResetKey: resetKey,
+      shownGen: state.shownGen,
+    });
+  }
+
+  useEffect(() => {
+    if (!active) return;
+    const captured = currentGen;
+    const t = window.setTimeout(
+      () => setState((s) => ({ ...s, shownGen: captured })),
+      delayMs,
+    );
+    return () => window.clearTimeout(t);
+  }, [active, delayMs, currentGen]);
+
+  return active && state.shownGen === currentGen;
+}

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -59,6 +59,7 @@ import {
   StopButton,
 } from "../components/ui/SessionControl";
 import { chunkIndicatesTuiReady, isFreshSpawn } from "../lib/sessionLifecycle";
+import { useDelayedFlag } from "../lib/useDelayedFlag";
 import { useTerminalBg } from "../lib/useTerminalBg";
 import {
   markArchivingMission,
@@ -526,6 +527,20 @@ export default function MissionWorkspace() {
     }
   }, [railView]);
 
+  // The mission-load IPC round-trip (mission.get + session.list +
+  // mission.eventsReplay) is fast in the common case but blocks the
+  // `loading` flag, so a naive `loading ? <pill /> : <content />`
+  // branch flashes the cyan "Starting mission…" pill on every click.
+  // Same trick as #179 for direct-chat nav: keep the render gate
+  // (correctness — the rail / tabs / overlays all assume `mission`
+  // is non-null) but delay the *visible* pill until the gate has
+  // been blocking for 150ms. Fast IPC never shows the pill; slow IPC
+  // (cold app start, contended SQLite) still gets user feedback.
+  // Resets per mission id so navigating between missions starts a
+  // fresh delay window.
+  const isLoading = loading || !mission;
+  const showLoadingPill = useDelayedFlag(isLoading, 150, id);
+
   return (
     // flex-row outer so the right rail becomes a top-level sibling
     // of the main column. The rail then spans the full workspace
@@ -696,13 +711,15 @@ export default function MissionWorkspace() {
         </div>
       ) : null}
 
-      {loading || !mission ? (
-        // Centered cyan pill while the mission's sessions/events/state
-        // are being fetched (and slot PTYs are still warming up after a
-        // fresh `mission_start`). Same visual vocabulary as the resume
-        // transition so every "session is coming up" moment reads
-        // consistently.
-        <StartingOverlay label="Starting mission…" inline />
+      {isLoading ? (
+        // Gate is kept (the tabs/feed/rail below assume `mission` is
+        // non-null) but the visible pill only renders after 150ms of
+        // continuous loading — see `useDelayedFlag` above. Same visual
+        // vocabulary as the resume transition so every "session is
+        // coming up" moment reads consistently.
+        showLoadingPill ? (
+          <StartingOverlay label="Starting mission…" inline />
+        ) : null
       ) : (
         <div className="flex flex-1 min-h-0 flex-col">
           <div className="flex h-[38px] items-end gap-1 border-b border-line bg-panel px-6">

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -42,6 +42,7 @@ import {
 } from "../components/SessionEndedOverlay";
 import { api, type DirectSessionEntry } from "../lib/api";
 import { chunkIndicatesTuiReady, isFreshSpawn } from "../lib/sessionLifecycle";
+import { useDelayedFlag } from "../lib/useDelayedFlag";
 import { useTerminalBg } from "../lib/useTerminalBg";
 import {
   markArchivingSession,
@@ -84,70 +85,6 @@ interface DirectSessionPane {
   handle: string;
   status: SessionStatus;
   exitCode: number | null;
-}
-
-// Render-gate companion: returns true only after `active` has held true
-// for `delayMs`. Used to suppress the navigation "Starting chat…" pill
-// on the common fast-IPC path — the gate itself still blocks the
-// terminal so archived rows never get a PTY listener; we only delay
-// the *visible* pill so chat-to-chat navigation doesn't flash cyan.
-//
-// Each fresh (active=true, resetKey) window gets its own monotonically
-// increasing generation. The timer captures the gen at schedule time;
-// the return value compares it against the *current* gen at render
-// time. Keying on a per-window gen (not the raw resetKey value)
-// matters for A→B→A: the same sessionId can start a new window after
-// active toggled off-and-on or after resetKey changed away and back,
-// and we don't want a stale fire from the first A window to match
-// the second A window's resetKey.
-//
-// Prev-value tracking lives in `useState` rather than `useRef`
-// because reading a ref during render is forbidden by our React
-// rules — state's documented "store info from prev renders" pattern
-// (setState during render → React replays the render with new state)
-// gives us the same behavior cleanly.
-function useDelayedFlag(
-  active: boolean,
-  delayMs: number,
-  resetKey?: unknown,
-): boolean {
-  const [state, setState] = useState<{
-    gen: number;
-    prevActive: boolean;
-    prevResetKey: unknown;
-    // -1 sentinel for "no timer has fired" — gen starts at 0 and
-    // only increments, so it can't collide.
-    shownGen: number;
-  }>({ gen: 0, prevActive: false, prevResetKey: undefined, shownGen: -1 });
-
-  // Detect a window transition during this render. Bumping gen
-  // synchronously is what makes a repeated resetKey value (A→B→A)
-  // get a distinct window, so a stale fire from the first A window
-  // can't match the second.
-  let currentGen = state.gen;
-  if (state.prevActive !== active || state.prevResetKey !== resetKey) {
-    if (active && (!state.prevActive || state.prevResetKey !== resetKey)) {
-      currentGen = state.gen + 1;
-    }
-    setState({
-      gen: currentGen,
-      prevActive: active,
-      prevResetKey: resetKey,
-      shownGen: state.shownGen,
-    });
-  }
-
-  useEffect(() => {
-    if (!active) return;
-    const captured = currentGen;
-    const t = window.setTimeout(
-      () => setState((s) => ({ ...s, shownGen: captured })),
-      delayMs,
-    );
-    return () => window.clearTimeout(t);
-  }, [active, delayMs, currentGen]);
-
-  return active && state.shownGen === currentGen;
 }
 
 export default function RunnerChat() {


### PR DESCRIPTION
## Summary
- `MissionWorkspace.tsx` flashed the cyan **Starting mission…** pill on every click because the `loading || !mission` render gate blocks until `Promise.all(mission.get, session.list, mission.eventsReplay)` resolves. Same shape as the direct-chat flash fixed in #179.
- Lifted the `useDelayedFlag` hook out of `RunnerChat.tsx` into `src/lib/useDelayedFlag.ts` so both pages share one implementation.
- Mission load: keep the render gate (tabs/feed/rail below all assume `mission` non-null), only render the pill after the gate has been blocking for **150ms**. Reset key is the mission id so A→B→A navigation starts a fresh delay window. Fast IPC never shows the pill; slow IPC (cold start, contended SQLite) still gets feedback.

## Test plan
- [ ] Click into a mission from the sidebar — no cyan pill flash on the fast-IPC path
- [ ] Force a slow load (cold app start) — pill appears after ~150ms and dismisses when content paints
- [ ] Navigate A → B → A between missions — no stale pill from the first A window
- [ ] Direct-chat nav still works (regression check, same hook)
- [ ] \`npm run lint\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)