### PR TITLE
fix(terminal): keep mission PTY panes measurable

### DIFF
--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -214,9 +214,11 @@ export const RunnerTerminal = forwardRef<
     ({
       focus = false,
       forceResizeDance = false,
+      pushBackendSize = false,
     }: {
       focus?: boolean;
       forceResizeDance?: boolean;
+      pushBackendSize?: boolean;
     } = {}) => {
       if (!activeRef.current) return;
       const t = termRef.current;
@@ -231,11 +233,27 @@ export const RunnerTerminal = forwardRef<
         webglRef.current?.clearTextureAtlas();
         t.refresh(0, t.rows - 1);
         if (focus) t.focus();
-        if (!forceResizeDance || disabledRef.current) return;
+        if ((!forceResizeDance && !pushBackendSize) || disabledRef.current) {
+          return;
+        }
         const sid = sessionIdRef.current;
         if (!sid) return;
         const cols = t.cols;
         const rows = t.rows;
+        if (!forceResizeDance) {
+          if (
+            cols === lastPushedColsRef.current &&
+            rows === lastPushedRowsRef.current
+          ) {
+            return;
+          }
+          lastPushedColsRef.current = cols;
+          lastPushedRowsRef.current = rows;
+          void api.session.resize(sid, cols, rows).catch(() => {
+            // session may have exited
+          });
+          return;
+        }
         // Force a full TUI redraw even when the final geometry
         // matches the backend's cached winsize. Same-size TIOCSWINSZ
         // calls are kernel no-ops on macOS/Linux, so we perturb rows
@@ -543,13 +561,13 @@ export const RunnerTerminal = forwardRef<
       if (wakeRefitScheduled) return;
       wakeRefitScheduled = true;
       scheduleWakeRaf(() => {
-        scheduleWakeRaf(() => refreshActiveTerminal());
+        scheduleWakeRaf(() => refreshActiveTerminal({ pushBackendSize: true }));
       });
       // macOS wake/focus can fire before WKWebView has settled its
       // final layout rect. Run one delayed renderer refresh for the
       // WebGL atlas without forcing a PTY SIGWINCH; ResizeObserver's
       // normal refit path still pushes real cols/rows changes.
-      scheduleWakeTimer(() => refreshActiveTerminal(), 250);
+      scheduleWakeTimer(() => refreshActiveTerminal({ pushBackendSize: true }), 250);
       scheduleWakeTimer(() => {
         wakeRefitScheduled = false;
       }, 300);

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -164,16 +164,13 @@ export const RunnerTerminal = forwardRef<
   // lengthen the redraw window the user perceives.
   const lastPushedColsRef = useRef(0);
   const lastPushedRowsRef = useRef(0);
-  // Snapshot replay is deferred until the pane is both active and
-  // measurable. Mission workspaces mount every slot's RunnerTerminal
-  // at once with `activeTab="feed"` by default — every slot pane is
-  // `display:none`, the mount-effect's `fit.fit()` is skipped (zero-
-  // size rect), and xterm sits at the constructor default 80×24.
-  // Replaying snapshot bytes into that 80-col grid bakes wrong cell
-  // positions into the buffer, and a later `fit.fit()` on tab focus
-  // can't move them. So we cache the fetched bytes here and drain
-  // them only once the pane has come to the front and fit at real
-  // cols. See #mission-tab-return-drift.
+  // Snapshot replay is deferred until the pane is measurable. Mission
+  // workspaces mount every slot's RunnerTerminal at once while the
+  // feed tab is active; inactive panes stay invisible but measurable
+  // so xterm can fit and build terminal state before the user opens
+  // that tab. If a pane ever has a 0×0 rect, keep the bytes cached
+  // until activation/resize gives us real cols. See
+  // #mission-tab-return-drift.
   const pendingSnapshotRef = useRef<OutputEvent[] | null>(null);
   const pendingLiveRef = useRef<OutputEvent[]>([]);
   const lastWrittenSeqRef = useRef(0);
@@ -546,18 +543,13 @@ export const RunnerTerminal = forwardRef<
       if (wakeRefitScheduled) return;
       wakeRefitScheduled = true;
       scheduleWakeRaf(() => {
-        scheduleWakeRaf(() =>
-          refreshActiveTerminal({ forceResizeDance: true }),
-        );
+        scheduleWakeRaf(() => refreshActiveTerminal());
       });
-      // macOS wake can fire focus before WKWebView has settled its
-      // final layout rect. Run one delayed pass so the PTY winsize
-      // lands on the post-wake container width even when ResizeObserver
-      // / browser focus events are skipped.
-      scheduleWakeTimer(
-        () => refreshActiveTerminal({ forceResizeDance: true }),
-        250,
-      );
+      // macOS wake/focus can fire before WKWebView has settled its
+      // final layout rect. Run one delayed renderer refresh for the
+      // WebGL atlas without forcing a PTY SIGWINCH; ResizeObserver's
+      // normal refit path still pushes real cols/rows changes.
+      scheduleWakeTimer(() => refreshActiveTerminal(), 250);
       scheduleWakeTimer(() => {
         wakeRefitScheduled = false;
       }, 300);
@@ -677,15 +669,14 @@ export const RunnerTerminal = forwardRef<
       termRef.current?.write(decodeBase64Chunk(ev.data));
     };
 
-    // Replay drains only when (a) the snapshot RPC has returned,
-    // (b) the pane is currently active, and (c) the container has a
-    // measurable rect so the in-line fit gives us real cols/rows.
+    // Replay drains only when (a) the snapshot RPC has returned and
+    // (b) the container has a measurable rect so the in-line fit gives
+    // us real cols/rows.
     // Until all three line up we keep the bytes parked on
     // pendingSnapshotRef and pendingLiveRef; activation / resize
     // observers re-call this helper as conditions change.
     const tryDrainReplay = () => {
       if (replayDoneRef.current) return;
-      if (!activeRef.current) return;
       const t = termRef.current;
       const fit = fitRef.current;
       const node = containerRef.current;

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -77,6 +77,7 @@ const RAIL_STORAGE_WIDTH = "runner.mission.rail.width";
 const RAIL_MIN = 200;
 const RAIL_MAX = 480;
 const RAIL_DEFAULT = 288;
+const SLOT_TERMINAL_FRAME_PADDING_PX = 12; // matches SlotPtyPane's p-3 wrapper
 
 /// Compute cols/rows for the would-be terminal area from the Pane
 /// container's bounding rect + a one-shot DOM cell-size measurement
@@ -89,15 +90,18 @@ const RAIL_DEFAULT = 288;
 /// feed tab and no slot was ever activated, so every slot pane is
 /// still `display:none` and every `RunnerTerminal.measure()` returns
 /// null. The cell size we compute here is close to but not exactly
-/// xterm's CharSizeService output (we don't account for renderer
-/// padding); a small drift is acceptable because the agent paints at
-/// whatever cols we pass and xterm soft-wraps from there if needed.
-/// "Approximately correct" beats "spawn at 80×24."
+/// xterm's CharSizeService output; a small drift is acceptable because
+/// the agent paints at whatever cols we pass and xterm soft-wraps from
+/// there if needed. "Approximately correct" beats "spawn at 80×24."
 function workspaceDimsFromContainer(
   container: HTMLElement,
+  framePaddingPx = SLOT_TERMINAL_FRAME_PADDING_PX,
 ): { cols: number; rows: number } | null {
   const rect = container.getBoundingClientRect();
   if (rect.width <= 0 || rect.height <= 0) return null;
+  const width = Math.max(0, rect.width - framePaddingPx * 2);
+  const height = Math.max(0, rect.height - framePaddingPx * 2);
+  if (width <= 0 || height <= 0) return null;
   const fontFamily = resolveTerminalFontStack(readTerminalFontFamily());
   const fontSize = readTerminalFontSize();
   const span = document.createElement("span");
@@ -122,8 +126,8 @@ function workspaceDimsFromContainer(
     document.body.removeChild(span);
   }
   return {
-    cols: Math.max(1, Math.floor(rect.width / cellWidth)),
-    rows: Math.max(1, Math.floor(rect.height / cellHeight)),
+    cols: Math.max(1, Math.floor(width / cellWidth)),
+    rows: Math.max(1, Math.floor(height / cellHeight)),
   };
 }
 
@@ -863,10 +867,10 @@ export default function MissionWorkspace() {
             className="relative flex flex-1 min-h-0 flex-col"
           >
             {/* All panes stay mounted so xterm's in-memory scrollback
-                survives tab switches. Inactive panes use display:none:
-                that keeps the React/xterm instances alive while making
-                the visible session unambiguous. The terminal activation
-                effect refits + repaints after the pane is shown. */}
+                survives tab switches. Inactive panes stay invisible
+                instead of display:none so hidden PTYs still have real
+                dimensions; RunnerTerminal can fit/replay Codex's first
+                frame before the user opens the tab. */}
             <Pane active={activeTab === "feed"}>
               <EventFeed
                 missionId={mission.id}
@@ -1237,16 +1241,16 @@ function Pane({
   active: boolean;
   children: React.ReactNode;
 }) {
-  // Pane wraps both the feed and the terminal slots. Background is
-  // `bg-panel` so the feed reads as a tinted "page" with the white
-  // event cards (`bg-bg`) lifting off it — solves the "all white,
-  // cards melt into the page" problem in Codex Light. Terminal slots
-  // cover this bg with their own `bg-terminal-chrome` wrapper, so
-  // changing it here only affects the feed pane visually.
+  // Pane wraps both the feed and the terminal slots. Inactive panes
+  // stay in layout (`visibility:hidden`, not `display:none`) so xterm
+  // can measure, fit, and replay buffered TUI bytes while hidden.
+  // Background is `bg-panel` so the feed reads as a tinted "page" with
+  // the white event cards (`bg-bg`) lifting off it.
   return (
     <div
-      className={`absolute inset-0 flex-col bg-panel ${
-        active ? "flex" : "hidden"
+      aria-hidden={!active}
+      className={`absolute inset-0 flex flex-col bg-panel ${
+        active ? "visible z-10" : "invisible z-0 pointer-events-none"
       }`}
     >
       {children}


### PR DESCRIPTION
Summary
- Keep inactive mission PTY panes invisible but measurable instead of display:none so hidden xterms can fit and replay initial Codex frames.
- Let RunnerTerminal drain replay once the pane is measurable, even before the tab is active.
- Avoid focus/display wake clear+SIGWINCH to remove terminal flash.

Validation
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check
- Manual: user confirmed fresh mission Codex input background now matches expected behavior.