### PR TITLE
Refactor PTY session runtime seam

### DIFF
--- a/docs/impls/0016-pty-session-pre-feature-refactor.md
+++ b/docs/impls/0016-pty-session-pre-feature-refactor.md
@@ -1,0 +1,110 @@
+# PTY Session Layer Pre-Feature Refactor
+
+> Behavior-preserving cleanup of the session/PTY stack before the next round of terminal features. No product-visible change; every step is a refactor or a deletion that keeps the existing tests green.
+
+## Context
+
+The session layer was designed around a tmux-backed runtime (`docs/impls/archive/0004`) and later migrated to an in-process `portable-pty` runtime (`docs/impls/archive/0011`). The migration swapped the implementation but left the *seam* — the `SessionRuntime` trait, `RuntimeSession`, and a large fraction of the comments — shaped around tmux. The result is an abstraction that describes a runtime that no longer exists, plus accumulated dead scaffolding from earlier prompt-delivery and reattach designs.
+
+`src-tauri/src/session/manager.rs` is now 5620 lines (one ~2160-line `impl SessionManager` block plus ~2900 lines of in-file tests), and per-session state is spread across six separate locks. Each new feature has to thread through this, and the misleading tmux vocabulary makes it easy to reason wrong.
+
+This plan does the no-behavior-change cleanup first, so feature work lands on an honest, smaller surface. The two larger architectural ideas surfaced during analysis — a host-side terminal model, and the frontend snapshot/live reconciliation rewrite — are explicit non-goals here and get their own docs if pursued.
+
+## Goal
+
+Leave the session/PTY layer functionally identical but materially smaller and truthful:
+
+- The runtime seam describes the PTY runtime that actually exists, not tmux.
+- Dead code (vestigial first-prompt schedulers, unused `OutputStream` API, the uncalled reattach machinery) is gone.
+- Per-session state has a single owner instead of six parallel maps.
+- `manager.rs` is split into reviewable modules.
+
+## Non-goals
+
+- No host-side terminal/VT model. The raw byte ring buffer + alt-screen escape scanning (`update_alt_screen_state`, the synthetic `seq=0` prepend in `output_snapshot`) stays as-is. A headless emulator is a separate design doc, justified only if a feature needs correct cross-restart replay, scrollback search, or server-side output.
+- No frontend reconciliation rewrite. `RunnerTerminal.tsx`'s snapshot/live ref-tangle is left alone; it gets its own doc when terminal UX features next touch it.
+- No change to spawn behavior, kill semantics, idle/busy detection, gate timing, event payloads, or DB-stored data that anything reads.
+
+## Decisions
+
+1. **Behavior-preserving only.** Any step that would change a product behavior is out of scope. The test suite is the contract; if a step needs a test changed for reasons other than a renamed symbol or deleted dead path, stop and reassess.
+2. **Collapse `RuntimeSession` to `{ runtime: String, session_id: String }`.** Keep `runtime` as a discriminator for a future second implementation (Windows). Drop `socket` (always `""`), `window` (always `"main"`), and `pane` (always `== session_id`).
+3. **Leave the dead DB columns as legacy; stop writing them.** `runtime_socket`, `runtime_window`, `runtime_pane` are write-only on the live path — nothing reads them back except the dead reattach reconstructor. No destructive migration: keep the columns (they go NULL on new rows), drop them only from the write statements, and add a schema comment marking them legacy/unused since the PTY-runtime migration. Keep writing `runtime_session` (it stores the session id and the column name is still meaningful).
+4. **Delete session reattach; keep resume and startup mission remount. These are different features.** *Session reattach* means re-binding to a still-running agent process that outlived the app — a tmux-era capability (the tmux server held panes across restarts). It is impossible under the in-process PTY runtime: agent processes are children of the app process and die with it. Startup still remounts routers/event buses for missions that are marked `running`, then runs `cleanup_stale_running_rows_on_startup` (demote `running` session rows → `stopped`). The session reattach machinery (`reattach_running_sessions` / `reattach_one` / `attach_existing` / `RowSnap::runtime_session()`) has no production caller and is kept alive only by its own tests and stale comments. *Resume* means re-spawning a fresh PTY and having the CLI agent continue its prior conversation via `agent_session_key` (claude-code `--resume`, codex rollout). That is `SessionManager::resume`, the live feature, which re-spawns and never uses the reattach path. **We support resume only.** Delete all session reattach code; leave `SessionManager::resume` and startup mission router/event-bus remounting intact.
+5. **Trim the trait to the real contract.** Remove the trait method `SessionRuntime::resume()` — despite the name it is the runtime-level *reattach* primitive (re-establish liveness from persisted metadata), always errors in `PtyRuntime`, and is unrelated to `SessionManager::resume`. Remove `RuntimeOutput::Replay` (never emitted by `PtyRuntime`; the forwarder's snapshot path is the manager's byte buffer) and `OutputStream::as_receiver` / `try_recv` (unused). Collapse `paste` into `send_bytes` at the runtime level — they are byte-identical (`write_to`), so `SessionManager::inject_paste` keeps its existing byte behavior by calling `send_bytes(payload)` and then submitting Enter.
+6. **One PR per step group, ordered by risk.** Steps 1–3 (deletions, seam, comments) are one PR; Step 4 (state consolidation) is its own PR; Step 5 (file split) is its own PR. This keeps each diff reviewable and bisectable.
+7. **Per-session locks, not a single global lock.** The consolidated state uses `Mutex<HashMap<String, Arc<Mutex<SessionState>>>>`, not `Mutex<HashMap<String, SessionState>>`. The forwarder's `record_output` runs per output chunk (hot path); a single global lock would make a busy agent's output stream contend with `spawn` / `kill` / `resume` on every other session — a real concurrency regression versus today's independent maps, dressed up as a cleanup. Per-session locks keep the hot path off the global lock; the `Arc` clone per lookup is negligible next to a PTY write. The map lock is held only for membership lookup/insert/remove.
+
+## Step 1: Delete vestigial code
+
+Files: `src-tauri/src/session/manager.rs`, `src-tauri/src/session/runtime.rs`, `src-tauri/src/commands/mission.rs`
+
+- Remove `schedule_mission_first_prompt` and `schedule_direct_first_prompt` (`manager.rs:2866`, `2903`). Since first-turn delivery moved to spawn-time argv (`docs/impls/archive/0007`), both are no-ops whose only effect is a `log::warn!` when argv delivery didn't happen. Inline that one warning at the call sites (or drop it — argv non-delivery for claude-code/codex is already an internal invariant) and delete the functions and their `_mgr`/`mgr` plumbing.
+- Remove `OutputStream::as_receiver` and `OutputStream::try_recv` (`runtime.rs`) — no caller in production or tests. Keep `recv_timeout` and `stop_flag`.
+- Delete the session reattach machinery: `reattach_running_sessions`, `reattach_one`, `attach_existing`, and `RowSnap::runtime_session()` (the only consumer of the persisted runtime columns), plus their tests (`manager.rs:5034`–`5360` block). Preserve the startup mission router/event-bus remount path, but rename/reword it away from session reattach and remove the failed-id plumbing that only existed for `SessionManager::reattach_running_sessions`.
+
+Validation: code shrinks, `cargo test -p runner` stays green minus the deleted reattach tests.
+
+## Step 2: Collapse `RuntimeSession` and trim the runtime trait
+
+Files: `src-tauri/src/session/runtime.rs`, `src-tauri/src/session/pty_runtime.rs`, `src-tauri/src/session/manager.rs`, `src-tauri/src/db.rs` (schema comment only)
+
+- Reduce `RuntimeSession` (`runtime.rs:70-90`) to `{ runtime: String, session_id: String }`. Update the doc comment to describe the PTY runtime, not tmux sockets/panes.
+- Update `PtyRuntime` (`pty_runtime.rs:215-221`) to construct the two-field value; replace every `session.session_name` / `session.pane` usage in `pty_runtime.rs` with `session.session_id`.
+- Remove the `runtime.paste` trait method; point `manager::inject_paste` at `runtime.send_bytes(payload)`. Do not add bracketed-paste wrapping in this refactor: the old `PtyRuntime::paste` wrote bytes unchanged, so wrapping would be a behavior change.
+- Remove the trait method `SessionRuntime::resume` (the reattach primitive — not `SessionManager::resume`, which stays) and `RuntimeOutput::Replay`. In the forwarder consumer (`manager.rs:1944`) the `Replay(bytes) | Stream(bytes)` arm becomes `Stream(bytes)`.
+- Stop writing the dead columns: update the three `UPDATE sessions SET runtime_* = …` sites (`manager.rs:968`, `1335`, `1765`) to persist only `runtime` + `runtime_session`. Leave `runtime_socket` / `runtime_window` / `runtime_pane` in the schema (no migration) and add comments/tests near the migration list and schema guard in `db.rs` marking them legacy/unused since the PTY-runtime migration.
+
+Validation: `cargo test -p runner`, plus a manual mission start + direct chat start to confirm spawn/inject/resize/kill still round-trip.
+
+## Step 3: Strip stale tmux comments
+
+Files: `src-tauri/src/session/*.rs`, `src-tauri/src/commands/session.rs`
+
+- Rewrite or delete the comments that narrate tmux mechanics for a PTY runtime: `kill()`'s "tmux's pipe-pane cleanup chain", `SessionHandle.stop`'s "kill-session → cat dies → FIFO POLLHUP → tx drops" (`manager.rs:392-398`, `2256-2260`), the `send-keys -l --` references, and the ~59 `tmux` mentions across `session/`. Describe the real mechanism: drop master PTY → child SIGHUP → reader `read()` returns 0 → forwarder winds down; `kill`'s explicit stop-flag breaks the consumer out within ~500ms if the disconnect path stalls.
+- This is comments-only; no code changes. Doing it as its own commit keeps Step 2's diff focused on behavior-bearing edits.
+
+Validation: none beyond `cargo fmt --check` and a read-through.
+
+## Step 4: Consolidate per-session state
+
+Files: `src-tauri/src/session/manager.rs`
+
+- Replace the four `Mutex<HashMap<String, _>>` (`sessions`, `output_buffers`, `output_seq`, `alt_screen_on`) and the two `Mutex<HashSet<String>>` (`killed`, `resuming_claims`) with a single `Mutex<HashMap<String, Arc<Mutex<SessionState>>>>`, where `SessionState` owns `handle: Option<SessionHandle>`, output buffer, seq counter, alt-screen flag, and per-session status flags. The outer map lock guards membership only; the inner mutex guards a session's mutable state. See Decision 7 for why per-session locks rather than a single global lock.
+- Keep `pending_mission_cancels` and `claude_launch_gate` as-is — they are keyed by `mission_id` / global, not by `session_id`, so they don't belong in the per-session map.
+- Preserve the kill state machine's contract without losing retained output: the live `handle` stays present until `runtime.stop` succeeds; then only `handle` is cleared and the forwarder is joined. The `SessionState` entry itself remains so `output_snapshot` can replay stopped-session output and `output_seq` continuity survives resume, and is removed only by the existing purge/forget paths. Lookups (`record_output`, `inject_stdin`, `resize`, `output_snapshot`) take the outer lock just long enough to clone the `Arc`, then operate under the inner lock — so the forwarder hot path never contends with `spawn` / `kill` / `resume` on a global lock.
+
+Validation: `cargo test -p runner` (the existing kill/resume/output_snapshot tests exercise this), plus a manual concurrent-kill check (Stop a mission with multiple live slots).
+
+## Step 5: Split `manager.rs` into modules
+
+Files: `src-tauri/src/session/manager/` (new directory)
+
+- Convert `session/manager.rs` into `session/manager/mod.rs` plus focused submodules, each with its own `impl SessionManager` block:
+  - `mod.rs` — struct definition, `new`, `runtime`, the consolidated `SessionState`.
+  - `spawn.rs` — `base_spawn_spec`, `apply_runtime_args`, `register_mission_session`, `complete_mission_session_spawn`, `spawn`, `spawn_direct*`, `enter_claude_launch_gate`.
+  - `lifecycle.rs` — `kill`, `kill_all_for_mission`, `kill_all_for_runner`, `forget`, the pending-mission-cancel helpers.
+  - `output.rs` — `start_forwarder_thread`, `record_output`, `output_snapshot`, `purge_*`, `update_alt_screen_state`, `inject_stdin`, `inject_paste`, `resize`.
+- Move the ~2900 lines of tests to `session/manager/tests.rs`.
+- Make struct fields `pub(super)` (or add thin accessors) as needed so the submodules can reach shared state. Step 4's single state map makes this cleaner — one field to expose instead of six.
+
+Validation: `cargo test --workspace` (pure code-move; behavior unchanged), `cargo fmt`, `cargo clippy`.
+
+## Open questions
+
+1. **Step 5 timing.** The file split is pure code-move with zero behavior change, but reshuffling a 5600-line file guarantees merge conflicts with any in-flight feature branch. Recommendation: ship Steps 1–4 regardless, and only run Step 5 when the feature queue is quiet enough that no large branch is open against `manager.rs`.
+
+Resolved:
+
+- **Reattach.** Not a supported feature — resume only. The reattach machinery is deleted outright; see Decision 4.
+- **Lock granularity.** Per-session `Arc<Mutex<SessionState>>`, not a single global lock; see Decision 7.
+- **Dead DB columns.** No destructive migration — keep `runtime_socket` / `runtime_window` / `runtime_pane` as legacy columns, stop writing them, and comment them in the schema; see Decision 3.
+
+## Validation (whole effort)
+
+- `pnpm exec tsc --noEmit`
+- `pnpm run lint`
+- `cargo fmt --check`
+- `cargo clippy --workspace --all-targets`
+- `cargo test --workspace`
+- Manual smoke: start a mission (multi-slot), inject input, resize, Stop; start a direct chat, send a prompt, resize, Stop; restart the app and confirm prior `running` rows show stopped (no reattach regression).

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -11,7 +11,6 @@
 // human's intent, which the orchestrator routes to the lead via the
 // built-in rule in C8).
 
-use std::collections::HashSet;
 use std::path::Path;
 
 use chrono::Utc;
@@ -910,9 +909,9 @@ pub async fn mission_attach(
 ///  * `mission_attach` — workspace UI mount path; runs on every
 ///    workspace navigation. After the startup reconciler runs, this is
 ///    almost always a no-op.
-///  * `reattach_all_running_missions` — app startup path; runs once
-///    per running mission before session reattach so forwarder threads
-///    don't emit `mission_*` events into a non-existent subscriber.
+///  * `mount_all_running_mission_routers` — app startup path; runs once
+///    per running mission so router/event-bus fanout is restored for
+///    missions that remain marked running in the DB.
 ///
 /// Returns `Ok(())` (no-op) when the mission's router is already
 /// registered, or when the mission isn't in the `running` state.
@@ -1024,52 +1023,41 @@ pub(crate) async fn ensure_mission_router_mounted(
 
 /// Walk every `running` mission and mount its Router + EventBus.
 ///
-/// Runs once at app startup, before `SessionManager::reattach_running_sessions`,
-/// so the bus is in place when forwarder threads start emitting
-/// `mission_*` events. The NDJSON log is the source of truth; this
-/// just re-wires the in-memory fanout layer that died with the old
-/// process.
+/// Runs once at app startup. The NDJSON log is the source of truth;
+/// this just re-wires the in-memory fanout layer that died with the
+/// old process. The PTY startup cleanup later demotes stale running
+/// session rows; it does not reattach child processes from the prior
+/// app process.
 ///
 /// Per-mission isolation: if one mission's mount fails (corrupt log,
 /// missing crew row, etc.), it gets logged and the loop continues.
-/// The returned set lists every mission whose mount failed —
-/// callers pass it to `SessionManager::reattach_running_sessions`
-/// so those missions' alive panes are stopped instead of reattached
-/// (preserving the pre-eager-mount safety property that mission
-/// bytes never stream into a non-existent bus).
-pub(crate) async fn reattach_all_running_missions(
-    state: &AppState,
-    app: &tauri::AppHandle,
-) -> HashSet<String> {
+pub(crate) async fn mount_all_running_mission_routers(state: &AppState, app: &tauri::AppHandle) {
     let mission_ids = match state.db.get() {
         Ok(conn) => list_running_mission_ids(&conn).unwrap_or_else(|e| {
-            log::error!("reattach_all_running_missions query failed: {e}");
+            log::error!("mount_all_running_mission_routers query failed: {e}");
             Vec::new()
         }),
         Err(e) => {
-            log::error!("reattach_all_running_missions db pool unavailable: {e}");
+            log::error!("mount_all_running_mission_routers db pool unavailable: {e}");
             Vec::new()
         }
     };
 
-    let mut failed = HashSet::new();
     for mission_id in mission_ids {
         match ensure_mission_router_mounted(state, app, &mission_id).await {
             Ok(()) => {
-                log::info!("mission reattach: id={mission_id} action=mounted");
+                log::info!("mission startup mount: id={mission_id} action=mounted");
             }
             Err(e) => {
-                log::info!("mission reattach: id={mission_id} action=mount_failed → stop");
-                log::warn!("mission {mission_id} mount-failed reattach: {e}");
-                failed.insert(mission_id);
+                log::info!("mission startup mount: id={mission_id} action=mount_failed");
+                log::warn!("mission {mission_id} startup mount failed: {e}");
             }
         }
     }
-    failed
 }
 
 /// Return the ids of every mission that's currently `running` and not
-/// archived. Factored out of `reattach_all_running_missions` so the
+/// archived. Factored out of `mount_all_running_mission_routers` so the
 /// filter logic is unit-testable without an `AppHandle`.
 fn list_running_mission_ids(conn: &Connection) -> rusqlite::Result<Vec<String>> {
     let mut stmt = conn.prepare(

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -53,11 +53,11 @@ fn init_connection(conn: &mut Connection) -> rusqlite::Result<()> {
 // runners on existing installs are unaffected. (Was 0003 pre-rename
 // — the freed 0002 slot used to hold the default-crew SQL seed,
 // which now lives in `seed_default_crew` below.)
-// 0003: nullable runtime_* columns on `sessions` for the tmux
-// runtime migration (docs/impls/0004-tmux-session-runtime.md). Pure
-// schema add — no data backfill, existing rows keep NULL runtime
-// metadata, which the manager (post-Step 9) treats as "legacy
-// portable-pty session, can't reattach."
+// 0003: nullable runtime_* columns on `sessions` from the old
+// runtime migration. `runtime` + `runtime_session` still identify
+// the live PTY runtime session while the app is running;
+// `runtime_socket`, `runtime_window`, and `runtime_pane` are legacy
+// and unused by new PTY-runtime writes.
 // 0004: adds `archived_at` to missions so the workspace can filter
 // archived missions out of search/list surfaces without conflating
 // them with `status = 'completed'`. Backfills existing completed
@@ -761,8 +761,8 @@ Talking to the human:
         // Regression guard for #51: the seed system_prompts must be
         // persona-only — the bus contract (runner msg post / runner
         // msg read / ask_lead, plus @<handle> framing) is now the
-        // job of WORKER_COORDINATION_PREAMBLE in
-        // session::manager::schedule_mission_first_prompt. If a
+        // job of WORKER_COORDINATION_PREAMBLE in the runtime prompt
+        // composer for mission first-turn argv delivery. If a
         // future drift adds bus verbs back into the seed prompts,
         // direct chats would surface verbs that don't work
         // (RUNNER_CREW_ID / RUNNER_MISSION_ID / RUNNER_EVENT_LOG are
@@ -913,10 +913,10 @@ Talking to the human:
 
     #[test]
     fn sessions_has_runtime_columns_after_migration() {
-        // Defensive: the tmux runtime layer (Step 5+) reads /
-        // writes these columns by name. If a future migration
-        // ever renames or drops one, this test fails before
-        // anything panics at runtime.
+        // Defensive: keep the legacy runtime columns present for
+        // existing databases. New PTY-runtime writes use only
+        // `runtime` + `runtime_session`; socket/window/pane are
+        // legacy and unused since the PTY migration.
         use tempfile::tempdir;
         let dir = tempdir().unwrap();
         let path = dir.path().join("runner.db");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -35,7 +35,7 @@ pub struct AppState {
     /// installs, a tempdir in tests. Mission commands resolve event-log paths
     /// relative to this via `runner_core::event_log::path`.
     pub app_data_dir: PathBuf,
-    /// Live per-mission session manager (tmux-backed). Created at app
+    /// Live per-mission session manager. Created at app
     /// start, shared across all Tauri commands and the per-session
     /// forwarder threads it spawns.
     pub sessions: Arc<session::SessionManager>,
@@ -128,14 +128,10 @@ pub fn run() {
 
             let db_path = app_data_dir.join("runner.db");
             let pool = Arc::new(db::open_pool(&db_path)?);
-            // Session reconciliation now happens AFTER the
-            // runtime is constructed (below) — for tmux-runtime
-            // rows we need to query the runtime's view of the
-            // pane before deciding whether to mark the row
-            // stopped. Live panes survive Runner restart by
-            // design (`exit-empty off` in the generated tmux
-            // config); the prior portable-pty-era bulk UPDATE
-            // would have killed that survival path.
+            // Session startup cleanup happens after the runtime is
+            // constructed. Under the in-process PTY runtime, child
+            // processes die with the prior app process, so stale
+            // `running` rows are demoted below.
             // Drop the bundled agent/MCP CLIs into $APPDATA/runner/bin/.
             // Child PTYs find `runner` on PATH (arch §5.3 Layer 2), while
             // Claude/Codex configs point at `runner-mcp`. Best-effort: a
@@ -178,10 +174,9 @@ pub fn run() {
 
             let sessions = session::SessionManager::new(login_shell_env, runtime);
 
-            // Build the AppState up front so the mission-side
-            // reattach (next block) has access to the bus + router
-            // registries it needs to mount. The session-side reattach
-            // still runs from the local `sessions` Arc handle.
+            // Build the AppState up front so the startup mission-bus
+            // remount has access to the bus + router registries it
+            // needs.
             let buses = event_bus::BusRegistry::new();
             let routers = router::RouterRegistry::new();
             let mcp_handle = Arc::new(mcp::McpHandle::new());
@@ -207,29 +202,21 @@ pub fn run() {
                 mcp: mcp_handle,
             };
 
-            // Mount router + bus for every `running` mission BEFORE
-            // session reattach starts. Forwarder threads begin
-            // emitting `mission_*` events as soon as `pipe-pane` is
-            // installed; if the bus isn't mounted yet, those events
-            // get fanout-dropped. The NDJSON log is unaffected (the
-            // agent writes straight through the bundled CLI) — this
-            // is purely about the in-memory fanout layer.
-            //
-            // Returns the set of mission ids whose mount FAILED;
-            // session reattach uses it to fall back to the
-            // stop+mark-stopped path for those missions' alive
-            // panes (matches the pre-eager-mount safety property).
+            // Mount router + bus for every `running` mission before
+            // stale session rows are demoted. The NDJSON log is the
+            // durable source of truth; this is purely about restoring
+            // the in-memory fanout layer for mission events.
             let app_handle = app.handle().clone();
-            let failed_mission_ids = tauri::async_runtime::block_on(
-                commands::mission::reattach_all_running_missions(&state, &app_handle),
-            );
+            tauri::async_runtime::block_on(commands::mission::mount_all_running_mission_routers(
+                &state,
+                &app_handle,
+            ));
 
             // Agents die with this Tauri process under the pty
             // runtime — any `running` row in the DB at this point
             // is from a prior process. Demote them to `stopped`
             // so the sidebar surfaces them with a Resume
             // affordance (impl 0011 §"Tauri startup").
-            let _ = failed_mission_ids;
             #[cfg(unix)]
             {
                 if let Err(e) = session::pty_runtime::cleanup_stale_running_rows_on_startup(&pool) {
@@ -318,10 +305,9 @@ pub fn run() {
             // runtime, this fires SIGTERM-via-ChildKiller so
             // children get a chance to flush conversation state
             // (claude-code session file, etc.) before the
-            // master-fd-close SIGHUP cascade lands. Under the tmux
-            // runtime this still demotes DB rows cleanly. We
-            // tolerate kill failures: best-effort path, and the
-            // startup cleanup is the safety net on next launch.
+            // master-fd-close SIGHUP cascade lands. We tolerate kill
+            // failures: best-effort path, and the startup cleanup is
+            // the safety net on next launch.
             match event {
                 tauri::RunEvent::ExitRequested { .. } => {
                     stop_running_sessions_on_quit(app_handle);

--- a/src-tauri/src/session/launch.rs
+++ b/src-tauri/src/session/launch.rs
@@ -1,11 +1,11 @@
-#![allow(dead_code)] // Wired into TmuxRuntime in Step 5; foundation now.
+#![allow(dead_code)] // Script renderer retained for tests/future launcher reuse.
 
-//! Per-session launcher script generator (Step 4 of
-//! docs/impls/0004-tmux-session-runtime.md).
+//! Per-session launch/path helpers.
 //!
-//! The tmux runtime invokes
-//! `tmux new-session … -- '<path-to-this-script>'` to spawn the
-//! agent. The script:
+//! The current PTY runtime uses the PATH/env composition helpers
+//! directly before spawning the agent with `portable-pty`. The script
+//! renderer is retained as a small, tested utility for any caller that
+//! needs a shell wrapper. The rendered script:
 //!
 //!   1. Exports the composed PATH so the agent CLI can resolve
 //!      regardless of launchd's stripped GUI PATH.
@@ -15,13 +15,9 @@
 //!   3. cds to the working directory.
 //!   4. execs the agent command + argv.
 //!
-//! Why a script instead of letting tmux invoke argv directly: tmux's
-//! trailing positional argument to `new-session` is a
-//! `shell-command` string, not argv — tmux passes it through the
-//! user's `default-shell -c`. Once we're crossing that boundary,
-//! owning the script (with controlled quoting in Rust, written to
-//! disk under our per-session runtime dir) is safer than building
-//! a single shell string out of user-supplied env values and argv.
+//! Why a script helper at all: if a caller crosses a shell boundary,
+//! owning the script with controlled quoting in Rust is safer than
+//! building one shell string out of user-supplied env values and argv.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -52,7 +48,7 @@ pub struct LaunchScript {
     /// rendered.
     pub args: Vec<String>,
     /// Working directory. None ⇒ omit the `cd` line entirely; the
-    /// agent inherits whatever cwd the tmux server runs in.
+    /// agent inherits the caller's cwd.
     pub cwd: Option<PathBuf>,
     /// Per-session env vars. PATH must NOT be in here — pass it via
     /// `path` so we can be explicit that PATH is not user-supplied.
@@ -209,8 +205,7 @@ pub fn render_launch_script(script: &LaunchScript) -> RuntimeResult<String> {
 
     let mut out = String::new();
     out.push_str("#!/usr/bin/env bash\n");
-    out.push_str("# Runner-generated session launcher — see\n");
-    out.push_str("# docs/impls/0004-tmux-session-runtime.md (Step 4).\n");
+    out.push_str("# Runner-generated session launcher.\n");
     out.push_str("# Do not hand-edit; regenerated on every session spawn.\n");
     out.push_str("set -e\n");
     out.push_str(&format!("export PATH={}\n", shell_quote(&script.path)));
@@ -251,9 +246,9 @@ pub fn render_launch_script(script: &LaunchScript) -> RuntimeResult<String> {
 }
 
 /// Write the rendered launcher to `dir/launch.sh` and chmod 700.
-/// Returns the absolute path so the runtime can pass it to tmux.
-/// Idempotent: rewrites every spawn so a stale script from a
-/// crashed prior session doesn't get reused with the wrong env.
+/// Returns the absolute path so a caller can execute it. Idempotent:
+/// rewrites every spawn so a stale script from a crashed prior
+/// session doesn't get reused with the wrong env.
 pub fn write_launch_script(dir: &Path, script: &LaunchScript) -> RuntimeResult<PathBuf> {
     let body = render_launch_script(script)?;
     std::fs::create_dir_all(dir)?;
@@ -436,10 +431,8 @@ mod tests {
 
     #[test]
     fn render_launch_script_quotes_command_with_spaces() {
-        // Defensive: tmux's shell-command boundary means an
-        // unquoted command path with spaces would break. Step 4
-        // tests this even though the runner row is unlikely to
-        // ever have such a path.
+        // Defensive: if a caller executes through a shell wrapper, an
+        // unquoted command path with spaces would break.
         let script = LaunchScript {
             command: "/Applications/Weird App/bin/agent".into(),
             args: vec![],

--- a/src-tauri/src/session/manager.rs
+++ b/src-tauri/src/session/manager.rs
@@ -1,22 +1,20 @@
 // Per-runner session manager.
 //
-// One `Session` = one tmux pane running the runner's CLI agent (via the
-// `SessionRuntime` trait → `TmuxRuntime`). The SessionManager holds the
-// map of live sessions so Tauri commands can look them up by id (for
-// stdin injection, pause/resume, kill). Each session owns:
+// One `Session` = one child process attached to an in-process PTY via
+// `SessionRuntime`. The SessionManager holds the map of live sessions
+// so Tauri commands can look them up by id (for stdin injection,
+// resume, kill). Each session owns:
 //
-//   - A `RuntimeSession` (tmux session/window/pane ids) that the manager
-//     hands back to the runtime for every operation.
+//   - A `RuntimeSession` that the manager hands back to the runtime
+//     for every operation.
 //   - A forwarder thread that drains the runtime's `OutputStream` into
-//     `session/output` Tauri events. When the channel closes (pane died
-//     or we killed it), the thread queries the runtime for final exit
-//     code, emits `session/exit`, and updates the DB row.
+//     `session/output` Tauri events. When the channel closes, the
+//     thread queries the runtime for final exit code, emits
+//     `session/exit`, and updates the DB row.
 //
-// Drop behavior: tmux server stays alive across app restart by design
-// (`exit-empty off` in the generated config). Reattach uses the
-// runtime_* columns persisted on each session row to find the pane and
-// re-establish the output stream. Step 9 of
-// docs/impls/0004-tmux-session-runtime.md.
+// At app restart, in-process PTYs are gone with the prior app process.
+// Startup cleanup demotes stale running DB rows to stopped; user-facing
+// resume respawns a fresh PTY with the same session row id.
 
 use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
@@ -136,14 +134,14 @@ pub(crate) struct ForwarderEmitCtx {
     /// not by session id.
     pub handle: String,
     /// Cached event-log handle. Constructed via `EventLog::open` on
-    /// the spawn/resume/reattach path; the forwarder consumer
+    /// the spawn/resume path; the forwarder consumer
     /// reuses it for every `try_append` so it never blocks on the
     /// open-time tail-repair flock.
     pub event_log: Arc<EventLog>,
 }
 
 /// Open the mission's event log on the calling (non-forwarder)
-/// thread. Used by spawn / resume / reattach to construct a
+/// thread. Used by spawn / resume to construct a
 /// `ForwarderEmitCtx`. Logs at WARN and returns `None` if the open
 /// fails — the forwarder still runs the detector for free; we just
 /// can't surface its events.
@@ -163,40 +161,6 @@ fn open_mission_event_log(
             None
         }
     }
-}
-
-/// Boot-time reattach helper: build the per-session
-/// `ForwarderEmitCtx` from the persisted session row. Pulls the
-/// mission's `crew_id` and the slot's `slot_handle` from the DB so
-/// the post-reattach forwarder emits the same `runner_status`
-/// shape a fresh spawn would. Returns `None` for direct chats and
-/// for any mission row missing its slot row (the row gets reaped
-/// elsewhere; we just don't emit for it here).
-fn mission_emit_ctx_for_row(
-    pool: &Arc<DbPool>,
-    row: &RowSnap,
-    app_data_dir: &Path,
-) -> Option<ForwarderEmitCtx> {
-    let mission_id = row.mission_id.as_deref()?;
-    let conn = pool.get().ok()?;
-    let (crew_id, slot_handle): (String, String) = conn
-        .query_row(
-            "SELECT m.crew_id, s.slot_handle
-               FROM sessions sess
-               JOIN missions m ON m.id = sess.mission_id
-               JOIN slots    s ON s.id = sess.slot_id
-              WHERE sess.id = ?1",
-            params![row.id],
-            |r| Ok((r.get(0)?, r.get(1)?)),
-        )
-        .ok()?;
-    let event_log = open_mission_event_log(app_data_dir, &crew_id, mission_id)?;
-    Some(ForwarderEmitCtx {
-        crew_id,
-        mission_id: mission_id.to_string(),
-        handle: slot_handle,
-        event_log,
-    })
 }
 
 /// Outcome of a single forwarder-side `try_append` attempt. Drives
@@ -377,10 +341,10 @@ struct SessionHandle {
     /// filters on this so deleting a runner can reap its live PTY
     /// children before the cascade nukes the DB rows underneath.
     runner_id: Option<String>,
-    /// Runtime-side identifiers (tmux session/window/pane) returned
-    /// from `SessionRuntime::spawn`. The manager passes this back
-    /// to `runtime.send_bytes` / `runtime.paste` / `runtime.resize`
-    /// / `runtime.stop` for every operation on the live session.
+    /// Runtime-side identity returned from `SessionRuntime::spawn`.
+    /// The manager passes this back to `runtime.send_bytes` /
+    /// `runtime.resize` / `runtime.stop` for every operation on the
+    /// live session.
     runtime_session: RuntimeSession,
     /// Forwarder thread that drains the runtime's `OutputStream`
     /// into `session/output` events. `kill` joins on this so callers
@@ -389,13 +353,11 @@ struct SessionHandle {
     forwarder: Option<thread::JoinHandle<()>>,
     /// Cancellation flag the forwarder thread polls between
     /// `recv_timeout` calls. `kill` flips it so the consumer
-    /// breaks out within ~500ms regardless of whether tmux's
-    /// pipe-pane cleanup chain (kill-session → cat dies → FIFO
-    /// POLLHUP → forward_fifo exits → tx drops → Disconnected)
-    /// has completed. Without this, kill could hang waiting on
-    /// the channel-disconnect path if anything in that chain
-    /// stalled — observed live as a stuck "Archiving…" pill on
-    /// the chat page.
+    /// breaks out within ~500ms regardless of whether the PTY reader
+    /// has observed EOF and dropped the channel sender. Without this,
+    /// kill could hang waiting on the channel-disconnect path if that
+    /// cleanup stalled — observed live as a stuck "Archiving…" pill
+    /// on the chat page.
     stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
@@ -454,12 +416,10 @@ pub struct SessionManager {
     /// the queued slots don't keep firing into a stopped /
     /// archived / reset mission. See `cancel_pending_mission_spawns`.
     pending_mission_cancels: Mutex<HashMap<String, Arc<AtomicBool>>>,
-    /// Underlying terminal runtime (Step 9 of
-    /// docs/impls/0004-tmux-session-runtime.md). v1 is `TmuxRuntime`
-    /// on macOS + Linux; Windows fails at runtime construction in
-    /// `lib.rs::run`. Every spawn / resume / kill / inject_stdin /
-    /// resize routes through this trait — the manager owns DB +
-    /// event-buffer state but never reads/writes a PTY directly.
+    /// Underlying terminal runtime. Every spawn / resume / kill /
+    /// inject_stdin / resize routes through this trait — the manager
+    /// owns DB + event-buffer state but never reads/writes a PTY
+    /// directly.
     runtime: Arc<dyn SessionRuntime>,
 }
 
@@ -959,30 +919,20 @@ impl SessionManager {
             return Ok(CompleteSpawnOutcome::Cancelled);
         }
 
-        // Persist the runtime-side ids so `resume` after app restart
-        // can find this pane.
+        // Persist the runtime-side identity for diagnostics and for
+        // the current runtime session row.
         if let Ok(conn) = pool.get() {
             let _ = conn.execute(
                 "UPDATE sessions
                     SET runtime = ?2,
-                        runtime_socket = ?3,
-                        runtime_session = ?4,
-                        runtime_window = ?5,
-                        runtime_pane = ?6
+                        runtime_session = ?3
                   WHERE id = ?1",
-                params![
-                    session_id,
-                    rt_session.runtime,
-                    rt_session.socket,
-                    rt_session.session_name,
-                    rt_session.window,
-                    rt_session.pane,
-                ],
+                params![session_id, rt_session.runtime, rt_session.session_id],
             );
         }
 
         let stop = output.stop_flag();
-        let pane_for_log = rt_session.pane.clone();
+        let runtime_session_for_log = rt_session.session_id.clone();
         self.sessions.lock().unwrap().insert(
             session_id.clone(),
             SessionHandle {
@@ -1032,20 +982,22 @@ impl SessionManager {
         }
 
         emit_runner_activity(&pool, &runner, events.as_ref());
-        schedule_mission_first_prompt(
-            self,
-            session_id.clone(),
-            &runner,
-            &plan,
-            first_turn_delivered_via_argv,
-        );
+        if matches!(runner.runtime.as_str(), "claude-code" | "codex")
+            && !plan.resuming
+            && !first_turn_delivered_via_argv
+        {
+            log::warn!(
+                "first-turn argv not delivered for {session_id} (runtime {}); skipping post-spawn injection",
+                runner.runtime,
+            );
+        }
 
         log::info!(
-            "session spawn: mission={} session={} runner={} pane={}",
+            "session spawn: mission={} session={} runner={} runtime_session={}",
             mission.id,
             session_id,
             slot_handle,
-            pane_for_log,
+            runtime_session_for_log,
         );
 
         Ok(CompleteSpawnOutcome::Spawned)
@@ -1120,8 +1072,8 @@ impl SessionManager {
             mission_id: Some(mission_id),
             runner_id: Some(runner_id),
             handle,
-            // pane_pid is populated lazily via runtime.status() when
-            // the manager needs it; the SpawnedSession field is
+            // PTY child pid is populated lazily via runtime.status()
+            // when the manager needs it; the SpawnedSession field is
             // informational and the frontend doesn't rely on it.
             pid: None,
             fresh_fallback_lead: false,
@@ -1331,19 +1283,9 @@ impl SessionManager {
             let _ = conn.execute(
                 "UPDATE sessions
                     SET runtime = ?2,
-                        runtime_socket = ?3,
-                        runtime_session = ?4,
-                        runtime_window = ?5,
-                        runtime_pane = ?6
+                        runtime_session = ?3
                   WHERE id = ?1",
-                params![
-                    session_id,
-                    rt_session.runtime,
-                    rt_session.socket,
-                    rt_session.session_name,
-                    rt_session.window,
-                    rt_session.pane,
-                ],
+                params![session_id, rt_session.runtime, rt_session.session_id],
             );
         }
 
@@ -1395,13 +1337,15 @@ impl SessionManager {
         if emit_activity {
             emit_runner_activity(&pool, runner, events.as_ref());
         }
-        schedule_direct_first_prompt(
-            self,
-            session_id.clone(),
-            runner,
-            &plan,
-            first_turn_delivered_via_argv,
-        );
+        if matches!(runner.runtime.as_str(), "claude-code" | "codex")
+            && !plan.resuming
+            && !first_turn_delivered_via_argv
+        {
+            log::warn!(
+                "first-turn argv not delivered for direct chat {session_id} (runtime {}); skipping post-spawn injection",
+                runner.runtime,
+            );
+        }
 
         Ok(SpawnedSession {
             id: session_id,
@@ -1761,19 +1705,9 @@ impl SessionManager {
             let _ = conn.execute(
                 "UPDATE sessions
                     SET runtime = ?2,
-                        runtime_socket = ?3,
-                        runtime_session = ?4,
-                        runtime_window = ?5,
-                        runtime_pane = ?6
+                        runtime_session = ?3
                   WHERE id = ?1",
-                params![
-                    session_id,
-                    rt_session.runtime,
-                    rt_session.socket,
-                    rt_session.session_name,
-                    rt_session.window,
-                    rt_session.pane,
-                ],
+                params![session_id, rt_session.runtime, rt_session.session_id],
             );
         }
 
@@ -1841,7 +1775,7 @@ impl SessionManager {
             emit_runner_activity(&pool, &runner, events.as_ref());
         }
 
-        // First-turn injection for fresh claude-code / codex spawns.
+        // First-turn warning for fresh claude-code / codex spawns.
         // `plan.resuming` is true on any resume against a real
         // prior_key — those skip naturally (the agent already has its
         // system context). For mission resume, the lead always
@@ -1852,19 +1786,20 @@ impl SessionManager {
         // inject — the commands::session::session_resume caller fires
         // that path when it sees `fresh_fallback_lead = true` on the
         // returned SpawnedSession. For direct-chat resume there's no
-        // slot/lead concept, and the off-bus persona-only injection
-        // (`schedule_direct_first_prompt`) is the right shape if the
-        // resume happens to degrade to fresh.
-        if mission_ctx.is_some() {
-            // Resume path: agent CLI restores prior conversation
-            // context via its own session resume. The
-            // `plan.resuming` guard inside the function makes this
-            // a no-op for the dominant case (a real resume). The
-            // resume-fresh-fallback case is handled separately by
-            // `Router::fire_lead_launch_prompt` via paste-verify.
-            schedule_mission_first_prompt(self, session_id.to_string(), &runner, &plan, false);
-        } else {
-            schedule_direct_first_prompt(self, session_id.to_string(), &runner, &plan, false);
+        // slot/lead concept; if that degrades to fresh and argv
+        // delivery was unavailable, we log the skipped injection.
+        if matches!(runner.runtime.as_str(), "claude-code" | "codex") && !plan.resuming {
+            if mission_ctx.is_some() {
+                log::warn!(
+                    "first-turn argv not delivered for {session_id} (runtime {}); skipping post-spawn injection",
+                    runner.runtime,
+                );
+            } else {
+                log::warn!(
+                    "first-turn argv not delivered for direct chat {session_id} (runtime {}); skipping post-spawn injection",
+                    runner.runtime,
+                );
+            }
         }
 
         // Return the slot's in-mission identity for mission rows so the
@@ -1916,18 +1851,15 @@ impl SessionManager {
         let started_at = std::time::Instant::now();
         // Capture the cancellation flag before moving `output` into
         // the thread. `kill` flips this flag so the consumer
-        // breaks out within ~500ms even if the channel-disconnect
-        // path stalls (tmux's pipe-pane cleanup chain has been
-        // observed hanging in the field, leaving the chat's
-        // "Archiving…" pill stuck).
+        // breaks out within ~500ms even if the reader/EOF
+        // disconnect path stalls.
         let stop = output.stop_flag();
         thread::spawn(move || {
-            // Drain pane output until the runtime closes the
-            // channel OR `kill` flips the stop flag. Replay and
-            // Stream both flow as `session/output` events — xterm.js
-            // appends sequentially regardless. StatusTransition is
-            // routed into the mission event log so the router /
-            // workspace rail see the busy/idle flip (issue #124).
+            // Drain PTY output until the runtime closes the channel
+            // OR `kill` flips the stop flag. Stream chunks flow as
+            // `session/output` events. StatusTransition is routed
+            // into the mission event log so the router / workspace
+            // rail see the busy/idle flip (issue #124).
             //
             // Failure bookkeeping for `runner_status` emission lives
             // here on the consumer's stack — single-threaded access,
@@ -1941,7 +1873,7 @@ impl SessionManager {
                     break;
                 }
                 match output.recv_timeout(Duration::from_millis(500)) {
-                    Ok(RuntimeOutput::Replay(bytes)) | Ok(RuntimeOutput::Stream(bytes)) => {
+                    Ok(RuntimeOutput::Stream(bytes)) => {
                         // Track alt-screen mode before recording so
                         // that the very next `output_snapshot` (if
                         // one races in here) reflects the latest
@@ -1992,16 +1924,16 @@ impl SessionManager {
                 }
             }
 
-            // Channel closed — query the runtime for the final pane
+            // Channel closed — query the runtime for the final child
             // status to recover an exit code. `Ok(None)` means the
-            // pane is gone (terminal-unavailable); we still need to
-            // flip the DB row, just without an exit code.
+            // runtime session is gone; we still need to flip the DB
+            // row, just without an exit code.
             let status = manager_t.runtime.status(&rt_session).ok().flatten();
             let exit_code = status.as_ref().and_then(|s| s.exit_code);
             let success = exit_code == Some(0);
 
-            // Best-effort: tear down the tmux session now that the
-            // pane is dead. Skipped if `kill` already did it.
+            // Best-effort: tear down the PTY child now that the
+            // output channel closed. Skipped if `kill` already did it.
             let _ = manager_t.runtime.stop(&rt_session);
 
             let _ = manager_t.forget(&session_id);
@@ -2060,9 +1992,8 @@ impl SessionManager {
 
     /// Write raw bytes to the session's stdin. Used for keystroke
     /// passthrough from xterm.js — small chunks, no embedded
-    /// newlines. Routed through `runtime.send_bytes` which uses
-    /// `tmux send-keys -l --` so each character lands as a
-    /// keystroke without bracketed-paste markers.
+    /// newlines. Routed through `runtime.send_bytes` so each byte
+    /// lands without bracketed-paste markers.
     ///
     /// Multi-line prompt blocks (the system_prompt injection on
     /// fresh spawn) should go through `inject_paste` instead so the
@@ -2079,8 +2010,8 @@ impl SessionManager {
             .ok_or_else(|| Error::msg(format!("session not found: {session_id}")))?;
         // ASCII CR (0x0D) is what claude-code's TUI editor reads as
         // "Enter" — bare-byte writes that just contain `\r` map to
-        // `send_key("Enter")` so tmux's key-name lookup runs.
-        // Everything else routes as a literal byte stream.
+        // `send_key("Enter")`. Everything else routes as a literal
+        // byte stream.
         if bytes == b"\r" {
             self.runtime
                 .send_key(&rt_session, "Enter")
@@ -2093,8 +2024,8 @@ impl SessionManager {
     }
 
     /// Paste a multi-line prompt block into the session, then submit
-    /// with Enter. Uses the runtime's paste primitive so LF stays
-    /// literal instead of becoming one submit per line.
+    /// with Enter. This preserves the old runtime paste behavior:
+    /// write the payload bytes unchanged, then send Enter.
     ///
     /// Sleeps 120ms between paste and Enter. Without this gap,
     /// Claude Code v2.1.x's input editor sometimes leaves pasted
@@ -2109,7 +2040,7 @@ impl SessionManager {
             .get(session_id)
             .map(|h| h.runtime_session.clone())
             .ok_or_else(|| Error::msg(format!("session not found: {session_id}")))?;
-        self.runtime.paste(&rt_session, payload)?;
+        self.runtime.send_bytes(&rt_session, payload)?;
         std::thread::sleep(std::time::Duration::from_millis(120));
         self.runtime
             .send_key(&rt_session, "Enter")
@@ -2164,9 +2095,8 @@ impl SessionManager {
         // 4096-chunk buffer over time, so a re-attach that just
         // replays the remaining chunks lands mid-alt-screen content
         // into xterm's main screen — visible as stacked redraws in
-        // scrollback and a blank alt-screen pane on route remount
-        // (docs/impls/archive/0009 has the tmux-era analysis of the
-        // same failure mode). seq=0 sits below every real event's
+        // scrollback and a blank alt-screen pane on route remount.
+        // seq=0 sits below every real event's
         // monotonic seq so the frontend's `seq <= lastWrittenSeq`
         // filter doesn't drop it on re-replay.
         let alt = self
@@ -2213,12 +2143,12 @@ impl SessionManager {
 
         // Look up the rt_session WITHOUT removing the handle yet.
         // The handle stays in the live map until we know
-        // `runtime.stop` succeeded. If it fails (pane survived
-        // kill-session), bailing here leaves the live handle
-        // intact and the caller can retry; if we'd already
-        // removed the handle + flipped the cancellation flag,
-        // the forwarder thread would reconcile the DB row to
-        // `stopped` even though the pane is still alive.
+        // `runtime.stop` succeeded. If it fails (child survived the
+        // stop request), bailing here leaves the live handle intact
+        // and the caller can retry; if we'd already removed the
+        // handle + flipped the cancellation flag, the forwarder
+        // thread would reconcile the DB row to `stopped` even
+        // though the child is still alive.
         let rt_session = {
             let sessions = self.sessions.lock().unwrap();
             match sessions.get(session_id) {
@@ -2234,10 +2164,10 @@ impl SessionManager {
             }
         };
 
-        // Stop verifies via has-session that the pane is actually
-        // gone. Returns Err if tmux refuses to reap.
+        // Stop verifies that the child was signaled. Returns Err if
+        // the runtime refuses to reap it.
         if let Err(e) = self.runtime.stop(&rt_session) {
-            // Roll back: pane is alive, the handle stays
+            // Roll back: child is alive, the handle stays
             // in the map, the killed marker is cleared. The
             // caller sees the error.
             self.killed.lock().unwrap().remove(session_id);
@@ -2254,9 +2184,8 @@ impl SessionManager {
         };
 
         // Flip the explicit cancellation flag so the consumer
-        // breaks out within ~500ms regardless of how the
-        // pipe-pane → FIFO POLLHUP → channel-disconnect chain
-        // progresses.
+        // breaks out within ~500ms regardless of how the reader EOF
+        // and channel-disconnect path progresses.
         stop.store(true, std::sync::atomic::Ordering::SeqCst);
 
         // Wait for the forwarder to drain + reconcile so the
@@ -2359,232 +2288,6 @@ impl SessionManager {
         };
         for id in ids {
             self.kill(&id)?;
-        }
-        Ok(())
-    }
-
-    /// App-startup reconciliation: for every `sessions` row still
-    /// marked `running`, ask the runtime whether the pane is alive.
-    /// If yes, reattach (rebuild the SessionHandle + forwarder
-    /// thread) so Tauri commands can target the surviving pane. If
-    /// the pane is gone or has exited, flip the row to
-    /// stopped/crashed using the captured exit code.
-    ///
-    /// This replaces the prior portable-pty-era logic that
-    /// indiscriminately marked every running row stopped on
-    /// startup — that was correct when the manager owned the PTY
-    /// lifecycle (process death = PTY death), but with tmux the
-    /// pane survives Runner's process and we'd lose live agent
-    /// sessions on every restart. Step 9 cutover follow-up.
-    ///
-    /// Best-effort. Errors per-row are logged to stderr; the
-    /// overall reattach loop never fails the caller (app startup
-    /// must not block on a transient runtime hiccup).
-    pub fn reattach_running_sessions(
-        self: &Arc<Self>,
-        pool: Arc<DbPool>,
-        events: Arc<dyn SessionEvents>,
-        failed_mission_ids: &HashSet<String>,
-        app_data_dir: &Path,
-    ) {
-        let now = Utc::now().to_rfc3339();
-        let rows: Vec<RowSnap> = match collect_running_rows(&pool) {
-            Ok(rows) => rows,
-            Err(e) => {
-                log::warn!("reattach query failed: {e}");
-                return;
-            }
-        };
-        for row in rows {
-            self.reattach_one(row, &now, &pool, &events, failed_mission_ids, app_data_dir);
-        }
-    }
-
-    fn reattach_one(
-        self: &Arc<Self>,
-        row: RowSnap,
-        now: &str,
-        pool: &Arc<DbPool>,
-        events: &Arc<dyn SessionEvents>,
-        failed_mission_ids: &HashSet<String>,
-        app_data_dir: &Path,
-    ) {
-        // No runtime metadata persisted (legacy row, or a row
-        // that crashed before we got a chance to write the
-        // runtime_* columns) → mark stopped and move on.
-        let Some(rt_session) = row.runtime_session() else {
-            mark_session_stopped(pool, &row.id, now);
-            return;
-        };
-
-        // Query status so we can apply the dead-pane crash
-        // discrimination uniformly across mission and direct rows.
-        let status = self.runtime.status(&rt_session);
-
-        // Mission rows whose router+bus mount failed earlier in
-        // startup must not have their alive panes reattached —
-        // forwarder bytes would land on no subscriber and
-        // mission_* events appended in the window before workspace
-        // mount would be silently dropped. Fall back to the
-        // pre-eager-mount path: stop the pane, mark the row
-        // stopped, let the user resume from the workspace
-        // (mission_attach on workspace mount retries the bus mount).
-        let mission_mount_failed = row
-            .mission_id
-            .as_ref()
-            .map(|m| failed_mission_ids.contains(m))
-            .unwrap_or(false);
-
-        match status {
-            Ok(Some(s)) if s.alive && mission_mount_failed => {
-                if let Err(e) = self.runtime.stop(&rt_session) {
-                    // Pane refused to die; leave the row alone
-                    // (still `running`) so the user's eventual
-                    // `mission_attach` from the workspace can find
-                    // it via the existing reconcile path. Marking
-                    // it stopped here would create a UI/DB-vs-tmux
-                    // mismatch.
-                    log::warn!(
-                        "reattach failed to stop mission session {} \
-                         after mount failure: {e}",
-                        row_dbg(&row.id)
-                    );
-                    return;
-                }
-                mark_session_stopped(pool, &row.id, now);
-                // Decision INFO fires only on the happy path —
-                // stop succeeded AND the row was actually marked.
-                // The Err branch above already returns without
-                // marking; a top-of-branch INFO would have lied.
-                log::info!(
-                    "session reattach: id={} action=stopped reason=mission_mount_failed",
-                    row_dbg(&row.id)
-                );
-            }
-            Ok(Some(s)) if s.alive => {
-                // Mission and direct rows take the same alive-pane
-                // path: rebuild the SessionHandle + forwarder. For
-                // mission rows the bus + router are mounted earlier
-                // in startup by `mission::reattach_all_running_missions`,
-                // so `mission_*` events emitted between pipe-pane
-                // install and workspace mount reach Tauri subscribers.
-                // On failure, try to kill the orphan pane before
-                // marking the row stopped — but only mark stopped if
-                // the kill actually succeeded; otherwise the agent
-                // is still running and lying in the DB would strand
-                // it.
-                let id = row.id.clone();
-                let pane_for_log = rt_session.pane.clone();
-                let rt_for_cleanup = rt_session.clone();
-                if let Err(e) = self.attach_existing(row, rt_session, pool, events, app_data_dir) {
-                    log::warn!("reattach session {} failed: {e}", row_dbg(&id));
-                    match self.runtime.stop(&rt_for_cleanup) {
-                        Ok(()) => mark_session_stopped(pool, &id, now),
-                        Err(e) => log::warn!(
-                            "reattach orphan-stop for {} failed: {e}; \
-                             leaving row as running",
-                            row_dbg(&id)
-                        ),
-                    }
-                } else {
-                    log::info!(
-                        "session reattach: id={} action=resumed pane={}",
-                        row_dbg(&id),
-                        pane_for_log,
-                    );
-                }
-            }
-            Ok(Some(status)) => {
-                // Pane is dead but tmux is still holding it
-                // (remain-on-exit). Capture the exit code, mark the
-                // row, then tear down the dead pane.
-                let final_status = if status.exit_code == Some(0) {
-                    "stopped"
-                } else {
-                    "crashed"
-                };
-                let exit_code = status.exit_code;
-                let _ = self.runtime.stop(&rt_session);
-                if let Ok(conn) = pool.get() {
-                    let _ = conn.execute(
-                        "UPDATE sessions
-                            SET status = ?2,
-                                stopped_at = COALESCE(stopped_at, ?3)
-                          WHERE id = ?1",
-                        params![row.id, final_status, now],
-                    );
-                }
-                log::info!(
-                    "session reattach: id={} action=stopped reason=pane_exited code={:?}",
-                    row_dbg(&row.id),
-                    exit_code,
-                );
-            }
-            Ok(None) | Err(_) => {
-                // tmux can't find the pane — terminal-unavailable.
-                mark_session_stopped(pool, &row.id, now);
-                log::info!(
-                    "session reattach: id={} action=stopped reason=pane_gone",
-                    row_dbg(&row.id)
-                );
-            }
-        }
-    }
-
-    fn attach_existing(
-        self: &Arc<Self>,
-        row: RowSnap,
-        rt_session: RuntimeSession,
-        pool: &Arc<DbPool>,
-        events: &Arc<dyn SessionEvents>,
-        app_data_dir: &Path,
-    ) -> Result<()> {
-        // Pull or reconstruct the runner-shaped launch config so the
-        // forwarder has the runtime name for resume-failure warnings.
-        let runner = if let Some(runner_id) = row.runner_id.as_deref() {
-            let conn = pool.get()?;
-            crate::commands::runner::get(&conn, runner_id)?
-        } else {
-            let runtime = row.agent_runtime.as_deref().ok_or_else(|| {
-                Error::msg(format!(
-                    "runtime-only session {} missing agent_runtime",
-                    row.id
-                ))
-            })?;
-            runtime_direct_runner(runtime, row.agent_command.as_deref())?
-        };
-        // For mission rows, resolve the crew_id + slot_handle from
-        // the same DB lookups the original spawn used so the
-        // forwarder can emit `runner_status` events post-reboot.
-        // Direct chats stay off-bus (None).
-        let emit_ctx = mission_emit_ctx_for_row(pool, &row, app_data_dir);
-        let output = self.runtime.resume(&rt_session)?;
-        let stop = output.stop_flag();
-        self.sessions.lock().unwrap().insert(
-            row.id.clone(),
-            SessionHandle {
-                id: row.id.clone(),
-                mission_id: row.mission_id.clone(),
-                runner_id: row.runner_id.clone(),
-                runtime_session: rt_session.clone(),
-                forwarder: None,
-                stop,
-            },
-        );
-        let forwarder = self.start_forwarder_thread(
-            row.id.clone(),
-            row.mission_id.clone(),
-            rt_session,
-            output,
-            Arc::clone(pool),
-            Arc::clone(events),
-            runner,
-            false, // resuming flag — re-attach to a live pane is not a resume_plan resume
-            row.runner_id.is_some(),
-            emit_ctx,
-        );
-        if let Some(h) = self.sessions.lock().unwrap().get_mut(&row.id) {
-            h.forwarder = Some(forwarder);
         }
         Ok(())
     }
@@ -2711,89 +2414,6 @@ impl SessionManager {
 /// falling back to the parent process's cwd when the spawn didn't
 /// set one (the child inherits parent's cwd, which is what codex
 /// stamps into the rollout's `payload.cwd`).
-/// Subset of the `sessions` row needed to reattach to a live pane
-/// at app startup. Pulled all-at-once so the conn drops before we
-/// start hitting the runtime layer per row.
-#[derive(Debug, Clone)]
-struct RowSnap {
-    id: String,
-    runner_id: Option<String>,
-    mission_id: Option<String>,
-    agent_runtime: Option<String>,
-    agent_command: Option<String>,
-    runtime: Option<String>,
-    runtime_socket: Option<String>,
-    runtime_session: Option<String>,
-    runtime_window: Option<String>,
-    runtime_pane: Option<String>,
-}
-
-impl RowSnap {
-    /// Reconstruct the `RuntimeSession` that the original spawn
-    /// persisted into the runtime_* columns. Returns `None` for
-    /// any row missing pieces — the caller treats that as a
-    /// legacy row and marks it stopped.
-    fn runtime_session(&self) -> Option<RuntimeSession> {
-        Some(RuntimeSession {
-            runtime: self.runtime.clone()?,
-            socket: self.runtime_socket.clone()?,
-            session_name: self.runtime_session.clone()?,
-            window: self.runtime_window.clone()?,
-            pane: self.runtime_pane.clone()?,
-        })
-    }
-}
-
-fn collect_running_rows(pool: &DbPool) -> Result<Vec<RowSnap>> {
-    let conn = pool.get()?;
-    let mut stmt = conn.prepare(
-        "SELECT id, runner_id, mission_id, agent_runtime, agent_command,
-                runtime, runtime_socket, runtime_session,
-                runtime_window, runtime_pane
-           FROM sessions
-          WHERE status = 'running'",
-    )?;
-    let rows = stmt
-        .query_map([], |r| {
-            Ok(RowSnap {
-                id: r.get("id")?,
-                runner_id: r.get("runner_id")?,
-                mission_id: r.get("mission_id")?,
-                agent_runtime: r.get("agent_runtime")?,
-                agent_command: r.get("agent_command")?,
-                runtime: r.get("runtime")?,
-                runtime_socket: r.get("runtime_socket")?,
-                runtime_session: r.get("runtime_session")?,
-                runtime_window: r.get("runtime_window")?,
-                runtime_pane: r.get("runtime_pane")?,
-            })
-        })?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-    Ok(rows)
-}
-
-fn mark_session_stopped(pool: &DbPool, id: &str, now: &str) {
-    if let Ok(conn) = pool.get() {
-        let _ = conn.execute(
-            "UPDATE sessions
-                SET status = 'stopped',
-                    stopped_at = COALESCE(stopped_at, ?2)
-              WHERE id = ?1",
-            params![id, now],
-        );
-    }
-}
-
-/// Trim a session id for stderr logging — show just enough to
-/// identify the row without dumping a full ULID into the log line.
-fn row_dbg(id: &str) -> &str {
-    if id.len() <= 8 {
-        id
-    } else {
-        &id[id.len() - 8..]
-    }
-}
-
 fn capture_cwd(explicit: Option<String>) -> Option<String> {
     if let Some(cwd) = explicit {
         if !cwd.is_empty() {
@@ -2841,86 +2461,11 @@ pub(crate) fn runtime_direct_runner(runtime: &str, command: Option<&str>) -> Res
 }
 
 // The first-prompt readback machinery (FirstPromptConfig,
-// FIRST_PROMPT_CONFIG, PLACEHOLDER_MIN_BODY_LEN) lived here under the
-// tmux runtime. docs/impls/0011 retired the verify-and-retry loop it
-// tuned; `inject_paste` is now a single paste-then-Enter and the
-// previous "schedule continue on resume" auto-nudge has been removed —
-// Resume now just respawns the PTY and lets the user drive the agent.
-
-/// Mission-flavored first-turn injection. Composes the platform
-/// coordination preamble (bus mechanics, --to human convention,
-/// signal verbs) followed by the user-authored brief on the runner
-/// template. Keeping bus protocol out of the user's system_prompt
-/// means template authors can focus on persona/role; the runtime
-/// adds the "how to talk to the rest of the crew" layer
-/// automatically.
-///
-/// Fresh mission starts deliver the composed first user turn through
-/// the runtime's positional argv when available. That keeps delivery
-/// deterministic: if the process starts, the prompt is already in the
-/// CLI's argv instead of depending on a later readiness/paste path.
-///
-/// Skipped on resume against a real prior conversation (the agent
-/// already has its system context) and on runtimes that have no
-/// concept of a first-turn prompt (shell).
-fn schedule_mission_first_prompt(
-    _mgr: &Arc<SessionManager>,
-    session_id: String,
-    runner: &Runner,
-    plan: &router::runtime::ResumePlan,
-    delivered_via_argv: bool,
-) {
-    if runner.runtime != "claude-code" && runner.runtime != "codex" {
-        return;
-    }
-    if plan.resuming {
-        return;
-    }
-    if delivered_via_argv {
-        return;
-    }
-    log::warn!(
-        "first-turn argv not delivered for {session_id} (runtime {}); skipping post-spawn injection",
-        runner.runtime,
-    );
-}
-
-/// Direct-chat-flavored first-turn injection: types just
-/// `runner.system_prompt` (the persona) into stdin, with NO
-/// `WORKER_COORDINATION_PREAMBLE` wrapper. Direct chats are off-bus —
-/// `runner msg post`, `runner status idle`, etc. wouldn't resolve to
-/// anything useful here (no `RUNNER_CREW_ID` / `RUNNER_MISSION_ID`
-/// set, the bundled CLI is not even on PATH). Adding the preamble
-/// would tell the agent to use verbs that don't exist in this
-/// context, which is worse than no instructions at all.
-///
-/// If `runner.system_prompt` is empty / None, no injection happens —
-/// claude-code direct chat then boots vanilla, which is the
-/// honest fallback for that edge case.
-///
-/// Skipped on resume (the agent already has its prior conversation)
-/// and on runtimes without a first-turn-prompt concept (shell).
-fn schedule_direct_first_prompt(
-    mgr: &Arc<SessionManager>,
-    session_id: String,
-    runner: &Runner,
-    plan: &router::runtime::ResumePlan,
-    delivered_via_argv: bool,
-) {
-    if runner.runtime != "claude-code" && runner.runtime != "codex" {
-        return;
-    }
-    if plan.resuming {
-        return;
-    }
-    if !delivered_via_argv {
-        log::warn!(
-            "first-turn argv not delivered for direct chat {session_id} (runtime {}); skipping post-spawn injection",
-            runner.runtime,
-        );
-    }
-    let _ = mgr;
-}
+// FIRST_PROMPT_CONFIG, PLACEHOLDER_MIN_BODY_LEN) lived here before
+// docs/impls/0011 retired the verify-and-retry loop it tuned;
+// `inject_paste` is now a single write-then-Enter and the previous
+// "schedule continue on resume" auto-nudge has been removed — Resume
+// now just respawns the PTY and lets the user drive the agent.
 
 // Pre-#88 `inject_first_turn` (the paste-fallback orchestrator) was
 // removed when first-turn delivery moved to spawn-time argv. The
@@ -3004,14 +2549,9 @@ mod tests {
     use std::sync::Mutex;
     use std::time::{Duration, Instant};
 
-    /// Test stand-in for `SessionRuntime`. Step 9 wires
-    /// `SessionManager` to hold an `Arc<dyn SessionRuntime>` so the
-    /// runtime layer is always present, but most legacy tests
-    /// exercise the portable-pty path through the manager and never
-    /// touch the runtime field. This stub errors on every method —
-    /// any test that *does* land in the runtime layer would surface
-    /// it, and intentional runtime tests live in
-    /// `session::tmux_runtime::tests` instead.
+    /// Test stand-in for `SessionRuntime`. Most legacy tests exercise
+    /// paths that should not touch the runtime field. This stub
+    /// errors on every method so any accidental runtime call surfaces.
     struct InertRuntime;
     impl SessionRuntime for InertRuntime {
         fn spawn(&self, _: SpawnSpec) -> RuntimeResult<(RuntimeSession, OutputStream)> {
@@ -3019,14 +2559,8 @@ mod tests {
                 "InertRuntime: spawn unsupported in unit tests".into(),
             ))
         }
-        fn resume(&self, _: &RuntimeSession) -> RuntimeResult<OutputStream> {
-            Err(RuntimeError::Msg("InertRuntime: resume unsupported".into()))
-        }
         fn stop(&self, _: &RuntimeSession) -> RuntimeResult<()> {
             Err(RuntimeError::Msg("InertRuntime: stop unsupported".into()))
-        }
-        fn paste(&self, _: &RuntimeSession, _: &[u8]) -> RuntimeResult<()> {
-            Err(RuntimeError::Msg("InertRuntime: paste unsupported".into()))
         }
         fn send_bytes(&self, _: &RuntimeSession, _: &[u8]) -> RuntimeResult<()> {
             Err(RuntimeError::Msg(
@@ -3052,12 +2586,11 @@ mod tests {
 
     /// Test stand-in that captures every call so assertions can read
     /// back what the manager handed to the runtime layer (env vars,
-    /// argv, paste payloads, key names, resize dimensions). Lets
+    /// argv, byte writes, key names, resize dimensions). Lets
     /// tests that depend on runtime-side behavior — DB writes after
     /// spawn, output buffer machinery, kill semantics, first-prompt
     /// scheduling, agent_session_key resume preservation — run
-    /// without a real tmux server. Real tmux interaction lives in
-    /// `session::tmux_runtime::tests::integration_*`.
+    /// without forking a real PTY.
     #[derive(Default)]
     struct FakeRuntime {
         spawns: std::sync::Mutex<Vec<FakeSpawn>>,
@@ -3069,22 +2602,6 @@ mod tests {
         /// wants exit_code=143 (SIGTERM) to verify the
         /// stop-vs-crash discrimination still flips correctly.
         status_response: std::sync::Mutex<SessionStatus>,
-        /// What `capture_visible` returns BEFORE the paste-count
-        /// crosses `acknowledge_after`. Empty by default — fresh
-        /// spawns have a blank pane, and the count-delta check
-        /// reduces to "any non-zero count in `after` accepts".
-        pane_pre_paste: std::sync::Mutex<Vec<u8>>,
-        /// What `capture_visible` returns AFTER the paste-count
-        /// has reached `acknowledge_after`. Default mirrors the
-        /// expected paste body so tests that don't override it
-        /// observe acknowledgement on attempt 1.
-        pane_post_paste: std::sync::Mutex<Vec<u8>>,
-        /// Number of `paste` calls before `capture_visible` flips
-        /// from `pane_pre_paste` to `pane_post_paste`. Default 0 ⇒
-        /// even the FIRST capture (`before`, taken before any paste)
-        /// returns `pane_post_paste`. Most tests rely on this and
-        /// don't touch it; retry/give-up tests bump it.
-        acknowledge_after: std::sync::Mutex<usize>,
     }
 
     /// One spawn/resume capture. `tx` is the live channel the
@@ -3098,9 +2615,8 @@ mod tests {
 
     #[derive(Debug, Clone, PartialEq, Eq)]
     enum FakeInput {
-        Paste { pane: String, payload: Vec<u8> },
-        Bytes { pane: String, bytes: Vec<u8> },
-        Key { pane: String, key: String },
+        Bytes { session_id: String, bytes: Vec<u8> },
+        Key { session_id: String, key: String },
     }
 
     impl FakeRuntime {
@@ -3112,46 +2628,8 @@ mod tests {
                     pid: Some(99999),
                     command: Some("/bin/sh".into()),
                 }),
-                // Default `pane_post_paste` is intentionally empty —
-                // empty acts as a sentinel that triggers
-                // `capture_visible` to synthesize a snapshot
-                // containing the most recent paste body, which means
-                // any test that doesn't configure post-paste content
-                // sees the verify loop accept on attempt 1 (the
-                // marker the verifier extracts from the body is
-                // present in the pasted body verbatim). Tests that
-                // need stale-content scenarios call
-                // `set_pane_post_paste` directly.
                 ..Default::default()
             }
-        }
-
-        /// Override what `capture_visible` returns once
-        /// `acknowledge_after` pastes have happened. Tests use this
-        /// to set the canned post-paste pane content (typically
-        /// containing the marker the verify loop expects to find).
-        #[allow(dead_code)]
-        fn set_pane_post_paste(&self, bytes: &[u8]) {
-            *self.pane_post_paste.lock().unwrap() = bytes.to_vec();
-        }
-
-        /// Override what `capture_visible` returns BEFORE
-        /// `acknowledge_after` pastes have happened. Stale-content
-        /// resume scenarios use this to seed the baseline capture
-        /// with old `[Pasted text #N]` placeholders.
-        #[allow(dead_code)]
-        fn set_pane_pre_paste(&self, bytes: &[u8]) {
-            *self.pane_pre_paste.lock().unwrap() = bytes.to_vec();
-        }
-
-        /// Number of paste calls that must elapse before
-        /// `capture_visible` switches from pre- to post-paste
-        /// content. Use to simulate "agent didn't see paste #1, did
-        /// see paste #2" retry scenarios, or "agent never sees
-        /// paste" give-up scenarios (set to a large value).
-        #[allow(dead_code)]
-        fn set_acknowledge_after(&self, n: usize) {
-            *self.acknowledge_after.lock().unwrap() = n;
         }
 
         /// Push a `Stream` event through the forwarder channel for
@@ -3192,25 +2670,13 @@ mod tests {
             self.spawns.lock().unwrap().last().map(|s| s.spec.clone())
         }
 
-        fn pastes(&self) -> Vec<(String, Vec<u8>)> {
-            self.inputs
-                .lock()
-                .unwrap()
-                .iter()
-                .filter_map(|i| match i {
-                    FakeInput::Paste { pane, payload } => Some((pane.clone(), payload.clone())),
-                    _ => None,
-                })
-                .collect()
-        }
-
         fn keys(&self) -> Vec<(String, String)> {
             self.inputs
                 .lock()
                 .unwrap()
                 .iter()
                 .filter_map(|i| match i {
-                    FakeInput::Key { pane, key } => Some((pane.clone(), key.clone())),
+                    FakeInput::Key { session_id, key } => Some((session_id.clone(), key.clone())),
                     _ => None,
                 })
                 .collect()
@@ -3222,7 +2688,9 @@ mod tests {
                 .unwrap()
                 .iter()
                 .filter_map(|i| match i {
-                    FakeInput::Bytes { pane, bytes } => Some((pane.clone(), bytes.clone())),
+                    FakeInput::Bytes { session_id, bytes } => {
+                        Some((session_id.clone(), bytes.clone()))
+                    }
                     _ => None,
                 })
                 .collect()
@@ -3235,10 +2703,7 @@ mod tests {
             let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
             let rt_session = RuntimeSession {
                 runtime: "fake".into(),
-                socket: "fake".into(),
-                session_name: format!("runner-{}", spec.session_id),
-                window: "main".into(),
-                pane: format!("%{}", spec.session_id),
+                session_id: spec.session_id.clone(),
             };
             self.spawns.lock().unwrap().push(FakeSpawn {
                 spec: spec.clone(),
@@ -3248,51 +2713,22 @@ mod tests {
             Ok((rt_session, OutputStream::new(rx, stop)))
         }
 
-        fn resume(&self, session: &RuntimeSession) -> RuntimeResult<OutputStream> {
-            let (tx, rx) = std::sync::mpsc::channel::<RuntimeOutput>();
-            let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-            self.spawns.lock().unwrap().push(FakeSpawn {
-                spec: SpawnSpec {
-                    session_id: session
-                        .session_name
-                        .strip_prefix("runner-")
-                        .unwrap_or("")
-                        .to_string(),
-                    ..Default::default()
-                },
-                rt_session: session.clone(),
-                tx: Some(tx),
-            });
-            Ok(OutputStream::new(rx, stop))
-        }
-
         fn stop(&self, session: &RuntimeSession) -> RuntimeResult<()> {
-            self.stops
-                .lock()
-                .unwrap()
-                .push(session.session_name.clone());
+            self.stops.lock().unwrap().push(session.session_id.clone());
             // Drop the matching tx so the forwarder sees Disconnected.
-            let target_pane = session.pane.clone();
+            let target_session_id = session.session_id.clone();
             let mut spawns = self.spawns.lock().unwrap();
             for s in spawns.iter_mut() {
-                if s.rt_session.pane == target_pane {
+                if s.rt_session.session_id == target_session_id {
                     s.tx = None;
                 }
             }
             Ok(())
         }
 
-        fn paste(&self, session: &RuntimeSession, payload: &[u8]) -> RuntimeResult<()> {
-            self.inputs.lock().unwrap().push(FakeInput::Paste {
-                pane: session.pane.clone(),
-                payload: payload.to_vec(),
-            });
-            Ok(())
-        }
-
         fn send_bytes(&self, session: &RuntimeSession, bytes: &[u8]) -> RuntimeResult<()> {
             self.inputs.lock().unwrap().push(FakeInput::Bytes {
-                pane: session.pane.clone(),
+                session_id: session.session_id.clone(),
                 bytes: bytes.to_vec(),
             });
             Ok(())
@@ -3300,7 +2736,7 @@ mod tests {
 
         fn send_key(&self, session: &RuntimeSession, key: &str) -> RuntimeResult<()> {
             self.inputs.lock().unwrap().push(FakeInput::Key {
-                pane: session.pane.clone(),
+                session_id: session.session_id.clone(),
                 key: key.to_string(),
             });
             Ok(())
@@ -3310,7 +2746,7 @@ mod tests {
             self.resizes
                 .lock()
                 .unwrap()
-                .push((session.session_name.clone(), cols, rows));
+                .push((session.session_id.clone(), cols, rows));
             Ok(())
         }
 
@@ -3875,9 +3311,9 @@ mod tests {
             "direct chat must NOT ship the worker coordination preamble in argv: {trailing:?}",
         );
         assert!(
-            fake.pastes().is_empty(),
-            "argv delivery must suppress the post-spawn paste fallback; got pastes = {:?}",
-            fake.pastes()
+            fake.bytes_writes().is_empty(),
+            "argv delivery must suppress the post-spawn byte injection fallback; got writes = {:?}",
+            fake.bytes_writes()
         );
 
         mgr.kill(&spawned.id).unwrap();
@@ -3966,9 +3402,9 @@ mod tests {
             "worker argv must ship the brief"
         );
         assert!(
-            fake.pastes().is_empty(),
-            "argv delivery must suppress the post-spawn paste fallback; got = {:?}",
-            fake.pastes()
+            fake.bytes_writes().is_empty(),
+            "argv delivery must suppress the post-spawn byte injection fallback; got = {:?}",
+            fake.bytes_writes()
         );
 
         mgr.kill(&spawned.id).unwrap();
@@ -4048,9 +3484,9 @@ mod tests {
             spec.args,
         );
         assert!(
-            fake.pastes().is_empty(),
-            "argv delivery must not schedule paste injection; got {:?}",
-            fake.pastes(),
+            fake.bytes_writes().is_empty(),
+            "argv delivery must not schedule byte injection; got {:?}",
+            fake.bytes_writes(),
         );
         assert!(
             fake.keys().is_empty(),
@@ -4237,18 +3673,18 @@ mod tests {
             .unwrap();
 
         // FIRST_PROMPT_DELAY = ZERO under cfg(test); a would-be
-        // injection would already be visible in fake.pastes() by
+        // injection would already be visible in fake.bytes_writes() by
         // the time resume() returns. The contract: codex resume
-        // MUST NOT paste anything containing the brief.
-        let pasted: String = fake
-            .pastes()
+        // MUST NOT write anything containing the brief.
+        let written: String = fake
+            .bytes_writes()
             .iter()
             .map(|(_, p)| String::from_utf8_lossy(p).to_string())
             .collect::<Vec<_>>()
             .join("\n");
         assert!(
-            !pasted.contains("CODEX_BRIEF_TOKEN_RESUME"),
-            "codex resume must NOT paste the brief; got = {pasted:?}"
+            !written.contains("CODEX_BRIEF_TOKEN_RESUME"),
+            "codex resume must NOT write the brief; got = {written:?}"
         );
 
         mgr.kill(&resumed.id).unwrap();
@@ -4993,364 +4429,12 @@ mod tests {
         mgr.kill(&spawned.id).unwrap();
     }
 
-    /// Helper: insert a runner row + a `running` direct-chat
-    /// session row with the runtime_* columns populated as if a
-    /// prior Runner process had spawned the session through tmux.
-    fn insert_running_row_with_runtime_meta(pool: &Arc<DbPool>) -> (String, String) {
-        let now = Utc::now().to_rfc3339();
-        let runner_id = ulid::Ulid::new().to_string();
-        let session_id = ulid::Ulid::new().to_string();
-        let conn = pool.get().unwrap();
-        conn.execute(
-            "INSERT INTO runners
-                (id, handle, display_name, runtime, command,
-                 args_json, working_dir, system_prompt, env_json,
-                 created_at, updated_at)
-             VALUES (?1, 'reattach', 'R', 'shell', '/bin/sh',
-                     NULL, NULL, NULL, NULL, ?2, ?2)",
-            params![runner_id, now],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO sessions
-                (id, mission_id, runner_id, cwd, status, started_at,
-                 runtime, runtime_socket, runtime_session,
-                 runtime_window, runtime_pane)
-             VALUES (?1, NULL, ?2, '/tmp', 'running', ?3,
-                     'tmux', 'runner', ?4, 'main', ?5)",
-            params![
-                session_id,
-                runner_id,
-                now,
-                format!("runner-{session_id}"),
-                format!("%{session_id}"),
-            ],
-        )
-        .unwrap();
-        (session_id, runner_id)
-    }
-
-    #[test]
-    fn reattach_running_sessions_recovers_live_pane() {
-        // Simulate "Runner restarted while a tmux pane survived":
-        // a sessions row is `running` with runtime_* populated.
-        // FakeRuntime's status() returns alive=true by default,
-        // so reattach should rebuild the SessionHandle (the row
-        // stays running) and the manager's sessions map gains
-        // an entry.
-        let pool = pool_with_schema();
-        let (session_id, _runner_id) = insert_running_row_with_runtime_meta(&pool);
-
-        let fake = fake_runtime();
-        // Override status: alive (the default exit_code=0 still
-        // applies but alive=true takes precedence).
-        {
-            let mut s = fake.status_response.lock().unwrap();
-            s.alive = true;
-            s.exit_code = None;
-        }
-        let mgr = mgr_with_fake(None, Arc::clone(&fake));
-        mgr.reattach_running_sessions(
-            Arc::clone(&pool),
-            capture(),
-            &HashSet::new(),
-            std::path::Path::new("."),
-        );
-
-        // Row should still be running.
-        let status: String = pool
-            .get()
-            .unwrap()
-            .query_row(
-                "SELECT status FROM sessions WHERE id = ?1",
-                params![session_id],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(status, "running");
-        // Manager should have the session in its live map.
-        assert!(mgr.sessions.lock().unwrap().contains_key(&session_id));
-
-        // Cleanup so the forwarder thread doesn't leak.
-        mgr.kill(&session_id).unwrap();
-    }
-
-    #[test]
-    fn reattach_running_sessions_marks_dead_pane_with_exit_code() {
-        // Pane is gone-but-flagged-dead: tmux still has the
-        // remain-on-exit row and reports pane_dead=1 with a
-        // non-zero exit code. Reattach should mark the row
-        // crashed (non-zero) and tear down the dead pane.
-        let pool = pool_with_schema();
-        let (session_id, _runner_id) = insert_running_row_with_runtime_meta(&pool);
-
-        let fake = fake_runtime();
-        {
-            let mut s = fake.status_response.lock().unwrap();
-            s.alive = false;
-            s.exit_code = Some(42);
-        }
-        let mgr = mgr_with_fake(None, Arc::clone(&fake));
-        mgr.reattach_running_sessions(
-            Arc::clone(&pool),
-            capture(),
-            &HashSet::new(),
-            std::path::Path::new("."),
-        );
-
-        let status: String = pool
-            .get()
-            .unwrap()
-            .query_row(
-                "SELECT status FROM sessions WHERE id = ?1",
-                params![session_id],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(status, "crashed");
-        // The row must NOT be in the live map — there's no live
-        // pane to attach to.
-        assert!(!mgr.sessions.lock().unwrap().contains_key(&session_id));
-    }
-
-    #[test]
-    fn reattach_running_sessions_reattaches_live_mission_panes() {
-        // Mission sessions take the same alive-pane path as direct
-        // chats. The bus + router are mounted earlier in startup by
-        // `mission::reattach_all_running_missions`, so the pane is
-        // safe to reattach: events emitted between pipe-pane install
-        // and workspace mount land on the already-live bus.
-        let pool = pool_with_schema();
-        let now = Utc::now().to_rfc3339();
-        let runner_id = ulid::Ulid::new().to_string();
-        let session_id = ulid::Ulid::new().to_string();
-        let crew_id = "c-mission-reattach".to_string();
-        let mission_id = ulid::Ulid::new().to_string();
-        {
-            let conn = pool.get().unwrap();
-            conn.execute(
-                "INSERT INTO crews (id, name, created_at, updated_at)
-                 VALUES (?1, 'c', ?2, ?2)",
-                params![crew_id, now],
-            )
-            .unwrap();
-            conn.execute(
-                "INSERT INTO runners
-                    (id, handle, display_name, runtime, command,
-                     args_json, working_dir, system_prompt, env_json,
-                     created_at, updated_at)
-                 VALUES (?1, 'mr', 'M', 'shell', '/bin/sh',
-                         NULL, NULL, NULL, NULL, ?2, ?2)",
-                params![runner_id, now],
-            )
-            .unwrap();
-            conn.execute(
-                "INSERT INTO missions (id, crew_id, title, status, started_at)
-                 VALUES (?1, ?2, 't', 'running', ?3)",
-                params![mission_id, crew_id, now],
-            )
-            .unwrap();
-            conn.execute(
-                "INSERT INTO sessions
-                    (id, mission_id, runner_id, status, started_at,
-                     runtime, runtime_socket, runtime_session,
-                     runtime_window, runtime_pane)
-                 VALUES (?1, ?2, ?3, 'running', ?4,
-                         'tmux', 'runner', ?5, 'main', ?6)",
-                params![
-                    session_id,
-                    mission_id,
-                    runner_id,
-                    now,
-                    format!("runner-{session_id}"),
-                    format!("%{session_id}"),
-                ],
-            )
-            .unwrap();
-        }
-
-        let fake = fake_runtime();
-        // Pane is alive — reattach should rebuild the SessionHandle.
-        {
-            let mut s = fake.status_response.lock().unwrap();
-            s.alive = true;
-            s.exit_code = None;
-        }
-        let mgr = mgr_with_fake(None, Arc::clone(&fake));
-        mgr.reattach_running_sessions(
-            Arc::clone(&pool),
-            capture(),
-            &HashSet::new(),
-            std::path::Path::new("."),
-        );
-
-        // Row stays `running` — the pane is alive and the manager
-        // has rebuilt its handle for it.
-        let status: String = pool
-            .get()
-            .unwrap()
-            .query_row(
-                "SELECT status FROM sessions WHERE id = ?1",
-                params![session_id],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(status, "running");
-        // Manager has the session in its live map again.
-        assert!(mgr.sessions.lock().unwrap().contains_key(&session_id));
-        // Nothing was stopped — the pane keeps running.
-        assert_eq!(fake.stops.lock().unwrap().len(), 0);
-    }
-
-    #[test]
-    fn reattach_running_sessions_stops_live_mission_panes_when_mount_failed() {
-        // If `mission::reattach_all_running_missions` failed to
-        // mount a mission's router+bus (corrupt log, missing crew,
-        // etc.), reattaching its alive panes would stream forwarder
-        // bytes into a non-existent subscriber and silently drop
-        // mission_* events. Fall back to the pre-eager-mount safety
-        // path: stop the pane and mark the row stopped so the user
-        // can resume from the workspace, where mission_attach will
-        // retry the mount.
-        let pool = pool_with_schema();
-        let now = Utc::now().to_rfc3339();
-        let runner_id = ulid::Ulid::new().to_string();
-        let session_id = ulid::Ulid::new().to_string();
-        let crew_id = "c-mount-failed".to_string();
-        let mission_id = ulid::Ulid::new().to_string();
-        {
-            let conn = pool.get().unwrap();
-            conn.execute(
-                "INSERT INTO crews (id, name, created_at, updated_at)
-                 VALUES (?1, 'c', ?2, ?2)",
-                params![crew_id, now],
-            )
-            .unwrap();
-            conn.execute(
-                "INSERT INTO runners
-                    (id, handle, display_name, runtime, command,
-                     args_json, working_dir, system_prompt, env_json,
-                     created_at, updated_at)
-                 VALUES (?1, 'mr', 'M', 'shell', '/bin/sh',
-                         NULL, NULL, NULL, NULL, ?2, ?2)",
-                params![runner_id, now],
-            )
-            .unwrap();
-            conn.execute(
-                "INSERT INTO missions (id, crew_id, title, status, started_at)
-                 VALUES (?1, ?2, 't', 'running', ?3)",
-                params![mission_id, crew_id, now],
-            )
-            .unwrap();
-            conn.execute(
-                "INSERT INTO sessions
-                    (id, mission_id, runner_id, status, started_at,
-                     runtime, runtime_socket, runtime_session,
-                     runtime_window, runtime_pane)
-                 VALUES (?1, ?2, ?3, 'running', ?4,
-                         'tmux', 'runner', ?5, 'main', ?6)",
-                params![
-                    session_id,
-                    mission_id,
-                    runner_id,
-                    now,
-                    format!("runner-{session_id}"),
-                    format!("%{session_id}"),
-                ],
-            )
-            .unwrap();
-        }
-
-        let fake = fake_runtime();
-        // Pane is alive — the failed-mount carve-out must override
-        // the uniform reattach and stop it.
-        {
-            let mut s = fake.status_response.lock().unwrap();
-            s.alive = true;
-            s.exit_code = None;
-        }
-        let mgr = mgr_with_fake(None, Arc::clone(&fake));
-        let mut failed = HashSet::new();
-        failed.insert(mission_id.clone());
-        mgr.reattach_running_sessions(
-            Arc::clone(&pool),
-            capture(),
-            &failed,
-            std::path::Path::new("."),
-        );
-
-        // Row flips to stopped — workspace mount path will retry
-        // and resume spawns a fresh pane.
-        let status: String = pool
-            .get()
-            .unwrap()
-            .query_row(
-                "SELECT status FROM sessions WHERE id = ?1",
-                params![session_id],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(status, "stopped");
-        // Manager must NOT hold a live handle for this session.
-        assert!(!mgr.sessions.lock().unwrap().contains_key(&session_id));
-        // Exactly one stop call — the safety carve-out tearing down
-        // the pane so it stops streaming bytes.
-        assert_eq!(fake.stops.lock().unwrap().len(), 1);
-    }
-
-    #[test]
-    fn reattach_running_sessions_marks_terminal_unavailable_stopped() {
-        // Pane is gone entirely (tmux returns Ok(None) — no such
-        // session). Mark the row stopped without inventing exit
-        // info.
-        let pool = pool_with_schema();
-        let (session_id, _runner_id) = insert_running_row_with_runtime_meta(&pool);
-
-        // FakeRuntime's status() always returns Ok(Some(...)) by
-        // default, so we can't easily express terminal-unavailable
-        // through the canned response. Instead, blank out the
-        // runtime_* columns to simulate a row that has no usable
-        // metadata — the reattach code path goes through
-        // `runtime_session()` returning None and immediately marks
-        // stopped.
-        pool.get()
-            .unwrap()
-            .execute(
-                "UPDATE sessions
-                    SET runtime = NULL, runtime_socket = NULL, runtime_session = NULL,
-                        runtime_window = NULL, runtime_pane = NULL
-                  WHERE id = ?1",
-                params![session_id],
-            )
-            .unwrap();
-
-        let fake = fake_runtime();
-        let mgr = mgr_with_fake(None, Arc::clone(&fake));
-        mgr.reattach_running_sessions(
-            Arc::clone(&pool),
-            capture(),
-            &HashSet::new(),
-            std::path::Path::new("."),
-        );
-
-        let status: String = pool
-            .get()
-            .unwrap()
-            .query_row(
-                "SELECT status FROM sessions WHERE id = ?1",
-                params![session_id],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(status, "stopped");
-    }
-
     // The verify-and-retry first-prompt readback tests
     // (`first_prompt_landed_first_try`, `*_after_retry`,
     // `*_gives_up_after_max_attempts`,
     // `continue_resume_rejects_stale_placeholder`) lived here
-    // before docs/impls/0011 retired tmux's capture-pane verify
-    // path. The post-spawn "continue" auto-paste on resume that
+    // before docs/impls/0011 retired the readback verify path. The
+    // post-spawn "continue" auto-paste on resume that
     // also lived here has been removed — Resume just respawns the
     // PTY with no stdin injection, so the helper that synthesized
     // a FakeRuntime SessionHandle for those tests is gone too.

--- a/src-tauri/src/session/pty_runtime.rs
+++ b/src-tauri/src/session/pty_runtime.rs
@@ -1,5 +1,4 @@
 // In-process `SessionRuntime` implementation over `portable-pty`.
-// Replaces the tmux runtime in `session::tmux_runtime` per impl 0011.
 //
 // One PtyRuntime instance owns a HashMap of session_id → SessionHandle.
 // Per session: PTY master fd, child handle, writer mutex, killer
@@ -10,12 +9,6 @@
 // consumes. There is no host-side terminal model; xterm.js on the
 // frontend is the only emulator. See plan §"Why no headless emulator"
 // for the trade-offs.
-//
-// `resume(...)` is intentionally defensive: under the in-process model
-// the manager's `reattach_running_sessions` is short-circuited at app
-// start (DB cleanup demotes any prior `running` rows to `stopped`), so
-// this trait method is never reached on the live path. If it does fire,
-// erroring loud is better than returning a half-initialized stream.
 //
 // The `#[cfg(unix)]` gate is applied at the parent `session/mod.rs`
 // when this module is registered, so no inner attribute is needed
@@ -96,11 +89,9 @@ const EXIT_UNSET: i32 = i32::MIN;
 
 impl SessionRuntime for PtyRuntime {
     fn spawn(&self, spec: SpawnSpec) -> RuntimeResult<(RuntimeSession, OutputStream)> {
-        // Compose PATH the same way the tmux runtime does so direct-chat
-        // sessions get identical shell-resolution behavior across the
-        // cutover. `launch::compose_path` is the canonical place for
-        // shim_dir / bundled_bin_dir / shell_path / HOME / inherited
-        // PATH precedence rules.
+        // `launch::compose_path` is the canonical place for shim_dir /
+        // bundled_bin_dir / shell_path / HOME / inherited PATH
+        // precedence rules.
         let inherited_path = std::env::var("PATH").ok();
         let home_path: Option<PathBuf> = std::env::var_os("HOME").map(PathBuf::from);
         let composed_path = launch::compose_path(
@@ -134,7 +125,7 @@ impl SessionRuntime for PtyRuntime {
         }
 
         // Reserved env names (PATH) come from the composed result, not
-        // from spec.env — same precedence as the tmux launch script.
+        // from spec.env.
         for (k, v) in &spec.env {
             if launch::is_reserved_env_name(k) {
                 continue;
@@ -148,7 +139,7 @@ impl SessionRuntime for PtyRuntime {
         }
         cmd.env("PATH", &composed_path);
         // COLUMNS/LINES so Node-based TUIs pick up the initial grid
-        // before SIGWINCH lands — same hint the tmux launcher injects.
+        // before SIGWINCH lands.
         cmd.env("COLUMNS", cols.to_string());
         cmd.env("LINES", rows.to_string());
 
@@ -214,29 +205,14 @@ impl SessionRuntime for PtyRuntime {
 
         let rt_session = RuntimeSession {
             runtime: RUNTIME_LABEL.to_string(),
-            socket: String::new(),
-            session_name: spec.session_id.clone(),
-            window: "main".to_string(),
-            pane: spec.session_id,
+            session_id: spec.session_id,
         };
         let stream = OutputStream::new(rx, stop);
         Ok((rt_session, stream))
     }
 
-    fn resume(&self, session: &RuntimeSession) -> RuntimeResult<OutputStream> {
-        // Under the in-process model the manager's reattach pass is
-        // short-circuited at startup, so this is only reachable via a
-        // legacy code path. Failing loud beats handing back a stream
-        // that drops the bytes a still-alive session is producing.
-        Err(RuntimeError::Msg(format!(
-            "pty runtime: resume() is not used in-process; \
-             session {} should be respawned via SessionManager::resume",
-            session.session_name
-        )))
-    }
-
     fn stop(&self, session: &RuntimeSession) -> RuntimeResult<()> {
-        let handle = lookup(self, &session.session_name)?;
+        let handle = lookup(self, &session.session_id)?;
         let mut killer = handle.killer.lock().expect("killer poisoned");
         killer
             .kill()
@@ -244,25 +220,17 @@ impl SessionRuntime for PtyRuntime {
         Ok(())
     }
 
-    fn paste(&self, session: &RuntimeSession, payload: &[u8]) -> RuntimeResult<()> {
-        // xterm.js handles bracketed-paste wrapping on the user-input
-        // path. Rust-side callers (manager's `inject_paste`) that want
-        // bracketing also prefix it themselves before calling — see
-        // `manager::inject_paste`. The runtime just writes the bytes.
-        write_to(self, &session.session_name, payload)
-    }
-
     fn send_bytes(&self, session: &RuntimeSession, bytes: &[u8]) -> RuntimeResult<()> {
-        write_to(self, &session.session_name, bytes)
+        write_to(self, &session.session_id, bytes)
     }
 
     fn send_key(&self, session: &RuntimeSession, key: &str) -> RuntimeResult<()> {
         let bytes = translate_key(key)?;
-        write_to(self, &session.session_name, &bytes)
+        write_to(self, &session.session_id, &bytes)
     }
 
     fn resize(&self, session: &RuntimeSession, cols: u16, rows: u16) -> RuntimeResult<()> {
-        let handle = lookup(self, &session.session_name)?;
+        let handle = lookup(self, &session.session_id)?;
         let master = handle.master.lock().expect("master poisoned");
         master
             .resize(PtySize {
@@ -280,7 +248,7 @@ impl SessionRuntime for PtyRuntime {
             .sessions
             .lock()
             .expect("PtyRuntime.sessions poisoned")
-            .get(&session.session_name)
+            .get(&session.session_id)
         {
             Some(h) => Arc::clone(h),
             None => return Ok(None),
@@ -640,15 +608,12 @@ fn format_command_summary(command: &str, args: &[String]) -> String {
 
 /// Demote any rows still marked `running` in the DB to `stopped`. Run
 /// once at app startup before `SessionManager` accepts work, so the
-/// sidebar reflects "agent died with prior app process" reality
-/// without trying to reattach to a PTY that doesn't exist anymore.
+/// sidebar reflects "agent died with prior app process" reality.
 ///
-/// Matches the legacy reattach pass's behavior on a dead pane: status
-/// flips to `stopped`, `stopped_at` records the wall-clock at cleanup
-/// time, `pid` is left as the prior value for diagnostics. Mission
-/// rows are demoted alongside direct chats — the router will need
-/// re-mount on next user interaction, same as today's tmux flow when
-/// reattach fails.
+/// Status flips to `stopped`, `stopped_at` records the wall-clock at
+/// cleanup time, and `pid` is left as the prior value for diagnostics.
+/// Mission rows are demoted alongside direct chats; users can resume
+/// them by spawning a fresh PTY through `SessionManager::resume`.
 pub fn cleanup_stale_running_rows_on_startup(
     pool: &r2d2::Pool<r2d2_sqlite::SqliteConnectionManager>,
 ) -> rusqlite::Result<usize> {
@@ -813,7 +778,6 @@ mod tests {
         while std::time::Instant::now() < deadline {
             match stream.recv_timeout(std::time::Duration::from_millis(200)) {
                 Ok(RuntimeOutput::Stream(bytes)) => collected.extend_from_slice(&bytes),
-                Ok(RuntimeOutput::Replay(_)) => panic!("pty runtime must not emit Replay"),
                 Ok(RuntimeOutput::StatusTransition { .. }) => {}
                 Err(_) => {}
             }
@@ -855,7 +819,6 @@ mod tests {
                     }
                 }
                 Ok(RuntimeOutput::Stream(_)) => {}
-                Ok(RuntimeOutput::Replay(_)) => panic!("pty runtime must not emit Replay"),
                 Err(mpsc::RecvTimeoutError::Timeout) => continue,
                 Err(mpsc::RecvTimeoutError::Disconnected) => break,
             }
@@ -905,10 +868,7 @@ mod tests {
         let rt = PtyRuntime::new();
         let phantom = RuntimeSession {
             runtime: RUNTIME_LABEL.into(),
-            socket: String::new(),
-            session_name: "nonexistent".into(),
-            window: "main".into(),
-            pane: "nonexistent".into(),
+            session_id: "nonexistent".into(),
         };
         assert!(rt.status(&phantom).unwrap().is_none());
     }
@@ -921,18 +881,5 @@ mod tests {
             .unwrap();
         rt.resize(&sess, 120, 40).expect("resize should succeed");
         rt.stop(&sess).unwrap();
-    }
-
-    #[test]
-    fn resume_returns_error_under_pty_runtime() {
-        let rt = PtyRuntime::new();
-        let phantom = RuntimeSession {
-            runtime: RUNTIME_LABEL.into(),
-            socket: String::new(),
-            session_name: "phantom".into(),
-            window: "main".into(),
-            pane: "phantom".into(),
-        };
-        assert!(matches!(rt.resume(&phantom), Err(RuntimeError::Msg(_))));
     }
 }

--- a/src-tauri/src/session/runtime.rs
+++ b/src-tauri/src/session/runtime.rs
@@ -1,10 +1,7 @@
-#![allow(dead_code)] // Wired into SessionManager in Step 5+; foundation now.
-
-// Internal runtime abstraction for the session layer (impl plan
-// docs/impls/0004-tmux-session-runtime.md, Step 1). The trait is the
-// seam between the command layer and whoever owns the terminal —
-// `TmuxRuntime` for v1 (Step 5+); a future `NativePtyRuntime` slots
-// in here for Windows or for the no-dependency mode without
+// Internal runtime abstraction for the session layer. The trait is the
+// seam between the manager and whoever owns the terminal process. The
+// current implementation is the in-process portable-pty runtime; a
+// future platform-specific implementation can slot in without
 // rewriting commands/frontend.
 //
 // Intentionally small. Add methods only when a caller needs them;
@@ -64,56 +61,38 @@ pub struct SpawnSpec {
     pub initial_size: Option<(u16, u16)>,
 }
 
-/// What `spawn`/`resume` returns: the runtime-side identifiers we
-/// persist on the `sessions` row so a future process can reattach.
-/// Everything is opaque to the caller; the runtime owns the schema.
+/// What `spawn` returns: the runtime-side identity persisted on the
+/// `sessions` row. Under the in-process PTY runtime this is just the
+/// runtime discriminator plus the session id used to look up the
+/// live handle while the app process is running.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RuntimeSession {
     /// Discriminator for the runtime that produced this row.
-    /// Currently always `"tmux"`. A future `NativePtyRuntime` would
-    /// emit `"native-pty"`.
+    /// Currently `"native-pty"` for the portable-pty implementation.
     pub runtime: String,
-    /// `-L` label (tmux) — distinct sockets let the dev / test
-    /// harness coexist with the production server. Persisted so
-    /// reattach knows which socket to talk to.
-    pub socket: String,
-    /// `-s` session name. Always `runner-<SpawnSpec.session_id>` for
-    /// the tmux runtime.
-    pub session_name: String,
-    /// Window id within the tmux session. The first window is
-    /// `main`; we don't yet create others, but the column is here
-    /// so the schema doesn't need to grow when we do.
-    pub window: String,
-    /// Pane id (e.g. `%3`). Pane ids survive index reshuffles —
-    /// always persist these, never `:0.0`-style indexes.
-    pub pane: String,
+    /// Session row id and key into the runtime's live-handle map.
+    pub session_id: String,
 }
 
 /// Liveness snapshot of a runtime session. Returned by
-/// `SessionRuntime::status` so the manager (Step 9) can reconcile
-/// the DB row against what the runtime knows: a live pane stays
-/// `running`; a dead pane with a captured exit code becomes
-/// `stopped` (status 0) or `crashed` (non-zero); a missing pane
+/// `SessionRuntime::status` so the manager can reconcile the DB row
+/// against what the runtime knows: a live child stays
+/// `running`; a dead child with a captured exit code becomes
+/// `stopped` (status 0) or `crashed` (non-zero); a missing session
 /// (the runtime returns `Ok(None)`) is treated as
 /// terminal-unavailable.
 #[derive(Debug, Clone, Default)]
 pub struct SessionStatus {
-    /// `true` while the agent process is still attached to the
-    /// pane. Once the agent exits and tmux flags `pane_dead=1`,
-    /// this flips to `false`.
+    /// `true` while the agent process is still attached to the PTY.
+    /// Once the agent exits and the reader observes EOF, this flips
+    /// to `false`.
     pub alive: bool,
-    /// Exit code captured from `pane_dead_status` once the agent
-    /// has exited. Only populated when `alive == false` AND the
-    /// runtime config has `remain-on-exit on` so tmux retains the
-    /// dead pane long enough for the manager to read it.
+    /// Exit code captured from the child process once the agent has
+    /// exited. Only populated when `alive == false`.
     pub exit_code: Option<i32>,
-    /// Process id of the most-recent foreground program in the
-    /// pane (`pane_pid` in tmux). Useful for "kill the bare pid"
-    /// flows from the manager.
+    /// Process id of the child process when available.
     pub pid: Option<i32>,
-    /// Name of the foreground command (`pane_current_command`).
-    /// Useful for diagnostics — "is this still claude or has it
-    /// fallen back to the shell?".
+    /// Name of the spawned command. Useful for diagnostics.
     pub command: Option<String>,
 }
 
@@ -129,23 +108,14 @@ pub enum RunnerStatus {
     Idle,
 }
 
-/// One unit of output produced by a runtime session. The manager
-/// forwards `Replay` / `Stream` to xterm.js with **distinct
-/// semantics** for each variant — collapsing them back into a
-/// single byte stream is the duplicated-cells bug the plan calls
-/// out (Step 6: snapshot ≠ stream). `StatusTransition` is the
-/// forwarder's busy/idle signal (issue #124) and never reaches
-/// xterm.js; the SessionManager consumer routes it to the event
-/// log.
+/// One unit of output produced by a runtime session. Raw stream bytes
+/// are appended to xterm.js; `StatusTransition` is the forwarder's
+/// busy/idle signal (issue #124) and never reaches xterm.js; the
+/// SessionManager consumer routes it to the event log.
 #[derive(Debug, Clone)]
 pub enum RuntimeOutput {
-    /// Attach-time snapshot. xterm.js **resets** its buffer to this
-    /// content. Includes alternate-screen handling — for a
-    /// Claude/Codex pane in alternate-screen mode, this is the
-    /// current TUI render, not the pre-TUI scrollback.
-    Replay(Vec<u8>),
-    /// Live PTY bytes the agent wrote since the last `Stream`
-    /// chunk. xterm.js **appends**. Sourced from `pipe-pane`.
+    /// Live PTY bytes the agent wrote since the last `Stream` chunk.
+    /// xterm.js **appends**.
     Stream(Vec<u8>),
     /// Forwarder-inferred busy/idle transition. `source` is
     /// `"forwarder"` for these synthetic events (the CLI's
@@ -159,7 +129,7 @@ pub enum RuntimeOutput {
 }
 
 /// Receiver half of a runtime session's output channel. Returned
-/// from `spawn` / `resume`; the runtime is the sender. Backed by a
+/// from `spawn`; the runtime is the sender. Backed by a
 /// blocking `std::sync::mpsc` because the manager already runs
 /// reader threads off `std::thread`; matching that avoids dragging
 /// in a tokio runtime for the session layer.
@@ -169,15 +139,13 @@ pub enum RuntimeOutput {
 /// polls — without that, dropping the receiver while no bytes are
 /// arriving leaves the forwarder blocked forever in `read()`,
 /// which leaks one OS thread per detach. The wrapper trades the
-/// `Receiver` API for explicit `recv_timeout` / `try_recv`
-/// methods; callers that want the full receiver surface can take
-/// `&self.inner` via the `as_receiver` accessor.
+/// `Receiver` API for explicit `recv_timeout`.
 pub struct OutputStream {
     inner: std::sync::mpsc::Receiver<RuntimeOutput>,
     /// Set to true when this `OutputStream` is dropped. The
-    /// runtime's forwarder thread polls this flag every tick and
-    /// exits when it flips, releasing its FIFO read fd and
-    /// `Sender` half of the channel.
+    /// runtime's reader thread polls this flag every tick and exits
+    /// when it flips, releasing the PTY reader and `Sender` half of
+    /// the channel.
     stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
@@ -185,7 +153,7 @@ impl OutputStream {
     /// Construct from a `Receiver` plus the stop flag the runtime
     /// already gave to its forwarder thread. Internal — only the
     /// runtime impl wires this; manager code drops in via
-    /// `recv_timeout` / `try_recv`.
+    /// `recv_timeout`.
     pub(crate) fn new(
         inner: std::sync::mpsc::Receiver<RuntimeOutput>,
         stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
@@ -203,26 +171,14 @@ impl OutputStream {
         self.inner.recv_timeout(dur)
     }
 
-    /// Mirrors `Receiver::try_recv`.
-    pub fn try_recv(&self) -> Result<RuntimeOutput, std::sync::mpsc::TryRecvError> {
-        self.inner.try_recv()
-    }
-
-    /// Borrow the inner receiver for callers that need the full
-    /// surface (iterator chains, select-style multiplexing).
-    pub fn as_receiver(&self) -> &std::sync::mpsc::Receiver<RuntimeOutput> {
-        &self.inner
-    }
-
     /// Clone of the cancellation flag. Set this from outside the
     /// consumer thread to break it out of `recv_timeout` on the
     /// next tick, regardless of whether the channel has
     /// disconnected. Used by `SessionManager::kill` so kill
-    /// doesn't hang waiting on tmux's pipe-pane cleanup chain
-    /// (kill-session → cat dies → FIFO POLLHUP → forward_fifo
-    /// exits → tx drops → Disconnected) — that chain is normally
-    /// fast but can stall under load, and `kill` must not block
-    /// the calling Tauri command indefinitely.
+    /// doesn't hang waiting on the reader thread to observe EOF and
+    /// drop its sender. That path is normally fast but can stall
+    /// under load, and `kill` must not block the calling Tauri
+    /// command indefinitely.
     pub fn stop_flag(&self) -> std::sync::Arc<std::sync::atomic::AtomicBool> {
         std::sync::Arc::clone(&self.stop)
     }
@@ -244,10 +200,7 @@ impl Drop for OutputStream {
 /// `crate::error::Error` via the `From` impl so command code can `?`
 /// across the boundary. v1 keeps the surface narrow: I/O failures
 /// (from the master fd / writer half) and free-form `Msg(...)` for
-/// every other condition the runtime wants to name. Earlier
-/// drafts had tmux-specific variants (`TmuxRequiresUnix`,
-/// `TmuxNotFound`, `TmuxFailed`); those went away when the tmux
-/// runtime was retired (docs/impls/0011).
+/// every other condition the runtime wants to name.
 #[derive(Debug, thiserror::Error)]
 pub enum RuntimeError {
     #[error("io: {0}")]
@@ -268,65 +221,40 @@ impl From<RuntimeError> for crate::error::Error {
 
 pub type RuntimeResult<T> = std::result::Result<T, RuntimeError>;
 
-/// The session runtime trait. `TmuxRuntime` (Step 5) is the only
-/// implementer right now. Frontend / Tauri commands never touch
+/// The session runtime trait. Frontend / Tauri commands never touch
 /// this — they go through `SessionManager`, which in turn delegates
-/// to a `dyn SessionRuntime` for the per-pane work.
-///
-/// Output / input are split into distinct shapes by intent so
-/// callers can't accidentally collapse a snapshot into the live
-/// stream (Step 6 anti-pattern) or send a literal byte payload as a
-/// paste (Step 7 anti-pattern).
+/// to a `dyn SessionRuntime` for the per-session PTY work.
 pub trait SessionRuntime: Send + Sync {
     /// Start a fresh session. Returns the runtime-side ids to
     /// persist on the `sessions` row, plus the output channel the
-    /// runtime will write `RuntimeOutput::Replay` (once) and
-    /// `RuntimeOutput::Stream` (indefinitely) into.
+    /// runtime will write `RuntimeOutput::Stream` into.
     fn spawn(&self, spec: SpawnSpec) -> RuntimeResult<(RuntimeSession, OutputStream)>;
-
-    /// Re-establish liveness for a session that already has runtime
-    /// metadata persisted (app restart, route switch, etc.). Errors
-    /// out if the underlying pane is gone — the manager treats that
-    /// as `terminal-unavailable` and marks the session stopped.
-    /// Returns a fresh output channel: a `Replay` snapshot of the
-    /// pane's current state arrives first, then live `Stream`
-    /// events resume.
-    fn resume(&self, session: &RuntimeSession) -> RuntimeResult<OutputStream>;
 
     /// Best-effort terminate. The runtime is responsible for
     /// triggering whatever exit-status capture the manager needs;
     /// this method only signals.
     fn stop(&self, session: &RuntimeSession) -> RuntimeResult<()>;
 
-    /// Multi-line prompt paste. Runtime keeps LF literal so the
-    /// agent sees one paste, not one submit per line. The runtime
-    /// does **not** submit — the manager follows up with `send_key`
-    /// when it wants the agent to act.
-    fn paste(&self, session: &RuntimeSession, payload: &[u8]) -> RuntimeResult<()>;
-
     /// Literal byte stream from xterm.js passthrough — the user is
-    /// typing directly into the foreground terminal. Runtime uses
-    /// `send-keys -l -- <bytes>` so the bytes arrive as keystrokes
-    /// without bracketed-paste markers.
+    /// typing directly into the foreground terminal, or the manager
+    /// is preserving the old paste path by writing prompt bytes
+    /// unchanged before sending Enter.
     fn send_bytes(&self, session: &RuntimeSession, bytes: &[u8]) -> RuntimeResult<()>;
 
     /// Named key. Examples: `"Enter"`, `"C-c"`, `"Up"`,
-    /// `"Escape"`. Runtime uses `send-keys -t=<pane> <key>` (no
-    /// `-l`, no `--`, so tmux's key-name lookup runs). Caller is
-    /// responsible for using a name tmux understands; the runtime
-    /// validates the name shape but does not enumerate every
-    /// possible key.
+    /// `"Escape"`. The runtime translates names to PTY byte
+    /// sequences. Caller is responsible for using a supported key
+    /// name.
     fn send_key(&self, session: &RuntimeSession, key: &str) -> RuntimeResult<()>;
 
     /// Frontend resize event. The runtime is expected to debounce
     /// internally if multiple `resize` calls land back-to-back.
     fn resize(&self, session: &RuntimeSession, cols: u16, rows: u16) -> RuntimeResult<()>;
 
-    /// Liveness probe used by the manager's reconciliation loop
-    /// (Step 8). `Ok(None)` means the runtime can't find the
-    /// session — treat as terminal-unavailable. `Ok(Some(_))`
-    /// means the pane exists; the caller branches on
-    /// `SessionStatus.alive` and `exit_code`. Errors are reserved
-    /// for transport failures (tmux daemon gone, etc.).
+    /// Liveness probe used by the manager's exit reconciliation.
+    /// `Ok(None)` means the runtime can't find the session — treat
+    /// as terminal-unavailable. `Ok(Some(_))` means the PTY child is
+    /// known; the caller branches on `SessionStatus.alive` and
+    /// `exit_code`. Errors are reserved for transport failures.
     fn status(&self, session: &RuntimeSession) -> RuntimeResult<Option<SessionStatus>>;
 }


### PR DESCRIPTION
## Summary
- add the PTY session pre-feature refactor implementation plan
- remove runtime-level session reattach, replay output, runtime paste, and unused OutputStream helpers
- collapse RuntimeSession to runtime + session_id and stop writing legacy runtime pane/socket/window fields
- retain SessionManager::resume and startup mission router/bus mounting before stale-row cleanup
- strip stale tmux-era comments from the PTY/session layer

## Validation
- cargo fmt --check
- cargo test -p runner
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check
- manual smoke: mission start/input/resize/stop, direct chat start/input/resize/stop, app restart shows prior running rows as stopped/resumable

No behavior-preservation findings remained after Runner mission review.