### PR TITLE
Fix mission Codex input background

### DIFF
--- a/src-tauri/src/session/pty_runtime.rs
+++ b/src-tauri/src/session/pty_runtime.rs
@@ -41,6 +41,15 @@ const RUNTIME_LABEL: &str = "native-pty";
 const READ_BUF: usize = 8 * 1024;
 const DEFAULT_IDLE_THRESHOLD: Duration = Duration::from_millis(750);
 const IDLE_MONITOR_POLL: Duration = Duration::from_millis(50);
+// Mission PTYs boot while their frontend xterm panes are often hidden on
+// the feed tab. Answer Codex's startup terminal probes here so the process
+// does not cache fallback colors before xterm has a chance to attach.
+const TERMINAL_QUERY_STARTUP_BUDGET: usize = 8 * 1024;
+const TERMINAL_QUERY_TAIL: usize = 16;
+const DEFAULT_OSC10_FG_REPLY: &[u8] = b"\x1b]10;rgb:dcdc/dcdc/e0e0\x1b\\";
+const DEFAULT_OSC11_BG_REPLY: &[u8] = b"\x1b]11;rgb:1515/1616/1b1b\x1b\\";
+const DSR_CURSOR_POS_REPLY: &[u8] = b"\x1b[1;1R";
+const DA1_XTERM_REPLY: &[u8] = b"\x1b[?1;2c";
 
 /// Public constructor. Holds no external state — the runtime is purely
 /// in-memory and the per-session resources tear down with their handles.
@@ -188,6 +197,7 @@ impl SessionRuntime for PtyRuntime {
         let stop_for_reader = Arc::clone(&stop);
         let handle_for_reader = Arc::clone(&handle);
         let session_id_for_reader = spec.session_id.clone();
+        let query_responder = spec.mission.then(TerminalQueryResponder::default);
         thread::Builder::new()
             .name(format!("pty-reader-{}", spec.session_id))
             .spawn(move || {
@@ -197,6 +207,7 @@ impl SessionRuntime for PtyRuntime {
                     stop_for_reader,
                     handle_for_reader,
                     session_id_for_reader,
+                    query_responder,
                 );
             })
             .map_err(|e| RuntimeError::Msg(format!("spawn reader thread: {e}")))?;
@@ -376,6 +387,7 @@ fn reader_thread(
     stop: Arc<AtomicBool>,
     handle: Arc<SessionHandle>,
     session_id: String,
+    mut query_responder: Option<TerminalQueryResponder>,
 ) {
     let detector = Arc::new(Mutex::new(IdleDetector::new(DEFAULT_IDLE_THRESHOLD)));
     let monitor_done = Arc::new(AtomicBool::new(false));
@@ -404,6 +416,9 @@ fn reader_thread(
         match reader.read(&mut buf) {
             Ok(0) => break, // EOF
             Ok(n) => {
+                if let Some(responder) = query_responder.as_mut() {
+                    answer_terminal_queries(responder, &buf[..n], &handle, &session_id);
+                }
                 let transition = {
                     let mut detector = detector.lock().expect("idle detector poisoned");
                     detector.on_bytes(n)
@@ -462,6 +477,96 @@ fn reader_thread(
 }
 
 // --- Helpers ------------------------------------------------------------
+
+#[derive(Default)]
+struct TerminalQueryResponder {
+    tail: Vec<u8>,
+    observed: usize,
+}
+
+impl TerminalQueryResponder {
+    fn observe(&mut self, chunk: &[u8]) -> Vec<&'static [u8]> {
+        if chunk.is_empty() {
+            return Vec::new();
+        }
+        if self.observed >= TERMINAL_QUERY_STARTUP_BUDGET {
+            self.observed = self.observed.saturating_add(chunk.len());
+            self.tail.clear();
+            return Vec::new();
+        }
+
+        let remaining = TERMINAL_QUERY_STARTUP_BUDGET - self.observed;
+        let scan_len = chunk.len().min(remaining);
+        let scan_chunk = &chunk[..scan_len];
+        let old_len = self.tail.len();
+        let mut combined = Vec::with_capacity(old_len + scan_chunk.len());
+        combined.extend_from_slice(&self.tail);
+        combined.extend_from_slice(scan_chunk);
+
+        let mut matches: Vec<(usize, &'static [u8])> = Vec::new();
+        for (needle, response) in terminal_query_patterns() {
+            for pos in find_subsequence_positions(&combined, needle) {
+                if pos + needle.len() > old_len {
+                    matches.push((pos, response));
+                }
+            }
+        }
+        matches.sort_by_key(|(pos, _)| *pos);
+
+        let tail_start = combined.len().saturating_sub(TERMINAL_QUERY_TAIL);
+        self.tail.clear();
+        self.tail.extend_from_slice(&combined[tail_start..]);
+        self.observed = self.observed.saturating_add(chunk.len());
+
+        matches.into_iter().map(|(_, response)| response).collect()
+    }
+}
+
+fn terminal_query_patterns() -> &'static [(&'static [u8], &'static [u8])] {
+    &[
+        (b"\x1b]10;?\x1b\\", DEFAULT_OSC10_FG_REPLY),
+        (b"\x1b]10;?\x07", DEFAULT_OSC10_FG_REPLY),
+        (b"\x1b]11;?\x1b\\", DEFAULT_OSC11_BG_REPLY),
+        (b"\x1b]11;?\x07", DEFAULT_OSC11_BG_REPLY),
+        (b"\x1b[6n", DSR_CURSOR_POS_REPLY),
+        (b"\x1b[c", DA1_XTERM_REPLY),
+        (b"\x1b[0c", DA1_XTERM_REPLY),
+    ]
+}
+
+fn find_subsequence_positions(haystack: &[u8], needle: &[u8]) -> Vec<usize> {
+    if needle.is_empty() || haystack.len() < needle.len() {
+        return Vec::new();
+    }
+    haystack
+        .windows(needle.len())
+        .enumerate()
+        .filter_map(|(idx, window)| (window == needle).then_some(idx))
+        .collect()
+}
+
+fn answer_terminal_queries(
+    responder: &mut TerminalQueryResponder,
+    bytes: &[u8],
+    handle: &SessionHandle,
+    session_id: &str,
+) {
+    let responses = responder.observe(bytes);
+    if responses.is_empty() {
+        return;
+    }
+
+    let mut writer = handle.writer.lock().expect("writer poisoned");
+    for response in responses {
+        if let Err(e) = writer.write_all(response) {
+            log::warn!("terminal query response write failed for {session_id}: {e}");
+            return;
+        }
+    }
+    if let Err(e) = writer.flush() {
+        log::warn!("terminal query response flush failed for {session_id}: {e}");
+    }
+}
 
 fn lookup(runtime: &PtyRuntime, session_id: &str) -> RuntimeResult<Arc<SessionHandle>> {
     runtime
@@ -599,6 +704,59 @@ mod tests {
         assert_eq!(translate_key("C-D").unwrap(), vec![0x04]);
         assert!(translate_key("OhNoMyKey").is_err());
         assert!(translate_key("C-").is_err());
+    }
+
+    #[test]
+    fn terminal_query_responder_answers_codex_startup_handshake() {
+        let mut responder = TerminalQueryResponder::default();
+        let responses =
+            responder.observe(b"\x1b[?2004h\x1b[6n\x1b]10;?\x1b\\\x1b]11;?\x1b\\\x1b[c");
+
+        assert_eq!(
+            responses,
+            vec![
+                DSR_CURSOR_POS_REPLY,
+                DEFAULT_OSC10_FG_REPLY,
+                DEFAULT_OSC11_BG_REPLY,
+                DA1_XTERM_REPLY,
+            ]
+        );
+    }
+
+    #[test]
+    fn terminal_query_responder_handles_fragmented_osc_without_duplicates() {
+        let mut responder = TerminalQueryResponder::default();
+
+        assert!(responder.observe(b"\x1b]1").is_empty());
+        assert_eq!(
+            responder.observe(b"1;?\x1b\\trail"),
+            vec![DEFAULT_OSC11_BG_REPLY]
+        );
+        assert!(responder.observe(b" more output").is_empty());
+    }
+
+    #[test]
+    fn terminal_query_responder_supports_bel_terminated_colors_and_da_zero() {
+        let mut responder = TerminalQueryResponder::default();
+        let responses = responder.observe(b"\x1b]10;?\x07\x1b]11;?\x07\x1b[0c");
+
+        assert_eq!(
+            responses,
+            vec![
+                DEFAULT_OSC10_FG_REPLY,
+                DEFAULT_OSC11_BG_REPLY,
+                DA1_XTERM_REPLY,
+            ]
+        );
+    }
+
+    #[test]
+    fn terminal_query_responder_only_answers_startup_window() {
+        let mut responder = TerminalQueryResponder::default();
+        let filler = vec![b'x'; TERMINAL_QUERY_STARTUP_BUDGET];
+
+        assert!(responder.observe(&filler).is_empty());
+        assert!(responder.observe(b"\x1b]11;?\x1b\\").is_empty());
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- Answer Codex startup terminal probes from the mission PTY reader while frontend xterm panes are hidden on the feed tab.
- Reply to OSC 10/11, DSR, and DA1 during the startup window so Codex detects terminal colors before caching its composer palette.
- Scope the responder to mission PTYs and bound it to the first 8KB of output; direct chats still rely on visible xterm.
- Add unit coverage for the captured Codex handshake, fragmented OSC, BEL terminators, and startup-window cutoff.

Verification:
- cargo test -p runner --lib session::pty_runtime::tests
- cargo test --workspace
- cargo clippy -- -D warnings
- git diff --check

Manual:
- Confirmed fresh mission Codex slots now render the input composer with the gray background on first reveal.