### PR TITLE
fix(sidebar): dim mission dot when no slot is live + tighten paused-card labels

### DIFF
--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -144,6 +144,13 @@ pub struct MissionSummary {
     pub mission: Mission,
     pub crew_name: String,
     pub pending_ask_count: usize,
+    /// True iff at least one of the mission's session rows is `status =
+    /// 'running'`. Drives the sidebar mission-row status dot: live
+    /// missions paint with the accent, "paused" missions (status =
+    /// running but every slot is stopped/crashed) mute the dot so the
+    /// human can tell which workspaces will accept input at a glance,
+    /// without entering each one.
+    pub any_session_live: bool,
 }
 
 pub fn get(conn: &Connection, id: &str) -> Result<Mission> {
@@ -1562,10 +1569,23 @@ pub async fn mission_list_summary(
                 count_pending_asks_from_log(&mission_dir)
             }
         };
+        // Cheap EXISTS — the sessions table is small and the mission_id
+        // column is indexed. Returns 1 if any slot is `running`, else 0;
+        // a missing row (mission with zero seeded sessions) also reads
+        // as 0, which is correct ("no live PTY").
+        let any_session_live: bool = conn
+            .query_row(
+                "SELECT EXISTS(SELECT 1 FROM sessions
+                                WHERE mission_id = ?1 AND status = 'running')",
+                params![m.id],
+                |row| row.get::<_, i64>(0).map(|n| n != 0),
+            )
+            .unwrap_or(false);
         summaries.push(MissionSummary {
             mission: m,
             crew_name,
             pending_ask_count,
+            any_session_live,
         });
     }
     Ok(summaries)

--- a/src/components/SessionEndedOverlay.tsx
+++ b/src/components/SessionEndedOverlay.tsx
@@ -75,11 +75,16 @@ export function SessionEndedOverlay({
         : "The PTY exited unexpectedly. Resume to start a fresh process — the prior agent conversation is preserved."
       : "The PTY is closed, but the conversation is preserved. Resume to pick up where you left off.";
   const finalSubtitle = subtitle ?? computedSubtitle;
+  // Short labels. The title above ("Chat paused" / "Mission paused")
+  // already names the surface, so the button just needs to name the
+  // action. Slot-level callsites still get a "Resume @handle" form
+  // when `handle` is provided — there's no enclosing title there to
+  // tell the user which slot the action targets.
   const computedResumeLabel = handle
     ? `Resume @${handle}`
     : resumable
-      ? "Resume chat"
-      : "Restart chat";
+      ? "Resume"
+      : "Restart";
   const finalResumeLabel = resumeLabel ?? computedResumeLabel;
   const finalTitle = title ?? "Chat paused";
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -277,9 +277,18 @@ export function Sidebar({
     void Promise.all([
       listen("session/exit", () => {
         void refreshDirectSessions();
+        // A mission slot exiting flips `any_session_live` from true →
+        // false (if it was the last live slot). Without this, the
+        // dot stays accent until something else triggers a refresh.
+        void refreshMissions();
       }),
       listen("runner/activity", () => {
         void refreshDirectSessions();
+        // Same reason in reverse: resuming a slot flips
+        // `any_session_live` from false → true. `runner/activity`
+        // fires whenever the sessions table changes (spawn/exit),
+        // covering both directions cheaply.
+        void refreshMissions();
       }),
       listen("session/archived", () => {
         // Fired by `session_archive` after the archived_at flip. Lets
@@ -317,7 +326,7 @@ export function Sidebar({
       unlistenArchived?.();
       unlistenUpdated?.();
     };
-  }, [refreshDirectSessions]);
+  }, [refreshDirectSessions, refreshMissions]);
 
   const openMission = useCallback(
     (id: string) => {
@@ -656,6 +665,15 @@ export function Sidebar({
                         onContextMenu={(anchor) => openMissionMenu(m, anchor)}
                         title={m.crew_name || ""}
                         pinned={!!m.pinned_at}
+                        // Mute the dot when the mission has no live
+                        // session — `mission.status === "running"` is
+                        // not enough to call a workspace "live", since
+                        // a paused mission (every slot stopped) keeps
+                        // the running status until the user archives.
+                        // `any_session_live` is computed on the backend
+                        // (see `mission_list_summary`) so the sidebar
+                        // doesn't need to fetch session rows per mission.
+                        dim={!m.any_session_live}
                         renaming={renamingMissionId === m.id}
                         onRenameSubmit={(next) =>
                           void submitMissionRename(m.id, next)

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -606,8 +606,14 @@ export function Sidebar({
           <div className="flex min-h-0 flex-1 flex-col pb-4">
             {/* Brand row — open state only. Toggle has moved to the
                 bottom Settings row, so this is brand + wordmark
-                only. */}
-            <div className="flex shrink-0 items-center gap-2 px-5 pb-5 pt-1">
+                only. `data-tauri-drag-region` extends the draggable
+                top band past the h-7 traffic-light strip above so the
+                whole header band (brand + workspace header) reads as
+                one continuous title bar. */}
+            <div
+              data-tauri-drag-region
+              className="flex shrink-0 items-center gap-2 px-5 pb-5 pt-1"
+            >
               <BrandMark />
               <span className="text-base font-semibold tracking-tight text-fg">
                 Runner

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -306,6 +306,13 @@ export interface StartMissionOutput {
 export interface MissionSummary extends Mission {
   crew_name: string;
   pending_ask_count: number;
+  /** True iff at least one of the mission's sessions is `status =
+   *  'running'`. Drives the sidebar mission-row status dot — live
+   *  missions get the accent, paused missions (mission.status =
+   *  running but every slot is stopped/crashed) get a muted dot so
+   *  the operator can tell which workspaces accept input without
+   *  entering each one. */
+  any_session_live: boolean;
 }
 
 // Tauri payload for `event/appended` — the bus emits this on every newly

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -548,7 +548,15 @@ export default function MissionWorkspace() {
     // across the divider — same layout shape as RunnerChat.
     <div className="flex h-full flex-1 flex-row bg-bg">
       <div className="flex min-w-0 flex-1 flex-col">
-      <header className="flex items-center justify-between gap-4 border-b border-line bg-panel px-6 pb-3.5 pt-9">
+      {/* `data-tauri-drag-region` makes the entire header strip drag
+          the window, matching macOS toolbar behavior. Buttons inside
+          (Resume / Stop / kebab / panel toggle) keep their click
+          handlers — Tauri only enters drag mode on mousedowns that
+          land on the bare header, not on interactive children. */}
+      <header
+        data-tauri-drag-region
+        className="flex items-center justify-between gap-4 border-b border-line bg-panel px-6 pb-3.5 pt-9"
+      >
         <div className="flex min-w-0 items-center gap-3.5">
           {/* Mission glyph — matches Pencil node `nEpyL`: a 36×36
               rounded square with a lucide `flag` icon at 18px in the
@@ -846,8 +854,14 @@ export default function MissionWorkspace() {
               rhythm as the workspace topbar so the divider lines up
               across the column boundary. The icon strip on the left
               flips between Runners (roster) and Mission (meta); the
-              collapse button stays on the right. */}
-          <header className="flex shrink-0 items-center justify-between gap-2 border-b border-line px-5 pb-3.5 pt-9">
+              collapse button stays on the right.
+              `data-tauri-drag-region` keeps the rail header in the
+              same draggable band as the workspace topbar — anywhere
+              not on a button drags the window. */}
+          <header
+            data-tauri-drag-region
+            className="flex shrink-0 items-center justify-between gap-2 border-b border-line px-5 pb-3.5 pt-9"
+          >
             <div className="flex h-9 items-center gap-0.5">
               <RailViewButton
                 icon={UsersIcon}

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -1356,9 +1356,9 @@ function MissionPausedCard({
           ? "One or more slots are paused. Resume the mission to respawn every paused slot — partial-mission states aren't a valid run."
           : "All slots are paused. Resume to respawn every slot and pick up the conversation — the event log is preserved."
       }
-      resumeLabel="Resume mission"
+      resumeLabel="Resume"
       onResume={() => void onResumeMission()}
-      archiveLabel="Archive mission"
+      archiveLabel="Archive"
       onArchive={() => void onArchiveMission()}
       variant="inline"
     />

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -771,7 +771,15 @@ export default function RunnerChat() {
   return (
     <div className="flex h-full flex-1 flex-row bg-bg">
       <div className="flex min-w-0 flex-1 flex-col">
-      <header className="flex items-center justify-between gap-4 border-b border-line bg-panel px-6 pb-3.5 pt-9">
+      {/* `data-tauri-drag-region` makes the entire header strip drag
+          the window, matching macOS toolbar behavior. Interactive
+          children (Stop / Resume / kebab / panel toggle) keep their
+          click handlers — Tauri only enters drag mode on mousedowns
+          that land on the bare header, not on buttons. */}
+      <header
+        data-tauri-drag-region
+        className="flex items-center justify-between gap-4 border-b border-line bg-panel px-6 pb-3.5 pt-9"
+      >
         <div className="flex min-w-0 items-center gap-3.5">
           {/* Avatar — 36×36, matches MissionWorkspace's mission glyph
               dimensions so the chat + mission headers line up at the
@@ -1077,7 +1085,13 @@ function RunnerSidePanel({
       }`}
     >
       <div className="flex h-full w-80 flex-col">
-        <header className="flex shrink-0 items-center justify-end border-b border-line px-5 pb-3.5 pt-9">
+        {/* Side-panel header — same draggable-window rules as the
+            workspace topbar. The lone Collapse button keeps its
+            handler; everywhere else the strip drags the window. */}
+        <header
+          data-tauri-drag-region
+          className="flex shrink-0 items-center justify-end border-b border-line px-5 pb-3.5 pt-9"
+        >
           <div className="flex h-9 items-center">
             <button
               type="button"


### PR DESCRIPTION
## Summary
- Sidebar mission rows hardcoded the status dot to \`bg-accent\` because the row component took a \`dim\` prop nobody passed. A paused mission (mission.status = 'running' but every slot stopped/crashed) read as "live" in the rail even though it accepted no input.
- Backend adds \`any_session_live: bool\` to \`MissionSummary\`, computed via a cheap \`EXISTS\` query against the sessions table. Sidebar passes \`dim={!m.any_session_live}\` so the dot tracks live state per mission. No new RPC.
- Tightens paused-card buttons: the card titles ("Mission paused" / "Chat paused") already name the surface, so "Resume mission" / "Archive mission" / "Resume chat" are redundant. Defaults now collapse to **Resume** / **Restart** / **Archive**. Slot-level callsites keep the \`Resume @handle\` form (no enclosing title).

## Test plan
- [ ] Pause every slot in a running mission — sidebar dot goes muted; resuming a slot brings the dot back to accent
- [ ] Brand-new mission with running slots — dot is accent
- [ ] Paused-card buttons show **Resume** + **Archive** on both Mission and Chat surfaces
- [ ] Slot-level resume still reads \`Resume @architect\` etc.
- [ ] \`cargo test\` (235 backend tests), \`cargo fmt --check\`, \`cargo clippy -D warnings\`, \`npm run lint\`, \`tsc\` all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)