### PR TITLE
feat(ui): right side panels resizable (#188)

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -53,6 +53,7 @@ import {
   unmarkArchivingMission,
   unmarkArchivingSession,
 } from "../lib/archivingState";
+import { useResizableWidth } from "../hooks/useResizableWidth";
 import {
   BRAND_MARK_PINNED_COLOR,
   readBrandTint,
@@ -70,16 +71,6 @@ const SIDEBAR_DEFAULT = 240;
 const STORAGE_WIDTH = "runner.sidebar.width";
 const STORAGE_MISSION_OPEN = "runner.sidebar.mission.open";
 const STORAGE_SESSION_OPEN = "runner.sidebar.session.open";
-
-function getStoredWidth(): number {
-  if (typeof localStorage === "undefined") return SIDEBAR_DEFAULT;
-  const stored = localStorage.getItem(STORAGE_WIDTH);
-  if (stored) {
-    const n = parseInt(stored, 10);
-    if (!Number.isNaN(n) && n >= SIDEBAR_MIN && n <= SIDEBAR_MAX) return n;
-  }
-  return SIDEBAR_DEFAULT;
-}
 
 function getStoredFlag(key: string, fallback: boolean): boolean {
   if (typeof localStorage === "undefined") return fallback;
@@ -121,8 +112,20 @@ export function Sidebar({
   const navigate = useNavigate();
   const location = useLocation();
 
-  // Width + resize state.
-  const [width, setWidth] = useState<number>(getStoredWidth);
+  // Width + resize state. The right-edge handle below grows the
+  // sidebar when dragged rightward. The aside ref lets the hook
+  // write style.width directly during drag instead of going through
+  // setState per mousemove (avoids re-rendering the whole sidebar
+  // subtree per frame).
+  const asideRef = useRef<HTMLElement>(null);
+  const { width, onResizeStart: handleResizeStart } = useResizableWidth({
+    storageKey: STORAGE_WIDTH,
+    defaultWidth: SIDEBAR_DEFAULT,
+    min: SIDEBAR_MIN,
+    max: SIDEBAR_MAX,
+    edge: "right",
+    targets: [asideRef],
+  });
 
   // Runtime state.
   const [missions, setMissions] = useState<MissionSummary[]>([]);
@@ -519,44 +522,10 @@ export function Sidebar({
     });
   }, []);
 
-  // Drag-to-resize handle on the right edge — same logic as before.
-  const handleResizeStart = useCallback(
-    (e: React.MouseEvent) => {
-      e.preventDefault();
-      const startX = e.clientX;
-      const startWidth = width;
-      const onMouseMove = (ev: MouseEvent) => {
-        const next = Math.min(
-          SIDEBAR_MAX,
-          Math.max(SIDEBAR_MIN, startWidth + ev.clientX - startX),
-        );
-        setWidth(next);
-      };
-      const onMouseUp = () => {
-        document.removeEventListener("mousemove", onMouseMove);
-        document.removeEventListener("mouseup", onMouseUp);
-        document.body.style.cursor = "";
-        document.body.style.userSelect = "";
-        setWidth((w) => {
-          try {
-            localStorage.setItem(STORAGE_WIDTH, String(w));
-          } catch {
-            // ignore quota / disabled-storage errors
-          }
-          return w;
-        });
-      };
-      document.body.style.cursor = "col-resize";
-      document.body.style.userSelect = "none";
-      document.addEventListener("mousemove", onMouseMove);
-      document.addEventListener("mouseup", onMouseUp);
-    },
-    [width],
-  );
-
   return (
     <>
       <aside
+        ref={asideRef}
         style={{ width: collapsed ? 52 : width }}
         className="relative flex h-full shrink-0 select-none flex-col overflow-hidden border-r border-line bg-sidebar transition-[width] duration-150"
       >
@@ -762,7 +731,7 @@ export function Sidebar({
             render a noop placeholder so the DOM stays stable, just
             without the col-resize cursor / mousedown handler. */}
         <div
-          onMouseDown={collapsed ? undefined : handleResizeStart}
+          onPointerDown={collapsed ? undefined : handleResizeStart}
           title={collapsed ? undefined : "Drag to resize"}
           className={
             collapsed

--- a/src/hooks/useResizableWidth.ts
+++ b/src/hooks/useResizableWidth.ts
@@ -1,0 +1,169 @@
+// Drag-to-resize state for a panel with persisted width.
+//
+// One small primitive shared by the left sidebar and the right side
+// panels (RunnerChat, MissionWorkspace) so the three resize handles
+// don't drift in clamps or persistence shape. The `edge` arg picks
+// whether dragging right grows the panel (left sidebar, `right`) or
+// dragging left grows it (right-side panels, `left`).
+//
+// Drag write path: while the user is dragging, we write directly to
+// the target elements' `style.width` (via the refs passed in
+// `targets`) and skip React renders entirely. State + localStorage
+// get a single commit at the end of the drag. Two reasons:
+//   - the panels these targets render contain heavy children (system
+//     prompt readout, runners rail, xterm pane), and a setState per
+//     pointermove re-renders the whole subtree → visible drag jank.
+//   - the panels carry a `transition-[width]` class for the collapse
+//     animation; if we leave the transition on during drag, each
+//     style.width update fires a fresh 150–200ms transition and the
+//     width visibly trails the cursor. We snapshot + clear inline
+//     `transition` on every target for the drag, restore at end.
+//
+// Cursor lock + lost-release safety: this runs on Tauri desktop where
+// the user can alt-tab mid-drag, release the mouse outside the OS
+// window, or have the pointer otherwise yanked away. We use Pointer
+// Events with `setPointerCapture` so the browser guarantees the drag
+// terminates via `pointerup`, `pointercancel`, or
+// `lostpointercapture` — all routed through one idempotent cleanup.
+// A `blur` listener on window is added as belt-and-suspenders for
+// the edge case where capture is somehow held across a window blur.
+// Without these, a lost release would strand the fullscreen overlay
+// and freeze the app until reload.
+//
+// The fullscreen transparent overlay during drag is what actually
+// keeps the cursor consistent: `document.body.style.cursor` is
+// inherited, but element-level cursor declarations (xterm uses
+// `cursor: text` on its renderer) win as the pointer crosses them.
+// The overlay sits at the top of the stacking context with
+// `cursor: col-resize` and absorbs accidental clicks underneath.
+
+import { useState, type RefObject } from "react";
+
+export type ResizeEdge = "left" | "right";
+
+export interface UseResizableWidthOptions {
+  storageKey: string;
+  defaultWidth: number;
+  min: number;
+  max: number;
+  edge: ResizeEdge;
+  /** Refs to elements whose `style.width` should track the cursor
+   *  during drag. The hook also suspends each target's CSS
+   *  transition for the duration of the drag so width updates render
+   *  immediately instead of animating along the collapse curve. */
+  targets: ReadonlyArray<RefObject<HTMLElement | null>>;
+}
+
+export interface UseResizableWidth {
+  width: number;
+  onResizeStart: (e: React.PointerEvent) => void;
+}
+
+export function useResizableWidth({
+  storageKey,
+  defaultWidth,
+  min,
+  max,
+  edge,
+  targets,
+}: UseResizableWidthOptions): UseResizableWidth {
+  const [width, setWidth] = useState<number>(() => {
+    if (typeof localStorage === "undefined") return defaultWidth;
+    const stored = localStorage.getItem(storageKey);
+    if (stored) {
+      const n = parseInt(stored, 10);
+      if (!Number.isNaN(n) && n >= min && n <= max) return n;
+    }
+    return defaultWidth;
+  });
+
+  const onResizeStart = (e: React.PointerEvent) => {
+    e.preventDefault();
+    const handle = e.currentTarget as HTMLElement;
+    const pointerId = e.pointerId;
+    const startX = e.clientX;
+    const startWidth = width;
+    const sign = edge === "right" ? 1 : -1;
+    let liveWidth = startWidth;
+
+    const snapshot = targets
+      .map((ref) => {
+        const el = ref.current;
+        if (!el) return null;
+        const prevTransition = el.style.transition;
+        el.style.transition = "none";
+        return { el, prevTransition };
+      })
+      .filter(
+        (x): x is { el: HTMLElement; prevTransition: string } => x !== null,
+      );
+
+    const overlay = document.createElement("div");
+    overlay.style.cssText =
+      "position:fixed;inset:0;z-index:2147483647;cursor:col-resize;user-select:none;";
+    document.body.appendChild(overlay);
+    const prevBodyUserSelect = document.body.style.userSelect;
+    document.body.style.userSelect = "none";
+
+    // Route capture so events still fire on `handle` even when the
+    // pointer leaves the 4px strip. Some browsers/scenarios throw
+    // (capture already held, pointer no longer active) — best-effort.
+    try {
+      handle.setPointerCapture(pointerId);
+    } catch {
+      // ignore — listeners below still terminate the drag via
+      // pointerup/cancel even without capture.
+    }
+
+    let cleanedUp = false;
+    const cleanup = () => {
+      if (cleanedUp) return;
+      cleanedUp = true;
+      handle.removeEventListener("pointermove", onPointerMove);
+      handle.removeEventListener("pointerup", onPointerEnd);
+      handle.removeEventListener("pointercancel", onPointerEnd);
+      handle.removeEventListener("lostpointercapture", onPointerEnd);
+      window.removeEventListener("blur", onPointerEnd);
+      try {
+        handle.releasePointerCapture(pointerId);
+      } catch {
+        // already released / never captured — fine.
+      }
+      overlay.remove();
+      document.body.style.userSelect = prevBodyUserSelect;
+      for (const { el, prevTransition } of snapshot) {
+        el.style.transition = prevTransition;
+      }
+      setWidth(liveWidth);
+      try {
+        localStorage.setItem(storageKey, String(liveWidth));
+      } catch {
+        // ignore quota / disabled-storage errors
+      }
+    };
+
+    const onPointerMove = (ev: PointerEvent) => {
+      if (ev.pointerId !== pointerId) return;
+      const next = Math.min(
+        max,
+        Math.max(min, startWidth + sign * (ev.clientX - startX)),
+      );
+      liveWidth = next;
+      for (const { el } of snapshot) {
+        el.style.width = `${next}px`;
+      }
+    };
+
+    const onPointerEnd = () => {
+      cleanup();
+    };
+
+    handle.addEventListener("pointermove", onPointerMove);
+    handle.addEventListener("pointerup", onPointerEnd);
+    handle.addEventListener("pointercancel", onPointerEnd);
+    handle.addEventListener("lostpointercapture", onPointerEnd);
+    window.addEventListener("blur", onPointerEnd);
+  };
+
+  return { width, onResizeStart };
+}

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -60,12 +60,18 @@ import {
 } from "../components/ui/SessionControl";
 import { chunkIndicatesTuiReady, isFreshSpawn } from "../lib/sessionLifecycle";
 import { useDelayedFlag } from "../lib/useDelayedFlag";
+import { useResizableWidth } from "../hooks/useResizableWidth";
 import { useTerminalBg } from "../lib/useTerminalBg";
 import {
   markArchivingMission,
   unmarkArchivingMission,
   useArchivingMission,
 } from "../lib/archivingState";
+
+const RAIL_STORAGE_WIDTH = "runner.mission.rail.width";
+const RAIL_MIN = 200;
+const RAIL_MAX = 480;
+const RAIL_DEFAULT = 288;
 
 export default function MissionWorkspace() {
   const { id } = useParams<{ id: string }>();
@@ -510,6 +516,22 @@ export default function MissionWorkspace() {
       // ignore storage errors
     }
   }, [railOpen]);
+  // Drag-to-resize width for the rail. Persisted separately from the
+  // open/closed flag so collapse → expand restores the last dragged
+  // width instead of the hardcoded default. The hook writes
+  // style.width directly through the refs during drag — avoids the
+  // RunnersRail / MissionMetaPanel subtree re-rendering per frame.
+  const railAsideRef = useRef<HTMLElement>(null);
+  const railInnerRef = useRef<HTMLDivElement>(null);
+  const { width: railWidth, onResizeStart: onRailResizeStart } =
+    useResizableWidth({
+      storageKey: RAIL_STORAGE_WIDTH,
+      defaultWidth: RAIL_DEFAULT,
+      min: RAIL_MIN,
+      max: RAIL_MAX,
+      edge: "left",
+      targets: [railAsideRef, railInnerRef],
+    });
   // Right rail content toggle — Runners roster vs Mission meta. Persists
   // per-app (not per-mission): the user's preference for which view to
   // see on entry is consistent across missions.
@@ -840,16 +862,24 @@ export default function MissionWorkspace() {
       </div>
       {/* Collapsible right rail — top-level sibling of the main
           column so it spans the full workspace height (header
-          included). Mirrors the RunnerChat pattern: the inner w-72
-          wrapper stays mounted and clipped by overflow-hidden so
-          width animates without reflowing the children. */}
+          included). Mirrors the RunnerChat pattern: the inner
+          wrapper stays mounted at the persisted width and clipped
+          by overflow-hidden so width animates without reflowing
+          the children. A 4px drag strip on the left edge resizes
+          the rail. */}
       <aside
+        ref={railAsideRef}
         aria-hidden={!railOpen}
-        className={`flex shrink-0 flex-col overflow-hidden bg-panel transition-[width,border-left-width] duration-200 ease-in-out ${
-          railOpen ? "w-72 border-l border-line" : "w-0 border-l-0"
+        style={{ width: railOpen ? railWidth : 0 }}
+        className={`relative flex shrink-0 flex-col overflow-hidden bg-panel transition-[width,border-left-width] duration-200 ease-in-out ${
+          railOpen ? "border-l border-line" : "border-l-0"
         }`}
       >
-        <div className="flex h-full w-72 flex-col">
+        <div
+          ref={railInnerRef}
+          style={{ width: railWidth }}
+          className="flex h-full flex-col"
+        >
           {/* Rail header — same px-5 / pt-9 / pb-3.5 / border-b
               rhythm as the workspace topbar so the divider lines up
               across the column boundary. The icon strip on the left
@@ -906,6 +936,17 @@ export default function MissionWorkspace() {
             ) : null}
           </div>
         </div>
+        {/* Drag-to-resize strip on the left edge — mirrors the left
+            sidebar's right-edge handle. Inert when collapsed. */}
+        <div
+          onPointerDown={railOpen ? onRailResizeStart : undefined}
+          title={railOpen ? "Drag to resize" : undefined}
+          className={
+            railOpen
+              ? "absolute left-0 top-0 z-20 h-full w-1 cursor-col-resize bg-transparent transition-colors hover:bg-accent/40"
+              : "absolute left-0 top-0 z-20 h-full w-1 bg-transparent"
+          }
+        />
       </aside>
       <MissionResetConfirm
         open={resetConfirmOpen && mission !== null}

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -43,6 +43,7 @@ import {
 import { api, type DirectSessionEntry } from "../lib/api";
 import { chunkIndicatesTuiReady, isFreshSpawn } from "../lib/sessionLifecycle";
 import { useDelayedFlag } from "../lib/useDelayedFlag";
+import { useResizableWidth } from "../hooks/useResizableWidth";
 import { useTerminalBg } from "../lib/useTerminalBg";
 import {
   markArchivingSession,
@@ -79,6 +80,10 @@ interface RunnerChatLocationState {
 }
 
 const STORAGE_PANEL_OPEN = "runner.chat.panel.open";
+const STORAGE_PANEL_WIDTH = "runner.chat.panel.width";
+const PANEL_MIN = 200;
+const PANEL_MAX = 480;
+const PANEL_DEFAULT = 320;
 
 interface DirectSessionPane {
   id: string;
@@ -1065,9 +1070,11 @@ export default function RunnerChat() {
 // column to its left, not above it). The panel-header strip mirrors
 // the topbar's pt-9 + h-9 + pb-3.5 structure so the bottom divider
 // lines up across both columns. The whole aside slides via a
-// CSS width transition: open = w-80, closed = w-0 (with the inner
-// w-80 wrapper kept intact and clipped by overflow-hidden so layout
-// doesn't reflow during the animation).
+// CSS width transition: open = persisted width, closed = 0 (with the
+// inner wrapper kept at the persisted width and clipped by
+// overflow-hidden so content doesn't reflow during the animation).
+// A 4px drag strip on the left edge resizes the panel, mirroring the
+// left sidebar's right-edge handle.
 function RunnerSidePanel({
   runner,
   open,
@@ -1077,14 +1084,26 @@ function RunnerSidePanel({
   open: boolean;
   onClose: () => void;
 }) {
+  const asideRef = useRef<HTMLElement>(null);
+  const innerRef = useRef<HTMLDivElement>(null);
+  const { width, onResizeStart } = useResizableWidth({
+    storageKey: STORAGE_PANEL_WIDTH,
+    defaultWidth: PANEL_DEFAULT,
+    min: PANEL_MIN,
+    max: PANEL_MAX,
+    edge: "left",
+    targets: [asideRef, innerRef],
+  });
   return (
     <aside
+      ref={asideRef}
       aria-hidden={!open}
-      className={`flex shrink-0 flex-col overflow-hidden bg-panel transition-[width,border-left-width] duration-200 ease-in-out ${
-        open ? "w-80 border-l border-line" : "w-0 border-l-0"
+      style={{ width: open ? width : 0 }}
+      className={`relative flex shrink-0 flex-col overflow-hidden bg-panel transition-[width,border-left-width] duration-200 ease-in-out ${
+        open ? "border-l border-line" : "border-l-0"
       }`}
     >
-      <div className="flex h-full w-80 flex-col">
+      <div ref={innerRef} style={{ width }} className="flex h-full flex-col">
         {/* Side-panel header — same draggable-window rules as the
             workspace topbar. The lone Collapse button keeps its
             handler; everywhere else the strip drags the window. */}
@@ -1160,6 +1179,20 @@ function RunnerSidePanel({
           )}
         </div>
       </div>
+      {/* Drag-to-resize strip on the left edge — mirrors the left
+          sidebar's right-edge handle. Inert when collapsed: the
+          aside's overflow-hidden + width:0 already hides it, but we
+          also skip the mousedown binding so the cursor doesn't
+          briefly read as resizable inside the chat column. */}
+      <div
+        onPointerDown={open ? onResizeStart : undefined}
+        title={open ? "Drag to resize" : undefined}
+        className={
+          open
+            ? "absolute left-0 top-0 z-20 h-full w-1 cursor-col-resize bg-transparent transition-colors hover:bg-accent/40"
+            : "absolute left-0 top-0 z-20 h-full w-1 bg-transparent"
+        }
+      />
     </aside>
   );
 }


### PR DESCRIPTION
## Summary
- Drag-to-resize handle on the left edge of both right panels (`RunnerChat` side panel + `MissionWorkspace` right rail), mirroring the existing left-sidebar pattern.
- Width persists per surface in localStorage (`runner.chat.panel.width`, `runner.mission.rail.width`); collapse → expand restores the last dragged width instead of the hardcoded default.
- Shared `useResizableWidth` hook drives all three handles (left sidebar refactored onto it too). Pointer Events with `setPointerCapture` + idempotent cleanup from pointerup / pointercancel / lostpointercapture / window blur, so the drag overlay can't get stranded on alt-tab. Ref-based DOM writes during drag for 1:1 cursor tracking; single state/localStorage commit on release.

Closes #188.

## Test plan
- [ ] Drag the left edge of the RunnerChat side panel → width changes live, clamps at 200/480.
- [ ] Drag the left edge of the MissionWorkspace right rail → same behavior.
- [ ] Reload → both widths persist.
- [ ] Collapse then expand each panel → restores last dragged width, not hardcoded default.
- [ ] Hover the handle → `col-resize` cursor; during drag the cursor stays `col-resize` even when pointer leaves the 4px strip (overlay + capture lock).
- [ ] Alt-tab mid-drag, return to window → no stranded overlay, cursor and selection back to normal.
- [ ] Release mouse outside the Tauri window → same.
- [ ] Left sidebar drag-to-resize still feels right post-refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)