### PR TITLE
feat(sidebar): simplify collapsed sidebar preview

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,6 +17,7 @@
         "height": 900,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
+        "trafficLightPosition": { "x": 16, "y": 22 },
         "visible": false,
         "acceptFirstMouse": true
       }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -18,6 +18,8 @@ import {
   writeStoredBool,
 } from "../lib/settings";
 
+const SIDEBAR_TOGGLE_EVENT = "runner:toggle-sidebar";
+
 export function AppShell({ children }: { children?: ReactNode }) {
   // Settings modal state hoisted here so both the Sidebar's bottom
   // Settings row and the UpdateToast's "Update" button can open it.
@@ -44,10 +46,16 @@ export function AppShell({ children }: { children?: ReactNode }) {
     if (!collapsed) setSidebarPreviewOpen(false);
   }, [collapsed]);
 
-  // Cmd+S (mac) / Ctrl+S (others) toggles the sidebar. Mirrors the
-  // input-tag skip used by the ⌘K palette shortcut in Sidebar so we
-  // don't hijack editing inside text fields. Cmd+\ remains as a
-  // legacy alias for anyone who picked it up during development.
+  useEffect(() => {
+    const onToggle = () => setCollapsed((prev) => !prev);
+    window.addEventListener(SIDEBAR_TOGGLE_EVENT, onToggle);
+    return () => window.removeEventListener(SIDEBAR_TOGGLE_EVENT, onToggle);
+  }, []);
+
+  // Cmd+S (mac) / Ctrl+S (others) toggles the sidebar. Skip real text
+  // fields, but let xterm's hidden textarea through so terminal focus
+  // doesn't swallow the app-level shortcut. Cmd+\ remains as a legacy
+  // alias for anyone who picked it up during development.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey)) return;
@@ -55,12 +63,16 @@ export function AppShell({ children }: { children?: ReactNode }) {
       if (key !== "s" && e.key !== "\\") return;
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName?.toLowerCase();
-      if (tag === "input" || tag === "textarea") return;
+      const isTextInput =
+        tag === "input" || tag === "textarea" || !!target?.isContentEditable;
+      const isXtermInput = !!target?.closest(".xterm");
+      if (isTextInput && !isXtermInput) return;
       e.preventDefault();
-      setCollapsed((prev) => !prev);
+      e.stopPropagation();
+      window.dispatchEvent(new Event(SIDEBAR_TOGGLE_EVENT));
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    window.addEventListener("keydown", onKey, { capture: true });
+    return () => window.removeEventListener("keydown", onKey, { capture: true });
   }, []);
 
   return (
@@ -69,7 +81,7 @@ export function AppShell({ children }: { children?: ReactNode }) {
         <div
           aria-hidden
           onMouseEnter={() => setSidebarPreviewOpen(true)}
-          className="absolute left-0 top-0 z-30 h-full w-1"
+          className="absolute left-0 top-0 z-30 h-full w-4"
         />
       ) : null}
       <Sidebar

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -52,13 +52,13 @@ export function AppShell({ children }: { children?: ReactNode }) {
     return () => window.removeEventListener(SIDEBAR_TOGGLE_EVENT, onToggle);
   }, []);
 
-  // Cmd+S (mac) / Ctrl+S (others) toggles the sidebar. Skip real text
-  // fields, but let xterm's hidden textarea through so terminal focus
-  // doesn't swallow the app-level shortcut. Cmd+\ remains as a legacy
-  // alias for anyone who picked it up during development.
+  // Cmd+S toggles the sidebar. Skip real text fields, but let xterm's
+  // hidden textarea through so terminal focus doesn't swallow the
+  // app-level shortcut. Cmd+\ remains as a legacy alias for anyone who
+  // picked it up during development.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey)) return;
+      if (!e.metaKey) return;
       const key = e.key.toLowerCase();
       if (key !== "s" && e.key !== "\\") return;
       const target = e.target as HTMLElement | null;

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -24,14 +24,15 @@ export function AppShell({ children }: { children?: ReactNode }) {
   // Toast → settings → download mirrors Quill's flow: the toast just
   // routes the user, the actual download/install lives in the pane.
   const [settingsOpen, setSettingsOpen] = useState(false);
-  // Sidebar collapsed/expanded lives at the shell so cmd+\ can toggle
+  // Sidebar collapsed/expanded lives at the shell so Cmd+S can toggle
   // it from anywhere in the app, not just when the sidebar is the
   // focused subtree.
   const [collapsed, setCollapsed] = useState<boolean>(() =>
     readStoredBool(STORAGE_SIDEBAR_COLLAPSED, false),
   );
+  const [sidebarPreviewOpen, setSidebarPreviewOpen] = useState(false);
   // Single source of truth for persistence — both the Sidebar's
-  // chevron click (setCollapsed via prop) and the cmd+\ keydown
+  // chevron click (setCollapsed via prop) and the Cmd+S keydown
   // funnel through `collapsed`, so one effect keeps localStorage in
   // sync. The harmless one-write at mount with the already-stored
   // value is fine.
@@ -39,13 +40,19 @@ export function AppShell({ children }: { children?: ReactNode }) {
     writeStoredBool(STORAGE_SIDEBAR_COLLAPSED, collapsed);
   }, [collapsed]);
 
-  // cmd+\ (mac) / ctrl+\ (others) toggles the sidebar. Mirrors the
+  useEffect(() => {
+    if (!collapsed) setSidebarPreviewOpen(false);
+  }, [collapsed]);
+
+  // Cmd+S (mac) / Ctrl+S (others) toggles the sidebar. Mirrors the
   // input-tag skip used by the ⌘K palette shortcut in Sidebar so we
-  // don't hijack a real backslash inside text fields.
+  // don't hijack editing inside text fields. Cmd+\ remains as a
+  // legacy alias for anyone who picked it up during development.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key !== "\\") return;
       if (!(e.metaKey || e.ctrlKey)) return;
+      const key = e.key.toLowerCase();
+      if (key !== "s" && e.key !== "\\") return;
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName?.toLowerCase();
       if (tag === "input" || tag === "textarea") return;
@@ -57,12 +64,21 @@ export function AppShell({ children }: { children?: ReactNode }) {
   }, []);
 
   return (
-    <div className="flex h-screen overflow-hidden bg-bg text-fg">
+    <div className="relative flex h-screen overflow-hidden bg-bg text-fg">
+      {collapsed ? (
+        <div
+          aria-hidden
+          onMouseEnter={() => setSidebarPreviewOpen(true)}
+          className="absolute left-0 top-0 z-30 h-full w-1"
+        />
+      ) : null}
       <Sidebar
         settingsOpen={settingsOpen}
         onSettingsOpenChange={setSettingsOpen}
         collapsed={collapsed}
         onCollapsedChange={setCollapsed}
+        previewOpen={sidebarPreviewOpen}
+        onPreviewOpenChange={setSidebarPreviewOpen}
       />
       <main className="relative flex flex-1 flex-col overflow-hidden">
         <div

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -307,6 +307,11 @@ export const RunnerTerminal = forwardRef<
       });
     });
 
+    // App-level shortcuts that should win even while xterm owns focus.
+    // WKWebView/xterm can keep these from reaching AppShell's global
+    // keydown listener, so dispatch the same shell event from here and
+    // return false to keep the shortcut out of the PTY.
+    //
     // Shift+Enter → ESC+CR so claude-code/codex insert a newline in their
     // input frame instead of submitting. Plain Enter falls through to the
     // default \r emission via onData above.
@@ -316,6 +321,14 @@ export const RunnerTerminal = forwardRef<
     // emit \r (same as plain Enter) unless this handler also returns
     // false for that event (see #99).
     term.attachCustomKeyEventHandler((e) => {
+      if (e.type === "keydown" && (e.metaKey || e.ctrlKey)) {
+        const key = e.key.toLowerCase();
+        if (key === "s" || e.key === "\\") {
+          e.preventDefault();
+          window.dispatchEvent(new Event("runner:toggle-sidebar"));
+          return false;
+        }
+      }
       if (
         e.key === "Enter" &&
         e.shiftKey &&

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -307,7 +307,8 @@ export const RunnerTerminal = forwardRef<
       });
     });
 
-    // App-level shortcuts that should win even while xterm owns focus.
+    // App-level Command shortcuts that should win even while xterm owns
+    // focus. Ctrl shortcuts are left to the PTY/TUI.
     // WKWebView/xterm can keep these from reaching AppShell's global
     // keydown listener, so dispatch the same shell event from here and
     // return false to keep the shortcut out of the PTY.
@@ -321,7 +322,7 @@ export const RunnerTerminal = forwardRef<
     // emit \r (same as plain Enter) unless this handler also returns
     // false for that event (see #99).
     term.attachCustomKeyEventHandler((e) => {
-      if (e.type === "keydown" && (e.metaKey || e.ctrlKey)) {
+      if (e.type === "keydown" && e.metaKey) {
         const key = e.key.toLowerCase();
         if (key === "s" || e.key === "\\") {
           e.preventDefault();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -975,12 +975,13 @@ function RuntimeRow({
             dim ? "bg-fg-3" : "bg-accent"
           }`}
         />
-        <span className={`truncate flex-1 ${mono ? "font-mono" : ""}`}>
-          {label}
-        </span>
         {pinned ? (
-          <Pin aria-hidden className="h-3 w-3 shrink-0 text-fg-3" />
+          <Pin
+            aria-hidden
+            className="h-2.5 w-2.5 shrink-0 -rotate-45 text-fg-3"
+          />
         ) : null}
+        <span className={`truncate ${mono ? "font-mono" : ""}`}>{label}</span>
       </button>
       {/* Kebab anchor for the same context menu the row's
           right-click triggers. Mirrors SessionRow's affordance so

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -95,12 +95,14 @@ interface SidebarProps {
   // outsiders trigger it.
   settingsOpen: boolean;
   onSettingsOpenChange: (open: boolean) => void;
-  // Collapsed/expanded state lives in AppShell so the global cmd+\
+  // Collapsed/expanded state lives in AppShell so the global Cmd+S
   // shortcut can toggle it. The `width` resize state stays local —
   // it's preserved across collapse/expand cycles so users get their
   // last full width back when they re-open.
   collapsed: boolean;
   onCollapsedChange: (collapsed: boolean) => void;
+  previewOpen: boolean;
+  onPreviewOpenChange: (open: boolean) => void;
 }
 
 export function Sidebar({
@@ -108,6 +110,8 @@ export function Sidebar({
   onSettingsOpenChange,
   collapsed,
   onCollapsedChange,
+  previewOpen,
+  onPreviewOpenChange,
 }: SidebarProps) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -522,63 +526,34 @@ export function Sidebar({
     });
   }, []);
 
+  const sidebarVisible = !collapsed || previewOpen;
+  const sidebarPreview = collapsed && previewOpen;
+
   return (
     <>
       <aside
         ref={asideRef}
-        style={{ width: collapsed ? 52 : width }}
-        className="relative flex h-full shrink-0 select-none flex-col overflow-hidden border-r border-line bg-sidebar transition-[width] duration-150"
+        onMouseLeave={
+          sidebarPreview ? () => onPreviewOpenChange(false) : undefined
+        }
+        style={{ width: sidebarVisible ? width : 0 }}
+        className={`${
+          collapsed
+            ? "absolute left-0 top-0 z-40"
+            : "relative"
+        } ${
+          sidebarPreview ? "shadow-2xl shadow-black/40" : ""
+        } flex h-full shrink-0 select-none flex-col overflow-hidden transition-[width] duration-150 ${
+          sidebarVisible ? "border-r border-line bg-sidebar" : "bg-transparent"
+        }`}
       >
-        <div data-tauri-drag-region className="h-7" />
-
-        {collapsed ? (
-          // Rail body: single flex column. The h-7 drag strip above
-          // already contributes 28px of top padding; pt-2 brings the
-          // brand to y=36 to match the .pen frame's [36, 0, 16, 0]
-          // padding. gap-1 (4px) between siblings; explicit h-2
-          // spacer adds the 8px gap below the divider that the
-          // designer called for.
-          <div className="flex min-h-0 flex-1 flex-col items-center gap-1 pb-4 pt-2">
-            <BrandMark />
-            <div className="h-px w-full bg-line" />
-            <div className="h-2 w-full" />
-            <RailIconButton
-              icon={Search}
-              label="Search"
-              onClick={() => setPaletteOpen(true)}
-            />
-            <RailIconLink icon={Terminal} to="/runners" label="runner" />
-            <RailIconLink icon={Users} to="/crews" label="crew" />
-            {/* Archived rail icon — slot reserved for feature #31.
-                When the archived nav lands, render a RailIconLink
-                here pointing at its route (icon: lucide Archive).
-                Leaving this as a clearly-marked placeholder so the
-                merge with #31 is mechanical. */}
-            <div className="w-full flex-1" />
-            <div className="h-px w-full bg-line" />
-            <button
-              type="button"
-              onClick={() => onCollapsedChange(false)}
-              title="Expand sidebar (⌘\\)"
-              aria-label="Expand sidebar"
-              className="flex h-9 w-9 cursor-pointer items-center justify-center rounded text-fg-2 transition-colors hover:bg-line/50 hover:text-fg"
-            >
-              <ChevronsRight aria-hidden className="h-4 w-4" />
-            </button>
-            <RailIconButton
-              icon={SettingsIcon}
-              label="Settings"
-              onClick={() => setSettingsOpen(true)}
-            />
-          </div>
-        ) : (
+        {sidebarVisible ? (
           <div className="flex min-h-0 flex-1 flex-col pb-4">
-            {/* Brand row — open state only. Toggle has moved to the
-                bottom Settings row, so this is brand + wordmark
-                only. `data-tauri-drag-region` extends the draggable
-                top band past the h-7 traffic-light strip above so the
-                whole header band (brand + workspace header) reads as
-                one continuous title bar. */}
+            <div data-tauri-drag-region className="h-8 shrink-0" />
+
+            {/* Brand row — open state only. The drag region extends
+                below the traffic-light strip so the header band reads
+                as one continuous title bar. */}
             <div
               data-tauri-drag-region
               className="flex shrink-0 items-center gap-2 px-5 pb-5 pt-1"
@@ -701,10 +676,8 @@ export function Sidebar({
 
             {/* Settings row — pinned at the bottom of the sidebar
                 column. Mirrors Pencil node `IJsUO` (sidebar settings).
-                The collapse toggle now lives on the right of this
-                row (24×24, ChevronsLeft) — see frame s31wik. The
-                Settings button keeps the rest of the row width via
-                flex-1 so its hit target stays large. */}
+                The chevron points toward the action: left collapses
+                an open sidebar, right pins a hover-preview sidebar. */}
             <div className="flex shrink-0 items-center gap-2 border-t border-line px-3 pt-2">
               <button
                 type="button"
@@ -716,29 +689,39 @@ export function Sidebar({
               </button>
               <button
                 type="button"
-                onClick={() => onCollapsedChange(true)}
-                title="Collapse sidebar (⌘\\)"
-                aria-label="Collapse sidebar"
+                onClick={() => {
+                  if (sidebarPreview) {
+                    onCollapsedChange(false);
+                    onPreviewOpenChange(false);
+                    return;
+                  }
+                  onCollapsedChange(true);
+                }}
+                title={
+                  sidebarPreview ? "Keep sidebar open" : "Collapse sidebar (⌘S)"
+                }
+                aria-label={
+                  sidebarPreview ? "Keep sidebar open" : "Collapse sidebar"
+                }
                 className="flex h-6 w-6 cursor-pointer items-center justify-center rounded text-fg-3 transition-colors hover:bg-bg hover:text-fg"
               >
-                <ChevronsLeft aria-hidden className="h-3.5 w-3.5" />
+                {sidebarPreview ? (
+                  <ChevronsRight aria-hidden className="h-3.5 w-3.5" />
+                ) : (
+                  <ChevronsLeft aria-hidden className="h-3.5 w-3.5" />
+                )}
               </button>
             </div>
           </div>
-        )}
+        ) : null}
 
-        {/* Resize handle is inert in rail mode (no width to drag). We
-            render a noop placeholder so the DOM stays stable, just
-            without the col-resize cursor / mousedown handler. */}
-        <div
-          onPointerDown={collapsed ? undefined : handleResizeStart}
-          title={collapsed ? undefined : "Drag to resize"}
-          className={
-            collapsed
-              ? "absolute right-0 top-0 z-20 h-full w-1 bg-transparent"
-              : "absolute right-0 top-0 z-20 h-full w-1 cursor-col-resize bg-transparent transition-colors hover:bg-accent/40"
-          }
-        />
+        {sidebarVisible ? (
+          <div
+            onPointerDown={handleResizeStart}
+            title="Drag to resize"
+            className="absolute right-0 top-0 z-20 h-full w-1 cursor-col-resize bg-transparent transition-colors hover:bg-accent/40"
+          />
+        ) : null}
       </aside>
 
       <SettingsModal
@@ -849,64 +832,6 @@ function NavRow({
         </>
       )}
     </NavLink>
-  );
-}
-
-// Icon-only nav row used in the collapsed rail. Reuses NavLink for
-// the active-state styling so the rail and full sidebar agree on
-// what's selected. The label is exposed via a native `title`
-// tooltip — there is no in-tree tooltip primitive, so we keep this
-// lightweight rather than introduce one for v1.
-function RailIconLink({
-  icon: Icon,
-  to,
-  label,
-}: {
-  icon: ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
-  to: string;
-  label: string;
-}) {
-  return (
-    <NavLink
-      to={to}
-      title={label}
-      aria-label={label}
-      className={({ isActive }) =>
-        `flex h-9 w-9 items-center justify-center rounded transition-colors ${
-          isActive
-            ? "bg-line text-fg"
-            : "text-fg-2 hover:bg-line/50 hover:text-fg"
-        }`
-      }
-    >
-      <Icon aria-hidden className="h-4 w-4" />
-    </NavLink>
-  );
-}
-
-// Icon-only button variant for non-routing actions in the rail
-// (search palette, settings). Border-transparent → border-line on
-// hover keeps the layout stable while matching the active treatment
-// on the link variant.
-function RailIconButton({
-  icon: Icon,
-  label,
-  onClick,
-}: {
-  icon: ComponentType<{ className?: string; "aria-hidden"?: boolean }>;
-  label: string;
-  onClick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      title={label}
-      aria-label={label}
-      className="flex h-9 w-9 cursor-pointer items-center justify-center rounded text-fg-2 transition-colors hover:bg-line/50 hover:text-fg"
-    >
-      <Icon aria-hidden className="h-4 w-4" />
-    </button>
   );
 }
 


### PR DESCRIPTION
Closes #184.

Reworks the collapsed-sidebar behavior away from the 52px rail-switcher design. The collapsed state now hides the sidebar completely, with a narrow left-edge hover target that temporarily previews the full sidebar as an overlay. Users can pin that preview open from the footer chevron, or collapse the pinned sidebar from the same control.

## What's in it

- **No collapsed rail** — collapsed sidebar width is zero, with no icon rail or leftover divider.
- **Hover preview** — a 16px left-edge hit region opens the full sidebar as an overlay without resizing the main content.
- **Pin from preview** — the footer chevron switches direction by state: right chevron pins a hover preview open; left chevron collapses an open sidebar.
- **Keyboard shortcut** — `Cmd+S` toggles collapsed state globally, including xterm-focused terminals, with `Cmd+\` kept as a legacy alias. `Ctrl` shortcuts pass through to the PTY/TUI.
- **Consistent pinned rows** — mission and chat pins use the same inline treatment.
- **Traffic-light spacing** — native macOS traffic lights are offset to give more vertical breathing room.

## Verification

- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run lint`
- [x] `git diff --check`
