### PR TITLE
feat(chat): add direct runtime chats

### DIFF
--- a/docs/impls/0013-direct-chat-runtime-picker.md
+++ b/docs/impls/0013-direct-chat-runtime-picker.md
@@ -1,0 +1,196 @@
+# Direct Chat Runtime Picker
+
+> Implements [#195](https://github.com/yicheng47/runner/issues/195). Product spec: [docs/features/25-direct-chat-runtime-picker.md](../features/25-direct-chat-runtime-picker.md).
+
+## Context
+
+Direct chats are currently runner-template chats end to end. `StartChatModal` fetches runners, `session_start_direct` requires a `runner_id`, `sessions.runner_id` is `NOT NULL`, direct-chat listing joins `runners`, and `RunnerChat` is routed through `/runners/:handle/chat/:sessionId` so it can fetch the runner by URL handle for the header and terminal runtime.
+
+Issue #195 adds the second direct-chat path: pick an agent runtime plus cwd, spawn immediately, and do not create a runner template. The main design constraint is that a runtime-only chat has no stable runner handle or runner row, so this cannot be just a modal change.
+
+## Decisions
+
+1. Replace the runner-scoped direct-chat route with `/chats/:sessionId`.
+2. Make `sessions.runner_id` nullable while preserving `ON DELETE CASCADE` for rows that still reference a runner.
+3. Add explicit agent-runtime metadata on `sessions` instead of reusing `sessions.runtime`.
+4. Keep runtime mode intentionally bare: runtime dropdown, cwd picker, Start. No model, effort, permission, args, env, or prompt fields.
+5. Runtime-only direct chats are resumable. Resume reconstructs the same ephemeral runner config from the session row instead of looking up `runners`.
+6. Add a Chat settings section for the default runtime picker. Do not add default args.
+
+The route change is the biggest tradeoff. Keeping `/runners/:handle/chat/:sessionId` would make runner-template chats look structurally different from runtime-only chats even though both are the same product surface: a direct session. A session-owned route is cleaner; runner context can be loaded from `session_get` when the row still references a runner.
+
+The metadata naming matters. `sessions.runtime` already exists, but it is PTY-runtime reattach metadata (`pty`, legacy `tmux`, etc.), not the agent runtime kind. Add columns such as `agent_runtime` and `agent_command` so `claude-code` / `codex` state does not collide with runtime-layer bookkeeping.
+
+Runtime mode uses the app's normal new-runner defaults in memory. Model and effort stay `NULL` so the CLI picks its own model/reasoning defaults; permission mode uses `default_permission_mode()` and is applied to the ephemeral args with `router::runtime::apply_permission_mode`. The user does not see or edit those fields in runtime mode.
+
+Settings should only choose the default runtime shown in Start Chat's Runtime mode. A global default-args setting would create an invisible runner template without the runner list's affordances, so custom args stay in Runner mode.
+
+## Step 1: Schema and model shape
+
+**Files:** `src-tauri/migrations/0007_direct_runtime_sessions.sql`, `src-tauri/src/db.rs`, `src-tauri/src/model.rs`, `src/lib/types.ts`, `src/lib/api.ts`
+
+- Add migration `0007_direct_runtime_sessions.sql`.
+- Rebuild `sessions` in SQLite so `runner_id TEXT REFERENCES runners(id) ON DELETE CASCADE` is nullable.
+- Add nullable `agent_runtime TEXT` and `agent_command TEXT` columns.
+- Copy existing rows with `agent_runtime = NULL` and `agent_command = NULL`; runner-template rows continue deriving agent metadata from `runners`.
+- Register migration version 7 in `db.rs`.
+- Change shared frontend/backend types so direct-session surfaces accept `runner_id: string | null`.
+- Add `agent_runtime`, `agent_command`, and `runtime_label`/`display_name` fields to direct-session DTOs where the UI needs a label without fetching a runner.
+
+Do not overload `SessionRow` for mission sessions. Mission sessions should still have non-null runner ids because slots always reference runners. Keep `session_list` as an inner join on `runners`.
+
+## Step 2: Runtime registry command
+
+**Files:** `src-tauri/src/router/runtime.rs`, `src-tauri/src/commands/runtime.rs`, `src-tauri/src/commands/mod.rs`, `src-tauri/src/lib.rs`, `src/lib/api.ts`
+
+- Add a small backend registry:
+
+```rust
+claude-code -> command claude -> display Claude Code
+codex       -> command codex  -> display Codex
+```
+
+- Expose it through `runtime_list`.
+- Add a `RuntimeDefinition` TS interface and `api.runtime.list()`.
+- Use the backend list for Start Chat runtime mode.
+
+The existing frontend `RUNTIME_OPTIONS` can stay for runner create/edit in this pass. Consolidating both forms onto the backend registry is reasonable later, but it is not required to ship #195.
+
+## Step 3: Runtime-only spawn path
+
+**Files:** `src-tauri/src/commands/session.rs`, `src-tauri/src/session/manager.rs`, `src-tauri/src/router/prompt.rs`
+
+- Add `session_start_runtime(runtime: String, cwd: Option<String>, cols: Option<u16>, rows: Option<u16>)`.
+- Validate the runtime name through the registry.
+- Construct an ephemeral `Runner` value with:
+  - `id` as a non-persisted synthetic value used only inside the live manager map.
+  - `handle` as the runtime name.
+  - `display_name` as the runtime display name.
+  - `runtime` and `command` from the registry.
+  - args computed from `router::runtime::apply_permission_mode(runtime, &[], default_permission_mode())`.
+  - empty env and null working_dir/system_prompt/model/effort.
+- Call a direct-spawn path that can insert `runner_id = NULL`, `agent_runtime = runtime.name`, and `agent_command = runtime.command`.
+
+Implementation detail: either extend `spawn_direct` with a `DirectSpawnIdentity` enum or add a focused `spawn_runtime_direct` wrapper that shares the same internal helper. Avoid pretending the ephemeral runner id is persisted; that will create subtle bugs in `runner/activity`, runner deletion, and resume.
+
+Do not emit `runner/activity` for runtime-only chats. There is no runner row to update, and the sidebar/chat list will refresh through session events.
+
+## Step 4: Direct-session queries
+
+**Files:** `src-tauri/src/commands/session.rs`, `src/components/Sidebar.tsx`, `src/pages/RunnerChat.tsx`, `src/components/CommandPalette.tsx`
+
+- Change `session_list_recent_direct` and `session_get` to `LEFT JOIN runners`.
+- Return:
+  - `runner_id: Option<String>`
+  - `handle: Option<String>` or a separate `runner_handle`
+  - `agent_runtime: String`
+  - `agent_command: String`
+  - `display_name` derived from runner display/name for runner rows or registry display for runtime rows.
+- For existing runner-template rows, compute agent runtime from `r.runtime`.
+- For runtime rows, compute display from registry and fall back to raw `agent_runtime` if a future registry no longer knows the value.
+
+Update default labels:
+
+- Runner-template chat: `@handle · <started>`.
+- Runtime-only chat: `Runtime Display · <started>`.
+
+## Step 5: Resume and reattach
+
+**Files:** `src-tauri/src/session/manager.rs`, `src-tauri/src/commands/session.rs`
+
+- In `SessionManager::resume`, read nullable `runner_id`, `agent_runtime`, and `agent_command`.
+- If `runner_id` is present, keep the existing runner lookup path.
+- If `runner_id` is null, reconstruct an ephemeral runner from the persisted agent runtime metadata and the registry display fallback.
+- Reapply the same in-memory new-runner defaults used by `session_start_runtime`: default permission mode, null model/effort/system_prompt, empty env.
+- Use the row `cwd` as the effective cwd. Runtime-mode rows have no runner working_dir fallback.
+- Keep agent-native resume behavior (`agent_session_key`) unchanged for claude-code and codex.
+- Update startup reattach (`collect_running_rows` / `attach_existing`) to handle null `runner_id`; the forwarder should skip runner activity emission for runtime-only rows.
+- Change `SessionHandle.runner_id` to `Option<String>` or otherwise tag runtime-only handles so `kill_all_for_runner` ignores them.
+
+This is the main correctness risk. If resume keeps assuming `runner_id` is a string, stopped runtime chats will render as resumable in the UI but fail when clicked.
+
+## Step 6: Start Chat modal
+
+**Files:** `src/components/StartChatModal.tsx`, `src/components/ui/RuntimeSelect.tsx`, `src/lib/settings.ts`
+
+- Add a segmented control at the top: `Runner` and `Runtime`.
+- Remember the last selected mode in local storage.
+- Runner mode keeps the existing runner picker, title behavior, cwd precedence, and `session_start_direct` call.
+- Runtime mode loads `api.runtime.list()`, defaults to the Chat settings runtime when present and valid, otherwise the first runtime, shows runtime dropdown plus working directory, and calls `session_start_runtime`.
+- Runtime mode title default should be `Chat with <display name>`, but keep the title field optional and user-editable like runner mode.
+- Runtime mode cwd handling should mirror runner mode without a runner fallback: typed cwd wins; otherwise pass `readDefaultWorkingDir() || null`.
+- Runtime mode cwd placeholder should show the global default working directory, then `(no working directory)`.
+- Runtime mode does not expose model, effort, permission, args, env, or system prompt; those come from the default ephemeral runner config above.
+- Start button is enabled when the selected mode has the required selection: runner id for runner mode, runtime name for runtime mode.
+
+Design pass required before implementation: update `design/runners-design.pen` for the segmented modal state and confirm the dropdown/cwd spacing. The Pencil file was not open during this planning pass, so this plan does not claim node-level validation.
+
+## Step 7: Chat settings
+
+**Files:** `src/components/SettingsModal.tsx`, `src/lib/settings.ts`
+
+- Add a `Chat` section in Settings.
+- Add a `Default runtime` dropdown backed by `runtime_list`.
+- Persist as a local setting, for example `runner.default_chat_runtime`.
+- On load, validate the stored runtime against `runtime_list`; if it is missing or stale, fall back to the first runtime and do not block opening the modal.
+- Do not add default args, model, effort, permission, env, or prompt settings here.
+
+## Step 8: Chat route and header
+
+**Files:** `src/App.tsx`, `src/pages/RunnerChat.tsx`, `src/components/Sidebar.tsx`, `src/components/CommandPalette.tsx`, `src/pages/Runners.tsx`, `src/pages/RunnerDetail.tsx`
+
+- Add route `/chats/:sessionId` pointing at `RunnerChat`.
+- Remove `/runners/:handle/chat/:sessionId`.
+- Make `RunnerChat` load `chatMeta` first and treat it as the source of truth for title, status, cwd, runtime, and optional runner handle.
+- Fetch runner details only when `chatMeta.runner_id` exists.
+- Pass `runnerRuntime={chatMeta.agent_runtime}` to `RunnerTerminal` so runtime-only chats still get the claude-code/codex resize behavior.
+- Sidebar and command palette should navigate to `/chats/:sessionId` for all direct-session rows after this change.
+- Runner Detail and Runners page should also navigate to `/chats/:sessionId` after spawning a runner-template chat.
+- Back button behavior:
+  - Runner-template row with runner metadata: back to `/runners/:handle`.
+  - Runtime-only row: back to `/runners` or the prior location if present.
+- Side panel behavior:
+  - Runner-template chat: current runner detail panel.
+- Runtime-only chat: compact runtime panel showing display name, command, cwd, and no system prompt section.
+
+## Step 9: Tests
+
+**Rust**
+
+- Migration preserves existing runner sessions and permits `runner_id = NULL`.
+- `runtime_list` returns `claude-code` and `codex`.
+- `session_start_runtime` rejects unknown runtime names.
+- `session_start_runtime` applies the same default permission args a new runner would get for the selected runtime.
+- Direct-session listing returns runtime-only rows without joining `runners`.
+- `session_get` returns archived runtime-only rows for direct URL reload.
+- Runtime-only resume reconstructs an ephemeral runner and does not call `runner::get`.
+- Startup reattach handles a running runtime-only row.
+
+**Frontend**
+
+- Typecheck catches nullable runner ids across Sidebar, CommandPalette, and RunnerChat.
+- Settings Chat default runtime persists and Start Chat uses it when valid.
+- Invalid/stale stored default runtime falls back to the first runtime.
+- Add focused component tests only if the existing setup already supports them; otherwise rely on typecheck plus manual app verification.
+
+## Step 10: Manual verification
+
+1. Start Chat → Runner mode → existing runner-template chat still spawns and navigates.
+2. Start Chat → Runtime mode → `claude-code` with a cwd spawns without creating a runner row.
+3. Settings → Chat → Default runtime changes which runtime is preselected in Start Chat Runtime mode.
+4. Start Chat → Runtime mode → `codex` with no cwd uses the app/global fallback behavior.
+5. Sidebar CHAT row for runtime-only chat shows runtime display name, not `@handle`.
+6. Chat header and meta row show runtime display, status, started time, cwd, and no runner handle.
+7. Reload `/chats/:sessionId` for a runtime-only chat and reattach successfully.
+8. Stop a runtime-only chat, reload, click Resume, and verify it resumes the same row.
+9. Delete a runner that has runner-template chats and confirm existing cascade behavior is unchanged.
+10. Invalid runtime through the command returns a clear error.
+
+## CI gates
+
+- `pnpm exec tsc --noEmit`
+- `pnpm run lint`
+- `cargo fmt --check`
+- `cargo test --workspace`
+
+Run a targeted Rust test first while iterating on the session manager, then the full workspace test once the null-runner path compiles.

--- a/src-tauri/migrations/0007_direct_runtime_sessions.sql
+++ b/src-tauri/migrations/0007_direct_runtime_sessions.sql
@@ -1,0 +1,79 @@
+-- Allow direct-chat sessions to be backed by a runtime without a
+-- persisted runner template.
+--
+-- `sessions.runtime` already stores PTY-runtime metadata (`pty`, legacy
+-- tmux), so agent identity uses explicit `agent_*` columns.
+
+CREATE TABLE sessions_new (
+    id TEXT PRIMARY KEY,
+    mission_id TEXT REFERENCES missions(id) ON DELETE SET NULL,
+    runner_id TEXT REFERENCES runners(id) ON DELETE CASCADE,
+    slot_id TEXT,
+    cwd TEXT,
+    status TEXT NOT NULL,
+    pid INTEGER,
+    started_at TEXT,
+    stopped_at TEXT,
+    agent_session_key TEXT,
+    archived_at TEXT,
+    title TEXT,
+    pinned_at TEXT,
+    runtime TEXT,
+    runtime_socket TEXT,
+    runtime_session TEXT,
+    runtime_window TEXT,
+    runtime_pane TEXT,
+    runtime_cursor INTEGER,
+    agent_runtime TEXT,
+    agent_command TEXT
+);
+
+INSERT INTO sessions_new (
+    id,
+    mission_id,
+    runner_id,
+    slot_id,
+    cwd,
+    status,
+    pid,
+    started_at,
+    stopped_at,
+    agent_session_key,
+    archived_at,
+    title,
+    pinned_at,
+    runtime,
+    runtime_socket,
+    runtime_session,
+    runtime_window,
+    runtime_pane,
+    runtime_cursor,
+    agent_runtime,
+    agent_command
+)
+SELECT
+    id,
+    mission_id,
+    runner_id,
+    slot_id,
+    cwd,
+    status,
+    pid,
+    started_at,
+    stopped_at,
+    agent_session_key,
+    archived_at,
+    title,
+    pinned_at,
+    runtime,
+    runtime_socket,
+    runtime_session,
+    runtime_window,
+    runtime_pane,
+    runtime_cursor,
+    NULL,
+    NULL
+FROM sessions;
+
+DROP TABLE sessions;
+ALTER TABLE sessions_new RENAME TO sessions;

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -8,5 +8,6 @@ pub mod app;
 pub mod crew;
 pub mod mission;
 pub mod runner;
+pub mod runtime;
 pub mod session;
 pub mod slot;

--- a/src-tauri/src/commands/runner.rs
+++ b/src-tauri/src/commands/runner.rs
@@ -55,7 +55,7 @@ pub struct CreateRunnerInput {
 /// Default permission mode for new runners — `Auto`. Matches the
 /// frontend's dropdown default and the seed's runner args.
 /// Pulled out so serde's `#[serde(default = "...")]` can name it.
-fn default_permission_mode() -> crate::router::runtime::PermissionMode {
+pub(crate) fn default_permission_mode() -> crate::router::runtime::PermissionMode {
     crate::router::runtime::PermissionMode::Auto
 }
 

--- a/src-tauri/src/commands/runtime.rs
+++ b/src-tauri/src/commands/runtime.rs
@@ -1,0 +1,20 @@
+use serde::Serialize;
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeDefinition {
+    pub name: String,
+    pub display_name: String,
+    pub command: String,
+}
+
+#[tauri::command]
+pub async fn runtime_list() -> Vec<RuntimeDefinition> {
+    crate::router::runtime::runtime_definitions()
+        .iter()
+        .map(|runtime| RuntimeDefinition {
+            name: runtime.name.to_string(),
+            display_name: runtime.display_name.to_string(),
+            command: runtime.command.to_string(),
+        })
+        .collect()
+}

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -552,7 +552,7 @@ pub async fn session_resume(
     cols: Option<u16>,
     rows: Option<u16>,
 ) -> Result<SpawnedSession> {
-    let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app));
+    let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app.clone()));
     let spawned = state
         .sessions
         .resume(
@@ -577,6 +577,10 @@ pub async fn session_resume(
             }
         }
     }
+    let _ = app.emit(
+        "session/updated",
+        serde_json::json!({ "session_id": session_id }),
+    );
     Ok(spawned)
 }
 
@@ -641,7 +645,7 @@ pub async fn session_start_runtime(
     rows: Option<u16>,
 ) -> Result<SpawnedSession> {
     let runner = runtime_direct_runner(&runtime, None)?;
-    let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app));
+    let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app.clone()));
     let spawned = state
         .sessions
         .spawn_runtime_direct(
@@ -654,6 +658,10 @@ pub async fn session_start_runtime(
             emitter,
         )
         .map_err(|e| Error::msg(format!("session_start_runtime: {e}")))?;
+    let _ = app.emit(
+        "session/updated",
+        serde_json::json!({ "session_id": spawned.id }),
+    );
     Ok(spawned)
 }
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -20,7 +20,9 @@ use crate::{
     commands::runner,
     error::{Error, Result},
     model::{Session, SessionStatus, Timestamp},
-    session::manager::{OutputEvent, SessionEvents, SpawnedSession, TauriSessionEvents},
+    session::manager::{
+        runtime_direct_runner, OutputEvent, SessionEvents, SpawnedSession, TauriSessionEvents,
+    },
     AppState,
 };
 
@@ -245,8 +247,11 @@ pub async fn session_paste_image(bytes: Vec<u8>) -> Result<()> {
 #[derive(Debug, Clone, Serialize)]
 pub struct DirectSessionEntry {
     pub session_id: String,
-    pub runner_id: String,
-    pub handle: String,
+    pub runner_id: Option<String>,
+    pub handle: Option<String>,
+    pub agent_runtime: String,
+    pub agent_command: String,
+    pub display_name: String,
     pub status: SessionStatus,
     /// User-authored label. NULL → frontend derives a default from
     /// handle + start time. Set via `session_rename`.
@@ -273,6 +278,55 @@ pub struct DirectSessionEntry {
     pub archived_at: Option<Timestamp>,
 }
 
+fn direct_entry_from_row(row: &Row<'_>) -> rusqlite::Result<DirectSessionEntry> {
+    let status: String = row.get("status")?;
+    let status = match status.as_str() {
+        "running" => SessionStatus::Running,
+        "stopped" => SessionStatus::Stopped,
+        "crashed" => SessionStatus::Crashed,
+        other => {
+            return Err(rusqlite::Error::FromSqlConversionFailure(
+                0,
+                rusqlite::types::Type::Text,
+                format!("unknown session status {other:?}").into(),
+            ))
+        }
+    };
+    let parse_ts = |s: String| -> rusqlite::Result<Timestamp> {
+        s.parse().map_err(|e: chrono::ParseError| {
+            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+        })
+    };
+    let started_at: Option<String> = row.get("started_at")?;
+    let stopped_at: Option<String> = row.get("stopped_at")?;
+    let archived_at: Option<String> = row.get("archived_at")?;
+    let resumable: i64 = row.get("resumable")?;
+    let pinned: i64 = row.get("pinned")?;
+    let handle: Option<String> = row.get("handle")?;
+    let agent_runtime: String = row.get("agent_runtime")?;
+    let agent_command: String = row.get("agent_command")?;
+    let runner_display_name: Option<String> = row.get("runner_display_name")?;
+    let display_name = runner_display_name
+        .filter(|_| handle.is_some())
+        .unwrap_or_else(|| crate::router::runtime::runtime_display_name(&agent_runtime));
+    Ok(DirectSessionEntry {
+        session_id: row.get("session_id")?,
+        runner_id: row.get("runner_id")?,
+        handle,
+        agent_runtime,
+        agent_command,
+        display_name,
+        status,
+        title: row.get("title")?,
+        cwd: row.get("cwd")?,
+        started_at: started_at.map(parse_ts).transpose()?,
+        stopped_at: stopped_at.map(parse_ts).transpose()?,
+        resumable: resumable != 0,
+        pinned: pinned != 0,
+        archived_at: archived_at.map(parse_ts).transpose()?,
+    })
+}
+
 #[tauri::command]
 pub async fn session_list_recent_direct(
     state: State<'_, AppState>,
@@ -287,6 +341,9 @@ pub async fn session_list_recent_direct(
         "SELECT s.id        AS session_id,
                 s.runner_id AS runner_id,
                 r.handle    AS handle,
+                r.display_name AS runner_display_name,
+                COALESCE(s.agent_runtime, r.runtime) AS agent_runtime,
+                COALESCE(s.agent_command, r.command) AS agent_command,
                 s.status    AS status,
                 s.title     AS title,
                 s.cwd       AS cwd,
@@ -296,55 +353,14 @@ pub async fn session_list_recent_direct(
                 CASE WHEN s.agent_session_key IS NOT NULL THEN 1 ELSE 0 END AS resumable,
                 CASE WHEN s.pinned_at         IS NOT NULL THEN 1 ELSE 0 END AS pinned
            FROM sessions s
-           JOIN runners r ON r.id = s.runner_id
+           LEFT JOIN runners r ON r.id = s.runner_id
           WHERE s.mission_id IS NULL
             AND s.archived_at IS NULL
           ORDER BY CASE WHEN s.pinned_at IS NOT NULL THEN 0 ELSE 1 END,
                    CASE WHEN s.status = 'running'    THEN 0 ELSE 1 END,
                    COALESCE(s.stopped_at, s.started_at) DESC",
     )?;
-    let rows = stmt.query_map([], |row| {
-        let status: String = row.get("status")?;
-        let status = match status.as_str() {
-            "running" => SessionStatus::Running,
-            "stopped" => SessionStatus::Stopped,
-            "crashed" => SessionStatus::Crashed,
-            other => {
-                return Err(rusqlite::Error::FromSqlConversionFailure(
-                    0,
-                    rusqlite::types::Type::Text,
-                    format!("unknown session status {other:?}").into(),
-                ))
-            }
-        };
-        let parse_ts = |s: String| -> rusqlite::Result<Timestamp> {
-            s.parse().map_err(|e: chrono::ParseError| {
-                rusqlite::Error::FromSqlConversionFailure(
-                    0,
-                    rusqlite::types::Type::Text,
-                    Box::new(e),
-                )
-            })
-        };
-        let started_at: Option<String> = row.get("started_at")?;
-        let stopped_at: Option<String> = row.get("stopped_at")?;
-        let archived_at: Option<String> = row.get("archived_at")?;
-        let resumable: i64 = row.get("resumable")?;
-        let pinned: i64 = row.get("pinned")?;
-        Ok(DirectSessionEntry {
-            session_id: row.get("session_id")?,
-            runner_id: row.get("runner_id")?,
-            handle: row.get("handle")?,
-            status,
-            title: row.get("title")?,
-            cwd: row.get("cwd")?,
-            started_at: started_at.map(parse_ts).transpose()?,
-            stopped_at: stopped_at.map(parse_ts).transpose()?,
-            resumable: resumable != 0,
-            pinned: pinned != 0,
-            archived_at: archived_at.map(parse_ts).transpose()?,
-        })
-    })?;
+    let rows = stmt.query_map([], direct_entry_from_row)?;
     rows.collect::<rusqlite::Result<Vec<_>>>()
         .map_err(Into::into)
 }
@@ -382,6 +398,9 @@ fn get_direct(conn: &rusqlite::Connection, session_id: &str) -> Result<Option<Di
         "SELECT s.id        AS session_id,
                 s.runner_id AS runner_id,
                 r.handle    AS handle,
+                r.display_name AS runner_display_name,
+                COALESCE(s.agent_runtime, r.runtime) AS agent_runtime,
+                COALESCE(s.agent_command, r.command) AS agent_command,
                 s.status    AS status,
                 s.title     AS title,
                 s.cwd       AS cwd,
@@ -391,53 +410,12 @@ fn get_direct(conn: &rusqlite::Connection, session_id: &str) -> Result<Option<Di
                 CASE WHEN s.agent_session_key IS NOT NULL THEN 1 ELSE 0 END AS resumable,
                 CASE WHEN s.pinned_at         IS NOT NULL THEN 1 ELSE 0 END AS pinned
            FROM sessions s
-           JOIN runners r ON r.id = s.runner_id
+           LEFT JOIN runners r ON r.id = s.runner_id
           WHERE s.id = ?1
             AND s.mission_id IS NULL",
     )?;
     let row = stmt
-        .query_row(params![session_id], |row| {
-            let status: String = row.get("status")?;
-            let status = match status.as_str() {
-                "running" => SessionStatus::Running,
-                "stopped" => SessionStatus::Stopped,
-                "crashed" => SessionStatus::Crashed,
-                other => {
-                    return Err(rusqlite::Error::FromSqlConversionFailure(
-                        0,
-                        rusqlite::types::Type::Text,
-                        format!("unknown session status {other:?}").into(),
-                    ))
-                }
-            };
-            let parse_ts = |s: String| -> rusqlite::Result<Timestamp> {
-                s.parse().map_err(|e: chrono::ParseError| {
-                    rusqlite::Error::FromSqlConversionFailure(
-                        0,
-                        rusqlite::types::Type::Text,
-                        Box::new(e),
-                    )
-                })
-            };
-            let started_at: Option<String> = row.get("started_at")?;
-            let stopped_at: Option<String> = row.get("stopped_at")?;
-            let archived_at: Option<String> = row.get("archived_at")?;
-            let resumable: i64 = row.get("resumable")?;
-            let pinned: i64 = row.get("pinned")?;
-            Ok(DirectSessionEntry {
-                session_id: row.get("session_id")?,
-                runner_id: row.get("runner_id")?,
-                handle: row.get("handle")?,
-                status,
-                title: row.get("title")?,
-                cwd: row.get("cwd")?,
-                started_at: started_at.map(parse_ts).transpose()?,
-                stopped_at: stopped_at.map(parse_ts).transpose()?,
-                resumable: resumable != 0,
-                pinned: pinned != 0,
-                archived_at: archived_at.map(parse_ts).transpose()?,
-            })
-        })
+        .query_row(params![session_id], direct_entry_from_row)
         .optional()?;
     Ok(row)
 }
@@ -653,6 +631,32 @@ pub async fn session_start_direct(
     Ok(spawned)
 }
 
+#[tauri::command]
+pub async fn session_start_runtime(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    runtime: String,
+    cwd: Option<String>,
+    cols: Option<u16>,
+    rows: Option<u16>,
+) -> Result<SpawnedSession> {
+    let runner = runtime_direct_runner(&runtime, None)?;
+    let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app));
+    let spawned = state
+        .sessions
+        .spawn_runtime_direct(
+            &runner,
+            cwd.as_deref(),
+            cols,
+            rows,
+            &state.app_data_dir,
+            state.db.clone(),
+            emitter,
+        )
+        .map_err(|e| Error::msg(format!("session_start_runtime: {e}")))?;
+    Ok(spawned)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -668,7 +672,7 @@ mod tests {
                 "SELECT s.id, s.status,
                         CASE WHEN s.pinned_at IS NOT NULL THEN 1 ELSE 0 END AS pinned
                    FROM sessions s
-                   JOIN runners r ON r.id = s.runner_id
+                   LEFT JOIN runners r ON r.id = s.runner_id
                   WHERE s.mission_id IS NULL
                     AND s.archived_at IS NULL
                   ORDER BY CASE WHEN s.pinned_at IS NOT NULL THEN 0 ELSE 1 END,

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -69,6 +69,9 @@ fn init_connection(conn: &mut Connection) -> rusqlite::Result<()> {
 // 0006: drops `crews.signal_types`. CLI validation is now enum-based
 // in runner-core (`KnownSignalType`); the per-crew column + sidecar
 // they used to feed no longer have a consumer. See feature 20.
+// 0007: makes direct-chat `sessions.runner_id` nullable and adds
+// `agent_runtime` / `agent_command` so runtime-only chats can resume
+// without a persisted runner template (#195).
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, include_str!("../migrations/0001_init.sql")),
     (2, include_str!("../migrations/0002_persona_only_seeds.sql")),
@@ -84,6 +87,10 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (
         6,
         include_str!("../migrations/0006_drop_crews_signal_types.sql"),
+    ),
+    (
+        7,
+        include_str!("../migrations/0007_direct_runtime_sessions.sql"),
     ),
 ];
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -250,6 +250,7 @@ pub fn run() {
             commands::runner::runner_update,
             commands::runner::runner_delete,
             commands::runner::runner_activity,
+            commands::runtime::runtime_list,
             commands::slot::slot_list,
             commands::slot::runner_crews_list,
             commands::slot::slot_create,
@@ -282,6 +283,7 @@ pub fn run() {
             commands::session::session_output_snapshot,
             commands::session::session_paste_image,
             commands::session::session_start_direct,
+            commands::session::session_start_runtime,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/src/router/runtime.rs
+++ b/src-tauri/src/router/runtime.rs
@@ -29,6 +29,43 @@
 // handler already owns prompt composition; the runtime adapter is the
 // related "how do we hand prompts and identity to a real CLI" piece.
 
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct RuntimeDefinition {
+    pub name: &'static str,
+    pub display_name: &'static str,
+    pub command: &'static str,
+}
+
+const RUNTIME_DEFINITIONS: &[RuntimeDefinition] = &[
+    RuntimeDefinition {
+        name: "codex",
+        display_name: "Codex",
+        command: "codex",
+    },
+    RuntimeDefinition {
+        name: "claude-code",
+        display_name: "Claude Code",
+        command: "claude",
+    },
+];
+
+pub fn runtime_definitions() -> &'static [RuntimeDefinition] {
+    RUNTIME_DEFINITIONS
+}
+
+pub fn runtime_definition(name: &str) -> Option<RuntimeDefinition> {
+    RUNTIME_DEFINITIONS
+        .iter()
+        .copied()
+        .find(|runtime| runtime.name == name)
+}
+
+pub fn runtime_display_name(name: &str) -> String {
+    runtime_definition(name)
+        .map(|runtime| runtime.display_name.to_string())
+        .unwrap_or_else(|| name.to_string())
+}
+
 /// Compute the extra args (in declaration order) to append after the
 /// runner's configured `args` so the child receives the pinned model
 /// and thinking effort via the runtime's native flags. Returns an

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -349,7 +349,7 @@ pub struct WarningEvent {
 pub struct SpawnedSession {
     pub id: String,
     pub mission_id: Option<String>,
-    pub runner_id: String,
+    pub runner_id: Option<String>,
     pub handle: String,
     pub pid: Option<u32>,
     /// True iff this resume detected a missing claude-code
@@ -376,7 +376,7 @@ struct SessionHandle {
     /// The runner this session is an instance of. `kill_all_for_runner`
     /// filters on this so deleting a runner can reap its live PTY
     /// children before the cascade nukes the DB rows underneath.
-    runner_id: String,
+    runner_id: Option<String>,
     /// Runtime-side identifiers (tmux session/window/pane) returned
     /// from `SessionRuntime::spawn`. The manager passes this back
     /// to `runtime.send_bytes` / `runtime.paste` / `runtime.resize`
@@ -977,7 +977,7 @@ impl SessionManager {
             SessionHandle {
                 id: session_id.clone(),
                 mission_id: Some(mission.id.clone()),
-                runner_id: runner.id.clone(),
+                runner_id: Some(runner.id.clone()),
                 runtime_session: rt_session.clone(),
                 forwarder: None,
                 stop,
@@ -1000,6 +1000,7 @@ impl SessionManager {
             Arc::clone(&events),
             runner.clone(),
             plan.resuming,
+            true,
             spawn_emit_ctx,
         );
         if let Some(h) = self.sessions.lock().unwrap().get_mut(&session_id) {
@@ -1107,7 +1108,7 @@ impl SessionManager {
         Ok(SpawnedSession {
             id: session_id,
             mission_id: Some(mission_id),
-            runner_id,
+            runner_id: Some(runner_id),
             handle,
             // pane_pid is populated lazily via runtime.status() when
             // the manager needs it; the SpawnedSession field is
@@ -1155,6 +1156,59 @@ impl SessionManager {
         events: Arc<dyn SessionEvents>,
         first_turn: Option<String>,
     ) -> Result<SpawnedSession> {
+        self.spawn_direct_inner(
+            runner,
+            Some(runner.id.as_str()),
+            cwd,
+            cols,
+            rows,
+            app_data_dir,
+            pool,
+            events,
+            first_turn,
+            true,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn spawn_runtime_direct(
+        self: &Arc<Self>,
+        runner: &Runner,
+        cwd: Option<&str>,
+        cols: Option<u16>,
+        rows: Option<u16>,
+        app_data_dir: &Path,
+        pool: Arc<DbPool>,
+        events: Arc<dyn SessionEvents>,
+    ) -> Result<SpawnedSession> {
+        self.spawn_direct_inner(
+            runner,
+            None,
+            cwd,
+            cols,
+            rows,
+            app_data_dir,
+            pool,
+            events,
+            None,
+            false,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn spawn_direct_inner(
+        self: &Arc<Self>,
+        runner: &Runner,
+        persisted_runner_id: Option<&str>,
+        cwd: Option<&str>,
+        cols: Option<u16>,
+        rows: Option<u16>,
+        app_data_dir: &Path,
+        pool: Arc<DbPool>,
+        events: Arc<dyn SessionEvents>,
+        first_turn: Option<String>,
+        emit_activity: bool,
+    ) -> Result<SpawnedSession> {
         let _ = app_data_dir; // direct chats don't get the bundled CLI on PATH
 
         // Agent-native session resume: `spawn_direct` always opens a *new*
@@ -1199,14 +1253,24 @@ impl SessionManager {
             conn.execute(
                 "INSERT INTO sessions
                     (id, mission_id, runner_id, cwd, status, pid, started_at,
-                     agent_session_key)
-                 VALUES (?1, NULL, ?2, ?3, 'running', NULL, ?4, ?5)",
+                     agent_session_key, agent_runtime, agent_command)
+                 VALUES (?1, NULL, ?2, ?3, 'running', NULL, ?4, ?5, ?6, ?7)",
                 params![
                     session_id,
-                    runner.id,
+                    persisted_runner_id,
                     resolved_cwd,
                     started_at,
-                    plan.assigned_key
+                    plan.assigned_key,
+                    if persisted_runner_id.is_none() {
+                        Some(runner.runtime.as_str())
+                    } else {
+                        None
+                    },
+                    if persisted_runner_id.is_none() {
+                        Some(runner.command.as_str())
+                    } else {
+                        None
+                    },
                 ],
             )?;
         }
@@ -1278,7 +1342,7 @@ impl SessionManager {
             SessionHandle {
                 id: session_id.clone(),
                 mission_id: None,
-                runner_id: runner.id.clone(),
+                runner_id: persisted_runner_id.map(str::to_string),
                 runtime_session: rt_session.clone(),
                 forwarder: None,
                 stop: output.stop_flag(),
@@ -1294,6 +1358,7 @@ impl SessionManager {
             Arc::clone(&events),
             runner.clone(),
             plan.resuming,
+            emit_activity,
             None, // direct chats are off-bus — no log to append runner_status to
         );
         if let Some(h) = self.sessions.lock().unwrap().get_mut(&session_id) {
@@ -1317,7 +1382,9 @@ impl SessionManager {
             }
         }
 
-        emit_runner_activity(&pool, runner, events.as_ref());
+        if emit_activity {
+            emit_runner_activity(&pool, runner, events.as_ref());
+        }
         schedule_direct_first_prompt(
             self,
             session_id.clone(),
@@ -1329,7 +1396,7 @@ impl SessionManager {
         Ok(SpawnedSession {
             id: session_id,
             mission_id: None,
-            runner_id: runner.id.clone(),
+            runner_id: persisted_runner_id.map(str::to_string),
             handle: runner.handle.clone(),
             pid: None,
             fresh_fallback_lead: false,
@@ -1389,28 +1456,32 @@ impl SessionManager {
         // across the spawn (which itself grabs a pool slot for the
         // status update).
         struct Snapshot {
-            runner_id: String,
+            runner_id: Option<String>,
             mission_id: Option<String>,
             slot_id: Option<String>,
             cwd: Option<String>,
+            agent_runtime: Option<String>,
+            agent_command: Option<String>,
             agent_session_key: Option<String>,
         }
         let snap = {
             let conn = pool.get()?;
             let mut stmt = conn.prepare(
                 "SELECT runner_id, mission_id, slot_id, cwd, status, archived_at,
-                        agent_session_key
+                        agent_runtime, agent_command, agent_session_key
                    FROM sessions WHERE id = ?1",
             )?;
             let row = stmt
                 .query_row(params![session_id], |r| {
                     Ok((
-                        r.get::<_, String>("runner_id")?,
+                        r.get::<_, Option<String>>("runner_id")?,
                         r.get::<_, Option<String>>("mission_id")?,
                         r.get::<_, Option<String>>("slot_id")?,
                         r.get::<_, Option<String>>("cwd")?,
                         r.get::<_, String>("status")?,
                         r.get::<_, Option<String>>("archived_at")?,
+                        r.get::<_, Option<String>>("agent_runtime")?,
+                        r.get::<_, Option<String>>("agent_command")?,
                         r.get::<_, Option<String>>("agent_session_key")?,
                     ))
                 })
@@ -1420,7 +1491,17 @@ impl SessionManager {
                     }
                     other => other.into(),
                 })?;
-            let (runner_id, mission_id, slot_id, cwd, status, archived_at, agent_session_key) = row;
+            let (
+                runner_id,
+                mission_id,
+                slot_id,
+                cwd,
+                status,
+                archived_at,
+                agent_runtime,
+                agent_command,
+                agent_session_key,
+            ) = row;
             if status == "running" {
                 return Err(Error::msg(format!(
                     "session {session_id} is already running — attach instead"
@@ -1436,6 +1517,8 @@ impl SessionManager {
                 mission_id,
                 slot_id,
                 cwd,
+                agent_runtime,
+                agent_command,
                 agent_session_key,
             }
         };
@@ -1500,12 +1583,18 @@ impl SessionManager {
                 _ => None,
             };
 
-        // Pull the runner config fresh — the user may have edited it
-        // since the session last ran, and we want the current command /
-        // args / env on respawn.
-        let runner = {
+        // Pull the runner config fresh for runner-backed rows; rebuild
+        // the default runtime config for runtime-only direct chats.
+        let runner = if let Some(runner_id) = snap.runner_id.as_deref() {
             let conn = pool.get()?;
-            crate::commands::runner::get(&conn, &snap.runner_id)?
+            crate::commands::runner::get(&conn, runner_id)?
+        } else {
+            let runtime = snap.agent_runtime.as_deref().ok_or_else(|| {
+                Error::msg(format!(
+                    "runtime-only session {session_id} missing agent_runtime"
+                ))
+            })?;
+            runtime_direct_runner(runtime, snap.agent_command.as_deref())?
         };
 
         // Resume plan: hand the prior agent_session_key back to the
@@ -1517,8 +1606,11 @@ impl SessionManager {
         // print "No conversation found" and leave the TUI half-broken.
         // Detect the missing file up front and degrade to a fresh
         // spawn that *keeps* the same uuid via `--session-id`.
-        let resolved_cwd_for_check: Option<String> =
-            snap.cwd.clone().or_else(|| runner.working_dir.clone());
+        let resolved_cwd_for_check: Option<String> = snap.cwd.clone().or_else(|| {
+            snap.runner_id
+                .as_ref()
+                .and_then(|_| runner.working_dir.clone())
+        });
         let is_lead_slot = mission_ctx.as_ref().is_some_and(|c| c.lead);
         let conversation_missing = matches!(
             (runner.runtime.as_str(), snap.agent_session_key.as_deref()),
@@ -1539,7 +1631,11 @@ impl SessionManager {
         // Working directory: same precedence as `spawn_direct` — the
         // row's stored cwd wins; otherwise fall back to the runner's
         // current `working_dir`.
-        let resolved_cwd: Option<String> = snap.cwd.clone().or_else(|| runner.working_dir.clone());
+        let resolved_cwd: Option<String> = snap.cwd.clone().or_else(|| {
+            snap.runner_id
+                .as_ref()
+                .and_then(|_| runner.working_dir.clone())
+        });
 
         // Refresh the per-slot runner shim before composing PATH —
         // mission cwd may have been edited since the last spawn.
@@ -1671,7 +1767,7 @@ impl SessionManager {
             SessionHandle {
                 id: session_id.to_string(),
                 mission_id: snap.mission_id.clone(),
-                runner_id: runner.id.clone(),
+                runner_id: snap.runner_id.clone(),
                 runtime_session: rt_session.clone(),
                 forwarder: None,
                 stop: output.stop_flag(),
@@ -1703,6 +1799,7 @@ impl SessionManager {
             Arc::clone(&events),
             runner.clone(),
             plan.resuming,
+            snap.runner_id.is_some(),
             resume_emit_ctx,
         );
         if let Some(h) = self.sessions.lock().unwrap().get_mut(session_id) {
@@ -1725,7 +1822,9 @@ impl SessionManager {
             }
         }
 
-        emit_runner_activity(&pool, &runner, events.as_ref());
+        if snap.runner_id.is_some() {
+            emit_runner_activity(&pool, &runner, events.as_ref());
+        }
 
         // First-turn injection for fresh claude-code / codex spawns.
         // `plan.resuming` is true on any resume against a real
@@ -1763,7 +1862,7 @@ impl SessionManager {
         Ok(SpawnedSession {
             id: session_id.to_string(),
             mission_id: snap.mission_id.clone(),
-            runner_id: runner.id.clone(),
+            runner_id: snap.runner_id.clone(),
             handle: resumed_handle,
             pid: None,
             fresh_fallback_lead,
@@ -1795,6 +1894,7 @@ impl SessionManager {
         events: Arc<dyn SessionEvents>,
         runner: Runner,
         resuming: bool,
+        emit_activity: bool,
         emit_ctx: Option<ForwarderEmitCtx>,
     ) -> thread::JoinHandle<()> {
         let manager_t: Arc<SessionManager> = Arc::clone(self);
@@ -1931,7 +2031,9 @@ impl SessionManager {
                     ),
                 });
             }
-            emit_runner_activity(&pool, &runner, events.as_ref());
+            if emit_activity {
+                emit_runner_activity(&pool, &runner, events.as_ref());
+            }
             events.exit(&ExitEvent {
                 session_id,
                 mission_id,
@@ -2245,7 +2347,7 @@ impl SessionManager {
             let sessions = self.sessions.lock().unwrap();
             sessions
                 .values()
-                .filter(|s| s.runner_id == runner_id)
+                .filter(|s| s.runner_id.as_deref() == Some(runner_id))
                 .map(|s| s.id.clone())
                 .collect()
         };
@@ -2431,11 +2533,19 @@ impl SessionManager {
         events: &Arc<dyn SessionEvents>,
         app_data_dir: &Path,
     ) -> Result<()> {
-        // Pull the runner row so the forwarder thread can fire
-        // `runner/activity` events with the right handle.
-        let runner = {
+        // Pull or reconstruct the runner-shaped launch config so the
+        // forwarder has the runtime name for resume-failure warnings.
+        let runner = if let Some(runner_id) = row.runner_id.as_deref() {
             let conn = pool.get()?;
-            crate::commands::runner::get(&conn, &row.runner_id)?
+            crate::commands::runner::get(&conn, runner_id)?
+        } else {
+            let runtime = row.agent_runtime.as_deref().ok_or_else(|| {
+                Error::msg(format!(
+                    "runtime-only session {} missing agent_runtime",
+                    row.id
+                ))
+            })?;
+            runtime_direct_runner(runtime, row.agent_command.as_deref())?
         };
         // For mission rows, resolve the crew_id + slot_handle from
         // the same DB lookups the original spawn used so the
@@ -2457,13 +2567,14 @@ impl SessionManager {
         );
         let forwarder = self.start_forwarder_thread(
             row.id.clone(),
-            row.mission_id,
+            row.mission_id.clone(),
             rt_session,
             output,
             Arc::clone(pool),
             Arc::clone(events),
             runner,
             false, // resuming flag — re-attach to a live pane is not a resume_plan resume
+            row.runner_id.is_some(),
             emit_ctx,
         );
         if let Some(h) = self.sessions.lock().unwrap().get_mut(&row.id) {
@@ -2600,8 +2711,10 @@ impl SessionManager {
 #[derive(Debug, Clone)]
 struct RowSnap {
     id: String,
-    runner_id: String,
+    runner_id: Option<String>,
     mission_id: Option<String>,
+    agent_runtime: Option<String>,
+    agent_command: Option<String>,
     runtime: Option<String>,
     runtime_socket: Option<String>,
     runtime_session: Option<String>,
@@ -2628,7 +2741,7 @@ impl RowSnap {
 fn collect_running_rows(pool: &DbPool) -> Result<Vec<RowSnap>> {
     let conn = pool.get()?;
     let mut stmt = conn.prepare(
-        "SELECT id, runner_id, mission_id,
+        "SELECT id, runner_id, mission_id, agent_runtime, agent_command,
                 runtime, runtime_socket, runtime_session,
                 runtime_window, runtime_pane
            FROM sessions
@@ -2640,6 +2753,8 @@ fn collect_running_rows(pool: &DbPool) -> Result<Vec<RowSnap>> {
                 id: r.get("id")?,
                 runner_id: r.get("runner_id")?,
                 mission_id: r.get("mission_id")?,
+                agent_runtime: r.get("agent_runtime")?,
+                agent_command: r.get("agent_command")?,
                 runtime: r.get("runtime")?,
                 runtime_socket: r.get("runtime_socket")?,
                 runtime_session: r.get("runtime_session")?,
@@ -2682,6 +2797,41 @@ fn capture_cwd(explicit: Option<String>) -> Option<String> {
     std::env::current_dir()
         .ok()
         .and_then(|p| p.into_os_string().into_string().ok())
+}
+
+pub(crate) fn runtime_direct_runner(runtime: &str, command: Option<&str>) -> Result<Runner> {
+    let runtime = runtime.trim();
+    if runtime.is_empty() {
+        return Err(Error::msg("runtime is required"));
+    }
+    let registry = router::runtime::runtime_definition(runtime);
+    let command = command
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .or_else(|| registry.map(|r| r.command))
+        .ok_or_else(|| Error::msg(format!("unknown runtime: {runtime}")))?;
+    let now = Utc::now();
+    Ok(Runner {
+        id: format!("runtime:{runtime}"),
+        handle: runtime.to_string(),
+        display_name: registry
+            .map(|r| r.display_name.to_string())
+            .unwrap_or_else(|| runtime.to_string()),
+        runtime: runtime.to_string(),
+        command: command.to_string(),
+        args: router::runtime::apply_permission_mode(
+            runtime,
+            &[],
+            crate::commands::runner::default_permission_mode(),
+        ),
+        working_dir: None,
+        system_prompt: None,
+        env: HashMap::new(),
+        model: None,
+        effort: None,
+        created_at: now,
+        updated_at: now,
+    })
 }
 
 // The first-prompt readback machinery (FirstPromptConfig,
@@ -4151,7 +4301,7 @@ mod tests {
             )
             .unwrap();
         assert_eq!(spawned.mission_id, None);
-        assert_eq!(spawned.runner_id, runner_id);
+        assert_eq!(spawned.runner_id, Some(runner_id.clone()));
 
         // Direct chat must NOT have a mission-side shim or
         // bundled-bin in its SpawnSpec — the off-bus invariant.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,7 +80,7 @@ export default function App() {
             <Route path="/crews/:crewId" element={<CrewEditor />} />
             <Route path="/runners" element={<Runners />} />
             <Route path="/runners/:handle" element={<RunnerDetail />} />
-            <Route path="/runners/:handle/chat/:sessionId" element={<RunnerChat />} />
+            <Route path="/chats/:sessionId" element={<RunnerChat />} />
             <Route path="/missions/:id" element={<MissionWorkspace />} />
             <Route path="*" element={<Navigate to="/runners" replace />} />
           </Route>

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -81,12 +81,12 @@ export function CommandPalette({ open, onClose }: CommandPaletteProps) {
         next.push({
           kind: "chat",
           id: c.session_id,
-          label: c.title ?? `@${c.handle}`,
+          label: c.title ?? (c.handle ? `@${c.handle}` : c.display_name),
           navigate: () =>
-            navigate(`/runners/${c.handle}/chat/${c.session_id}`, {
+            navigate(`/chats/${c.session_id}`, {
               state: { sessionStatus: c.status },
             }),
-          searchText: `${c.handle} ${c.title ?? ""} ${c.cwd ?? ""}`.toLowerCase(),
+          searchText: `${c.handle ?? c.display_name} ${c.title ?? ""} ${c.cwd ?? ""}`.toLowerCase(),
           order: i,
         }),
       );

--- a/src/components/SessionEndedOverlay.tsx
+++ b/src/components/SessionEndedOverlay.tsx
@@ -23,7 +23,7 @@ export interface SessionEndedOverlayProps {
   resumable: boolean;
   /** Friendly label for the runner / slot ("@architect"). When set,
    *  the resume button reads "Resume @architect"; falls back to
-   *  generic "Resume chat" / "Restart chat" wording. */
+   *  generic "Resume" wording. */
   handle?: string;
   onResume: () => void;
   /** Optional. RunnerChat surfaces an Archive option (calls
@@ -80,11 +80,7 @@ export function SessionEndedOverlay({
   // action. Slot-level callsites still get a "Resume @handle" form
   // when `handle` is provided — there's no enclosing title there to
   // tell the user which slot the action targets.
-  const computedResumeLabel = handle
-    ? `Resume @${handle}`
-    : resumable
-      ? "Resume"
-      : "Restart";
+  const computedResumeLabel = handle ? `Resume @${handle}` : "Resume";
   const finalResumeLabel = resumeLabel ?? computedResumeLabel;
   const finalTitle = title ?? "Chat paused";
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -21,6 +21,7 @@ import {
   FolderOpen,
   Info,
   Loader2,
+  MessageSquare,
   Minus,
   Monitor,
   Moon,
@@ -55,6 +56,7 @@ import {
   readAppTheme,
   readAppZoom,
   readDarkVariant,
+  readDefaultChatRuntime,
   readDefaultWorkingDir,
   readLightVariant,
   readStoredBool,
@@ -93,6 +95,7 @@ import {
   writeAppFontFamily,
   writeAppTheme,
   writeDarkVariant,
+  writeDefaultChatRuntime,
   writeDefaultWorkingDir,
   writeLightVariant,
   writeStoredBool,
@@ -114,6 +117,7 @@ interface SettingsModalProps {
 
 type Pane =
   | "general"
+  | "chat"
   | "appearance"
   | "terminal"
   | "diagnostics"
@@ -126,6 +130,12 @@ const PANES: { key: Pane; label: string; subtitle: string; icon: typeof Settings
     label: "General",
     subtitle: "Startup & defaults",
     icon: SettingsIcon,
+  },
+  {
+    key: "chat",
+    label: "Chat",
+    subtitle: "Direct chat defaults",
+    icon: MessageSquare,
   },
   {
     key: "appearance",
@@ -242,6 +252,7 @@ export function SettingsModal({ open, onClose }: SettingsModalProps) {
             <X aria-hidden className="h-4 w-4" />
           </button>
           {pane === "general" ? <GeneralPane /> : null}
+          {pane === "chat" ? <ChatPane /> : null}
           {pane === "appearance" ? <AppearancePane /> : null}
           {pane === "terminal" ? <TerminalPane /> : null}
           {pane === "diagnostics" ? <DiagnosticsPane /> : null}
@@ -380,6 +391,63 @@ function GeneralPane() {
         sub="Whole-app scale. Doesn't apply to the runner terminal canvas — see Terminal pane."
       >
         <ZoomStepper value={appZoom} onChange={setAppZoom} />
+      </Row>
+    </>
+  );
+}
+
+function ChatPane() {
+  const [runtimes, setRuntimes] = useState<
+    { name: string; display_name: string; command: string }[]
+  >([]);
+  const [defaultRuntime, setDefaultRuntimeState] = useState<string>(() =>
+    readDefaultChatRuntime(),
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void api.runtime
+      .list()
+      .then((rows) => {
+        if (cancelled) return;
+        setRuntimes(rows);
+        const stored = readDefaultChatRuntime();
+        if (stored && !rows.some((runtime) => runtime.name === stored)) {
+          setDefaultRuntimeState("");
+          writeDefaultChatRuntime("");
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setRuntimes([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setDefaultRuntime = (runtime: string) => {
+    setDefaultRuntimeState(runtime);
+    writeDefaultChatRuntime(runtime);
+  };
+
+  return (
+    <>
+      <PaneHeader title="Chat" subtitle="Defaults for direct chats." />
+      <Row
+        label="Default runtime"
+        sub="Pre-selected in Start Chat's Direct mode."
+      >
+        <StyledSelect
+          value={defaultRuntime}
+          options={[
+            { value: "", label: "First available" },
+            ...runtimes.map((runtime) => ({
+              value: runtime.name,
+              label: runtime.display_name,
+            })),
+          ]}
+          onChange={setDefaultRuntime}
+        />
       </Row>
     </>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -610,7 +610,6 @@ export function Sidebar({
               <section className="flex flex-col">
                 <CollapsibleSectionHeader
                   label="MISSION"
-                  count={missions.length}
                   open={missionsOpen}
                   onToggle={toggleMissions}
                   onPlus={() => setCreatingMission(true)}
@@ -656,7 +655,6 @@ export function Sidebar({
               <section className="mt-5 flex flex-col">
                 <CollapsibleSectionHeader
                   label="CHAT"
-                  count={directSessions.length}
                   open={sessionsOpen}
                   onToggle={toggleSessions}
                   onPlus={handleNewDirectChat}
@@ -893,7 +891,6 @@ function SearchNavRow({ onOpen }: { onOpen: () => void }) {
 
 function CollapsibleSectionHeader({
   label,
-  count,
   open,
   onToggle,
   onPlus,
@@ -901,7 +898,6 @@ function CollapsibleSectionHeader({
   plusExpanded,
 }: {
   label: string;
-  count: number;
   open: boolean;
   onToggle: () => void;
   onPlus: () => void;
@@ -920,11 +916,6 @@ function CollapsibleSectionHeader({
       >
         <Chevron aria-hidden className="h-2.5 w-2.5" />
         <span>{label}</span>
-        {count > 0 ? (
-          <span className="ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-line bg-line-strong px-1 font-mono text-[9px] font-semibold leading-none text-fg-3">
-            {count}
-          </span>
-        ) : null}
       </button>
       <button
         type="button"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -35,6 +35,7 @@ import {
   ChevronRight,
   ChevronsLeft,
   ChevronsRight,
+  MessageSquarePlus,
   MoreHorizontal,
   Pin,
   PinOff,
@@ -187,7 +188,7 @@ export function Sidebar({
   // sidebar row. `useMatch` returns null when the URL doesn't match.
   const missionMatch = useMatch("/missions/:id");
   const currentMissionId = missionMatch?.params.id ?? null;
-  const chatMatch = useMatch("/runners/:handle/chat/:sessionId");
+  const chatMatch = useMatch("/chats/:sessionId");
   // Which direct-chat session is currently in view. The chat route
   // encodes the session id in the URL (a runner can host multiple
   // chats — see docs/impls/0003-direct-chats.md), so we match by
@@ -211,18 +212,29 @@ export function Sidebar({
     void refreshMissions();
   }, [refreshMissions]);
 
-  // ⌘K / Ctrl+K opens the command palette from anywhere in the app.
-  // Skip when the user is editing inside an <input> or <textarea>
-  // so the shortcut doesn't hijack normal text input.
+  // ⌘K / Ctrl+K opens the command palette. ⌘N / Ctrl+N opens the
+  // Start Chat modal. Skip while editing text controls so shortcuts
+  // don't hijack form input.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (e.key !== "k" && e.key !== "K") return;
       if (!(e.metaKey || e.ctrlKey)) return;
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName?.toLowerCase();
-      if (tag === "input" || tag === "textarea") return;
-      e.preventDefault();
-      setPaletteOpen(true);
+      if (
+        tag === "input" ||
+        tag === "textarea" ||
+        tag === "select" ||
+        target?.isContentEditable
+      ) {
+        return;
+      }
+      if (e.key === "k" || e.key === "K") {
+        e.preventDefault();
+        setPaletteOpen(true);
+      } else if (e.key === "n" || e.key === "N") {
+        e.preventDefault();
+        setCreatingChat(true);
+      }
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
@@ -442,12 +454,19 @@ export function Sidebar({
       // the user explicitly chose Archive on a live row.
       try {
         if (session.status === "running") {
-          await api.session.kill(session.session_id);
+          try {
+            await api.session.kill(session.session_id);
+          } catch (e) {
+            // The sidebar row can be stale for a beat after the PTY
+            // exits. Continue to archive; the backend still refuses
+            // rows that are genuinely running.
+            console.warn("sidebar: session_kill before archive failed", e);
+          }
         }
         await api.session.archive(session.session_id);
         await refreshDirectSessions();
         if (currentChatSessionId === session.session_id) {
-          navigate(`/runners/${session.handle}`);
+          navigate(session.handle ? `/runners/${session.handle}` : "/runners");
         }
       } catch (e) {
         console.error("sidebar: session_archive failed", e);
@@ -496,7 +515,7 @@ export function Sidebar({
   // longer in the live map → "session not found" banner.
   const openDirectChat = useCallback(
     (entry: DirectSessionEntry) => {
-      const target = `/runners/${entry.handle}/chat/${entry.session_id}`;
+      const target = `/chats/${entry.session_id}`;
       navigate(target, {
         state: { sessionStatus: entry.status },
         replace: location.pathname === target,
@@ -563,11 +582,12 @@ export function Sidebar({
                 Runner
               </span>
             </div>
-            {/* WORKSPACE keeps natural height; doesn't compete for the
-                flex-share allotted to MISSION + SESSION. */}
+            {/* WORKSPACE keeps natural height; it doesn't compete
+                with the scrollable Mission/Chat region below. */}
             <div className="shrink-0">
               <SectionHeader>WORKSPACE</SectionHeader>
               <nav className="flex flex-col gap-0.5 px-3 pb-1">
+                <NewChatNavRow onOpen={handleNewDirectChat} />
                 {/* Search opens a command-palette modal — matches design
                     `Fkoe8`. Default interaction is click-to-callout, not
                     type-in-place, so this lives as a nav row alongside
@@ -583,96 +603,92 @@ export function Sidebar({
 
             <div className="h-5 shrink-0" />
 
-            {/* MISSION + SESSION always split the remaining vertical
-                space 1:2 (mission takes 1 share, session takes 2),
-                regardless of expand/collapse state. Collapsing a
-                section just hides its body — the section still claims
-                its share of height so the column rhythm doesn't jump
-                when toggling. Each expanded body scrolls independently
-                so a long SESSION list can't push MISSION off-screen. */}
-            <section className="flex min-h-0 flex-[1] basis-0 flex-col">
-              <CollapsibleSectionHeader
-                label="MISSION"
-                count={missions.length}
-                open={missionsOpen}
-                onToggle={toggleMissions}
-                onPlus={() => setCreatingMission(true)}
-                plusTitle="Start mission"
-              />
-              {missionsOpen ? (
-                <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-3 pt-1">
-                  {missions.length === 0 ? (
-                    <p className="px-2.5 py-1 text-xs text-fg-3">
-                      No live missions.
-                    </p>
-                  ) : (
-                    missions.map((m) => (
-                      <RuntimeRow
-                        key={m.id}
-                        selected={m.id === currentMissionId}
-                        label={m.title}
-                        onClick={() => openMission(m.id)}
-                        onContextMenu={(anchor) => openMissionMenu(m, anchor)}
-                        title={m.crew_name || ""}
-                        pinned={!!m.pinned_at}
-                        // Mute the dot when the mission has no live
-                        // session — `mission.status === "running"` is
-                        // not enough to call a workspace "live", since
-                        // a paused mission (every slot stopped) keeps
-                        // the running status until the user archives.
-                        // `any_session_live` is computed on the backend
-                        // (see `mission_list_summary`) so the sidebar
-                        // doesn't need to fetch session rows per mission.
-                        dim={!m.any_session_live}
-                        renaming={renamingMissionId === m.id}
-                        onRenameSubmit={(next) =>
-                          void submitMissionRename(m.id, next)
-                        }
-                        onRenameCancel={() => setRenamingMissionId(null)}
-                      />
-                    ))
-                  )}
-                </div>
-              ) : null}
-            </section>
+            {/* Codex-desktop style: Mission and Chat live in one
+                natural scroll column. Sections stack by content
+                height; no pane reserves empty space. */}
+            <div className="min-h-0 flex-1 overflow-y-auto pb-3">
+              <section className="flex flex-col">
+                <CollapsibleSectionHeader
+                  label="MISSION"
+                  count={missions.length}
+                  open={missionsOpen}
+                  onToggle={toggleMissions}
+                  onPlus={() => setCreatingMission(true)}
+                  plusTitle="Start mission"
+                />
+                {missionsOpen ? (
+                  <div className="flex flex-col gap-0.5 px-3 pt-1">
+                    {missions.length === 0 ? (
+                      <p className="px-2.5 py-1 text-xs text-fg-3">
+                        No live missions.
+                      </p>
+                    ) : (
+                      missions.map((m) => (
+                        <SidebarListRow
+                          key={m.id}
+                          selected={m.id === currentMissionId}
+                          label={m.title}
+                          onClick={() => openMission(m.id)}
+                          onContextMenu={(anchor) => openMissionMenu(m, anchor)}
+                          title={m.crew_name || ""}
+                          pinned={!!m.pinned_at}
+                          // Mute the dot when the mission has no live
+                          // session — `mission.status === "running"` is
+                          // not enough to call a workspace "live", since
+                          // a paused mission (every slot stopped) keeps
+                          // the running status until the user archives.
+                          // `any_session_live` is computed on the backend
+                          // (see `mission_list_summary`) so the sidebar
+                          // doesn't need to fetch session rows per mission.
+                          dim={!m.any_session_live}
+                          renaming={renamingMissionId === m.id}
+                          onRenameSubmit={(next) =>
+                            void submitMissionRename(m.id, next)
+                          }
+                          onRenameCancel={() => setRenamingMissionId(null)}
+                        />
+                      ))
+                    )}
+                  </div>
+                ) : null}
+              </section>
 
-            <div className="h-8 shrink-0" />
-
-            <section className="flex min-h-0 flex-[2] basis-0 flex-col">
-              <CollapsibleSectionHeader
-                label="CHAT"
-                count={directSessions.length}
-                open={sessionsOpen}
-                onToggle={toggleSessions}
-                onPlus={handleNewDirectChat}
-                plusTitle="Start a chat"
-                plusExpanded={creatingChat}
-              />
-              {sessionsOpen ? (
-                <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-3 pt-1">
-                  {directSessions.length === 0 ? (
-                    <p className="px-2.5 py-1 text-xs text-fg-3">
-                      No chats yet.
-                    </p>
-                  ) : (
-                    directSessions.map((s) => (
-                      <SessionRow
-                        key={s.session_id}
-                        session={s}
-                        selected={s.session_id === currentChatSessionId}
-                        renaming={renamingId === s.session_id}
-                        onClick={() => openDirectChat(s)}
-                        onContextMenu={(anchor) => openSessionMenu(s, anchor)}
-                        onRenameSubmit={(nextTitle) =>
-                          void submitRename(s.session_id, nextTitle)
-                        }
-                        onRenameCancel={() => setRenamingId(null)}
-                      />
-                    ))
-                  )}
-                </div>
-              ) : null}
-            </section>
+              <section className="mt-5 flex flex-col">
+                <CollapsibleSectionHeader
+                  label="CHAT"
+                  count={directSessions.length}
+                  open={sessionsOpen}
+                  onToggle={toggleSessions}
+                  onPlus={handleNewDirectChat}
+                  plusTitle="Start a chat"
+                  plusExpanded={creatingChat}
+                />
+                {sessionsOpen ? (
+                  <div className="flex flex-col gap-0.5 px-3 pt-1">
+                    {directSessions.length === 0 ? (
+                      <p className="px-2.5 py-1 text-xs text-fg-3">
+                        No chats yet.
+                      </p>
+                    ) : (
+                      directSessions.map((s) => (
+                        <SessionRow
+                          key={s.session_id}
+                          session={s}
+                          selected={s.session_id === currentChatSessionId}
+                          renaming={renamingId === s.session_id}
+                          onClick={() => openDirectChat(s)}
+                          onContextMenu={(anchor) => openSessionMenu(s, anchor)}
+                          onRenameSubmit={(nextTitle) =>
+                            void submitRename(s.session_id, nextTitle)
+                          }
+                          onRenameCancel={() => setRenamingId(null)}
+                        />
+                      ))
+                    )}
+                  </div>
+                ) : null}
+              </section>
+            </div>
 
             {/* Settings row — pinned at the bottom of the sidebar
                 column. Mirrors Pencil node `IJsUO` (sidebar settings).
@@ -747,9 +763,9 @@ export function Sidebar({
       <StartChatModal
         open={creatingChat}
         onClose={() => setCreatingChat(false)}
-        onStarted={(spawned, handle) => {
+        onStarted={(spawned) => {
           setCreatingChat(false);
-          navigate(`/runners/${handle}/chat/${spawned.id}`, {
+          navigate(`/chats/${spawned.id}`, {
             state: { sessionStatus: "running" },
           });
         }}
@@ -815,10 +831,10 @@ function NavRow({
     <NavLink
       to={to}
       className={({ isActive }) =>
-        `flex items-center gap-2 rounded px-2.5 py-1.5 text-sm transition-colors ${
+        `flex items-center gap-2 rounded border px-2.5 py-1.5 text-sm transition-colors ${
           isActive
-            ? "bg-line font-semibold text-fg"
-            : "text-fg-2 hover:bg-line/50 hover:text-fg"
+            ? "border-sidebar-selected-border bg-sidebar-selected font-semibold text-fg shadow-sm"
+            : "border-transparent text-fg-2 hover:bg-sidebar-selected/60 hover:text-fg"
         }`
       }
     >
@@ -835,20 +851,40 @@ function NavRow({
   );
 }
 
+function NewChatNavRow({ onOpen }: { onOpen: () => void }) {
+  return (
+    <button
+      type="button"
+      title="New chat"
+      onClick={onOpen}
+      className="group flex w-full cursor-pointer items-center gap-2 rounded border border-transparent px-2.5 py-1.5 text-left text-sm text-fg-2 transition-colors hover:bg-sidebar-selected/60 hover:text-fg focus:bg-sidebar-selected/60 focus:text-fg focus:outline-none"
+    >
+      <MessageSquarePlus aria-hidden className="h-3 w-3 text-fg-2" />
+      <span className="min-w-0 flex-1 truncate">new chat</span>
+      <span className="shrink-0 rounded border border-line bg-bg px-1.5 py-px font-mono text-[10px] leading-tight text-fg-3 opacity-0 transition-opacity group-hover:opacity-100 group-focus:opacity-100">
+        ⌘N
+      </span>
+    </button>
+  );
+}
+
 /// Search nav row — visually indistinguishable from runner/crew rows
 /// but opens the CommandPalette modal instead of routing. The ⌘K
 /// keyboard binding (registered above) still works; the shortcut
-/// hint just isn't displayed in the UI.
+/// hint appears on hover/focus.
 function SearchNavRow({ onOpen }: { onOpen: () => void }) {
   return (
     <button
       type="button"
       title="Search"
       onClick={onOpen}
-      className="flex w-full cursor-pointer items-center gap-2 rounded px-2.5 py-1.5 text-left text-sm text-fg-2 transition-colors hover:text-fg"
+      className="group flex w-full cursor-pointer items-center gap-2 rounded border border-transparent px-2.5 py-1.5 text-left text-sm text-fg-2 transition-colors hover:bg-sidebar-selected/60 hover:text-fg focus:bg-sidebar-selected/60 focus:text-fg focus:outline-none"
     >
       <Search aria-hidden className="h-3 w-3 text-fg-2" />
-      <span>search</span>
+      <span className="min-w-0 flex-1 truncate">search</span>
+      <span className="shrink-0 rounded border border-line bg-bg px-1.5 py-px font-mono text-[10px] leading-tight text-fg-3 opacity-0 transition-opacity group-hover:opacity-100 group-focus:opacity-100">
+        ⌘K
+      </span>
     </button>
   );
 }
@@ -885,7 +921,7 @@ function CollapsibleSectionHeader({
         <Chevron aria-hidden className="h-2.5 w-2.5" />
         <span>{label}</span>
         {count > 0 ? (
-          <span className="ml-1 rounded-full bg-bg px-1.5 py-px font-mono text-[10px] font-semibold text-fg-3">
+          <span className="ml-1 inline-flex h-4 min-w-4 items-center justify-center rounded-full border border-line bg-line-strong px-1 font-mono text-[9px] font-semibold leading-none text-fg-3">
             {count}
           </span>
         ) : null}
@@ -905,9 +941,9 @@ function CollapsibleSectionHeader({
   );
 }
 
-// ---- runtime row (mission or direct-session) --------------------------
+// ---- sidebar list rows ------------------------------------------------
 
-function RuntimeRow({
+function SidebarListRow({
   selected,
   label,
   onClick,
@@ -917,6 +953,8 @@ function RuntimeRow({
   dim,
   pinned,
   renaming,
+  renameValue,
+  renamePlaceholder,
   onRenameSubmit,
   onRenameCancel,
 }: {
@@ -935,14 +973,21 @@ function RuntimeRow({
   pinned?: boolean;
   /** When true, replaces the label with an inline rename input. */
   renaming?: boolean;
+  /** Current editable value. Defaults to `label`. */
+  renameValue?: string;
+  /** Placeholder shown while the editable value is empty. */
+  renamePlaceholder?: string;
   onRenameSubmit?: (next: string) => void;
   onRenameCancel?: () => void;
 }) {
   if (renaming && onRenameSubmit && onRenameCancel) {
     return (
-      <RowRenameInput
-        initial={label}
+      <SidebarRowRenameInput
+        initial={renameValue ?? label}
+        placeholder={renamePlaceholder ?? label}
+        title={title}
         mono={mono}
+        dim={dim}
         onSubmit={onRenameSubmit}
         onCancel={onRenameCancel}
       />
@@ -960,8 +1005,8 @@ function RuntimeRow({
       }
       className={`group flex w-full items-center gap-2 rounded border px-2.5 py-1.5 text-left text-xs transition-colors ${
         selected
-          ? "border-line bg-bg text-fg"
-          : "border-transparent text-fg-2 hover:text-fg"
+          ? "border-sidebar-selected-border bg-sidebar-selected font-semibold text-fg shadow-sm"
+          : "border-transparent text-fg-2 hover:bg-sidebar-selected/60 hover:text-fg"
       }`}
     >
       <button
@@ -1005,14 +1050,20 @@ function RuntimeRow({
   );
 }
 
-function RowRenameInput({
+function SidebarRowRenameInput({
   initial,
+  placeholder,
+  title,
   mono,
+  dim,
   onSubmit,
   onCancel,
 }: {
   initial: string;
+  placeholder: string;
+  title?: string;
   mono?: boolean;
+  dim?: boolean;
   onSubmit: (next: string) => void;
   onCancel: () => void;
 }) {
@@ -1023,16 +1074,24 @@ function RowRenameInput({
     inputRef.current?.select();
   }, []);
   return (
-    <div className="flex w-full items-center gap-2 rounded border border-line bg-bg px-2.5 py-1 text-xs">
-      <span className="inline-flex h-1.5 w-1.5 shrink-0 rounded-full bg-accent" />
+    <div
+      className="flex w-full items-center gap-2 rounded border border-sidebar-selected-border bg-sidebar-selected px-2.5 py-1.5 text-xs shadow-sm"
+      title={title}
+    >
+      <span
+        className={`inline-flex h-1.5 w-1.5 shrink-0 rounded-full ${
+          dim ? "bg-fg-3" : "bg-accent"
+        }`}
+      />
       <input
         ref={inputRef}
         value={draft}
+        placeholder={placeholder}
         onChange={(e) => setDraft(e.target.value)}
         onKeyDown={(e) => {
           if (e.key === "Enter") {
             e.preventDefault();
-            onSubmit(draft);
+            onSubmit(draft.trim());
           } else if (e.key === "Escape") {
             e.preventDefault();
             onCancel();
@@ -1040,9 +1099,9 @@ function RowRenameInput({
         }}
         onBlur={() => {
           if (draft.trim() === initial.trim()) onCancel();
-          else onSubmit(draft);
+          else onSubmit(draft.trim());
         }}
-        className={`min-w-0 flex-1 bg-transparent text-fg outline-none placeholder:text-fg-3 ${
+        className={`min-w-0 flex-1 bg-transparent text-xs text-fg outline-none placeholder:text-fg-3 ${
           mono ? "font-mono" : ""
         }`}
       />
@@ -1050,11 +1109,9 @@ function RowRenameInput({
   );
 }
 
-// SESSION row: thin wrapper around RuntimeRow that adds (a) a trailing
-// ellipsis button to open the per-row context menu, (b) right-click on
-// the whole row as the same affordance, (c) an inline rename input
-// that swaps in for the label while editing, and (d) a pin glyph for
-// pinned rows. Mirrors the Pencil design `P5CLA` inside `u6woG`.
+// SESSION row: adapter from DirectSessionEntry to the shared sidebar
+// row shell. Keeps chat-specific label and rename-null semantics out
+// of the generic visual component.
 function SessionRow({
   session,
   selected,
@@ -1072,100 +1129,33 @@ function SessionRow({
   onRenameSubmit: (nextTitle: string | null) => void;
   onRenameCancel: () => void;
 }) {
-  const defaultLabel = `@${session.handle} · ${formatStartedAt(session)}`;
+  const defaultLabel = session.handle
+    ? `@${session.handle} · ${formatStartedAt(session)}`
+    : `${session.display_name} · ${formatStartedAt(session)}`;
   const label = session.title ?? defaultLabel;
   const dim = session.status !== "running";
-  const tooltip = `@${session.handle} · ${session.status}${
+  const tooltip = `${session.handle ? `@${session.handle}` : session.display_name} · ${session.status}${
     session.status !== "running" && session.resumable ? " · resumable" : ""
   }${session.pinned ? " · pinned" : ""}`;
 
-  if (renaming) {
-    // Inline rename input: pre-fills with the current label, submits
-    // on Enter, cancels on Escape or blur. Empty input means clear back
-    // to the auto-derived label.
-    return (
-      <div
-        className="flex items-center gap-2 rounded border border-line bg-bg px-2.5 py-1.5"
-        title={tooltip}
-      >
-        <span
-          className={`inline-flex h-1.5 w-1.5 shrink-0 rounded-full ${
-            dim ? "bg-fg-3" : "bg-accent"
-          }`}
-        />
-        <input
-          autoFocus
-          defaultValue={session.title ?? ""}
-          placeholder={defaultLabel}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              const next = (e.target as HTMLInputElement).value.trim();
-              onRenameSubmit(next.length === 0 ? null : next);
-            } else if (e.key === "Escape") {
-              e.preventDefault();
-              onRenameCancel();
-            }
-          }}
-          onBlur={(e) => {
-            const next = e.target.value.trim();
-            const prior = session.title ?? "";
-            if (next === prior.trim()) {
-              onRenameCancel();
-            } else {
-              onRenameSubmit(next.length === 0 ? null : next);
-            }
-          }}
-          className="flex-1 truncate bg-transparent font-mono text-xs text-fg outline-none placeholder:text-fg-3"
-        />
-      </div>
-    );
-  }
-
   return (
-    <div
-      className={`group flex w-full items-center gap-2 rounded border px-2.5 py-1.5 text-left text-xs transition-colors ${
-        selected
-          ? "border-line-strong bg-bg font-semibold text-fg shadow-sm"
-          : "border-transparent text-fg-2 hover:bg-line/40 hover:text-fg"
-      }`}
-      onContextMenu={(e) => {
-        e.preventDefault();
-        onContextMenu({ x: e.clientX, y: e.clientY });
+    <SidebarListRow
+      selected={selected}
+      label={label}
+      onClick={onClick}
+      onContextMenu={onContextMenu}
+      title={tooltip}
+      mono={!!session.handle}
+      dim={dim}
+      pinned={session.pinned}
+      renaming={renaming}
+      renameValue={session.title ?? ""}
+      renamePlaceholder={defaultLabel}
+      onRenameSubmit={(next) => {
+        onRenameSubmit(next.length === 0 ? null : next);
       }}
-    >
-      <button
-        type="button"
-        onClick={onClick}
-        title={tooltip}
-        className="flex min-w-0 flex-1 cursor-pointer items-center gap-2"
-      >
-        <span
-          className={`inline-flex h-1.5 w-1.5 shrink-0 rounded-full ${
-            dim ? "bg-fg-3" : "bg-accent"
-          }`}
-        />
-        {session.pinned ? (
-          <Pin
-            aria-hidden
-            className="h-2.5 w-2.5 shrink-0 -rotate-45 text-fg-3"
-          />
-        ) : null}
-        <span className="truncate font-mono">{label}</span>
-      </button>
-      <button
-        type="button"
-        onClick={(e) => {
-          e.stopPropagation();
-          onContextMenu({ x: e.clientX, y: e.clientY });
-        }}
-        title="More actions"
-        aria-label="More actions"
-        className="cursor-pointer rounded p-0.5 text-fg-3 opacity-0 transition-opacity hover:bg-raised hover:text-fg group-hover:opacity-100 focus:opacity-100"
-      >
-        <MoreHorizontal aria-hidden className="h-3 w-3" />
-      </button>
-    </div>
+      onRenameCancel={onRenameCancel}
+    />
   );
 }
 

--- a/src/components/StartChatModal.tsx
+++ b/src/components/StartChatModal.tsx
@@ -12,19 +12,26 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { ChevronDown, X } from "lucide-react";
 
-import { api } from "../lib/api";
-import { readDefaultWorkingDir } from "../lib/settings";
+import { api, type RuntimeDefinition } from "../lib/api";
+import {
+  readDefaultChatRuntime,
+  readDefaultWorkingDir,
+} from "../lib/settings";
 import type { Runner, SpawnedSession } from "../lib/types";
 import { Button } from "./ui/Button";
 import { Modal } from "./ui/Overlay";
+import { StyledSelect } from "./ui/StyledSelect";
 
 interface StartChatModalProps {
   open: boolean;
   onClose: () => void;
   /** Called after spawn (and rename if title was provided). Caller owns
    *  navigation to the spawned chat URL. */
-  onStarted: (spawned: SpawnedSession, runnerHandle: string) => void;
+  onStarted: (spawned: SpawnedSession) => void;
 }
+
+type ChatMode = "runner" | "runtime";
+const STORAGE_START_CHAT_MODE = "runner.startChat.mode";
 
 export function StartChatModal({
   open,
@@ -32,7 +39,10 @@ export function StartChatModal({
   onStarted,
 }: StartChatModalProps) {
   const [runners, setRunners] = useState<Runner[]>([]);
+  const [runtimes, setRuntimes] = useState<RuntimeDefinition[]>([]);
+  const [mode, setModeState] = useState<ChatMode>(() => readStartChatMode());
   const [runnerId, setRunnerId] = useState<string>("");
+  const [runtimeName, setRuntimeName] = useState<string>("");
   const [runnerPickerOpen, setRunnerPickerOpen] = useState(false);
   const [title, setTitle] = useState("");
   // Tracks whether the user has typed in the title field. While false
@@ -57,8 +67,11 @@ export function StartChatModal({
   useEffect(() => {
     if (open) return;
     setRunners([]);
+    setRuntimes([]);
     setRunnerId("");
+    setRuntimeName("");
     setRunnerPickerOpen(false);
+    setModeState(readStartChatMode());
     setTitle("");
     setTitleEdited(false);
     titleEditedRef.current = false;
@@ -86,7 +99,7 @@ export function StartChatModal({
         // Atomic initial title fill — the ref is the authoritative
         // signal here, since a keystroke during the pre-load window
         // would have flipped it true synchronously.
-        if (first && !titleEditedRef.current) {
+        if (first && mode === "runner" && !titleEditedRef.current) {
           setTitle(defaultTitleFor(first));
         }
       })
@@ -97,7 +110,32 @@ export function StartChatModal({
     return () => {
       cancelled = true;
     };
-  }, [open]);
+  }, [open, mode]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void api.runtime
+      .list()
+      .then((rows) => {
+        if (cancelled) return;
+        const preferred = readDefaultChatRuntime();
+        const selected =
+          rows.find((runtime) => runtime.name === preferred) ?? rows[0] ?? null;
+        setRuntimes(rows);
+        setRuntimeName(selected?.name ?? "");
+        if (selected && !titleEditedRef.current && mode === "runtime") {
+          setTitle(defaultTitleForRuntime(selected));
+        }
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, mode]);
 
   // Inner dropdown's own dismiss handlers. The Modal shell handles
   // Escape/backdrop for the dialog itself; this scopes to the
@@ -124,6 +162,18 @@ export function StartChatModal({
     () => runners.find((r) => r.id === runnerId) ?? null,
     [runners, runnerId],
   );
+  const selectedRuntime = useMemo(
+    () => runtimes.find((runtime) => runtime.name === runtimeName) ?? null,
+    [runtimes, runtimeName],
+  );
+
+  const setMode = (next: ChatMode) => {
+    setModeState(next);
+    writeStartChatMode(next);
+    if (titleEditedRef.current) return;
+    if (next === "runner") setTitle(defaultTitleFor(selectedRunner));
+    else setTitle(defaultTitleForRuntime(selectedRuntime));
+  };
 
   // Follow runner-picker changes: while the user hasn't typed in the
   // title field, re-derive the title from the currently-picked runner.
@@ -133,9 +183,9 @@ export function StartChatModal({
   useEffect(() => {
     if (!open) return;
     if (titleEdited) return;
-    if (!selectedRunner) return;
-    setTitle(defaultTitleFor(selectedRunner));
-  }, [open, selectedRunner, titleEdited]);
+    if (mode === "runner") setTitle(defaultTitleFor(selectedRunner));
+    else setTitle(defaultTitleForRuntime(selectedRuntime));
+  }, [open, mode, selectedRunner, selectedRuntime, titleEdited]);
 
   const browseCwd = async () => {
     try {
@@ -151,7 +201,8 @@ export function StartChatModal({
   };
 
   const start = async () => {
-    if (!selectedRunner) return;
+    if (mode === "runner" && !selectedRunner) return;
+    if (mode === "runtime" && !selectedRuntime) return;
     setSubmitting(true);
     setError(null);
     try {
@@ -165,18 +216,24 @@ export function StartChatModal({
       // what blank-leave will produce, so we don't have to thread a
       // separate "edited" flag for this field.
       const trimmedCwd = cwd.trim();
-      const effectiveCwd =
-        trimmedCwd.length > 0
-          ? trimmedCwd
-          : selectedRunner.working_dir
-            ? null
-            : (readDefaultWorkingDir() || null);
-      const spawned = await api.session.startDirect(
-        selectedRunner.id,
-        effectiveCwd,
-        null,
-        null,
-      );
+      const spawned =
+        mode === "runner" && selectedRunner
+          ? await api.session.startDirect(
+              selectedRunner.id,
+              trimmedCwd.length > 0
+                ? trimmedCwd
+                : selectedRunner.working_dir
+                  ? null
+                  : (readDefaultWorkingDir() || null),
+              null,
+              null,
+            )
+          : await api.session.startRuntime(
+              selectedRuntime!.name,
+              trimmedCwd.length > 0 ? trimmedCwd : (readDefaultWorkingDir() || null),
+              null,
+              null,
+            );
       const trimmedTitle = title.trim();
       if (trimmedTitle.length > 0) {
         try {
@@ -187,7 +244,7 @@ export function StartChatModal({
           console.error("StartChatModal: session_rename failed", e);
         }
       }
-      onStarted(spawned, selectedRunner.handle);
+      onStarted(spawned);
     } catch (e) {
       setError(String(e));
     } finally {
@@ -206,7 +263,7 @@ export function StartChatModal({
               Start a chat
             </span>
             <span className="text-xs font-normal text-fg-2">
-              Spawns a direct PTY with the selected runner.
+              Spawns a direct PTY in the selected directory.
             </span>
           </div>
           <button
@@ -229,7 +286,11 @@ export function StartChatModal({
           <Button
             variant="primary"
             onClick={() => void start()}
-            disabled={submitting || !runnerId || runners.length === 0}
+            disabled={
+              submitting ||
+              (mode === "runner" && (!runnerId || runners.length === 0)) ||
+              (mode === "runtime" && (!runtimeName || runtimes.length === 0))
+            }
           >
             {submitting ? "Starting…" : "Start chat"}
           </Button>
@@ -243,68 +304,101 @@ export function StartChatModal({
           </div>
         ) : null}
 
-        <Field label="Runner">
-          <div ref={runnerPickerRef} className="relative">
+        <div className="grid grid-cols-2 rounded-md border border-line bg-bg p-0.5">
+          {(["runner", "runtime"] as const).map((option) => (
             <button
+              key={option}
               type="button"
-              disabled={submitting || runners.length === 0}
-              onClick={() => setRunnerPickerOpen((v) => !v)}
-              className="flex w-full cursor-pointer items-center gap-3 rounded-md border border-line bg-bg px-3 py-2.5 text-left transition-colors hover:border-line-strong focus:border-fg-3 focus:outline-none disabled:cursor-default disabled:opacity-60"
-              aria-haspopup="listbox"
-              aria-expanded={runnerPickerOpen}
+              role="tab"
+              aria-selected={mode === option}
+              onClick={() => setMode(option)}
+              disabled={submitting}
+              className={`cursor-pointer rounded px-3 py-1.5 text-xs font-medium transition-colors disabled:cursor-default disabled:opacity-60 ${
+                mode === option
+                  ? "bg-raised text-fg"
+                  : "text-fg-2 hover:text-fg"
+              }`}
             >
-              <span className="min-w-0 flex-1">
-                <span className="block truncate font-mono text-[13px] font-semibold text-fg">
-                  {selectedRunner ? `@${selectedRunner.handle}` : "No runners yet"}
-                </span>
-                <span className="block truncate text-[11px] text-fg-2">
-                  {summarizeRunner(selectedRunner)}
-                </span>
-              </span>
-              <ChevronDown aria-hidden className="h-3.5 w-3.5 text-fg-3" />
+              {option === "runner" ? "Runner" : "Direct"}
             </button>
-            {runnerPickerOpen ? (
-              <div
-                role="listbox"
-                className="absolute left-0 right-0 top-full z-30 mt-1 max-h-56 overflow-y-auto rounded-md border border-line bg-panel p-1 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
+          ))}
+        </div>
+
+        {mode === "runner" ? (
+          <Field label="Runner">
+            <div ref={runnerPickerRef} className="relative">
+              <button
+                type="button"
+                disabled={submitting || runners.length === 0}
+                onClick={() => setRunnerPickerOpen((v) => !v)}
+                className="flex w-full cursor-pointer items-center gap-3 rounded-md border border-line bg-bg px-3 py-2.5 text-left transition-colors hover:border-line-strong focus:border-fg-3 focus:outline-none disabled:cursor-default disabled:opacity-60"
+                aria-haspopup="listbox"
+                aria-expanded={runnerPickerOpen}
               >
-                {runners.map((r) => (
-                  <button
-                    key={r.id}
-                    type="button"
-                    role="option"
-                    aria-selected={r.id === runnerId}
-                    onClick={() => {
-                      setRunnerId(r.id);
-                      setRunnerPickerOpen(false);
-                    }}
-                    className={`flex w-full cursor-pointer items-center justify-between gap-3 rounded px-2.5 py-2 text-left transition-colors hover:bg-raised ${
-                      r.id === runnerId ? "bg-raised" : ""
-                    }`}
-                  >
-                    <span className="min-w-0">
-                      <span className="block truncate font-mono text-[13px] font-semibold text-fg">
-                        @{r.handle}
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate font-mono text-[13px] font-semibold text-fg">
+                    {selectedRunner ? `@${selectedRunner.handle}` : "No runners yet"}
+                  </span>
+                  <span className="block truncate text-[11px] text-fg-2">
+                    {summarizeRunner(selectedRunner)}
+                  </span>
+                </span>
+                <ChevronDown aria-hidden className="h-3.5 w-3.5 text-fg-3" />
+              </button>
+              {runnerPickerOpen ? (
+                <div
+                  role="listbox"
+                  className="absolute left-0 right-0 top-full z-30 mt-1 max-h-56 overflow-y-auto rounded-md border border-line bg-panel p-1 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
+                >
+                  {runners.map((r) => (
+                    <button
+                      key={r.id}
+                      type="button"
+                      role="option"
+                      aria-selected={r.id === runnerId}
+                      onClick={() => {
+                        setRunnerId(r.id);
+                        setRunnerPickerOpen(false);
+                      }}
+                      className={`flex w-full cursor-pointer items-center justify-between gap-3 rounded px-2.5 py-2 text-left transition-colors hover:bg-raised ${
+                        r.id === runnerId ? "bg-raised" : ""
+                      }`}
+                    >
+                      <span className="min-w-0">
+                        <span className="block truncate font-mono text-[13px] font-semibold text-fg">
+                          @{r.handle}
+                        </span>
+                        <span className="block truncate text-[11px] text-fg-2">
+                          {summarizeRunner(r)}
+                        </span>
                       </span>
-                      <span className="block truncate text-[11px] text-fg-2">
-                        {summarizeRunner(r)}
-                      </span>
-                    </span>
-                  </button>
-                ))}
-              </div>
+                    </button>
+                  ))}
+                </div>
+              ) : null}
+            </div>
+            {runners.length === 0 ? (
+              <p className="mt-1 text-[11px] text-warn">
+                No runners yet. Create one from the runner page first.
+              </p>
             ) : null}
-          </div>
-          {runners.length === 0 ? (
-            <p className="mt-1 text-[11px] text-warn">
-              No runners yet. Create one from the runner page first.
-            </p>
-          ) : null}
-        </Field>
+          </Field>
+        ) : (
+          <Field label="Agent runtime">
+            <StyledSelect
+              value={runtimeName}
+              options={runtimes.map((runtime) => ({
+                value: runtime.name,
+                label: runtime.display_name,
+              }))}
+              onChange={(next) => setRuntimeName(next)}
+            />
+          </Field>
+        )}
 
         <Field
           label="Chat name"
-          subtitle="Optional. Leave blank to use the runner's default label."
+          subtitle="Optional. Leave blank to use the default label."
         >
           <input
             value={title}
@@ -324,7 +418,11 @@ export function StartChatModal({
             <input
               value={cwd}
               onChange={(e) => setCwd(e.target.value)}
-              placeholder={cwdPlaceholderFor(selectedRunner)}
+              placeholder={
+                mode === "runner"
+                  ? cwdPlaceholderFor(selectedRunner)
+                  : cwdPlaceholderForRuntime()
+              }
               disabled={submitting}
               className="min-w-0 flex-1 rounded-md border border-line bg-bg px-3 py-2 font-mono text-xs text-fg placeholder:text-fg-3 focus:border-fg-3 focus:outline-none"
             />
@@ -333,7 +431,7 @@ export function StartChatModal({
             </Button>
           </div>
           <p className="text-[11px] text-fg-2">
-            Leave blank to use the runner&apos;s working directory.
+            Leave blank to use the default working directory.
           </p>
         </Field>
       </div>
@@ -375,6 +473,11 @@ function defaultTitleFor(runner: Runner | null): string {
   return `Chat with @${runner.handle}`;
 }
 
+function defaultTitleForRuntime(runtime: RuntimeDefinition | null): string {
+  if (!runtime) return "";
+  return `Chat with ${runtime.display_name}`;
+}
+
 // Dynamic placeholder for the working-directory input. Shows what
 // blank-leave will produce: the runner's own working_dir if set,
 // else the global settings default, else a parenthetical hint that
@@ -384,4 +487,28 @@ function cwdPlaceholderFor(runner: Runner | null): string {
   const fallback = readDefaultWorkingDir();
   if (fallback) return fallback;
   return "(no working directory)";
+}
+
+function cwdPlaceholderForRuntime(): string {
+  const fallback = readDefaultWorkingDir();
+  if (fallback) return fallback;
+  return "(no working directory)";
+}
+
+function readStartChatMode(): ChatMode {
+  try {
+    return localStorage.getItem(STORAGE_START_CHAT_MODE) === "runtime"
+      ? "runtime"
+      : "runner";
+  } catch {
+    return "runner";
+  }
+}
+
+function writeStartChatMode(mode: ChatMode): void {
+  try {
+    localStorage.setItem(STORAGE_START_CHAT_MODE, mode);
+  } catch {
+    // best-effort
+  }
 }

--- a/src/components/ui/SessionControl.tsx
+++ b/src/components/ui/SessionControl.tsx
@@ -95,9 +95,8 @@ export function StopButton({
 }
 
 // Back — neutral chrome pill without an icon. Used as the escape
-// hatch for archived rows or non-resumable sessions ("Back to
-// runner"). Same shape as Stop so the buttons align visually when
-// they share a row.
+// hatch for archived rows or routes without a live session target.
+// Same shape as Stop so the buttons align visually when they share a row.
 export function BackButton({
   onClick,
   title,

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,8 @@
      bright bg, since "raised" in light themes is pure white and
      wouldn't read as a sidebar. */
   --color-sidebar: #272930;
+  --color-sidebar-selected: #333640;
+  --color-sidebar-selected-border: #3b3e49;
 
   --color-fg: #dcdce0;
   --color-fg-2: #9a9ba5;
@@ -43,6 +45,8 @@
   --color-line: #e5e5e7;
   --color-line-strong: #d1d1d6;
   --color-sidebar: #f7f7f8;
+  --color-sidebar-selected: #eaeaed;
+  --color-sidebar-selected-border: #d8d8de;
 
   --color-fg: #1a1c1f;
   --color-fg-2: #6e6e73;
@@ -68,6 +72,8 @@
   --color-line: #45475a;
   --color-line-strong: #585b70;
   --color-sidebar: #313244;
+  --color-sidebar-selected: #3b3d52;
+  --color-sidebar-selected-border: #51546b;
 
   --color-fg: #cdd6f4;
   --color-fg-2: #a6adc8;
@@ -96,6 +102,8 @@
   --color-line: #ccd0da;
   --color-line-strong: #bcc0cc;
   --color-sidebar: #e6e9ef;
+  --color-sidebar-selected: #dce0ea;
+  --color-sidebar-selected-border: #c8ccda;
 
   --color-fg: #4c4f69;
   --color-fg-2: #6c6f85;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -51,8 +51,11 @@ export interface SessionRow extends Session {
  */
 export interface DirectSessionEntry {
   session_id: string;
-  runner_id: string;
-  handle: string;
+  runner_id: string | null;
+  handle: string | null;
+  agent_runtime: string;
+  agent_command: string;
+  display_name: string;
   status: "running" | "stopped" | "crashed";
   title: string | null;
   cwd: string | null;
@@ -66,6 +69,12 @@ export interface DirectSessionEntry {
   // to detect an archived direct-URL navigation and lock the
   // workspace read-only.
   archived_at: string | null;
+}
+
+export interface RuntimeDefinition {
+  name: string;
+  display_name: string;
+  command: string;
 }
 
 export const api = {
@@ -106,6 +115,9 @@ export const api = {
     activity: (id: string) => invoke<RunnerActivity>("runner_activity", { id }),
     crews: (runnerId: string) =>
       invoke<CrewMembership[]>("runner_crews_list", { runnerId }),
+  },
+  runtime: {
+    list: () => invoke<RuntimeDefinition[]>("runtime_list"),
   },
   mission: {
     list: (crewId?: string) =>
@@ -192,6 +204,18 @@ export const api = {
     ) =>
       invoke<SpawnedSession>("session_start_direct", {
         runnerId,
+        cwd,
+        cols,
+        rows,
+      }),
+    startRuntime: (
+      runtime: string,
+      cwd: string | null,
+      cols: number | null,
+      rows: number | null,
+    ) =>
+      invoke<SpawnedSession>("session_start_runtime", {
+        runtime,
         cwd,
         cols,
         rows,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -19,6 +19,7 @@ export const STORAGE_TERMINAL_SCROLLBACK = "settings.terminalScrollback";
 // palettes ship in the list for users who explicitly want them.
 export const STORAGE_TERMINAL_THEME = "settings.terminalTheme";
 export const STORAGE_DEFAULT_WORKING_DIR = "settings.defaultWorkingDir";
+export const STORAGE_DEFAULT_CHAT_RUNTIME = "settings.defaultChatRuntime";
 export const STORAGE_APP_THEME = "settings.appTheme";
 export const STORAGE_APP_LIGHT_VARIANT = "settings.appLightVariant";
 export const STORAGE_APP_DARK_VARIANT = "settings.appDarkVariant";
@@ -535,6 +536,24 @@ export function writeDefaultWorkingDir(value: string): void {
     const trimmed = value.trim();
     if (trimmed) localStorage.setItem(STORAGE_DEFAULT_WORKING_DIR, trimmed);
     else localStorage.removeItem(STORAGE_DEFAULT_WORKING_DIR);
+  } catch {
+    // best-effort
+  }
+}
+
+export function readDefaultChatRuntime(): string {
+  try {
+    return (localStorage.getItem(STORAGE_DEFAULT_CHAT_RUNTIME) ?? "").trim();
+  } catch {
+    return "";
+  }
+}
+
+export function writeDefaultChatRuntime(value: string): void {
+  try {
+    const trimmed = value.trim();
+    if (trimmed) localStorage.setItem(STORAGE_DEFAULT_CHAT_RUNTIME, trimmed);
+    else localStorage.removeItem(STORAGE_DEFAULT_CHAT_RUNTIME);
   } catch {
     // best-effort
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -119,7 +119,7 @@ export interface WarningEvent {
 export interface SpawnedSession {
   id: string;
   mission_id: string | null;
-  runner_id: string;
+  runner_id: string | null;
   handle: string;
   pid: number | null;
 }

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -639,17 +639,10 @@ export default function MissionWorkspace() {
     }
   }, [railView]);
 
-  // The mission-load IPC round-trip (mission.get + session.list +
-  // mission.eventsReplay) is fast in the common case but blocks the
-  // `loading` flag, so a naive `loading ? <pill /> : <content />`
-  // branch flashes the cyan "Starting mission…" pill on every click.
-  // Same trick as #179 for direct-chat nav: keep the render gate
-  // (correctness — the rail / tabs / overlays all assume `mission`
-  // is non-null) but delay the *visible* pill until the gate has
-  // been blocking for 150ms. Fast IPC never shows the pill; slow IPC
-  // (cold app start, contended SQLite) still gets user feedback.
-  // Resets per mission id so navigating between missions starts a
-  // fresh delay window.
+  // Keep a render gate while mission/session/event data loads: the
+  // tabs/feed/rail below assume `mission` is non-null. Show only a
+  // neutral delayed loading pill here; route switching is not a start
+  // or resume action.
   const isLoading = loading || !mission;
   const showLoadingPill = useDelayedFlag(isLoading, 150, id);
 
@@ -832,14 +825,11 @@ export default function MissionWorkspace() {
       ) : null}
 
       {isLoading ? (
-        // Gate is kept (the tabs/feed/rail below assume `mission` is
-        // non-null) but the visible pill only renders after 150ms of
-        // continuous loading — see `useDelayedFlag` above. Same visual
-        // vocabulary as the resume transition so every "session is
-        // coming up" moment reads consistently.
         showLoadingPill ? (
-          <StartingOverlay label="Starting mission…" inline />
-        ) : null
+          <StartingOverlay label="Loading mission…" inline />
+        ) : (
+          <div className="flex flex-1 min-h-0" />
+        )
       ) : (
         <div className="flex flex-1 min-h-0 flex-col">
           <div className="flex h-[38px] items-end gap-1 border-b border-line bg-panel px-6">

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -580,7 +580,7 @@ export default function RunnerChat() {
       attach(
         sessionId,
         chatMeta.handle ? `@${chatMeta.handle}` : chatMeta.display_name,
-        state?.sessionStatus ?? "stopped",
+        state?.sessionStatus ?? chatMeta.status,
         isFreshSpawn(chatMeta?.started_at),
       );
     }

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -1,4 +1,4 @@
-// Direct-chat pane (C8.5) — `/runners/:handle/chat`.
+// Direct-chat pane (C8.5) — `/chats/:sessionId`.
 //
 // One-on-one PTY between the human and the runner's CLI. No mission, no
 // orchestrator, no event bus. Each direct session gets its own mounted
@@ -66,7 +66,7 @@ interface ExitEvent {
 // Removing in-effect spawning was the cleanest fix for the StrictMode
 // double-mount race that left two visible sessions per click.
 //
-// The session id rides on the URL itself (`/runners/:handle/chat/:sessionId`),
+// The session id rides on the URL itself (`/chats/:sessionId`),
 // so refresh / back-forward / paste all attach to the right chat.
 // `location.state.sessionStatus` is an optional optimistic seed that
 // avoids a one-tick "running" flicker when the originating row is
@@ -87,14 +87,13 @@ const PANEL_DEFAULT = 320;
 
 interface DirectSessionPane {
   id: string;
-  handle: string;
+  label: string;
   status: SessionStatus;
   exitCode: number | null;
 }
 
 export default function RunnerChat() {
-  const { handle, sessionId: sessionIdParam } = useParams<{
-    handle: string;
+  const { sessionId: sessionIdParam } = useParams<{
     sessionId: string;
   }>();
   const location = useLocation();
@@ -171,14 +170,16 @@ export default function RunnerChat() {
   // because SIGKILL bubbles up as a non-zero exit.
   const killedSessionsRef = useRef<Set<string>>(new Set());
   // Last route/session request this component attached for. React
-  // Router reuses RunnerChat when moving between
-  // `/runners/:handle/chat/:sessionId` routes, so this must be keyed
-  // by the URL params instead of a one-shot boolean.
+  // Router reuses RunnerChat when moving between `/chats/:sessionId`
+  // routes, so this must be keyed by the URL param instead of a
+  // one-shot boolean.
   const startedKeyRef = useRef<string | null>(null);
 
   const activeSession = directSessions.find((s) => s.id === sessionId) ?? null;
   const status = activeSession?.status ?? "running";
   const exitCode = activeSession?.exitCode ?? null;
+  const backTarget = chatMeta?.handle ? `/runners/${chatMeta.handle}` : "/runners";
+  const backLabel = chatMeta?.handle ? "Back to runner" : "Back to runners";
   // Archived rows can be reached by direct URL but render read-only.
   // We don't attach a PTY, mount RunnerTerminal, or expose Resume /
   // End / Archive — the row is terminal and the operator can only
@@ -205,7 +206,7 @@ export default function RunnerChat() {
         s.id === next.id
           ? {
               ...s,
-              handle: next.handle,
+              label: next.label,
               status: next.status,
               exitCode: next.exitCode,
             }
@@ -217,14 +218,14 @@ export default function RunnerChat() {
   const attach = useCallback(
     (
       id: string,
-      sessionHandle: string,
+      label: string,
       status: SessionStatus = "running",
       freshSpawn = false,
     ) => {
       setErr(null);
       upsertSession({
         id,
-        handle: sessionHandle,
+        label,
         status,
         exitCode: null,
       });
@@ -253,17 +254,16 @@ export default function RunnerChat() {
     );
   }, []);
 
-  // Pull the runner config so the header can show the runtime
-  // (`claude-code`, `codex`, …) next to the @handle. One-shot per
-  // handle change.
+  // Pull runner config only for runner-backed chats. Runtime-only
+  // chats render from chatMeta.agent_* instead.
   useEffect(() => {
-    if (!handle) {
+    if (!chatMeta?.runner_id) {
       setRunner(null);
       return;
     }
     let cancelled = false;
     void api.runner
-      .getByHandle(handle)
+      .get(chatMeta.runner_id)
       .then((r) => {
         if (!cancelled) setRunner(r);
       })
@@ -273,7 +273,7 @@ export default function RunnerChat() {
     return () => {
       cancelled = true;
     };
-  }, [handle]);
+  }, [chatMeta?.runner_id]);
 
   // Pull this chat's metadata (started_at, cwd, title) for the header.
   // Refetched on session/exit so status changes flip the pill.
@@ -557,7 +557,7 @@ export default function RunnerChat() {
   // navigate here with the URL-encoded `sessionId`, so this effect only
   // ever runs the deterministic attach path.
   useEffect(() => {
-    const requestKey = [handle ?? "", sessionId ?? ""].join(" ");
+    const requestKey = sessionId ?? "";
     if (startedKeyRef.current === requestKey) return;
     // Wait for chatMeta to resolve before attaching. Without this
     // gate, the brief window between mount and the first
@@ -571,7 +571,7 @@ export default function RunnerChat() {
     // Skip attach for archived rows: the workspace renders read-only,
     // so mounting RunnerTerminal would spawn a PTY listener for a row
     // that's terminal by definition.
-    if (sessionId && handle && !isArchived) {
+    if (sessionId && chatMeta && !isArchived) {
       // `freshSpawn` is the only signal that distinguishes "user just
       // clicked Chat now and we're navigating into the spawn" from
       // "user clicked an existing chat row in the sidebar." We key
@@ -579,23 +579,23 @@ export default function RunnerChat() {
       // pill only fires on rows whose PTY was born seconds ago.
       attach(
         sessionId,
-        handle,
+        chatMeta.handle ? `@${chatMeta.handle}` : chatMeta.display_name,
         state?.sessionStatus ?? "stopped",
         isFreshSpawn(chatMeta?.started_at),
       );
     }
   }, [
     attach,
-    handle,
     sessionId,
     state?.sessionStatus,
     isArchived,
     metaLoaded,
+    chatMeta,
     chatMeta?.started_at,
   ]);
 
   async function endChat() {
-    if (!sessionId || !handle) return;
+    if (!sessionId) return;
     const targetId = sessionId;
     killedSessionsRef.current.add(targetId);
     try {
@@ -633,7 +633,7 @@ export default function RunnerChat() {
   //      `resuming` flag waits for chatMeta.status to confirm the
   //      DB-backed truth (the sync effect drives that).
   async function resumeChat() {
-    if (!sessionId || !handle) return;
+    if (!sessionId) return;
     const targetId = sessionId;
     setResuming(true);
     setErr(null);
@@ -679,7 +679,9 @@ export default function RunnerChat() {
   // still owns the inline-rename affordance for power users.
   const renameChatPrompt = useCallback(async () => {
     if (!sessionId) return;
-    const current = chatMeta?.title ?? (handle ? `@${handle}` : "");
+    const current =
+      chatMeta?.title ??
+      (chatMeta?.handle ? `@${chatMeta.handle}` : (chatMeta?.display_name ?? ""));
     const next = window.prompt("Rename chat", current);
     if (next === null) return; // cancelled
     const trimmed = next.trim();
@@ -690,32 +692,38 @@ export default function RunnerChat() {
     } catch (e) {
       setErr(String(e));
     }
-  }, [sessionId, chatMeta, handle, refreshChatMeta]);
+  }, [sessionId, chatMeta, refreshChatMeta]);
 
   // Archive: hide this chat from the sidebar's SESSION tray. The row
   // stays in the DB so a future Archived workspace surface can list
   // it, but it's gone from the live tray. We navigate back to the
-  // runner detail since this chat surface no longer maps to anything
-  // discoverable. Mirrors `Sidebar.archiveSession`: the backend
+  // appropriate parent surface. Mirrors `Sidebar.archiveSession`: the backend
   // refuses to archive a running row (`commands::session::session_archive`
   // → "kill before archiving"), so kill first when the row is live.
   async function archiveChat() {
-    if (!sessionId || !handle) return;
+    if (!sessionId) return;
     const targetId = sessionId;
-    const targetHandle = handle;
-    const wasRunning = chatMeta?.status === "running";
+    const effectiveStatus = activeSession?.status ?? chatMeta?.status;
     markArchivingSession(targetId);
     try {
-      if (wasRunning) {
+      if (effectiveStatus === "running") {
         // Mark the kill as user-initiated so the exit handler reads it
         // as "stopped" rather than "crashed" (matches endChat's
         // pattern). Without this the sidebar would briefly show a
         // crashed row before the archive RPC removes it.
         killedSessionsRef.current.add(targetId);
-        await api.session.kill(targetId);
+        try {
+          await api.session.kill(targetId);
+        } catch (e) {
+          // The terminal exit event can beat the SQLite metadata
+          // refresh. If the process is already gone, archive can
+          // still succeed; if it is truly running, the backend
+          // archive call below remains the guardrail.
+          console.warn("RunnerChat: session_kill before archive failed", e);
+        }
       }
       await api.session.archive(targetId);
-      navigate(`/runners/${targetHandle}`);
+      navigate(backTarget);
     } catch (e) {
       setErr(String(e));
     } finally {
@@ -759,13 +767,20 @@ export default function RunnerChat() {
           : "bg-fg-3";
   const statusLabel = chatState === "resuming" ? "resuming…" : status;
   const titleLabel =
-    chatMeta?.title ?? (handle ? `@${handle}` : "chat");
+    chatMeta?.title ??
+    (chatMeta?.handle
+      ? `@${chatMeta.handle}`
+      : (chatMeta?.display_name ?? "chat"));
   // Padding wrapper around the xterm canvas tracks the current
   // terminal palette's background so the canvas + frame stay
   // seamless across theme switches.
   const terminalBg = useTerminalBg();
   const metaParts = [
-    runner ? `${runner.runtime}-${runner.handle}` : null,
+    chatMeta
+      ? chatMeta.handle
+        ? `${chatMeta.agent_runtime}-${chatMeta.handle}`
+        : chatMeta.agent_runtime
+      : null,
     chatMeta?.started_at
       ? `started ${formatRelative(chatMeta.started_at)}`
       : null,
@@ -844,24 +859,24 @@ export default function RunnerChat() {
           {isArchived ? (
             // Archived rows are terminal: no Resume / Stop / Archive.
             // Only surface the navigation escape hatch.
-            <BackButton onClick={() => navigate(`/runners/${handle}`)} />
+            <BackButton onClick={() => navigate(backTarget)}>{backLabel}</BackButton>
           ) : chatState === "resuming" ? (
             <ResumingButton />
           ) : chatState === "running" && sessionId ? (
             <StopButton onClick={() => void endChat()} />
-          ) : sessionId && (chatMeta?.resumable ?? true) ? (
-            // Stopped/crashed with a resumable row → Resume, matching
+          ) : sessionId ? (
+            // Stopped/crashed → Resume, matching
             // Pencil node `HLXK6` in `vS5ce`. Same action the inline
             // SessionEndedOverlay card fires; mirroring it in the
             // topbar lets the user recover without scrolling to the
-            // bottom of the feed. `chatMeta?.resumable` falls back to
-            // true while the row is still loading so we don't briefly
-            // misrender as "Back to runner."
+            // bottom of the feed. If `agent_session_key` is missing,
+            // the backend resume path starts a fresh agent process
+            // for the same row; the overlay subtitle explains that
+            // history is unavailable.
             <ResumeButton onClick={() => void resumeChat()} />
           ) : (
-            // Last-resort fallback: no session yet, or the row is
-            // genuinely non-resumable (no agent_session_key on file).
-            <BackButton onClick={() => navigate(`/runners/${handle}`)} />
+            // Last-resort fallback: no session yet.
+            <BackButton onClick={() => navigate(backTarget)}>{backLabel}</BackButton>
           )}
           {/* Topbar overflow menu — Pin / Rename / Archive, matching
               the design's `session_ctx_menu` (`P5CLA` / `L31Zb`) and
@@ -1001,7 +1016,7 @@ export default function RunnerChat() {
                     else terminalsRef.current.delete(s.id);
                   }}
                   sessionId={s.id}
-                  runnerRuntime={runner?.runtime ?? ""}
+                  runnerRuntime={chatMeta?.agent_runtime ?? runner?.runtime ?? ""}
                   // While the loader is up the canvas is hidden, so
                   // we want xterm to behave as inactive (no resize
                   // pushes, no focus). When `resuming`/`starting`
@@ -1054,6 +1069,7 @@ export default function RunnerChat() {
       </div>
       <RunnerSidePanel
         runner={runner}
+        chatMeta={chatMeta}
         open={panelOpen}
         onClose={() => setPanelOpen(false)}
       />
@@ -1077,10 +1093,12 @@ export default function RunnerChat() {
 // left sidebar's right-edge handle.
 function RunnerSidePanel({
   runner,
+  chatMeta,
   open,
   onClose,
 }: {
   runner: Runner | null;
+  chatMeta: DirectSessionEntry | null;
   open: boolean;
   onClose: () => void;
 }) {
@@ -1174,8 +1192,39 @@ function RunnerSidePanel({
                 </section>
               ) : null}
             </>
+          ) : chatMeta ? (
+            <section className="flex flex-col gap-2.5">
+              <span className="text-[10px] font-semibold uppercase tracking-[0.15em] text-fg-3">
+                Runtime
+              </span>
+              <div className="flex flex-col gap-2.5 rounded-lg border border-line-strong bg-bg p-3.5">
+                <div className="flex items-center gap-2">
+                  <span className="text-[14px] font-semibold text-fg">
+                    {chatMeta.display_name}
+                  </span>
+                  <span className="rounded bg-line-strong px-1.5 py-px text-[9px] font-bold uppercase tracking-[0.5px] text-fg-2">
+                    {chatMeta.agent_runtime}
+                  </span>
+                </div>
+                <div className="h-px w-full bg-line" />
+                <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-[11px]">
+                  <dt className="text-fg-3">cmd</dt>
+                  <dd className="break-all font-mono text-fg-2">
+                    {chatMeta.agent_command}
+                  </dd>
+                  {chatMeta.cwd ? (
+                    <>
+                      <dt className="text-fg-3">cwd</dt>
+                      <dd className="break-all font-mono text-fg-2">
+                        {chatMeta.cwd}
+                      </dd>
+                    </>
+                  ) : null}
+                </dl>
+              </div>
+            </section>
           ) : (
-            <p className="text-xs text-fg-3">Loading runner…</p>
+            <p className="text-xs text-fg-3">Loading chat…</p>
           )}
         </div>
       </div>

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -580,7 +580,7 @@ export default function RunnerChat() {
       attach(
         sessionId,
         chatMeta.handle ? `@${chatMeta.handle}` : chatMeta.display_name,
-        state?.sessionStatus ?? chatMeta.status,
+        chatMeta.status,
         isFreshSpawn(chatMeta?.started_at),
       );
     }

--- a/src/pages/RunnerDetail.tsx
+++ b/src/pages/RunnerDetail.tsx
@@ -106,7 +106,7 @@ export default function RunnerDetail() {
         null,
         null,
       );
-      navigate(`/runners/${runner.handle}/chat/${spawned.id}`, {
+      navigate(`/chats/${spawned.id}`, {
         state: { sessionStatus: "running" },
       });
     } catch (e) {

--- a/src/pages/Runners.tsx
+++ b/src/pages/Runners.tsx
@@ -105,7 +105,7 @@ export default function Runners() {
         null,
         null,
       );
-      navigate(`/runners/${item.handle}/chat/${spawned.id}`, {
+      navigate(`/chats/${spawned.id}`, {
         state: { sessionStatus: "running" },
       });
     } catch (e) {


### PR DESCRIPTION
Summary
- Add direct runtime chat sessions persisted with agent runtime and command metadata.
- Add the direct/runtime chat picker plus Chat settings for default runtime args.
- Wire direct chat resume/archive/sidebar flows and clean up sidebar selection/loading states.

Closes #195

Validation
- pnpm exec tsc --noEmit
- pnpm run lint
- cargo check
- cargo test --workspace
- cargo fmt --check
- git diff --check