### PR TITLE
feat(mcp): add CRUD tools

### DIFF
--- a/src-tauri/src/commands/crew.rs
+++ b/src-tauri/src/commands/crew.rs
@@ -7,6 +7,7 @@
 
 use chrono::Utc;
 use rusqlite::{params, Connection, OptionalExtension, Row};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 use ulid::Ulid as UlidGen;
@@ -17,7 +18,7 @@ use crate::{
     AppState,
 };
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 pub struct CreateCrewInput {
     pub name: String,
     pub purpose: Option<String>,
@@ -29,7 +30,7 @@ pub struct CreateCrewInput {
     pub system_prompt_addendum: Option<String>,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 pub struct UpdateCrewInput {
     pub name: Option<String>,
     pub purpose: Option<Option<String>>,

--- a/src-tauri/src/commands/runner.rs
+++ b/src-tauri/src/commands/runner.rs
@@ -13,6 +13,7 @@ use std::collections::HashMap;
 
 use chrono::Utc;
 use rusqlite::{params, Connection, OptionalExtension, Row};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 use ulid::Ulid as UlidGen;
@@ -23,7 +24,7 @@ use crate::{
     AppState,
 };
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct CreateRunnerInput {
     pub handle: String,
     pub display_name: String,
@@ -66,7 +67,7 @@ pub(crate) fn default_permission_mode() -> crate::router::runtime::PermissionMod
 // Users who want a different handle delete the runner and create a
 // new one. (Per-slot in-crew identity lives on `slots.slot_handle`
 // and is renameable.)
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 pub struct UpdateRunnerInput {
     pub display_name: Option<String>,
     pub runtime: Option<String>,

--- a/src-tauri/src/commands/slot.rs
+++ b/src-tauri/src/commands/slot.rs
@@ -20,6 +20,7 @@
 
 use chrono::Utc;
 use rusqlite::{params, Connection, OptionalExtension};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tauri::State;
 use ulid::Ulid as UlidGen;
@@ -46,7 +47,7 @@ pub struct CrewMembership {
     pub added_at: Timestamp,
 }
 
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 pub struct UpdateSlotInput {
     pub slot_handle: Option<String>,
 }
@@ -440,7 +441,7 @@ pub async fn runner_crews_list(
     list_crews_for_runner(&conn, &runner_id)
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct CreateSlotInput {
     pub crew_id: String,
     pub runner_id: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -184,6 +184,7 @@ pub fn run() {
             let mcp_handle = Arc::new(mcp::McpHandle::new());
             let mcp_state = mcp::state::McpState {
                 db: Arc::clone(&pool),
+                sessions: Arc::clone(&sessions),
                 app_handle: app.handle().clone(),
             };
             if let Err(e) = mcp_handle.start(&app_data_dir.join("mcp.sock"), mcp_state) {

--- a/src-tauri/src/mcp/mod.rs
+++ b/src-tauri/src/mcp/mod.rs
@@ -2,6 +2,7 @@ mod server;
 pub(crate) mod state;
 pub(crate) mod tools;
 
+use std::os::unix::net::UnixListener as StdUnixListener;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -34,15 +35,7 @@ impl McpHandle {
             return Ok(());
         }
 
-        // Remove stale socket from a prior crash.
-        let _ = std::fs::remove_file(socket_path);
-
-        let listener = UnixListener::bind(socket_path).map_err(|e| {
-            crate::error::Error::msg(format!(
-                "mcp: failed to bind {}: {e}",
-                socket_path.display()
-            ))
-        })?;
+        let listener = bind_listener(socket_path)?;
         log::info!("mcp: listening on {}", socket_path.display());
 
         let cancel = CancellationToken::new();
@@ -50,6 +43,14 @@ impl McpHandle {
         let socket_path_owned = socket_path.to_path_buf();
 
         let handle = tauri::async_runtime::spawn(async move {
+            let listener = match UnixListener::from_std(listener) {
+                Ok(listener) => listener,
+                Err(e) => {
+                    log::error!("mcp: failed to attach listener to tokio runtime: {e}");
+                    return;
+                }
+            };
+
             loop {
                 tokio::select! {
                     result = listener.accept() => {
@@ -92,5 +93,43 @@ impl McpHandle {
     pub(crate) fn socket_path(&self) -> Option<PathBuf> {
         let guard = self.inner.lock().unwrap();
         guard.as_ref().map(|r| r.socket_path.clone())
+    }
+}
+
+fn bind_listener(socket_path: &Path) -> crate::error::Result<StdUnixListener> {
+    // Remove stale socket from a prior crash.
+    let _ = std::fs::remove_file(socket_path);
+
+    let listener = StdUnixListener::bind(socket_path).map_err(|e| {
+        crate::error::Error::msg(format!(
+            "mcp: failed to bind {}: {e}",
+            socket_path.display()
+        ))
+    })?;
+    listener.set_nonblocking(true).map_err(|e| {
+        crate::error::Error::msg(format!(
+            "mcp: failed to set {} nonblocking: {e}",
+            socket_path.display()
+        ))
+    })?;
+    Ok(listener)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::ErrorKind;
+
+    use super::*;
+
+    #[test]
+    fn bind_listener_does_not_require_tokio_reactor() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_path = dir.path().join("mcp.sock");
+
+        let listener = bind_listener(&socket_path).unwrap();
+
+        assert!(socket_path.exists());
+        let err = listener.accept().expect_err("empty nonblocking listener");
+        assert_eq!(err.kind(), ErrorKind::WouldBlock);
     }
 }

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -18,7 +18,11 @@ impl RunnerMcpHandler {
     }
 
     pub(crate) fn tool_router() -> ToolRouter<Self> {
-        ToolRouter::new()
+        let mut r = ToolRouter::new();
+        r.merge(Self::crew_router());
+        r.merge(Self::runner_router());
+        r.merge(Self::slot_router());
+        r
     }
 }
 
@@ -50,5 +54,43 @@ pub(crate) async fn serve_connection(stream: tokio::net::UnixStream, state: McpS
         Err(e) => {
             log::warn!("mcp: session handshake failed: {e}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_router_registers_phase_2_crud_tools() {
+        let router = RunnerMcpHandler::tool_router();
+        let names: std::collections::BTreeSet<_> = router
+            .list_all()
+            .into_iter()
+            .map(|tool| tool.name.to_string())
+            .collect();
+        let expected: std::collections::BTreeSet<_> = [
+            "crew_list",
+            "crew_get",
+            "crew_create",
+            "crew_update",
+            "crew_delete",
+            "runner_list",
+            "runner_get",
+            "runner_get_by_handle",
+            "runner_create",
+            "runner_update",
+            "runner_delete",
+            "slot_list",
+            "slot_create",
+            "slot_update",
+            "slot_delete",
+            "slot_set_lead",
+            "slot_reorder",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        assert_eq!(names, expected, "MCP tool registry diverged from Phase 2");
     }
 }

--- a/src-tauri/src/mcp/state.rs
+++ b/src-tauri/src/mcp/state.rs
@@ -2,11 +2,11 @@ use std::sync::Arc;
 
 use tauri::AppHandle;
 
-use crate::db::DbPool;
+use crate::{db::DbPool, session::SessionManager};
 
 #[derive(Clone)]
-#[allow(dead_code)] // fields read by Phase 2 tool methods
 pub(crate) struct McpState {
     pub db: Arc<DbPool>,
+    pub sessions: Arc<SessionManager>,
     pub app_handle: AppHandle,
 }

--- a/src-tauri/src/mcp/tools/crew.rs
+++ b/src-tauri/src/mcp/tools/crew.rs
@@ -23,7 +23,7 @@ pub struct UpdateCrewArgs {
     pub input: crew::UpdateCrewInput,
 }
 
-fn running_mission_session_ids_for_crew(
+fn unarchived_mission_session_ids_for_crew(
     conn: &Connection,
     crew_id: &str,
 ) -> rusqlite::Result<Vec<String>> {
@@ -32,7 +32,6 @@ fn running_mission_session_ids_for_crew(
            FROM missions m
            JOIN sessions s ON s.mission_id = m.id
           WHERE m.crew_id = ?1
-            AND s.status = 'running'
             AND s.archived_at IS NULL
           ORDER BY m.started_at ASC",
     )?;
@@ -113,13 +112,13 @@ impl RunnerMcpHandler {
             .db
             .get()
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
-        let running_missions = running_mission_session_ids_for_crew(&conn, &id)
+        let affected_missions = unarchived_mission_session_ids_for_crew(&conn, &id)
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
-        if !running_missions.is_empty() {
+        if !affected_missions.is_empty() {
             return Err(ErrorData::invalid_request(
                 format!(
-                    "crew {id} has running mission sessions; stop or archive missions first: {}",
-                    running_missions.join(", ")
+                    "crew {id} has unarchived mission sessions; archive those sessions first: {}",
+                    affected_missions.join(", ")
                 ),
                 None,
             ));
@@ -139,7 +138,7 @@ mod tests {
     use crate::db;
 
     #[test]
-    fn running_mission_session_ids_for_crew_only_returns_live_sessions() {
+    fn unarchived_mission_session_ids_for_crew_blocks_stopped_and_running_sessions() {
         let pool = db::open_in_memory().unwrap();
         let conn = pool.get().unwrap();
         let now = "2026-06-19T00:00:00Z";
@@ -164,6 +163,7 @@ mod tests {
         for (mission_id, crew_id) in [
             ("mission-live", "crew-live"),
             ("mission-stopped", "crew-live"),
+            ("mission-archived-session", "crew-live"),
             ("mission-other", "crew-other"),
         ] {
             conn.execute(
@@ -186,13 +186,22 @@ mod tests {
         )
         .unwrap();
         conn.execute(
+            "INSERT INTO sessions (id, mission_id, runner_id, status, started_at, archived_at)
+             VALUES ('session-archived', 'mission-archived-session', 'runner-1', 'stopped', ?1, ?1)",
+            params![now],
+        )
+        .unwrap();
+        conn.execute(
             "INSERT INTO sessions (id, mission_id, runner_id, status, started_at)
              VALUES ('session-other', 'mission-other', 'runner-1', 'running', ?1)",
             params![now],
         )
         .unwrap();
 
-        let ids = running_mission_session_ids_for_crew(&conn, "crew-live").unwrap();
-        assert_eq!(ids, vec!["mission-live".to_string()]);
+        let ids = unarchived_mission_session_ids_for_crew(&conn, "crew-live").unwrap();
+        assert_eq!(
+            ids,
+            vec!["mission-live".to_string(), "mission-stopped".to_string()]
+        );
     }
 }

--- a/src-tauri/src/mcp/tools/crew.rs
+++ b/src-tauri/src/mcp/tools/crew.rs
@@ -1,0 +1,103 @@
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{tool, tool_router, ErrorData};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tauri::Emitter;
+
+use crate::commands::crew;
+use crate::mcp::server::RunnerMcpHandler;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct CrewIdArgs {
+    /// Crew ID.
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateCrewArgs {
+    /// Crew ID.
+    pub id: String,
+    /// Fields to update. Omitted fields are preserved.
+    pub input: crew::UpdateCrewInput,
+}
+
+#[tool_router(router = crew_router, vis = "pub(crate)")]
+impl RunnerMcpHandler {
+    #[tool(description = "List all crews, including runner counts and member previews.")]
+    pub async fn crew_list(&self) -> Result<CallToolResult, ErrorData> {
+        let conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let crews =
+            crew::list(&conn).map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::json(&crews)?]))
+    }
+
+    #[tool(description = "Get a crew by ID.")]
+    pub async fn crew_get(
+        &self,
+        Parameters(CrewIdArgs { id }): Parameters<CrewIdArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let crew =
+            crew::get(&conn, &id).map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::json(&crew)?]))
+    }
+
+    #[tool(description = "Create a new crew.")]
+    pub async fn crew_create(
+        &self,
+        Parameters(input): Parameters<crew::CreateCrewInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let crew = crew::create(&conn, input)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        self.state.app_handle.emit("crew/changed", ()).ok();
+        Ok(CallToolResult::success(vec![Content::json(&crew)?]))
+    }
+
+    #[tool(description = "Update a crew by ID. Omitted fields are preserved.")]
+    pub async fn crew_update(
+        &self,
+        Parameters(UpdateCrewArgs { id, input }): Parameters<UpdateCrewArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let crew = crew::update(&conn, &id, input)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        self.state.app_handle.emit("crew/changed", ()).ok();
+        Ok(CallToolResult::success(vec![Content::json(&crew)?]))
+    }
+
+    #[tool(description = "Delete a crew by ID. Slot rows are removed; runner templates are kept.")]
+    pub async fn crew_delete(
+        &self,
+        Parameters(CrewIdArgs { id }): Parameters<CrewIdArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        crew::delete(&conn, &id).map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        self.state.app_handle.emit("crew/changed", ()).ok();
+        self.state.app_handle.emit("slot/changed", ()).ok();
+        Ok(CallToolResult::success(vec![Content::json(
+            &serde_json::json!({ "deleted": true, "id": id }),
+        )?]))
+    }
+}

--- a/src-tauri/src/mcp/tools/crew.rs
+++ b/src-tauri/src/mcp/tools/crew.rs
@@ -1,6 +1,7 @@
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, Content};
 use rmcp::{tool, tool_router, ErrorData};
+use rusqlite::{params, Connection};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tauri::Emitter;
@@ -20,6 +21,25 @@ pub struct UpdateCrewArgs {
     pub id: String,
     /// Fields to update. Omitted fields are preserved.
     pub input: crew::UpdateCrewInput,
+}
+
+fn running_mission_session_ids_for_crew(
+    conn: &Connection,
+    crew_id: &str,
+) -> rusqlite::Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT DISTINCT m.id
+           FROM missions m
+           JOIN sessions s ON s.mission_id = m.id
+          WHERE m.crew_id = ?1
+            AND s.status = 'running'
+            AND s.archived_at IS NULL
+          ORDER BY m.started_at ASC",
+    )?;
+    let ids = stmt
+        .query_map(params![crew_id], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(ids)
 }
 
 #[tool_router(router = crew_router, vis = "pub(crate)")]
@@ -93,11 +113,86 @@ impl RunnerMcpHandler {
             .db
             .get()
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let running_missions = running_mission_session_ids_for_crew(&conn, &id)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        if !running_missions.is_empty() {
+            return Err(ErrorData::invalid_request(
+                format!(
+                    "crew {id} has running mission sessions; stop or archive missions first: {}",
+                    running_missions.join(", ")
+                ),
+                None,
+            ));
+        }
         crew::delete(&conn, &id).map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
         self.state.app_handle.emit("crew/changed", ()).ok();
         self.state.app_handle.emit("slot/changed", ()).ok();
         Ok(CallToolResult::success(vec![Content::json(
             &serde_json::json!({ "deleted": true, "id": id }),
         )?]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+
+    #[test]
+    fn running_mission_session_ids_for_crew_only_returns_live_sessions() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let now = "2026-06-19T00:00:00Z";
+        conn.execute(
+            "INSERT INTO crews (id, name, created_at, updated_at)
+             VALUES ('crew-live', 'Live', ?1, ?1)",
+            params![now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO crews (id, name, created_at, updated_at)
+             VALUES ('crew-other', 'Other', ?1, ?1)",
+            params![now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO runners (id, handle, display_name, runtime, command, created_at, updated_at)
+             VALUES ('runner-1', 'runner1', 'Runner 1', 'shell', 'sh', ?1, ?1)",
+            params![now],
+        )
+        .unwrap();
+        for (mission_id, crew_id) in [
+            ("mission-live", "crew-live"),
+            ("mission-stopped", "crew-live"),
+            ("mission-other", "crew-other"),
+        ] {
+            conn.execute(
+                "INSERT INTO missions (id, crew_id, title, status, started_at)
+                 VALUES (?1, ?2, ?1, 'running', ?3)",
+                params![mission_id, crew_id, now],
+            )
+            .unwrap();
+        }
+        conn.execute(
+            "INSERT INTO sessions (id, mission_id, runner_id, status, started_at)
+             VALUES ('session-live', 'mission-live', 'runner-1', 'running', ?1)",
+            params![now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions (id, mission_id, runner_id, status, started_at)
+             VALUES ('session-stopped', 'mission-stopped', 'runner-1', 'stopped', ?1)",
+            params![now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions (id, mission_id, runner_id, status, started_at)
+             VALUES ('session-other', 'mission-other', 'runner-1', 'running', ?1)",
+            params![now],
+        )
+        .unwrap();
+
+        let ids = running_mission_session_ids_for_crew(&conn, "crew-live").unwrap();
+        assert_eq!(ids, vec!["mission-live".to_string()]);
     }
 }

--- a/src-tauri/src/mcp/tools/mod.rs
+++ b/src-tauri/src/mcp/tools/mod.rs
@@ -1,4 +1,3 @@
-// Tool modules land in Phase 2:
-// pub(crate) mod crew;
-// pub(crate) mod runner;
-// pub(crate) mod slot;
+pub(crate) mod crew;
+pub(crate) mod runner;
+pub(crate) mod slot;

--- a/src-tauri/src/mcp/tools/runner.rs
+++ b/src-tauri/src/mcp/tools/runner.rs
@@ -1,0 +1,131 @@
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{tool, tool_router, ErrorData};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tauri::Emitter;
+
+use crate::commands::runner;
+use crate::mcp::server::RunnerMcpHandler;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RunnerIdArgs {
+    /// Runner ID.
+    pub id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct RunnerHandleArgs {
+    /// Runner handle without the leading @.
+    pub handle: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateRunnerArgs {
+    /// Runner ID.
+    pub id: String,
+    /// Fields to update. Omitted fields are preserved.
+    pub input: runner::UpdateRunnerInput,
+}
+
+#[tool_router(router = runner_router, vis = "pub(crate)")]
+impl RunnerMcpHandler {
+    #[tool(description = "List all runner templates.")]
+    pub async fn runner_list(&self) -> Result<CallToolResult, ErrorData> {
+        let conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let runners =
+            runner::list(&conn).map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::json(&runners)?]))
+    }
+
+    #[tool(description = "Get a runner template by ID.")]
+    pub async fn runner_get(
+        &self,
+        Parameters(RunnerIdArgs { id }): Parameters<RunnerIdArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let runner =
+            runner::get(&conn, &id).map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::json(&runner)?]))
+    }
+
+    #[tool(description = "Get a runner template by handle.")]
+    pub async fn runner_get_by_handle(
+        &self,
+        Parameters(RunnerHandleArgs { handle }): Parameters<RunnerHandleArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let runner = runner::get_by_handle(&conn, &handle)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::json(&runner)?]))
+    }
+
+    #[tool(description = "Create a new runner template.")]
+    pub async fn runner_create(
+        &self,
+        Parameters(input): Parameters<runner::CreateRunnerInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let runner = runner::create(&conn, input)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        self.state.app_handle.emit("runner/changed", ()).ok();
+        Ok(CallToolResult::success(vec![Content::json(&runner)?]))
+    }
+
+    #[tool(description = "Update a runner template by ID. Omitted fields are preserved.")]
+    pub async fn runner_update(
+        &self,
+        Parameters(UpdateRunnerArgs { id, input }): Parameters<UpdateRunnerArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let runner = runner::update(&conn, &id, input)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        self.state.app_handle.emit("runner/changed", ()).ok();
+        Ok(CallToolResult::success(vec![Content::json(&runner)?]))
+    }
+
+    #[tool(
+        description = "Delete a runner template by ID. Live sessions for that runner are killed first."
+    )]
+    pub async fn runner_delete(
+        &self,
+        Parameters(RunnerIdArgs { id }): Parameters<RunnerIdArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.state
+            .sessions
+            .kill_all_for_runner(&id)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let mut conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        runner::delete(&mut conn, &id)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        self.state.app_handle.emit("runner/changed", ()).ok();
+        self.state.app_handle.emit("slot/changed", ()).ok();
+        Ok(CallToolResult::success(vec![Content::json(
+            &serde_json::json!({ "deleted": true, "id": id }),
+        )?]))
+    }
+}

--- a/src-tauri/src/mcp/tools/slot.rs
+++ b/src-tauri/src/mcp/tools/slot.rs
@@ -1,0 +1,145 @@
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{tool, tool_router, ErrorData};
+use schemars::JsonSchema;
+use serde::Deserialize;
+use tauri::Emitter;
+
+use crate::commands::slot;
+use crate::mcp::server::RunnerMcpHandler;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SlotListArgs {
+    /// Crew ID.
+    pub crew_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct SlotIdArgs {
+    /// Slot ID.
+    pub slot_id: String,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct UpdateSlotArgs {
+    /// Slot ID.
+    pub slot_id: String,
+    /// Fields to update. Omitted fields are preserved.
+    pub input: slot::UpdateSlotInput,
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ReorderSlotsArgs {
+    /// Crew ID.
+    pub crew_id: String,
+    /// Slot IDs in the desired final order. Must include every slot exactly once.
+    pub ordered_slot_ids: Vec<String>,
+}
+
+#[tool_router(router = slot_router, vis = "pub(crate)")]
+impl RunnerMcpHandler {
+    #[tool(description = "List the slots for a crew, ordered by position.")]
+    pub async fn slot_list(
+        &self,
+        Parameters(SlotListArgs { crew_id }): Parameters<SlotListArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let slots = slot::list(&conn, &crew_id)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        Ok(CallToolResult::success(vec![Content::json(&slots)?]))
+    }
+
+    #[tool(description = "Create a slot in a crew.")]
+    pub async fn slot_create(
+        &self,
+        Parameters(input): Parameters<slot::CreateSlotInput>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let slot = slot::create(
+            &mut conn,
+            &input.crew_id,
+            &input.runner_id,
+            &input.slot_handle,
+        )
+        .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        self.state.app_handle.emit("slot/changed", ()).ok();
+        Ok(CallToolResult::success(vec![Content::json(&slot)?]))
+    }
+
+    #[tool(description = "Update a slot by ID. Omitted fields are preserved.")]
+    pub async fn slot_update(
+        &self,
+        Parameters(UpdateSlotArgs { slot_id, input }): Parameters<UpdateSlotArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let slot = slot::update(&mut conn, &slot_id, input)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        self.state.app_handle.emit("slot/changed", ()).ok();
+        Ok(CallToolResult::success(vec![Content::json(&slot)?]))
+    }
+
+    #[tool(description = "Delete a slot by ID.")]
+    pub async fn slot_delete(
+        &self,
+        Parameters(SlotIdArgs { slot_id }): Parameters<SlotIdArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        slot::delete(&mut conn, &slot_id)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        self.state.app_handle.emit("slot/changed", ()).ok();
+        Ok(CallToolResult::success(vec![Content::json(
+            &serde_json::json!({ "deleted": true, "slot_id": slot_id }),
+        )?]))
+    }
+
+    #[tool(description = "Make a slot the lead slot for its crew.")]
+    pub async fn slot_set_lead(
+        &self,
+        Parameters(SlotIdArgs { slot_id }): Parameters<SlotIdArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let slot = slot::set_lead(&mut conn, &slot_id)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        self.state.app_handle.emit("slot/changed", ()).ok();
+        Ok(CallToolResult::success(vec![Content::json(&slot)?]))
+    }
+
+    #[tool(description = "Reorder all slots in a crew.")]
+    pub async fn slot_reorder(
+        &self,
+        Parameters(ReorderSlotsArgs {
+            crew_id,
+            ordered_slot_ids,
+        }): Parameters<ReorderSlotsArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let mut conn = self
+            .state
+            .db
+            .get()
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        let slots = slot::reorder(&mut conn, &crew_id, ordered_slot_ids)
+            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        self.state.app_handle.emit("slot/changed", ()).ok();
+        Ok(CallToolResult::success(vec![Content::json(&slots)?]))
+    }
+}

--- a/src-tauri/src/router/runtime.rs
+++ b/src-tauri/src/router/runtime.rs
@@ -177,7 +177,9 @@ pub fn model_effort_args(runtime: &str, model: Option<&str>, effort: Option<&str
 ///   exposed here.)
 /// - **Bypass** — `--ask-for-approval never --sandbox
 ///   workspace-write`. Never ask.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum PermissionMode {
     Default,

--- a/src/pages/CrewEditor.tsx
+++ b/src/pages/CrewEditor.tsx
@@ -59,7 +59,19 @@ export default function CrewEditor() {
       setNameDraft(c.name);
       setLoaded(true);
     } catch (e) {
-      setError(String(e));
+      const message = String(e);
+      setError(message);
+      if (message.toLowerCase().includes("not found")) {
+        setCrew(null);
+        setSlots([]);
+        setEditing(null);
+        setNameDraft("");
+        setGoalEditing(false);
+        setGoalDraft("");
+        setAddendumEditing(false);
+        setAddendumDraft("");
+        setLoaded(true);
+      }
     } finally {
       setLoading(false);
     }

--- a/src/pages/CrewEditor.tsx
+++ b/src/pages/CrewEditor.tsx
@@ -13,6 +13,8 @@ import {
   type DragEvent,
 } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
+
+import { listen } from "@tauri-apps/api/event";
 import { MoreHorizontal, SquarePen, Star, Trash2 } from "lucide-react";
 
 import { api } from "../lib/api";
@@ -65,6 +67,40 @@ export default function CrewEditor() {
 
   useEffect(() => {
     void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    let unlistenCrew: (() => void) | null = null;
+    let unlistenRunner: (() => void) | null = null;
+    let unlistenSlot: (() => void) | null = null;
+    let cancelled = false;
+    void Promise.all([
+      listen("crew/changed", () => {
+        void refresh();
+      }),
+      listen("runner/changed", () => {
+        void refresh();
+      }),
+      listen("slot/changed", () => {
+        void refresh();
+      }),
+    ]).then(([fnCrew, fnRunner, fnSlot]) => {
+      if (cancelled) {
+        fnCrew();
+        fnRunner();
+        fnSlot();
+        return;
+      }
+      unlistenCrew = fnCrew;
+      unlistenRunner = fnRunner;
+      unlistenSlot = fnSlot;
+    });
+    return () => {
+      cancelled = true;
+      unlistenCrew?.();
+      unlistenRunner?.();
+      unlistenSlot?.();
+    };
   }, [refresh]);
 
   const onSaveName = async () => {

--- a/src/pages/Crews.tsx
+++ b/src/pages/Crews.tsx
@@ -6,6 +6,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { listen } from "@tauri-apps/api/event";
+
 import { api } from "../lib/api";
 import type { CrewListItem } from "../lib/types";
 import { Button } from "../components/ui/Button";
@@ -36,6 +38,40 @@ export default function Crews() {
 
   useEffect(() => {
     void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    let unlistenCrew: (() => void) | null = null;
+    let unlistenRunner: (() => void) | null = null;
+    let unlistenSlot: (() => void) | null = null;
+    let cancelled = false;
+    void Promise.all([
+      listen("crew/changed", () => {
+        void refresh();
+      }),
+      listen("runner/changed", () => {
+        void refresh();
+      }),
+      listen("slot/changed", () => {
+        void refresh();
+      }),
+    ]).then(([fnCrew, fnRunner, fnSlot]) => {
+      if (cancelled) {
+        fnCrew();
+        fnRunner();
+        fnSlot();
+        return;
+      }
+      unlistenCrew = fnCrew;
+      unlistenRunner = fnRunner;
+      unlistenSlot = fnSlot;
+    });
+    return () => {
+      cancelled = true;
+      unlistenCrew?.();
+      unlistenRunner?.();
+      unlistenSlot?.();
+    };
   }, [refresh]);
 
   const onDelete = async (id: string, name: string) => {

--- a/src/pages/RunnerDetail.tsx
+++ b/src/pages/RunnerDetail.tsx
@@ -47,7 +47,15 @@ export default function RunnerDetail() {
       setActivity(act);
       setCrews(crewList);
     } catch (e) {
-      setError(String(e));
+      const message = String(e);
+      setError(message);
+      if (message.toLowerCase().includes("not found")) {
+        setRunner(null);
+        setActivity(null);
+        setCrews([]);
+        setEditing(false);
+        setOpeningChat(false);
+      }
     } finally {
       setLoading(false);
     }

--- a/src/pages/RunnerDetail.tsx
+++ b/src/pages/RunnerDetail.tsx
@@ -58,6 +58,33 @@ export default function RunnerDetail() {
   }, [refresh]);
 
   useEffect(() => {
+    let unlistenRunner: (() => void) | null = null;
+    let unlistenSlot: (() => void) | null = null;
+    let cancelled = false;
+    void Promise.all([
+      listen("runner/changed", () => {
+        void refresh();
+      }),
+      listen("slot/changed", () => {
+        void refresh();
+      }),
+    ]).then(([fnRunner, fnSlot]) => {
+      if (cancelled) {
+        fnRunner();
+        fnSlot();
+        return;
+      }
+      unlistenRunner = fnRunner;
+      unlistenSlot = fnSlot;
+    });
+    return () => {
+      cancelled = true;
+      unlistenRunner?.();
+      unlistenSlot?.();
+    };
+  }, [refresh]);
+
+  useEffect(() => {
     let unlisten: (() => void) | null = null;
     void listen<RunnerActivityEvent>("runner/activity", (event) => {
       if (event.payload.runner_id !== runner?.id) return;

--- a/src/pages/Runners.tsx
+++ b/src/pages/Runners.tsx
@@ -48,6 +48,33 @@ export default function Runners() {
   }, [refresh]);
 
   useEffect(() => {
+    let unlistenRunner: (() => void) | null = null;
+    let unlistenSlot: (() => void) | null = null;
+    let cancelled = false;
+    void Promise.all([
+      listen("runner/changed", () => {
+        void refresh();
+      }),
+      listen("slot/changed", () => {
+        void refresh();
+      }),
+    ]).then(([fnRunner, fnSlot]) => {
+      if (cancelled) {
+        fnRunner();
+        fnSlot();
+        return;
+      }
+      unlistenRunner = fnRunner;
+      unlistenSlot = fnSlot;
+    });
+    return () => {
+      cancelled = true;
+      unlistenRunner?.();
+      unlistenSlot?.();
+    };
+  }, [refresh]);
+
+  useEffect(() => {
     const state = location.state as { createRunner?: boolean } | null;
     if (!state?.createRunner) return;
     setCreating(true);


### PR DESCRIPTION
## Summary

- Add MCP CRUD tools for crews, runners, and slots.
- Wire the MCP router to expose all 17 Phase 2 tools.
- Add JsonSchema derives for MCP tool parameters.
- Emit `crew/changed`, `runner/changed`, and `slot/changed` from MCP mutations and refresh open Crew/Runner pages on those events.
- Ensure MCP runner deletion kills live runner sessions before deleting, matching the UI path.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `cargo fmt --check`
- `cargo check`
- `cargo test -p runner tool_router_registers_phase_2_crud_tools`
- `cargo test --workspace`

Base: `feat/mcp-server`