### PR TITLE
Fix Codex mission spawn plumbing

### DIFF
--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -492,6 +492,15 @@ pub(crate) async fn mission_start_impl(
     app: &tauri::AppHandle,
     input: StartMissionInput,
 ) -> Result<StartMissionOutput> {
+    mission_start_impl_with_size(state, app, input, None).await
+}
+
+async fn mission_start_impl_with_size(
+    state: &AppState,
+    app: &tauri::AppHandle,
+    input: StartMissionInput,
+    initial_size: Option<(u16, u16)>,
+) -> Result<StartMissionOutput> {
     use crate::event_bus::{BusEmitter, TauriBusEvents};
     use crate::router::{
         open_log_for_mission, CompositeBusEmitter, Router, RouterSubscriber, StdinInjector,
@@ -678,6 +687,7 @@ pub(crate) async fn mission_start_impl(
             events_log_path.clone(),
             state.db.clone(),
             first_turn,
+            initial_size,
         );
         match register_res {
             Ok(pending) => {
@@ -856,8 +866,13 @@ pub async fn mission_start(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     input: StartMissionInput,
+    initial_cols: Option<u16>,
+    initial_rows: Option<u16>,
 ) -> Result<StartMissionOutput> {
-    mission_start_impl(&state, &app, input).await
+    let initial_size = initial_cols
+        .zip(initial_rows)
+        .filter(|(cols, rows)| *cols > 0 && *rows > 0);
+    mission_start_impl_with_size(&state, &app, input, initial_size).await
 }
 
 /// Re-attach a mission's router + bus after app restart. The mission row
@@ -1377,6 +1392,7 @@ pub(crate) async fn mission_reset_impl(
             events_log_path.clone(),
             state.db.clone(),
             first_turn,
+            None,
         );
         match register_res {
             Ok(pending) => {

--- a/src-tauri/src/router/prompt.rs
+++ b/src-tauri/src/router/prompt.rs
@@ -58,10 +58,7 @@ pub struct LaunchPromptInput<'a> {
 /// is always present).
 ///
 /// Delivered as the trailing positional `[PROMPT]` argv at spawn time
-/// when the runtime accepts it (see `router::runtime::first_turn_argv`);
-/// callers that can't use argv inject the same body via stdin paste.
-/// Source of truth lives here so both delivery paths use byte-identical
-/// content.
+/// when the runtime accepts it (see `router::runtime::first_turn_argv`).
 pub fn compose_worker_first_turn(
     system_prompt: Option<&str>,
     crew_addendum: Option<&str>,

--- a/src-tauri/src/router/runtime.rs
+++ b/src-tauri/src/router/runtime.rs
@@ -7,13 +7,9 @@
 //      CLI via its native argv hook, when one exists. claude-code's
 //      `--append-system-prompt` / `--system-prompt` are SDK-only
 //      (require `-p` / print mode); the interactive TUI silently
-//      ignores them. So claude-code returns no argv from this
-//      function — the prompt is delivered via stdin as a first user
-//      turn instead, by `SessionManager::schedule_first_prompt`.
-//      Codex follows the same stdin path: a startup permission /
-//      approval dialog can swallow or misorder the positional
-//      `[PROMPT]` argv, so codex also returns empty here and the
-//      brief lands via stdin once the TUI has settled.
+//      ignores them. Codex has no equivalent system-prompt flag.
+//      Both return no args here; callers deliver persona/brief text
+//      through the separate first-turn path instead.
 //      arch §4.2 / §4.3.
 //
 //   2. `resume_plan` — pass the agent CLI's *own* resumable
@@ -28,6 +24,8 @@
 // of drift. Lives under router/ because the router's `mission_goal`
 // handler already owns prompt composition; the runtime adapter is the
 // related "how do we hand prompts and identity to a real CLI" piece.
+
+use std::path::Path;
 
 #[derive(Debug, Clone, Copy, serde::Serialize)]
 pub struct RuntimeDefinition {
@@ -438,7 +436,7 @@ fn flag_value_matches(args: &[String], flag: &str, expected: Option<&str>) -> bo
 /// Compute the extra args (in declaration order) to append after the
 /// runner's configured `args` so the child receives `system_prompt` via the
 /// runtime's native flag. Returns an empty Vec when no prompt is set or
-/// when the runtime delivers prompts through stdin instead of argv.
+/// when the runtime has no native system-prompt flag.
 pub fn system_prompt_args(runtime: &str, system_prompt: Option<&str>) -> Vec<String> {
     let prompt = match system_prompt {
         Some(p) if !p.trim().is_empty() => p,
@@ -450,20 +448,12 @@ pub fn system_prompt_args(runtime: &str, system_prompt: Option<&str>) -> Vec<Str
         // are documented as SDK-only — they require `-p` (print
         // mode), which is incompatible with our interactive TUI
         // launches. Passing them in interactive mode is silently
-        // dropped. Workaround: the call site delivers the prompt via
-        // stdin once the TUI is up (see
-        // SessionManager::schedule_first_prompt).
+        // dropped. Workaround: call sites fold persona/brief text
+        // into a first user turn instead.
         "claude-code" => Vec::new(),
         // codex has no system-prompt flag (we tried `--instructions` and
         // it's rejected; `~/.codex/config.toml` doesn't expose one
-        // either). Codex's positional `[PROMPT]` argv was the closest
-        // available hook, but it loses races with codex's startup
-        // permission / approval dialog: when the TUI shows that
-        // dialog before hitting its main loop, the positional prompt
-        // is swallowed, replayed stale, or misordered. So we fall
-        // through to the same stdin-injection path claude-code uses —
-        // see `SessionManager::schedule_first_prompt`, which waits
-        // for the TUI to settle and then types the brief + Enter.
+        // either). First-turn delivery is handled separately.
         "codex" => Vec::new(),
         // shell / unknown — no prompt mechanism.
         _ => Vec::new(),
@@ -487,9 +477,8 @@ pub const FIRST_TURN_ARGV_MAX_BYTES: usize = 32 * 1024;
 /// (verified against claude-code and codex-cli 0.130.0). Delivering
 /// the first turn at spawn-time eliminates the post-spawn paste race
 /// the original `inject_paste_with_verify` machinery was working
-/// around: the agent reads its argv during init, before the TUI binds
-/// raw input, before any trust-folder dialog, before the input editor
-/// even exists. See `docs/impls/0007-spawn-time-prompt-delivery.md`.
+/// around: if the child starts, the prompt is already part of its
+/// argv.
 ///
 /// Returns empty when:
 ///   - the body is None or blank,
@@ -500,11 +489,6 @@ pub const FIRST_TURN_ARGV_MAX_BYTES: usize = 32 * 1024;
 /// persist-time validation upstream. Release builds silently truncate
 /// the argv to empty to fail safe.
 ///
-/// The old comment block in `system_prompt_args` claiming codex's
-/// positional gets swallowed by a startup approval dialog was stale
-/// (likely pre-0.130.0); modern codex has no startup dialog by
-/// default. `--ask-for-approval` modes gate in-session *command*
-/// approvals, not boot.
 pub fn first_turn_argv(runtime: &str, body: Option<&str>) -> Vec<String> {
     let body = match body {
         Some(s) if !s.trim().is_empty() => s,
@@ -556,6 +540,17 @@ pub fn trailing_runtime_args(
     let first_turn_for_argv = if plan_resuming { None } else { first_turn };
     out.extend(first_turn_argv(runtime, first_turn_for_argv));
     out
+}
+
+/// Extra sandbox roots Runner must grant to agent runtimes for mission-bus
+/// operations. Codex's `workspace-write` sandbox only allows writes under the
+/// workspace by default, while `runner signal/msg` appends to the mission log
+/// under app data. Scope the grant to the single mission directory.
+pub fn mission_bus_sandbox_args(runtime: &str, mission_dir: Option<&Path>) -> Vec<String> {
+    match (runtime, mission_dir) {
+        ("codex", Some(dir)) => vec!["--add-dir".into(), dir.to_string_lossy().to_string()],
+        _ => Vec::new(),
+    }
 }
 
 /// Output of `resume_plan` — the args to layer onto the spawn command plus
@@ -625,7 +620,7 @@ pub fn resume_plan(runtime: &str, prior_key: Option<&str>) -> ResumePlan {
                 // use") — it treats `--session-id` as fresh-only. The
                 // edge case `--resume` exposes ("session not found"
                 // when the conversation file was never persisted)
-                // is now masked by `schedule_first_prompt`, which
+                // is now masked by spawn-time first-turn delivery, which
                 // always sends a first user turn to claude-code on
                 // fresh spawn so the conversation file lands on disk
                 // before any future resume tries to load it. If a
@@ -675,8 +670,8 @@ fn is_uuid(s: &str) -> bool {
 
 /// True iff claude-code's conversation file for `(cwd, uuid)` exists on
 /// disk. Used by `SessionManager::resume` to skip `--resume <uuid>` when
-/// the agent never persisted a turn (lead PTYs reset within the
-/// schedule_first_prompt window, fast Stop after spawn) — passing
+/// the agent never persisted a turn (for example, fast Stop after
+/// spawn before a first response persists) — passing
 /// `--resume` against a missing file makes claude-code print
 /// "No conversation found with session ID …" and leave the TUI sitting
 /// in a half-initialised state. Path scheme:
@@ -736,25 +731,21 @@ mod tests {
     fn claude_code_returns_no_argv_for_system_prompt() {
         // claude-code's --append-system-prompt is SDK-only; the
         // interactive TUI ignores it. The argv path returns empty,
-        // and SessionManager::schedule_first_prompt delivers the
-        // prompt as a first user turn via stdin instead.
+        // and call sites fold the prompt into first-turn delivery
+        // instead.
         let args = system_prompt_args("claude-code", Some("be helpful"));
         assert!(args.is_empty());
     }
 
     #[test]
     fn codex_runtime_returns_no_argv_for_system_prompt() {
-        // Codex's positional `[PROMPT]` argv races codex's startup
-        // permission / approval dialog (the prompt gets swallowed,
-        // replayed stale, or misordered when the TUI shows the dialog
-        // before hitting its main loop). The brief is now delivered via
-        // stdin once the TUI has settled — see
-        // `SessionManager::schedule_first_prompt` — so the argv path
-        // returns empty for codex too.
+        // Codex has no dedicated system-prompt flag. Persona/brief
+        // delivery is handled through first-turn plumbing, not
+        // `system_prompt_args`.
         let args = system_prompt_args("codex", Some("be helpful"));
         assert!(
             args.is_empty(),
-            "codex system_prompt is delivered via stdin, not positional argv: {args:?}",
+            "codex has no native system_prompt argv flag: {args:?}",
         );
     }
 
@@ -798,9 +789,8 @@ mod tests {
     fn claude_code_resumes_with_prior_uuid() {
         // `--resume <uuid>` is the right flag. `--session-id` would
         // be rejected as "already in use" because claude-code treats
-        // it as fresh-only. `schedule_first_prompt` ensures the
-        // conversation file exists before any resume attempt by
-        // pushing a first user turn on initial spawn.
+        // it as fresh-only. Fresh-spawn first-turn delivery ensures
+        // the conversation file exists before any resume attempt.
         let prior = uuid::Uuid::new_v4().to_string();
         let plan = resume_plan("claude-code", Some(&prior));
         assert!(plan.resuming);
@@ -908,6 +898,18 @@ mod tests {
     }
 
     #[test]
+    fn codex_mission_bus_sandbox_args_grants_only_mission_dir() {
+        let dir = std::path::PathBuf::from("/tmp/runner/crews/c/missions/m");
+        assert_eq!(
+            mission_bus_sandbox_args("codex", Some(&dir)),
+            vec!["--add-dir".to_string(), dir.to_string_lossy().to_string()],
+        );
+        assert!(mission_bus_sandbox_args("codex", None).is_empty());
+        assert!(mission_bus_sandbox_args("claude-code", Some(&dir)).is_empty());
+        assert!(mission_bus_sandbox_args("shell", Some(&dir)).is_empty());
+    }
+
+    #[test]
     fn claude_code_forwards_effort_verbatim() {
         // Asymmetric on purpose: claude-code's `--effort` is case-
         // insensitive (accepts `High`), so we forward the row's
@@ -923,19 +925,10 @@ mod tests {
 
     #[test]
     fn codex_trailing_args_omit_positional_prompt() {
-        // Codex's positional `[PROMPT]` argv races codex's startup
-        // permission / approval dialog, so we deliver the brief via
-        // stdin instead (see `SessionManager::schedule_first_prompt`).
-        // The trailing args MUST NOT include the brief as positional
-        // argv on either fresh or resume spawns. Model/effort flags
-        // still ride along so the runner row's pinned settings reach
-        // the spawned CLI.
+        // `system_prompt` is not a positional first turn. Model/effort
+        // flags still ride along so the runner row's pinned settings
+        // reach the spawned CLI.
         for plan_resuming in [false, true] {
-            // `system_prompt` (the role/persona stub) still rides via
-            // stdin for both runtimes — `system_prompt_args` returns
-            // empty. The first-user-turn body is delivered separately
-            // via `first_turn` (spawn-time positional argv) per
-            // `docs/impls/0007-spawn-time-prompt-delivery.md`.
             let args = trailing_runtime_args(
                 "codex",
                 plan_resuming,

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -678,14 +678,15 @@ impl SessionManager {
     /// persona for direct chats). When the runtime accepts the
     /// positional `[PROMPT]` argv and the body fits in
     /// `FIRST_TURN_ARGV_MAX_BYTES`, the body lands as the trailing
-    /// positional and the caller skips post-spawn paste injection.
-    /// Returns whether the body was delivered via argv — the caller
-    /// uses this to decide whether to schedule the paste fallback.
+    /// positional. Returns whether the body was delivered via argv
+    /// so the caller can warn if a supported runtime somehow missed
+    /// the deterministic path.
     fn apply_runtime_args(
         spec: &mut SpawnSpec,
         runner: &Runner,
         plan: &router::runtime::ResumePlan,
         first_turn: Option<&str>,
+        mission_bus_dir: Option<&Path>,
     ) -> bool {
         let mut composed: Vec<String> = Vec::new();
         if plan.prepend {
@@ -697,6 +698,10 @@ impl SessionManager {
         }
         let first_turn_for_argv = router::runtime::first_turn_argv(&runner.runtime, first_turn);
         let delivered_via_argv = !first_turn_for_argv.is_empty();
+        composed.extend(router::runtime::mission_bus_sandbox_args(
+            &runner.runtime,
+            mission_bus_dir,
+        ));
         for extra in router::runtime::trailing_runtime_args(
             &runner.runtime,
             plan.resuming,
@@ -734,6 +739,7 @@ impl SessionManager {
         events_log_path: PathBuf,
         pool: Arc<DbPool>,
         first_turn: Option<String>,
+        initial_size: Option<(u16, u16)>,
     ) -> Result<PendingMissionSpawn> {
         // Agent-native session resume: this is a *fresh* session row, so
         // there's no prior key to inherit. The runtime adapter still
@@ -792,11 +798,18 @@ impl SessionManager {
             true,
             shim_dir,
             bundled_bin_dir,
-            None, // mission spawn doesn't yet receive cols/rows from the caller
+            initial_size,
             mission_env,
         );
-        let first_turn_delivered_via_argv =
-            Self::apply_runtime_args(&mut spec, runner, &plan, first_turn.as_deref());
+        let mission_bus_dir =
+            runner_core::event_log::path::mission_dir(app_data_dir, &mission.crew_id, &mission.id);
+        let first_turn_delivered_via_argv = Self::apply_runtime_args(
+            &mut spec,
+            runner,
+            &plan,
+            first_turn.as_deref(),
+            Some(&mission_bus_dir),
+        );
 
         // Insert the row first (status=running with no runtime_*
         // metadata yet) so a fast-failing runtime spawn doesn't leave
@@ -1053,11 +1066,9 @@ impl SessionManager {
     /// plus brief for a non-lead). When the runtime accepts the
     /// positional `[PROMPT]` argv and the body fits
     /// `FIRST_TURN_ARGV_MAX_BYTES`, it lands as the trailing
-    /// positional during process init — eliminating the post-spawn
-    /// paste race. Otherwise the body falls through to
-    /// `schedule_mission_first_prompt`'s stdin-paste path. Pass
-    /// `None` to skip first-turn delivery entirely, for tests that
-    /// don't care about boot context.
+    /// positional during process init. Pass `None` to skip
+    /// first-turn delivery entirely, for tests that don't care about
+    /// boot context.
     ///
     /// Synchronous, all-or-nothing wrapper: row insert + PTY spawn +
     /// reader thread happen on the calling thread. Rolls back the
@@ -1086,6 +1097,7 @@ impl SessionManager {
             events_log_path,
             Arc::clone(&pool),
             first_turn,
+            None,
         )?;
         let session_id = pending.session_id.clone();
         let mission_id = pending.mission.id.clone();
@@ -1140,10 +1152,9 @@ impl SessionManager {
     /// `first_turn` is the composed persona body for the direct chat
     /// (no preamble — direct chats are off-bus). When the runtime
     /// supports argv-based delivery the persona lands as the
-    /// trailing positional at spawn; otherwise the body falls
-    /// through to `schedule_direct_first_prompt`'s stdin-paste
-    /// path. Pass `None` when there's no persona to deliver, or for
-    /// tests that don't care about boot context.
+    /// trailing positional at spawn. Pass `None` when there's no
+    /// persona to deliver, or for tests that don't care about boot
+    /// context.
     #[allow(clippy::too_many_arguments)]
     pub fn spawn_direct(
         self: &Arc<Self>,
@@ -1244,7 +1255,7 @@ impl SessionManager {
             direct_env,
         );
         let first_turn_delivered_via_argv =
-            Self::apply_runtime_args(&mut spec, runner, &plan, first_turn.as_deref());
+            Self::apply_runtime_args(&mut spec, runner, &plan, first_turn.as_deref(), None);
 
         // Insert the row first so a fast-failing spawn doesn't leave
         // a half-row.
@@ -1692,13 +1703,17 @@ impl SessionManager {
             initial_size,
             env_extra,
         );
+        let mission_bus_dir = mission_ctx.as_ref().map(|ctx| {
+            runner_core::event_log::path::mission_dir(app_data_dir, &ctx.crew_id, &ctx.mission_id)
+        });
         // Resume never delivers a first-turn via argv: a real resume
         // restores prior context via the agent CLI's own session
         // resume, and the rare fresh-fallback case routes its launch
         // prompt through paste-and-verify via the caller in
         // `commands::session::session_resume`. `first_turn = None`
         // here so the argv path stays inert.
-        let _ = Self::apply_runtime_args(&mut spec, &runner, &plan, None);
+        let _ =
+            Self::apply_runtime_args(&mut spec, &runner, &plan, None, mission_bus_dir.as_deref());
 
         let started_at_dt = Utc::now();
         let started_at = started_at_dt.to_rfc3339();
@@ -2078,23 +2093,14 @@ impl SessionManager {
     }
 
     /// Paste a multi-line prompt block into the session, then submit
-    /// with Enter. Uses tmux `paste-buffer -p -r -d` semantics so
-    /// the agent's TUI sees the whole block as one bracketed-paste
-    /// event (LF stays literal — the runtime would otherwise
-    /// translate LF → CR and submit per line).
+    /// with Enter. Uses the runtime's paste primitive so LF stays
+    /// literal instead of becoming one submit per line.
     ///
     /// Sleeps 120ms between paste and Enter. Without this gap,
     /// Claude Code v2.1.x's input editor sometimes leaves pasted
-    /// content sitting in the input box unsubmitted — the
-    /// bracketed-paste end marker (`\e[201~`) and the trailing
-    /// Enter arrive too close together for the TUI to transition
-    /// out of paste mode before interpreting the keystroke.
-    /// (Observed live, fix-port of the prior portable-pty path's
-    /// 80ms gap between body-bytes and `\r` writes; tmux adds a
-    /// little server-side queueing latency on top, hence the
-    /// slightly larger 120ms.) `cfg(test)` keeps the same
-    /// constant — fake runtimes complete instantly so the wait
-    /// is harmless.
+    /// content sitting in the input box unsubmitted. `cfg(test)`
+    /// keeps the same constant — fake runtimes complete instantly so
+    /// the wait is harmless.
     pub fn inject_paste(&self, session_id: &str, payload: &[u8]) -> Result<()> {
         let rt_session = self
             .sessions
@@ -2849,23 +2855,16 @@ pub(crate) fn runtime_direct_runner(runtime: &str, command: Option<&str>) -> Res
 /// adds the "how to talk to the rest of the crew" layer
 /// automatically.
 ///
-/// `suppress_lead_preamble` is set by the initial mission_start
-/// spawn path: there, the bus's `mission_goal` handler injects a
-/// richer launch prompt with `system_prompt` embedded in its "Your
-/// brief" section, so a separate first-turn injection would race the
-/// launch prompt and waste a turn. On a resume that degrades to a
-/// fresh spawn (claude-code conversation file went missing — see
-/// `claude_code_conversation_exists`) the bus does NOT replay
-/// `mission_goal`, so the lead would otherwise come up with no
-/// system context; the resume path passes `false` here so the
-/// preamble + system_prompt land via this stdin-injection route
-/// instead.
+/// Fresh mission starts deliver the composed first user turn through
+/// the runtime's positional argv when available. That keeps delivery
+/// deterministic: if the process starts, the prompt is already in the
+/// CLI's argv instead of depending on a later readiness/paste path.
 ///
 /// Skipped on resume against a real prior conversation (the agent
 /// already has its system context) and on runtimes that have no
 /// concept of a first-turn prompt (shell).
 fn schedule_mission_first_prompt(
-    mgr: &Arc<SessionManager>,
+    _mgr: &Arc<SessionManager>,
     session_id: String,
     runner: &Runner,
     plan: &router::runtime::ResumePlan,
@@ -2877,23 +2876,13 @@ fn schedule_mission_first_prompt(
     if plan.resuming {
         return;
     }
-    // Spawn-time argv is the only first-turn delivery path on a
-    // fresh mission (plan 0007). The caller in
-    // `commands::mission::mission_start` always passes the composed
-    // body; persistence-layer validation caps `system_prompt` and
-    // `goal` so the body never exceeds the runtime's argv slot.
-    // If we reach this point with `delivered_via_argv == false`,
-    // either the runtime doesn't support argv (`shell`, future
-    // adapters) or the body slipped past validation — log and skip
-    // rather than re-introducing the paste race the plan got rid
-    // of.
-    if !delivered_via_argv {
-        log::warn!(
-            "first-turn argv not delivered for {session_id} (runtime {}); skipping post-spawn injection",
-            runner.runtime,
-        );
+    if delivered_via_argv {
+        return;
     }
-    let _ = mgr;
+    log::warn!(
+        "first-turn argv not delivered for {session_id} (runtime {}); skipping post-spawn injection",
+        runner.runtime,
+    );
 }
 
 /// Direct-chat-flavored first-turn injection: types just
@@ -2940,10 +2929,8 @@ fn schedule_direct_first_prompt(
 
 // `WORKER_COORDINATION_PREAMBLE` and the per-runtime first-turn
 // composition helpers (`compose_worker_first_turn`,
-// `compose_direct_first_turn`) live in `router::prompt` — both the
-// spawn-time argv path (here) and any post-spawn paste fallback
-// pull from the same composers so the delivered body is byte-
-// identical regardless of route.
+// `compose_direct_first_turn`) live in `router::prompt`; the spawn
+// paths here only decide how to hand that composed text to the CLI.
 
 fn emit_runner_activity(pool: &DbPool, runner: &Runner, events: &dyn SessionEvents) {
     let Ok(conn) = pool.get() else { return };
@@ -3415,6 +3402,10 @@ mod tests {
 
     fn capture() -> Arc<Capture> {
         Arc::new(Capture::default())
+    }
+
+    fn has_arg_pair(args: &[String], flag: &str, value: &str) -> bool {
+        args.windows(2).any(|w| w[0] == flag && w[1] == value)
     }
 
     fn pool_with_schema() -> Arc<DbPool> {
@@ -3981,6 +3972,131 @@ mod tests {
         );
 
         mgr.kill(&spawned.id).unwrap();
+    }
+
+    #[test]
+    fn codex_mission_spawn_grants_event_log_dir_to_sandbox() {
+        // Codex's workspace-write sandbox cannot append to Runner's
+        // app-data mission log unless we grant the mission directory.
+        let pool = pool_with_schema();
+        let mission_base = Mission {
+            crew_id: "c".into(),
+            ..mission()
+        };
+        let mut runner = runner(
+            "codex",
+            &[
+                "--ask-for-approval",
+                "on-request",
+                "--sandbox",
+                "workspace-write",
+            ],
+        );
+        runner.runtime = "codex".into();
+        runner.handle = "codex-worker".into();
+        let slot_id = insert_crew_runner(&pool, &mission_base.id, &runner.id);
+        let fresh_mission_id: String = {
+            let conn = pool.get().unwrap();
+            conn.query_row("SELECT id FROM missions LIMIT 1", [], |r| r.get(0))
+                .unwrap()
+        };
+        let mission = Mission {
+            id: fresh_mission_id,
+            ..mission_base
+        };
+        let mut slot = slot_for(&runner);
+        slot.id = slot_id;
+
+        let app_data = tempfile::tempdir().unwrap();
+        let mission_dir = runner_core::event_log::path::mission_dir(
+            app_data.path(),
+            &mission.crew_id,
+            &mission.id,
+        );
+        let events_log_path = runner_core::event_log::path::events_path(
+            app_data.path(),
+            &mission.crew_id,
+            &mission.id,
+        );
+
+        let fake = fake_runtime();
+        let mgr = mgr_with_fake(None, Arc::clone(&fake));
+        let first_turn = "mission first turn".to_string();
+        let spawned = mgr
+            .spawn(
+                &mission,
+                &runner,
+                &slot,
+                app_data.path(),
+                events_log_path,
+                Arc::clone(&pool),
+                capture(),
+                Some(first_turn.clone()),
+            )
+            .unwrap();
+
+        let spec = fake.last_spawn_spec().expect("spawn was called");
+        let mission_dir_arg = mission_dir.to_string_lossy().to_string();
+        assert!(
+            has_arg_pair(&spec.args, "--add-dir", &mission_dir_arg),
+            "codex mission spawn must grant mission dir with --add-dir; args = {:?}",
+            spec.args,
+        );
+        assert!(
+            spec.args.iter().any(|arg| arg == &first_turn),
+            "codex mission first turn must ride argv; args = {:?}",
+            spec.args,
+        );
+        assert!(
+            fake.pastes().is_empty(),
+            "argv delivery must not schedule paste injection; got {:?}",
+            fake.pastes(),
+        );
+        assert!(
+            fake.keys().is_empty(),
+            "argv delivery must not schedule submit key injection; got {:?}",
+            fake.keys(),
+        );
+
+        mgr.kill(&spawned.id).unwrap();
+    }
+
+    #[test]
+    fn mission_registration_preserves_initial_terminal_size() {
+        let pool = pool_with_schema();
+        let mission_base = Mission {
+            crew_id: "c".into(),
+            ..mission()
+        };
+        let runner = runner("/bin/cat", &[]);
+        let slot_id = insert_crew_runner(&pool, &mission_base.id, &runner.id);
+        let fresh_mission_id: String = {
+            let conn = pool.get().unwrap();
+            conn.query_row("SELECT id FROM missions LIMIT 1", [], |r| r.get(0))
+                .unwrap()
+        };
+        let mission = Mission {
+            id: fresh_mission_id,
+            ..mission_base
+        };
+        let mut slot = slot_for(&runner);
+        slot.id = slot_id;
+
+        let mgr = mgr_with_fake(None, fake_runtime());
+        let pending = mgr
+            .register_mission_session(
+                &mission,
+                &runner,
+                &slot,
+                std::path::Path::new("/tmp"),
+                PathBuf::from("/dev/null"),
+                Arc::clone(&pool),
+                None,
+                Some((132, 41)),
+            )
+            .unwrap();
+
+        assert_eq!(pending.spec.initial_size, Some((132, 41)));
     }
 
     #[test]
@@ -4795,6 +4911,86 @@ mod tests {
         );
 
         mgr.kill("mr-sid").unwrap();
+    }
+
+    #[test]
+    fn codex_mission_resume_grants_event_log_dir_to_sandbox() {
+        let pool = pool_with_schema();
+        let now = Utc::now().to_rfc3339();
+        let runner_id = ulid::Ulid::new().to_string();
+        let mission_id = ulid::Ulid::new().to_string();
+        let slot_id = ulid::Ulid::new().to_string();
+        {
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "INSERT INTO crews (id, name, created_at, updated_at)
+                 VALUES ('c-codex-resume', 'c', ?1, ?1)",
+                params![now],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, created_at, updated_at)
+                 VALUES (?1, 'codex-template', 'Codex', 'codex', 'codex',
+                         '[\"--ask-for-approval\",\"on-request\",\"--sandbox\",\"workspace-write\"]',
+                         ?2, ?2)",
+                params![runner_id, now],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO slots
+                    (id, crew_id, runner_id, slot_handle, position, lead, added_at)
+                 VALUES (?1, 'c-codex-resume', ?2, 'impl', 0, 1, ?3)",
+                params![slot_id, runner_id, now],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO missions
+                    (id, crew_id, title, status, started_at)
+                 VALUES (?1, 'c-codex-resume', 't', 'running', ?2)",
+                params![mission_id, now],
+            )
+            .unwrap();
+            conn.execute(
+                "INSERT INTO sessions
+                    (id, mission_id, runner_id, slot_id, status, started_at)
+                 VALUES ('codex-resume-sid', ?1, ?2, ?3, 'stopped', ?4)",
+                params![mission_id, runner_id, slot_id, now],
+            )
+            .unwrap();
+        }
+
+        let app_data = tempfile::tempdir().unwrap();
+        let mission_dir = runner_core::event_log::path::mission_dir(
+            app_data.path(),
+            "c-codex-resume",
+            &mission_id,
+        );
+        let fake = fake_runtime();
+        let mgr = mgr_with_fake(None, Arc::clone(&fake));
+        let spawned = mgr
+            .resume(
+                "codex-resume-sid",
+                None,
+                None,
+                app_data.path(),
+                Arc::clone(&pool),
+                capture(),
+            )
+            .unwrap();
+
+        let spec = fake
+            .last_spawn_spec()
+            .expect("resume should have called spawn");
+        let mission_dir_arg = mission_dir.to_string_lossy().to_string();
+        assert!(
+            has_arg_pair(&spec.args, "--add-dir", &mission_dir_arg),
+            "codex mission resume must grant mission dir with --add-dir; args = {:?}",
+            spec.args,
+        );
+
+        mgr.kill(&spawned.id).unwrap();
     }
 
     /// Helper: insert a runner row + a `running` direct-chat

--- a/src-tauri/src/session/runtime.rs
+++ b/src-tauri/src/session/runtime.rs
@@ -298,13 +298,10 @@ pub trait SessionRuntime: Send + Sync {
     /// this method only signals.
     fn stop(&self, session: &RuntimeSession) -> RuntimeResult<()>;
 
-    /// Multi-line prompt paste. Runtime applies bracketed-paste
-    /// (`paste-buffer -p -r -d`); LF stays literal so the agent
-    /// sees one paste, not one submit per line. The runtime does
-    /// **not** submit — the manager follows up with `send_key`
-    /// when it wants the agent to act, so the timing is explicit
-    /// (Step 7's `paste_after` readiness wait lives on the
-    /// manager).
+    /// Multi-line prompt paste. Runtime keeps LF literal so the
+    /// agent sees one paste, not one submit per line. The runtime
+    /// does **not** submit — the manager follows up with `send_key`
+    /// when it wants the agent to act.
     fn paste(&self, session: &RuntimeSession, payload: &[u8]) -> RuntimeResult<()>;
 
     /// Literal byte stream from xterm.js passthrough — the user is

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -164,13 +164,16 @@ export const RunnerTerminal = forwardRef<
   // lengthen the redraw window the user perceives.
   const lastPushedColsRef = useRef(0);
   const lastPushedRowsRef = useRef(0);
-  // Snapshot replay is deferred until the pane is measurable. Mission
-  // workspaces mount every slot's RunnerTerminal at once while the
-  // feed tab is active; inactive panes stay invisible but measurable
-  // so xterm can fit and build terminal state before the user opens
-  // that tab. If a pane ever has a 0×0 rect, keep the bytes cached
-  // until activation/resize gives us real cols. See
-  // #mission-tab-return-drift.
+  // Snapshot replay is deferred until the pane is both active and
+  // measurable. Mission workspaces mount every slot's RunnerTerminal
+  // at once with `activeTab="feed"` by default — every slot pane is
+  // `display:none`, the mount-effect's `fit.fit()` is skipped (zero-
+  // size rect), and xterm sits at the constructor default 80×24.
+  // Replaying snapshot bytes into that 80-col grid bakes wrong cell
+  // positions into the buffer, and a later `fit.fit()` on tab focus
+  // can't move them. So we cache the fetched bytes here and drain
+  // them only once the pane has come to the front and fit at real
+  // cols. See #mission-tab-return-drift.
   const pendingSnapshotRef = useRef<OutputEvent[] | null>(null);
   const pendingLiveRef = useRef<OutputEvent[]>([]);
   const lastWrittenSeqRef = useRef(0);
@@ -180,7 +183,15 @@ export const RunnerTerminal = forwardRef<
   // without lifting the whole closure into module scope. Cleared on
   // sessionId change so a stale closure can't keep writing into the
   // previous session's xterm grid.
-  const tryDrainReplayRef = useRef<(() => void) | null>(null);
+  const tryDrainReplayRef = useRef<(() => boolean) | null>(null);
+  const replayFlushPendingRef = useRef(false);
+  const replayAfterFlushRef = useRef<Array<() => void>>([]);
+  // A just-replayed snapshot already paints the current TUI frame,
+  // including SGR-dependent background cells. The activation resize
+  // dance should still wake the backend PTY, but must not locally
+  // clear those cells first or Codex can repaint text without the
+  // gray input background.
+  const replayJustDrainedRef = useRef(false);
 
   // Keep the latest sessionId visible to the data/resize callbacks without
   // re-creating the terminal on prop change. The session listener below
@@ -230,6 +241,19 @@ export const RunnerTerminal = forwardRef<
       try {
         fit.fit();
         tryDrainReplayRef.current?.();
+        if (replayFlushPendingRef.current) {
+          if (focus) t.focus();
+          replayAfterFlushRef.current.push(() => {
+            window.requestAnimationFrame(() => {
+              refreshActiveTerminal({
+                focus,
+                forceResizeDance,
+                pushBackendSize,
+              });
+            });
+          });
+          return;
+        }
         webglRef.current?.clearTextureAtlas();
         t.refresh(0, t.rows - 1);
         if (focus) t.focus();
@@ -259,9 +283,11 @@ export const RunnerTerminal = forwardRef<
         // calls are kernel no-ops on macOS/Linux, so we perturb rows
         // only: width stays constant, avoiding hard-wrapped narrow
         // lines in scrollback, while both ioctls still emit SIGWINCH.
-        if (runtimeClearsOnResize(runnerRuntimeRef.current)) {
+        const skipLocalClear = replayJustDrainedRef.current;
+        if (runtimeClearsOnResize(runnerRuntimeRef.current) && !skipLocalClear) {
           t.write("\x1b[2J\x1b[H");
         }
+        replayJustDrainedRef.current = false;
         lastPushedColsRef.current = cols;
         lastPushedRowsRef.current = rows;
         const nudgedRows = rows > 1 ? rows - 1 : rows + 1;
@@ -501,11 +527,13 @@ export const RunnerTerminal = forwardRef<
       // intact. Plain shells skip the wipe entirely and keep their
       // history. See docs/impls/0011-pty-host-terminal-runtime.md
       // §"Per-runtime clear-on-resize".
-      if (runtimeClearsOnResize(runnerRuntimeRef.current)) {
+      const skipLocalClear = replayJustDrainedRef.current;
+      if (runtimeClearsOnResize(runnerRuntimeRef.current) && !skipLocalClear) {
         // ESC[2J — erase visible region
         // ESC[H  — cursor home
         t.write("\x1b[2J\x1b[H");
       }
+      replayJustDrainedRef.current = false;
       void api.session.resize(sid, t.cols, t.rows).catch(() => {
         // session may have exited
       });
@@ -682,37 +710,42 @@ export const RunnerTerminal = forwardRef<
     pendingLiveRef.current = [];
     lastWrittenSeqRef.current = 0;
     replayDoneRef.current = false;
+    replayFlushPendingRef.current = false;
+    replayAfterFlushRef.current = [];
+    replayJustDrainedRef.current = false;
 
     const writeOutput = (ev: OutputEvent) => {
       termRef.current?.write(decodeBase64Chunk(ev.data));
     };
 
-    // Replay drains only when (a) the snapshot RPC has returned and
-    // (b) the container has a measurable rect so the in-line fit gives
-    // us real cols/rows.
+    // Replay drains only when (a) the snapshot RPC has returned,
+    // (b) the pane is currently active, and (c) the container has a
+    // measurable rect so the in-line fit gives us real cols/rows.
     // Until all three line up we keep the bytes parked on
     // pendingSnapshotRef and pendingLiveRef; activation / resize
     // observers re-call this helper as conditions change.
     const tryDrainReplay = () => {
-      if (replayDoneRef.current) return;
+      if (replayDoneRef.current) return false;
+      if (!activeRef.current) return false;
       const t = termRef.current;
       const fit = fitRef.current;
       const node = containerRef.current;
-      if (!t || !fit || !node) return;
+      if (!t || !fit || !node) return false;
       const rect = node.getBoundingClientRect();
-      if (rect.width <= 0 || rect.height <= 0) return;
-      if (pendingSnapshotRef.current === null) return;
+      if (rect.width <= 0 || rect.height <= 0) return false;
+      if (pendingSnapshotRef.current === null) return false;
 
       try {
         fit.fit();
       } catch {
         // teardown in progress
-        return;
+        return false;
       }
 
       t.reset();
+      const queued: OutputEvent[] = [];
       for (const ev of pendingSnapshotRef.current) {
-        writeOutput(ev);
+        queued.push(ev);
         lastWrittenSeqRef.current = Math.max(
           lastWrittenSeqRef.current,
           ev.seq,
@@ -721,11 +754,32 @@ export const RunnerTerminal = forwardRef<
       pendingSnapshotRef.current = null;
       for (const ev of pendingLiveRef.current) {
         if (ev.seq <= lastWrittenSeqRef.current) continue;
-        writeOutput(ev);
+        queued.push(ev);
         lastWrittenSeqRef.current = ev.seq;
       }
       pendingLiveRef.current = [];
       replayDoneRef.current = true;
+
+      if (queued.length === 0) {
+        return true;
+      }
+
+      replayFlushPendingRef.current = true;
+      const onReplayFlushed = () => {
+        replayFlushPendingRef.current = false;
+        replayJustDrainedRef.current = true;
+        const callbacks = replayAfterFlushRef.current.splice(0);
+        for (const cb of callbacks) cb();
+      };
+
+      queued.forEach((ev, index) => {
+        const isLast = index === queued.length - 1;
+        termRef.current?.write(
+          decodeBase64Chunk(ev.data),
+          isLast ? onReplayFlushed : undefined,
+        );
+      });
+      return true;
     };
     tryDrainReplayRef.current = tryDrainReplay;
 
@@ -777,10 +831,11 @@ export const RunnerTerminal = forwardRef<
     return () => {
       cancelled = true;
       tryDrainReplayRef.current = null;
+      replayAfterFlushRef.current = [];
       unlistenOutput?.();
       unlistenExit?.();
     };
-  }, [sessionId]);
+  }, [sessionId, refreshActiveTerminal]);
 
   // Activation effect: when this tab moves to the front, wait for the pane
   // to become measurable, fit to its container, repaint the WebGL/canvas

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -55,6 +55,8 @@ interface ExitEvent {
   success: boolean;
 }
 
+const MAX_PENDING_LIVE_EVENTS = 4096;
+
 interface RunnerTerminalProps {
   sessionId: string;
   /** Runtime kind of the runner driving this session (e.g.
@@ -69,10 +71,9 @@ interface RunnerTerminalProps {
   onExit?: (ev: ExitEvent) => void;
   /** Surface terminal-side errors (stdin push failures, resize errors). */
   onError?: (msg: string) => void;
-  /** True while this terminal's tab is the foremost one in the workspace.
-   *  Every terminal stays mounted (z-stacked) so each PTY's xterm
-   *  scrollback survives tab-switching, but only the active one needs to
-   *  refresh + claim focus when the user comes back to it. */
+  /** True while this terminal's pane is visible/measurable. A visible
+   *  terminal may still be disabled, e.g. a stopped mission slot that
+   *  should replay dimmed scrollback without accepting input. */
   active?: boolean;
   /** Stop forwarding keystrokes / resize events to the backend.
    *  Set by the parent when the bound session has exited so stray
@@ -186,6 +187,8 @@ export const RunnerTerminal = forwardRef<
   const tryDrainReplayRef = useRef<(() => boolean) | null>(null);
   const replayFlushPendingRef = useRef(false);
   const replayAfterFlushRef = useRef<Array<() => void>>([]);
+  const pendingLiveOverflowRef = useRef(false);
+  const snapshotRefreshPendingRef = useRef(false);
   // A just-replayed snapshot already paints the current TUI frame,
   // including SGR-dependent background cells. The activation resize
   // dance should still wake the backend PTY, but must not locally
@@ -242,7 +245,7 @@ export const RunnerTerminal = forwardRef<
         fit.fit();
         tryDrainReplayRef.current?.();
         if (replayFlushPendingRef.current) {
-          if (focus) t.focus();
+          if (focus && !disabledRef.current) t.focus();
           replayAfterFlushRef.current.push(() => {
             window.requestAnimationFrame(() => {
               refreshActiveTerminal({
@@ -256,7 +259,7 @@ export const RunnerTerminal = forwardRef<
         }
         webglRef.current?.clearTextureAtlas();
         t.refresh(0, t.rows - 1);
-        if (focus) t.focus();
+        if (focus && !disabledRef.current) t.focus();
         if ((!forceResizeDance && !pushBackendSize) || disabledRef.current) {
           return;
         }
@@ -712,6 +715,8 @@ export const RunnerTerminal = forwardRef<
     replayDoneRef.current = false;
     replayFlushPendingRef.current = false;
     replayAfterFlushRef.current = [];
+    pendingLiveOverflowRef.current = false;
+    snapshotRefreshPendingRef.current = false;
     replayJustDrainedRef.current = false;
 
     const writeOutput = (ev: OutputEvent) => {
@@ -734,6 +739,40 @@ export const RunnerTerminal = forwardRef<
       const rect = node.getBoundingClientRect();
       if (rect.width <= 0 || rect.height <= 0) return false;
       if (pendingSnapshotRef.current === null) return false;
+      if (pendingLiveOverflowRef.current) {
+        if (!snapshotRefreshPendingRef.current) {
+          snapshotRefreshPendingRef.current = true;
+          const refreshSessionId = sessionIdRef.current;
+          let refreshed = false;
+          void api.session
+            .outputSnapshot(refreshSessionId)
+            .then((snapshot) => {
+              if (cancelled || sessionIdRef.current !== refreshSessionId) {
+                return;
+              }
+              const maxSnapshotSeq = snapshot.reduce(
+                (max, ev) => Math.max(max, ev.seq),
+                0,
+              );
+              pendingSnapshotRef.current = snapshot;
+              pendingLiveRef.current = pendingLiveRef.current.filter(
+                (ev) => ev.seq > maxSnapshotSeq,
+              );
+              pendingLiveOverflowRef.current = false;
+              refreshed = true;
+            })
+            .catch((e) => {
+              if (!cancelled) onErrorRef.current?.(String(e));
+            })
+            .finally(() => {
+              if (sessionIdRef.current === refreshSessionId) {
+                snapshotRefreshPendingRef.current = false;
+                if (refreshed) tryDrainReplayRef.current?.();
+              }
+            });
+        }
+        return false;
+      }
 
       try {
         fit.fit();
@@ -789,6 +828,13 @@ export const RunnerTerminal = forwardRef<
           if (event.payload.session_id !== sessionId) return;
           if (!replayDoneRef.current) {
             pendingLiveRef.current.push(event.payload);
+            if (pendingLiveRef.current.length > MAX_PENDING_LIVE_EVENTS) {
+              pendingLiveRef.current.splice(
+                0,
+                pendingLiveRef.current.length - MAX_PENDING_LIVE_EVENTS,
+              );
+              pendingLiveOverflowRef.current = true;
+            }
             // The snapshot may have already arrived and be waiting
             // on activation; nudge the drain in case the live event
             // arrived after the user just brought the pane forward.

--- a/src/components/StartMissionModal.tsx
+++ b/src/components/StartMissionModal.tsx
@@ -13,6 +13,7 @@ import { ChevronDown, ChevronRight, X } from "lucide-react";
 
 import { api } from "../lib/api";
 import { readDefaultWorkingDir } from "../lib/settings";
+import { estimateMissionTerminalGrid } from "../lib/terminalSizing";
 import type { CrewListItem, Mission, SlotWithRunner } from "../lib/types";
 import { Button } from "./ui/Button";
 import { Modal } from "./ui/Overlay";
@@ -143,7 +144,7 @@ export function StartMissionModal({
         title: title.trim(),
         goal_override: goal.trim() ? goal.trim() : null,
         cwd: cwd.trim() ? cwd.trim() : null,
-      });
+      }, estimateMissionTerminalGrid());
       onStarted(out.mission);
     } catch (e) {
       setError(String(e));

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -128,8 +128,15 @@ export const api = {
         crewId ? { crewId } : {},
       ),
     get: (id: string) => invoke<Mission>("mission_get", { id }),
-    start: (input: StartMissionInput) =>
-      invoke<StartMissionOutput>("mission_start", { input }),
+    start: (
+      input: StartMissionInput,
+      initialSize?: { cols: number; rows: number } | null,
+    ) =>
+      invoke<StartMissionOutput>("mission_start", {
+        input,
+        initialCols: initialSize?.cols ?? null,
+        initialRows: initialSize?.rows ?? null,
+      }),
     /** Re-mount router/bus on workspace mount; idempotent. After app restart
      *  the in-memory router/bus need to be rebuilt from the persisted log
      *  before stdin pushes can land on resumed slot PTYs. */

--- a/src/lib/terminalSizing.ts
+++ b/src/lib/terminalSizing.ts
@@ -1,0 +1,100 @@
+import { FitAddon } from "@xterm/addon-fit";
+import { Terminal } from "@xterm/xterm";
+import "@xterm/xterm/css/xterm.css";
+
+import {
+  readTerminalFontFamily,
+  readTerminalFontSize,
+  resolveTerminalFontStack,
+} from "./settings";
+
+export interface TerminalGridSize {
+  cols: number;
+  rows: number;
+}
+
+export const SLOT_TERMINAL_FRAME_PADDING_PX = 12;
+
+const MISSION_HEADER_HEIGHT_PX = 88;
+const MISSION_TAB_STRIP_HEIGHT_PX = 38;
+const MISSION_RAIL_DEFAULT_WIDTH_PX = 288;
+const MISSION_RAIL_MIN_WIDTH_PX = 200;
+const MISSION_RAIL_MAX_WIDTH_PX = 480;
+
+function fitTemporaryTerminal(widthPx: number, heightPx: number): TerminalGridSize | null {
+  const fontFamily = resolveTerminalFontStack(readTerminalFontFamily());
+  const fontSize = readTerminalFontSize();
+  const host = document.createElement("div");
+  host.style.position = "absolute";
+  host.style.left = "-10000px";
+  host.style.top = "-10000px";
+  host.style.width = `${widthPx}px`;
+  host.style.height = `${heightPx}px`;
+  host.style.visibility = "hidden";
+  host.style.pointerEvents = "none";
+  document.body.appendChild(host);
+
+  const term = new Terminal({
+    cols: 80,
+    rows: 24,
+    fontFamily,
+    fontSize,
+    scrollback: 0,
+  });
+  const fit = new FitAddon();
+  try {
+    term.loadAddon(fit);
+    term.open(host);
+    fit.fit();
+    return { cols: term.cols, rows: term.rows };
+  } finally {
+    term.dispose();
+    document.body.removeChild(host);
+  }
+}
+
+export function terminalGridFromPixels(
+  widthPx: number,
+  heightPx: number,
+  framePaddingPx = SLOT_TERMINAL_FRAME_PADDING_PX,
+): TerminalGridSize | null {
+  const width = Math.max(0, widthPx - framePaddingPx * 2);
+  const height = Math.max(0, heightPx - framePaddingPx * 2);
+  if (width <= 0 || height <= 0) return null;
+  return fitTemporaryTerminal(width, height);
+}
+
+export function terminalGridFromElement(
+  container: HTMLElement,
+  framePaddingPx = SLOT_TERMINAL_FRAME_PADDING_PX,
+): TerminalGridSize | null {
+  const rect = container.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return null;
+  return terminalGridFromPixels(rect.width, rect.height, framePaddingPx);
+}
+
+export function estimateMissionTerminalGrid(): TerminalGridSize | null {
+  const main = document.querySelector("main");
+  const rect = main?.getBoundingClientRect();
+  const width = rect && rect.width > 0 ? rect.width : window.innerWidth;
+  const height = rect && rect.height > 0 ? rect.height : window.innerHeight;
+
+  let railWidth = 0;
+  try {
+    if (localStorage.getItem("runner.mission.rail.open") !== "0") {
+      const raw = Number(localStorage.getItem("runner.mission.rail.width"));
+      railWidth = Number.isFinite(raw) ? raw : MISSION_RAIL_DEFAULT_WIDTH_PX;
+      railWidth = Math.min(
+        MISSION_RAIL_MAX_WIDTH_PX,
+        Math.max(MISSION_RAIL_MIN_WIDTH_PX, railWidth),
+      );
+    }
+  } catch {
+    railWidth = MISSION_RAIL_DEFAULT_WIDTH_PX;
+  }
+
+  return terminalGridFromPixels(
+    Math.max(0, width - railWidth),
+    Math.max(0, height - MISSION_HEADER_HEIGHT_PX - MISSION_TAB_STRIP_HEIGHT_PX),
+  );
+}

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -59,11 +59,7 @@ import {
   StopButton,
 } from "../components/ui/SessionControl";
 import { chunkIndicatesTuiReady, isFreshSpawn } from "../lib/sessionLifecycle";
-import {
-  readTerminalFontFamily,
-  readTerminalFontSize,
-  resolveTerminalFontStack,
-} from "../lib/settings";
+import { terminalGridFromElement } from "../lib/terminalSizing";
 import { useDelayedFlag } from "../lib/useDelayedFlag";
 import { useResizableWidth } from "../hooks/useResizableWidth";
 import { useTerminalBg } from "../lib/useTerminalBg";
@@ -77,13 +73,11 @@ const RAIL_STORAGE_WIDTH = "runner.mission.rail.width";
 const RAIL_MIN = 200;
 const RAIL_MAX = 480;
 const RAIL_DEFAULT = 288;
-const SLOT_TERMINAL_FRAME_PADDING_PX = 12; // matches SlotPtyPane's p-3 wrapper
 
 /// Compute cols/rows for the would-be terminal area from the Pane
-/// container's bounding rect + a one-shot DOM cell-size measurement
-/// using the user's current terminal font settings. Returns null if
-/// the container has no rect (workspace not mounted yet) or the
-/// measurement span fails.
+/// container's bounding rect + xterm/FitAddon using the user's current
+/// terminal font settings. Returns null if the container has no rect
+/// (workspace not mounted yet) or xterm cannot measure.
 ///
 /// Used by `resumeMission`'s fallback chain when no individual slot
 /// terminal is measurable — e.g. the user clicked Resume from the
@@ -95,40 +89,8 @@ const SLOT_TERMINAL_FRAME_PADDING_PX = 12; // matches SlotPtyPane's p-3 wrapper
 /// there if needed. "Approximately correct" beats "spawn at 80×24."
 function workspaceDimsFromContainer(
   container: HTMLElement,
-  framePaddingPx = SLOT_TERMINAL_FRAME_PADDING_PX,
 ): { cols: number; rows: number } | null {
-  const rect = container.getBoundingClientRect();
-  if (rect.width <= 0 || rect.height <= 0) return null;
-  const width = Math.max(0, rect.width - framePaddingPx * 2);
-  const height = Math.max(0, rect.height - framePaddingPx * 2);
-  if (width <= 0 || height <= 0) return null;
-  const fontFamily = resolveTerminalFontStack(readTerminalFontFamily());
-  const fontSize = readTerminalFontSize();
-  const span = document.createElement("span");
-  span.style.position = "absolute";
-  span.style.visibility = "hidden";
-  span.style.top = "-9999px";
-  span.style.fontFamily = fontFamily;
-  span.style.fontSize = `${fontSize}px`;
-  span.style.lineHeight = "1";
-  span.style.whiteSpace = "pre";
-  // 100 chars to average out subpixel widths.
-  span.textContent = "M".repeat(100);
-  document.body.appendChild(span);
-  let cellWidth: number;
-  let cellHeight: number;
-  try {
-    const spanRect = span.getBoundingClientRect();
-    if (spanRect.width <= 0 || spanRect.height <= 0) return null;
-    cellWidth = spanRect.width / 100;
-    cellHeight = spanRect.height;
-  } finally {
-    document.body.removeChild(span);
-  }
-  return {
-    cols: Math.max(1, Math.floor(width / cellWidth)),
-    rows: Math.max(1, Math.floor(height / cellHeight)),
-  };
+  return terminalGridFromElement(container);
 }
 
 export default function MissionWorkspace() {
@@ -922,10 +884,10 @@ export default function MissionWorkspace() {
             className="relative flex flex-1 min-h-0 flex-col"
           >
             {/* All panes stay mounted so xterm's in-memory scrollback
-                survives tab switches. Inactive panes stay invisible
-                instead of display:none so hidden PTYs still have real
-                dimensions; RunnerTerminal can fit/replay Codex's first
-                frame before the user opens the tab. */}
+                survives tab switches. Inactive panes use display:none:
+                that keeps the React/xterm instances alive while making
+                the visible session unambiguous. The terminal activation
+                effect refits + replays after the pane is shown. */}
             <Pane active={activeTab === "feed"}>
               <EventFeed
                 missionId={mission.id}
@@ -1296,16 +1258,14 @@ function Pane({
   active: boolean;
   children: React.ReactNode;
 }) {
-  // Pane wraps both the feed and the terminal slots. Inactive panes
-  // stay in layout (`visibility:hidden`, not `display:none`) so xterm
-  // can measure, fit, and replay buffered TUI bytes while hidden.
-  // Background is `bg-panel` so the feed reads as a tinted "page" with
-  // the white event cards (`bg-bg`) lifting off it.
+  // Pane wraps both the feed and the terminal slots. Background is
+  // `bg-panel` so the feed reads as a tinted "page" with the white
+  // event cards (`bg-bg`) lifting off it. Terminal slots cover this bg
+  // with their own terminal palette wrapper.
   return (
     <div
-      aria-hidden={!active}
-      className={`absolute inset-0 flex flex-col bg-panel ${
-        active ? "visible z-10" : "invisible z-0 pointer-events-none"
+      className={`absolute inset-0 flex-col bg-panel ${
+        active ? "flex" : "hidden"
       }`}
     >
       {children}

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -1232,7 +1232,7 @@ function SlotPtyPane({
           sessionId={session.id}
           runnerRuntime={session.runtime}
           onError={onError}
-          active={active && !dead && !resuming && !starting}
+          active={active && !resuming && !starting}
           disabled={dead || resuming || starting}
         />
       </div>


### PR DESCRIPTION
Summary:
- Keep Codex mission first-turn delivery deterministic via spawn-time positional argv, while still granting mission bus access with --add-dir.
- Pass estimated mission terminal geometry into mission_start and preserve it through backend spawn registration so mission PTYs do not start at 80x24.
- Defer mission terminal snapshot replay until panes are active/measurable, then avoid clearing freshly replayed frames during activation.
- Keep inactive mission panes hidden while preserving mounted xterm state and refitting on activation.

Validation:
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check
- cargo test --workspace

Known follow-up:
- Codex mission prompt is now sent, but the prompt/input background can still render black on fresh mission start. That rendering issue remains for follow-up investigation.