### PR TITLE
fix(terminal): force agent redraw on tab activation (#177) + editable crew goal

### DIFF
--- a/docs/impls/0012-force-redraw-on-tab-activation.md
+++ b/docs/impls/0012-force-redraw-on-tab-activation.md
@@ -1,0 +1,205 @@
+# Force Agent Redraw on Tab Activation
+
+> Fixes [#177](https://github.com/yicheng47/runner/issues/177).
+
+## Context
+
+Switching back to a runner's PTY tab after it has accumulated output
+while hidden shows a mostly-black canvas with scattered text fragments
+instead of the agent's current rendered state. A manual window resize
+fixes it. Reproduces for every TUI runtime (`codex`, `claude-code`,
+`gemini`, …) once enough output landed while the tab was inactive.
+
+The activation effect at `src/components/RunnerTerminal.tsx:656–707`
+already does the right local-side work — `fit.fit()`, atlas clear,
+`term.refresh()`, focus — but `refresh()` only repaints the current
+xterm buffer. The buffer itself is the problem: while the pane was
+hidden, live PTY bytes wrote straight into it
+(`RunnerTerminal.tsx:605–607`). By the time the user returns the
+buffer is either mid-frame (the agent was halfway through a redraw at
+the moment of switch-away) or dim-mismatched (the window or a side
+panel resized while the pane was hidden, so xterm's grid no longer
+matches what the buffer was painted at). Refreshing it just shows the
+broken state.
+
+The pushSize path inside the activation effect is deduped against the
+previously-pushed cols/rows (`:694–697`) — a same-dim return never
+re-pushes, so the agent never receives a SIGWINCH and never knows to
+repaint.
+
+The "drag the window edge a pixel" workaround works because a real
+dim change releases the dedup, the backend resize fires, and the
+agent's full SIGWINCH redraw lands.
+
+## Approach
+
+Force the agent to repaint on every tab activation by doing a
+SIGWINCH dance (resize one row below current → resize back) so the
+kernel's TIOCSWINSZ dedup can't suppress the signal. Pair it with a
+viewport wipe for TUI runtimes so the user sees a clean black canvas
+during the few-ms gap before the agent's redraw lands, instead of the
+mid-frame mess.
+
+Why a dance and not just an unconditional `api.session.resize`: both
+Linux and macOS pty drivers compare the incoming `struct winsize`
+against the cached value and only signal `SIGWINCH` when the bytes
+differ
+(`drivers/tty/tty_io.c:tty_do_resize` on Linux,
+`bsd/kern/tty.c:ttioctl_locked` TIOCSWINSZ branch on Darwin). A
+single-call same-size resize is a no-op at the kernel level. Two
+resizes — `(cols, rows-1)` then `(cols, rows)` — guarantee the cached
+winsize changes between calls, so each ioctl produces a SIGWINCH.
+
+Why we perturb **rows**, not **cols**. An earlier draft of this plan
+used `(cols-1, rows) → (cols, rows)`. That worked for the alt-screen
+case (claude-code's alt buffer) but corrupted scrollback under any
+main-screen TUI mode: claude-code (and similar agents) wrap their
+own text by emitting explicit `\n` at their computed cols boundary,
+not relying on terminal auto-wrap. The intermediate `(cols-1)` paint
+deposited hard-wrapped narrow lines into xterm's buffer. xterm can
+only soft-reflow width-wrapped lines; explicit newlines stick. Every
+tab return then layered another stripe of narrower lines into
+scrollback, visible on scroll-up even though the current viewport
+looked fine. Row perturbation keeps content width at `cols`
+throughout — the `(rows-1)` intermediate paint is just one line
+shorter, and the second SIGWINCH's `\x1b[2J`-led repaint at the
+final row count cleans it up. No width pollution.
+
+Tradeoff: a one-cycle `(rows-1)`-tall intermediate frame may flash
+through the buffer before the second SIGWINCH's `rows`-tall repaint
+lands. The viewport wipe hides this for TUI runtimes. For plain
+shells (no `runtime` in `runtimeClearsOnResize`), the intermediate
+is harmless — shells don't redraw on SIGWINCH.
+
+---
+
+## Step 1: Replace the deduped pushSize in the activation effect with a SIGWINCH-guaranteeing dance
+
+**File: `src/components/RunnerTerminal.tsx`**
+
+In the activation effect (`useEffect` at `:650`), replace the
+conditional pushSize block at `:684–703` with an unconditional
+viewport wipe + dance. The wipe matches the existing pushSize behavior
+at `:417–421`: clear the visible region only for runtimes where
+`runtimeClearsOnResize` is true (claude-code, codex; plain shells
+keep their history).
+
+Replace the conditional pushSize block with an unconditional wipe +
+rows-perturbing dance:
+
+- For TUI runtimes (`runtimeClearsOnResize(runner)`), pre-wipe via
+  `t.write("\x1b[2J\x1b[H")` so the user sees a clean canvas during
+  the few-ms gap before the agent's redraw lands. Plain shells skip
+  the wipe (matches pushSize at `:417–421`) — they keep their
+  history and don't repaint on SIGWINCH.
+- Update `lastPushedColsRef`/`lastPushedRowsRef` to the *final*
+  `(cols, rows)` — not the intermediate `(cols, nudgedRows)` — so
+  `refitAndPush`'s dedup semantics for the non-bug off-screen-layout
+  paths are preserved.
+- Call `api.session.resize(sessionId, cols, nudgedRows)` then chain
+  `.then` to `api.session.resize(sessionId, cols, rows)`. Sequencing
+  matters: parallel calls could collapse to a single kernel state
+  change.
+- `const nudgedRows = rows > 1 ? rows - 1 : rows + 1` so the
+  pathological 1-row case still produces a real winsize-diff in both
+  directions of the dance.
+
+History note: an earlier draft of this plan used `(cols-1, rows) →
+(cols, rows)` instead. That worked for the alt-screen case but
+corrupted scrollback under main-screen TUIs — see the **Approach**
+section above for why row perturbation is required.
+
+## Step 2: Drop the stale comment fragment about the cols-1 → cols dance being obsolete
+
+**File: `src/components/RunnerTerminal.tsx`**
+
+The current comment at the deleted block (`:686–693`) says:
+
+> Single resize is enough once xterm enters alt-screen at attach
+> time (see docs/impls/0009). The earlier cols-1 → cols dance was
+> there to coax claude-code into a repaint that would land where
+> the user could see it; with the alt-screen state correct, the
+> agent's single SIGWINCH redraw lands in the right buffer.
+
+That's no longer true — Step 1 reintroduces the dance for a different
+reason (forcing SIGWINCH on same-dim returns, not buffer-state
+alignment). The replacement comment in Step 1 covers the new
+reasoning; just make sure the old text is fully replaced, not
+appended to.
+
+
+## Step 3: No backend changes
+
+`api.session.resize` already maps to
+`commands::session::session_resize → SessionManager::resize →
+PtyRuntime::resize → MasterPty::resize`. The backend is a thin
+pass-through to `portable_pty`'s `tcsetwinsz`. No changes needed.
+
+## Files to modify
+
+| File | Change |
+|------|--------|
+| `src/components/RunnerTerminal.tsx` | Replace the deduped pushSize at the end of the activation effect (`:684–703`) with an unconditional SIGWINCH dance + viewport wipe for TUI runtimes. |
+
+## Verification
+
+### Manual
+
+1. Start a mission with at least two runners; pick `codex` and
+   `claude-code` for the most visible coverage.
+2. Open a long-running task on one runner — get it producing output
+   that exceeds the viewport (file dumps, a long agent turn, etc.).
+3. Switch to another tab (Feed or another PTY) while output is
+   actively streaming.
+4. Wait ~10s for more output to accumulate.
+5. Switch back to the original PTY tab.
+
+**Expected (with fix)**: viewport flashes black briefly (TUI
+runtimes), then the agent's current frame lands fully painted.
+
+**Expected (before fix)**: black canvas with scattered, mispositioned
+text fragments until a manual window resize.
+
+Repeat for plain shells:
+
+1. Start a `shell` runner.
+2. `yes "long line of text"` or any output-flooding command.
+3. Switch tabs, wait, switch back.
+
+**Expected**: scrollback intact, current shell prompt visible. No
+viewport wipe (shells aren't in `runtimeClearsOnResize`).
+
+### Edge cases to manually verify
+
+- **Window resize between switch-away and switch-back.** Resize the
+  app window while a different tab is active, then come back. The
+  pane should land at the new dims with no residual content from
+  the old dims.
+- **Side-panel toggle while hidden.** Collapse / expand the right
+  rail while the source pane is hidden; the pane should refit and
+  repaint correctly on return.
+- **Rapid tab switching.** Click between tabs quickly. Each
+  activation should kick a fresh redraw; no race-induced stale
+  state.
+- **Session exited while hidden.** If the runner exited while the
+  tab was inactive, the dance's `.catch` should swallow the resize
+  rejection silently. Verify by killing the runner from another
+  pane and switching to the dead tab — should not throw.
+- **Direct-chat (RunnerChat) panes.** Same component is used; cover
+  by switching from a mission workspace to a direct chat and back
+  while output is flowing.
+
+### Automated
+
+The activation flow is a React effect driven by xterm + IPC, so a
+useful automated test would need to mock both. Existing tests in
+`src/` don't cover RunnerTerminal end-to-end, and adding a JSDOM-based
+xterm test for a one-edge-case redraw isn't worth the surface. Manual
+verification per the steps above is the bar.
+
+### CI gates
+
+Standard for runner Rust changes (per
+[`feedback_run_ci_checks_before_pushing.md`](../../) memory): nothing
+Rust changes here, so just `pnpm tsc --noEmit` + `pnpm lint`. Run
+`make lint` if reaching the full CI parity is needed.

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -683,24 +683,60 @@ export const RunnerTerminal = forwardRef<
         t.focus();
         const cols = t.cols;
         const rows = t.rows;
-        // Single resize is enough once xterm enters alt-screen at attach
-        // time (see docs/impls/0009). The earlier cols-1 → cols dance was
-        // there to coax claude-code into a repaint that would land where
-        // the user could see it; with the alt-screen state correct, the
-        // agent's single SIGWINCH redraw lands in the right buffer.
-        // Dedupe against the last value pushSize sent — common when this
-        // effect fires immediately after the mount-time fit pushed the
-        // same dims.
-        if (
-          cols !== lastPushedColsRef.current ||
-          rows !== lastPushedRowsRef.current
-        ) {
-          lastPushedColsRef.current = cols;
-          lastPushedRowsRef.current = rows;
-          void api.session.resize(sessionId, cols, rows).catch(() => {
-            // session may have exited
-          });
+        // Force the agent into a full redraw on every activation.
+        // While the pane was hidden, live PTY bytes wrote into
+        // xterm's buffer (the session-effect's "session/output"
+        // listener doesn't gate on active), so the buffer may be
+        // mid-frame (agent halfway through a redraw at switch
+        // time) or dim-mismatched (window / panel resize while
+        // hidden moved the container without us refitting). The
+        // refresh() above only repaints that broken state — we
+        // need the *agent* to redraw, which means a SIGWINCH.
+        //
+        // Both Linux (tty_do_resize) and macOS (TIOCSWINSZ in
+        // ttioctl) compare the incoming winsize against the cached
+        // value and only signal SIGWINCH when the bytes differ —
+        // a same-size resize is a kernel no-op. So a single
+        // unconditional api.session.resize wouldn't be enough on
+        // its own. We dance through (cols, rows-1) → (cols, rows)
+        // so both ioctls produce a SIGWINCH and the agent repaints
+        // at the final dims.
+        //
+        // Perturb *rows*, not cols. An earlier draft used cols-1
+        // and corrupted scrollback: claude-code (and similar TUIs)
+        // wrap their own text by emitting explicit `\n` at the
+        // computed cols boundary, so any intermediate paint at
+        // cols-1 deposits hard-wrapped narrow lines into xterm's
+        // buffer. xterm can only soft-reflow width-wrapped lines;
+        // explicit newlines stick. Every tab return then left a
+        // layer of narrower lines above the current paint, visible
+        // on scroll-up. Row perturbation keeps content width at
+        // cols throughout — the (rows-1) intermediate is just one
+        // line shorter, and the second SIGWINCH's `\x1b[2J`-led
+        // repaint at the final rows count cleans up.
+        //
+        // For TUI runtimes, wipe the viewport first so the user
+        // sees a clean black canvas during the brief gap before
+        // the redraw lands instead of the scattered mid-frame
+        // mess (#177). Plain shells skip the wipe — matches
+        // pushSize's behavior above (runtimeClearsOnResize), they
+        // keep their history and don't repaint on SIGWINCH.
+        if (runtimeClearsOnResize(runnerRuntimeRef.current)) {
+          t.write("\x1b[2J\x1b[H");
         }
+        lastPushedColsRef.current = cols;
+        lastPushedRowsRef.current = rows;
+        // Guard the pathological 1-row case so we never ioctl to
+        // 0 rows. portable-pty would reject it, but more importantly
+        // we want both directions of the dance to produce a real
+        // winsize-diff and therefore SIGWINCH.
+        const nudgedRows = rows > 1 ? rows - 1 : rows + 1;
+        void api.session
+          .resize(sessionId, cols, nudgedRows)
+          .then(() => api.session.resize(sessionId, cols, rows))
+          .catch(() => {
+            // session may have exited between the two ioctls
+          });
       } catch {
         // Layout not ready yet — the next activation / resize will drive it.
       }
@@ -726,7 +762,20 @@ export const RunnerTerminal = forwardRef<
         const node = containerRef.current;
         if (!t || !fit || !node) return null;
         const rect = node.getBoundingClientRect();
-        if (rect.width <= 0 || rect.height <= 0) return null;
+        if (rect.width <= 0 || rect.height <= 0) {
+          // Hidden pane (display:none via MissionWorkspace's Pane
+          // wrapper) — no rect to fit against. If a prior activation
+          // already fit this terminal, t.cols/t.rows still hold those
+          // dims, and they're far more useful at resume time than
+          // returning null (which forces the resume RPC to pass null
+          // → backend defaults to 80×24 → agent paints its `--resume`
+          // conversation history at 80 cols, and for main-screen TUIs
+          // those hard-wrapped lines stick in scrollback). 80×24 is
+          // the constructor default / "never fit" sentinel; treat it
+          // the same as null so callers can still fall back.
+          if (t.cols === 80 && t.rows === 24) return null;
+          return { cols: t.cols, rows: t.rows };
+        }
         try {
           // Force a fit before reading dims: stopped tabs gate their
           // resize listeners on activeRef, so cols/rows can be stale

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -681,6 +681,13 @@ export const RunnerTerminal = forwardRef<
         webglRef.current?.clearTextureAtlas();
         t.refresh(0, t.rows - 1);
         t.focus();
+        // No agent to dance with for stopped/crashed/resuming/starting
+        // sessions — the wipe would clear the last-paint behind the
+        // SessionEndedOverlay (the scrollback the `disabled` prop is
+        // meant to preserve) and the resize ioctls would reject. Keep
+        // the fit + refresh + focus above (correct for any active
+        // pane) but bail before the wipe + dance.
+        if (disabledRef.current) return;
         const cols = t.cols;
         const rows = t.rows;
         // Force the agent into a full redraw on every activation.

--- a/src/pages/CrewEditor.tsx
+++ b/src/pages/CrewEditor.tsx
@@ -1,7 +1,8 @@
 // Crew detail — matches design/runners-design.pen frame `CUKjM`.
 //
 // Layout: top toolbar (back to Crews + inline name field + Save + Start
-// mission) above a two-section body (Purpose, Slots).
+// mission) above a body of sections: Purpose, Default goal, Team
+// conventions, Slots.
 
 import {
   useCallback,
@@ -36,6 +37,9 @@ export default function CrewEditor() {
   const [addendumEditing, setAddendumEditing] = useState(false);
   const [addendumDraft, setAddendumDraft] = useState("");
   const [savingAddendum, setSavingAddendum] = useState(false);
+  const [goalEditing, setGoalEditing] = useState(false);
+  const [goalDraft, setGoalDraft] = useState("");
+  const [savingGoal, setSavingGoal] = useState(false);
   const [reordering, setReordering] = useState(false);
   const reorderInFlight = useRef(false);
   const navigate = useNavigate();
@@ -103,6 +107,34 @@ export default function CrewEditor() {
       setError(String(e));
     } finally {
       setSavingAddendum(false);
+    }
+  };
+
+  const onStartGoalEdit = () => {
+    setGoalDraft(crew?.goal ?? "");
+    setGoalEditing(true);
+  };
+
+  const onCancelGoalEdit = () => {
+    setGoalEditing(false);
+    setGoalDraft("");
+  };
+
+  const onSaveGoal = async () => {
+    if (!crewId) return;
+    const trimmed = goalDraft.trim();
+    setSavingGoal(true);
+    try {
+      await api.crew.update(crewId, {
+        goal: trimmed.length > 0 ? trimmed : null,
+      });
+      setGoalEditing(false);
+      setGoalDraft("");
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSavingGoal(false);
     }
   };
 
@@ -258,6 +290,63 @@ export default function CrewEditor() {
                 <p className="text-sm text-fg">{crew.purpose}</p>
               ) : (
                 <p className="text-sm italic text-fg-3">No purpose set.</p>
+              )}
+            </section>
+
+            <section className="flex flex-col gap-1.5">
+              <div className="flex items-center justify-between gap-3">
+                <div className="text-[10px] font-semibold uppercase tracking-[0.15em] text-fg-3">
+                  Default goal
+                </div>
+                {!goalEditing && crew.goal ? (
+                  <button
+                    type="button"
+                    onClick={onStartGoalEdit}
+                    className="text-xs text-fg-2 transition-colors hover:text-fg"
+                  >
+                    Edit
+                  </button>
+                ) : null}
+              </div>
+              {goalEditing ? (
+                <div className="flex flex-col gap-2">
+                  <textarea
+                    value={goalDraft}
+                    onChange={(e) => setGoalDraft(e.target.value)}
+                    placeholder="Pre-fills the Start Mission goal."
+                    rows={4}
+                    className="w-full rounded border border-line bg-bg px-3 py-2 text-sm text-fg focus:border-fg-3 focus:outline-none"
+                  />
+                  <div className="flex items-center gap-2">
+                    <Button onClick={onSaveGoal} disabled={savingGoal}>
+                      {savingGoal ? "Saving..." : "Save"}
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      onClick={onCancelGoalEdit}
+                      disabled={savingGoal}
+                    >
+                      Cancel
+                    </Button>
+                  </div>
+                </div>
+              ) : crew.goal ? (
+                <p className="whitespace-pre-wrap text-sm text-fg">
+                  {crew.goal}
+                </p>
+              ) : (
+                <div className="flex flex-col gap-1">
+                  <button
+                    type="button"
+                    onClick={onStartGoalEdit}
+                    className="self-start text-sm text-fg-2 transition-colors hover:text-fg"
+                  >
+                    + Add default goal
+                  </button>
+                  <p className="text-xs text-fg-3">
+                    Pre-fills the Start Mission goal. Optional.
+                  </p>
+                </div>
               )}
             </section>
 

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -383,13 +383,30 @@ export default function MissionWorkspace() {
     setResumingAll(true);
     let firstErr: string | null = null;
     try {
+      // Pre-walk for a shared fallback dim. Hidden tabs (display:none
+      // Pane wrappers) have 0×0 rects so their `measure()` may return
+      // null; without a fallback the resume RPC sends (null, null),
+      // backend spawns at 80×24, and the agent paints its `--resume`
+      // conversation history at 80 cols. For main-screen TUIs those
+      // hard-wrapped narrow lines stick in scrollback. Every Pane in
+      // the workspace shares the same container rect, so any one
+      // tab's measurable dims work as the fallback for every stopped
+      // tab.
+      let sharedDims: { cols: number; rows: number } | null = null;
+      for (const s of sessions) {
+        const d = terminalsRef.current.get(s.id)?.measure();
+        if (d) {
+          sharedDims = d;
+          break;
+        }
+      }
       // Best-effort over every stopped slot. Don't bail on the first
       // failure — earlier slots may have already resumed, and the
       // user wants the UI to reflect whatever actually came up.
       // Errors are collected and surfaced after the refresh.
       for (const s of sessions) {
         if (s.status === "running") continue;
-        const dims = terminalsRef.current.get(s.id)?.measure() ?? null;
+        const dims = terminalsRef.current.get(s.id)?.measure() ?? sharedDims;
         try {
           await api.session.resume(
             s.id,

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -59,6 +59,11 @@ import {
   StopButton,
 } from "../components/ui/SessionControl";
 import { chunkIndicatesTuiReady, isFreshSpawn } from "../lib/sessionLifecycle";
+import {
+  readTerminalFontFamily,
+  readTerminalFontSize,
+  resolveTerminalFontStack,
+} from "../lib/settings";
 import { useDelayedFlag } from "../lib/useDelayedFlag";
 import { useResizableWidth } from "../hooks/useResizableWidth";
 import { useTerminalBg } from "../lib/useTerminalBg";
@@ -72,6 +77,55 @@ const RAIL_STORAGE_WIDTH = "runner.mission.rail.width";
 const RAIL_MIN = 200;
 const RAIL_MAX = 480;
 const RAIL_DEFAULT = 288;
+
+/// Compute cols/rows for the would-be terminal area from the Pane
+/// container's bounding rect + a one-shot DOM cell-size measurement
+/// using the user's current terminal font settings. Returns null if
+/// the container has no rect (workspace not mounted yet) or the
+/// measurement span fails.
+///
+/// Used by `resumeMission`'s fallback chain when no individual slot
+/// terminal is measurable — e.g. the user clicked Resume from the
+/// feed tab and no slot was ever activated, so every slot pane is
+/// still `display:none` and every `RunnerTerminal.measure()` returns
+/// null. The cell size we compute here is close to but not exactly
+/// xterm's CharSizeService output (we don't account for renderer
+/// padding); a small drift is acceptable because the agent paints at
+/// whatever cols we pass and xterm soft-wraps from there if needed.
+/// "Approximately correct" beats "spawn at 80×24."
+function workspaceDimsFromContainer(
+  container: HTMLElement,
+): { cols: number; rows: number } | null {
+  const rect = container.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return null;
+  const fontFamily = resolveTerminalFontStack(readTerminalFontFamily());
+  const fontSize = readTerminalFontSize();
+  const span = document.createElement("span");
+  span.style.position = "absolute";
+  span.style.visibility = "hidden";
+  span.style.top = "-9999px";
+  span.style.fontFamily = fontFamily;
+  span.style.fontSize = `${fontSize}px`;
+  span.style.lineHeight = "1";
+  span.style.whiteSpace = "pre";
+  // 100 chars to average out subpixel widths.
+  span.textContent = "M".repeat(100);
+  document.body.appendChild(span);
+  let cellWidth: number;
+  let cellHeight: number;
+  try {
+    const spanRect = span.getBoundingClientRect();
+    if (spanRect.width <= 0 || spanRect.height <= 0) return null;
+    cellWidth = spanRect.width / 100;
+    cellHeight = spanRect.height;
+  } finally {
+    document.body.removeChild(span);
+  }
+  return {
+    cols: Math.max(1, Math.floor(rect.width / cellWidth)),
+    rows: Math.max(1, Math.floor(rect.height / cellHeight)),
+  };
+}
 
 export default function MissionWorkspace() {
   const { id } = useParams<{ id: string }>();
@@ -98,6 +152,14 @@ export default function MissionWorkspace() {
   // backend so the new PTY is forked at the right size instead of
   // pty_runtime's 80×24 fallback (#resume-pty-size-mismatch).
   const terminalsRef = useRef<Map<string, RunnerTerminalHandle>>(new Map());
+  // Wrapping element around every Pane (feed + per-slot PTY panes).
+  // Used by `resumeMission` as a last-resort source for cols/rows when
+  // no individual terminal is measurable — every Pane is
+  // `absolute inset-0` inside this container, so its rect is the size
+  // any pane *would* have if activated. See `resumeMission` for the
+  // fallback chain and `workspaceDimsFromContainer` for the cell-size
+  // measurement step.
+  const paneContainerRef = useRef<HTMLDivElement | null>(null);
 
   // Combined: subscribe to `event/appended` BEFORE running the
   // events_replay query, then merge both into a single ULID-deduped
@@ -388,10 +450,18 @@ export default function MissionWorkspace() {
       // null; without a fallback the resume RPC sends (null, null),
       // backend spawns at 80×24, and the agent paints its `--resume`
       // conversation history at 80 cols. For main-screen TUIs those
-      // hard-wrapped narrow lines stick in scrollback. Every Pane in
-      // the workspace shares the same container rect, so any one
-      // tab's measurable dims work as the fallback for every stopped
-      // tab.
+      // hard-wrapped narrow lines stick in scrollback. Three-tier
+      // fallback:
+      //   1. The clicked-from tab's own `measure()` (always works when
+      //      a slot tab is active).
+      //   2. Any other slot terminal that has been activated before
+      //      and remembers its last-fit dims (every Pane shares the
+      //      same container rect, so any one's dims work for all).
+      //   3. A direct measurement of the Pane container + DOM cell-
+      //      size probe. This catches the "Resume clicked from the
+      //      feed tab with no slot ever activated" path — every slot
+      //      terminal is still at the 80×24 sentinel so (1)/(2) both
+      //      return null.
       let sharedDims: { cols: number; rows: number } | null = null;
       for (const s of sessions) {
         const d = terminalsRef.current.get(s.id)?.measure();
@@ -399,6 +469,9 @@ export default function MissionWorkspace() {
           sharedDims = d;
           break;
         }
+      }
+      if (!sharedDims && paneContainerRef.current) {
+        sharedDims = workspaceDimsFromContainer(paneContainerRef.current);
       }
       // Best-effort over every stopped slot. Don't bail on the first
       // failure — earlier slots may have already resumed, and the
@@ -795,7 +868,10 @@ export default function MissionWorkspace() {
               : null}
           </div>
 
-          <div className="relative flex flex-1 min-h-0 flex-col">
+          <div
+            ref={paneContainerRef}
+            className="relative flex flex-1 min-h-0 flex-col"
+          >
             {/* All panes stay mounted so xterm's in-memory scrollback
                 survives tab switches. Inactive panes use display:none:
                 that keeps the React/xterm instances alive while making


### PR DESCRIPTION
## Summary

- **Fixes #177** — switching back to a runner's PTY tab after it had accumulated output while hidden showed a mostly-black canvas with scattered text. The activation effect now does an unconditional viewport wipe (TUI runtimes) + `(cols, rows-1) → (cols, rows)` SIGWINCH dance, replacing the dim-deduped pushSize. Kernel TIOCSWINSZ dedup means a same-size resize is a no-op, so the dance is required to force the agent to repaint. Rows-perturbation (not cols) — cols would deposit `claude-code`'s explicit-`\n` narrow lines into scrollback.
- **Resume contract fix** — `RunnerTerminal.measure()` returns last-fit dims on `0×0` rect when non-default, and `MissionWorkspace.resumeMission` pre-walks for any measurable terminal's dims and uses them as `sharedDims` fallback. Stops the resume RPC from sending `(null, null)` for hidden tabs (which made the backend spawn at 80×24 and the agent paint its `--resume` conversation history narrow).
- **Editable crew Default goal** — `CrewEditor` now has a section between Purpose and Team conventions for editing the crew's default goal, mirroring the addendum section pattern. Backend already supported it; the affordance just wasn't wired up.

Impl plan: `docs/impls/0012-force-redraw-on-tab-activation.md`.

## Test plan

- [ ] Start a mission with a `codex` and a `claude-code` runner. Get one busy producing output. Switch to another tab. Wait ~5s. Switch back → expect a brief black flash then a clean repaint, not the scattered-text state.
- [ ] Plain shell runner: `for i in {1..200}; do echo "line $i"; sleep 0.05; done`. Switch away while running, switch back → scrollback intact, no flash.
- [ ] Resize the app window between switch-away and switch-back. Resume should land at new dims with no residual content from the old dims.
- [ ] Toggle the right rail while the source pane is hidden, switch back → pane refits and repaints correctly.
- [ ] Rapid tab switching (A → B → A → C → A) → each return kicks a fresh redraw, no race-induced stale state.
- [ ] Stop a mission, then click Resume from the **feed tab** (not a slot tab). Switch to a paused slot tab and scroll up → conversation history should be at the full container width, not 80 cols.
- [ ] Dead session — kill a runner from its tab, switch away, switch back to the dead tab → no console errors, no thrown promise.
- [ ] Open a crew that has a Default goal set on creation — verify the new section displays it and has an Edit button.
- [ ] Open a crew with no goal — verify the "+ Add default goal" placeholder + hint.
- [ ] Edit the goal, Save → reload the crew page, confirm persistence. Clear the goal (empty text) + Save → confirm it reverts to the placeholder state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)