### PR TITLE
feat: show direct chat activity status

### DIFF
--- a/docs/impls/0014-direct-chat-response-status.md
+++ b/docs/impls/0014-direct-chat-response-status.md
@@ -1,24 +1,30 @@
-# Direct Chat Response Status
+# Direct Chat Activity Status
 
 > Implements the first narrowed slice of [#130](https://github.com/yicheng47/runner/issues/130). This does not implement macOS notifications.
 
 ## Context
 
-Issue #130 originally scoped OS notifications for agent-to-human events. The first useful product slice is smaller: while a direct chat is open or listed in Runner, the app should show that the agent has produced a response and is now idle. This gives the human an in-app attention signal before adding notification permission, routing, suppression, and mission-workspace complexity.
+Issue #130 originally scoped OS notifications for agent-to-human events. The first useful product slice is smaller: while a direct chat is open, the app should show whether the live agent is actively working or idle. This gives the human an in-app attention signal before adding notification permission, routing, suppression, and mission-workspace complexity.
 
 Direct chats are off-bus and do not have a mission event log, so the PTY forwarder's busy/idle transition is currently dropped for them. Stage one is direct chats only; mission sessions and mission workspace status are intentionally excluded.
 
+Current code map:
+
+- `SessionEvents`, `TauriSessionEvents`, `OutputEvent`, and `ExitEvent` live in `src-tauri/src/session/manager/mod.rs`.
+- The forwarder consumes `RuntimeOutput::StatusTransition` in `src-tauri/src/session/manager/output.rs`.
+- Session manager tests live in `src-tauri/src/session/manager/tests.rs`.
+- `RunnerTerminal` owns the xterm output subscription and PTY input paths; `RunnerChat` owns the direct-chat header status pill and Stop/Resume lifecycle.
+
 ## Goal
 
-When a direct chat has an unread agent response and the agent is idle, reflect that on the chat's status control.
+The direct chat status control should use four display states:
 
-For this plan, "has a response" means all of:
+- `busy` — the session process is live and the forwarder currently sees agent activity.
+- `idle` — the session process is live and the forwarder has settled after the latest output burst.
+- `stopped` — the session exited cleanly or was stopped by the user.
+- `crashed` — the session exited unsuccessfully.
 
-- The user has sent input into that direct chat since the last cleared response hint.
-- The PTY emitted output for that same session after that input.
-- The forwarder reported the session as idle after the output burst.
-
-The status control should return to normal live/running state once the user sends the next input, switches to another session, stops/resumes the session, or the session exits.
+There is no separate `response`, `ready`, unread, or notification state in this pass. The first slice is only live activity status for direct chats.
 
 ## Non-goals
 
@@ -28,98 +34,104 @@ The status control should return to normal live/running state once the user send
 - No global notification setting.
 - No persisted unread model.
 - No sidebar badge count.
+- No response-ready state.
 - No live status changes for mission sessions.
 - No mission behavior changes.
 
 ## Decisions
 
-1. Use the existing PTY idle detector as the source of truth for direct-chat "agent idle".
-2. Add a live Tauri event for direct-chat availability instead of appending direct-chat events to a mission log that does not exist.
-3. Track response-readiness in the direct chat frontend, not in SQLite.
-4. Keep this status visual-only for now. The status control remains the same surface; it just gains a response-ready state.
-5. Use the active direct session id as the correlation key. Do not infer readiness from runner id because one runner can have multiple direct chats.
+1. Use the existing PTY idle detector as the source of truth for direct-chat activity.
+2. Add a live Tauri event for direct-chat activity instead of appending direct-chat events to a mission log that does not exist.
+3. Keep SQLite session lifecycle unchanged: persisted `sessions.status` remains `running | stopped | crashed`. `busy | idle` are live UI projections for an alive direct chat.
+4. Use direct-chat display labels `busy | idle | stopped | crashed`. The live direct-chat event should expose `busy | idle`, matching the forwarder's `RunnerStatus::Busy | Idle`.
+5. Use the active direct session id as the correlation key. Do not infer activity from runner id because one runner can have multiple direct chats.
+6. Mission behavior remains exactly as-is: mission forwarder status still appends `runner_status` with `busy | idle` to the event log.
+7. Default alive direct chats to `idle` until a live activity event says otherwise. A DB `running` row only means the process is alive; it does not prove the agent is actively working.
 
-## Step 1: Emit live session status
+## Step 1: Emit Live Direct-Chat Status
 
-Files: `src-tauri/src/session/manager.rs`, `src/lib/types.ts`
+Files: `src-tauri/src/session/manager/mod.rs`, `src-tauri/src/session/manager/output.rs`, `src-tauri/src/session/manager/tests.rs`, `src/lib/types.ts`
 
-- Add a direct-chat `SessionStatusEvent` payload with `session_id` and `state`.
-- Add a `status` hook to `SessionEvents`.
-- Have `TauriSessionEvents` emit `session/status`.
-- In the forwarder consumer's `RuntimeOutput::StatusTransition` branch, emit `session/status` only when the session is a direct chat.
-- Keep the existing mission `runner_status` append path unchanged for mission sessions, and do not add a new live mission status event in this pass.
-- Direct chats still skip event-log append; they only consume the live `session/status` event.
+- Add a direct-chat `SessionActivityEvent` payload with `session_id`, `state`, and `source`.
+- Add `SessionActivityState = "busy" | "idle"` and `SessionActivityEvent` in `src/lib/types.ts`.
+- Add a default no-op `status(&SessionActivityEvent)` hook to `SessionEvents`.
+- Have `TauriSessionEvents::status` emit `session/status`.
+- In `output.rs`, when the forwarder receives `RuntimeOutput::StatusTransition`, emit `session/status` only when `emit_ctx.is_none()` (direct chat). Map `RunnerStatus::Busy` to `"busy"` and `RunnerStatus::Idle` to `"idle"`.
+- When `emit_ctx` is present, keep the existing mission event-log append path and do not emit the live direct-chat event.
 
-The important invariant: stage one adds a direct-chat projection only. Mission behavior remains exactly as-is.
+The important invariant: this adds a direct-chat projection only. Mission behavior remains unchanged.
 
-## Step 2: Track user-input and response output
+## Step 2: Track Live Status in RunnerChat
 
-Files: `src/components/RunnerTerminal.tsx`, `src/pages/RunnerChat.tsx`
-
-- Add an optional `onUserInput` callback to `RunnerTerminal`.
-- Fire it for all PTY input paths:
-  - normal `term.onData` bytes,
-  - Shift+Enter manual injection,
-  - image paste's Ctrl-V injection.
-- In `RunnerChat`, when the active terminal fires `onUserInput`, mark that session as awaiting a response and clear any existing response-ready hint.
-- Listen to `session/output` for the active direct session. If output arrives while awaiting a response, mark that a response has been seen.
-
-This intentionally keys off user input, not any output. Startup banners, resume replays, and initial TUI paints should not create a "response ready" state before the human has asked for anything.
-
-## Step 3: Combine response output with idle
-
-Files: `src/pages/RunnerChat.tsx`
+Files: `src/pages/RunnerChat.tsx`, `src/lib/types.ts`
 
 - Listen to `session/status` for the active direct session.
-- Track the latest `busy` / `idle` state.
-- Derive a new UI state only when `hasAgentResponse && latestStatus === "idle"`.
-- Clear both flags on:
+- Store the latest live activity state per active `sessionId`.
+- When a DB `running` row has no live activity event yet, display `idle` as the conservative default. The agent process is alive, but no current work has been observed.
+- Clear the live activity state on:
   - active `sessionId` change,
-  - user input,
   - `session/exit`,
   - `endChat`,
   - `resumeChat`,
+  - `archiveChat`,
   - archived/read-only route.
 
-The idle transition should be the final gate. Agent output alone means "work is in progress"; response-ready should wait until the output burst has settled.
+No user-input or output correlation is needed in this simplified model. Output activity drives the forwarder's `busy`/`idle` projection directly.
 
-## Step 4: Reflect on the chat status control
+## Step 3: Combine Activity with Lifecycle
 
 Files: `src/pages/RunnerChat.tsx`
 
-- Extend the existing chat state derivation with a response-ready visual state for running sessions.
-- Recommended label: `response`.
-- Recommended color: existing warning/amber token, because it is attention-worthy but not an error.
-- Keep the Stop action available in this state; the session is still live.
-- Do not show SessionEndedOverlay in this state.
+- Derive a direct-chat display status from persisted lifecycle plus live activity:
+  - `status === "stopped"` -> `stopped`
+  - `status === "crashed"` -> `crashed`
+  - `status === "running" && latestActivity === "busy"` -> `busy`
+  - `status === "running"` -> `idle`
+- Keep the existing resuming overlay/button as a transitional control state, but do not add `resuming` to the steady direct-chat status model.
+- Stop/Resume/session lifecycle behavior stays unchanged.
 
-If the label feels too verbose in the header, use `ready` instead. The behavioral contract matters more than the exact copy.
+## Step 4: Reflect on the Chat Status Control
+
+Files: `src/pages/RunnerChat.tsx`
+
+- Update the existing header status pill to show `busy`, `idle`, `stopped`, or `crashed`.
+- Recommended visual:
+  - `busy`: existing accent/live treatment.
+  - `idle`: muted accent or neutral treatment; the process is healthy, just settled.
+  - `stopped`: existing neutral stopped treatment.
+  - `crashed`: existing danger treatment.
+- Keep Stop available for both `busy` and `idle`; the session is live in both states.
+- Do not show `SessionEndedOverlay` for `idle`.
+- Do not change the sidebar in this pass. Sidebar badges/counts remain out of scope.
 
 ## Step 5: Tests
 
 Rust:
 
-- Unit-test that a direct session receiving `RuntimeOutput::StatusTransition { state: Idle }` emits `session/status`.
+- Unit-test in `src-tauri/src/session/manager/tests.rs` that a direct session receiving `RuntimeOutput::StatusTransition { state: Busy }` emits `session/status` with `state: "busy"`.
+- Unit-test that a direct session receiving `RuntimeOutput::StatusTransition { state: Idle }` emits `session/status` with `state: "idle"`.
+- Unit-test that a mission session still appends `runner_status` and does not emit the live direct-chat event.
 
 Frontend:
 
 - Typecheck is the main guard unless a component-test harness already exists for `RunnerChat`.
-- Add a small pure helper for status derivation only if the inline state logic starts getting hard to reason about.
+- Prefer a small pure helper for status derivation if the inline state logic starts getting hard to reason about.
 
 Manual:
 
 1. Start a direct chat.
-2. Send a prompt.
-3. While the agent is streaming, the status remains live/running.
-4. After the agent finishes and the forwarder idles, the status control shows `response`.
-5. Type the next prompt; the status returns to live/running immediately.
-6. Stop/resume the chat; no stale response state survives.
-7. Switch between two chats; response state is scoped to the correct session id.
+2. After the initial TUI settles, the status can show `idle`.
+3. Send a prompt.
+4. While the agent is streaming, the status shows `busy`.
+5. After the agent finishes and the forwarder idles, the status shows `idle`.
+6. Stop the chat; status shows `stopped`.
+7. Resume the chat; no stale `idle` state survives the resume transition.
+8. Switch between two chats; live activity state is scoped to the correct session id.
 
 ## Validation
 
 - `pnpm exec tsc --noEmit`
 - `pnpm run lint`
 - `cargo fmt --check`
-- `cargo test -p runner direct_forwarder_emits_live_session_status`
+- `cargo test -p runner direct_chat_status_transition_emits_session_status`
 - `cargo test --workspace`

--- a/src-tauri/src/session/manager/mod.rs
+++ b/src-tauri/src/session/manager/mod.rs
@@ -222,6 +222,9 @@ fn drop_streak_is_loggable(streak: u64) -> bool {
 pub trait SessionEvents: Send + Sync + 'static {
     fn output(&self, ev: &OutputEvent);
     fn exit(&self, ev: &ExitEvent);
+    /// Live direct-chat activity projection. Mission sessions keep using
+    /// `runner_status` rows in the mission log instead.
+    fn status(&self, _ev: &SessionActivityEvent) {}
     /// Live activity counter for a runner — emitted on every spawn/reap so
     /// the Runners list can update its "N sessions / M missions" badges
     /// without polling. Default no-op so test fakes don't have to opt in.
@@ -247,6 +250,31 @@ pub struct RunnerActivityEvent {
     pub direct_session_id: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionActivityState {
+    Busy,
+    Idle,
+}
+
+impl From<RunnerStatus> for SessionActivityState {
+    fn from(state: RunnerStatus) -> Self {
+        match state {
+            RunnerStatus::Busy => Self::Busy,
+            RunnerStatus::Idle => Self::Idle,
+        }
+    }
+}
+
+/// Payload for `session/status`. Emitted only for direct chats, where
+/// busy/idle is a live UI projection rather than persisted DB state.
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionActivityEvent {
+    pub session_id: String,
+    pub state: SessionActivityState,
+    pub source: String,
+}
+
 /// Emitter for the real Tauri app — emits `session/output`, `session/exit`,
 /// and `runner/activity`.
 pub struct TauriSessionEvents(pub tauri::AppHandle);
@@ -259,6 +287,10 @@ impl SessionEvents for TauriSessionEvents {
     fn exit(&self, ev: &ExitEvent) {
         use tauri::Emitter;
         let _ = self.0.emit("session/exit", ev);
+    }
+    fn status(&self, ev: &SessionActivityEvent) {
+        use tauri::Emitter;
+        let _ = self.0.emit("session/status", ev);
     }
     fn runner_activity(&self, ev: &RunnerActivityEvent) {
         use tauri::Emitter;

--- a/src-tauri/src/session/manager/output.rs
+++ b/src-tauri/src/session/manager/output.rs
@@ -40,8 +40,8 @@ impl SessionManager {
             // Drain PTY output until the runtime closes the channel
             // OR `kill` flips the stop flag. Stream chunks flow as
             // `session/output` events. StatusTransition is routed
-            // into the mission event log so the router / workspace
-            // rail see the busy/idle flip (issue #124).
+            // into either the mission event log or a direct-chat
+            // live status event so the UI sees busy/idle flips.
             //
             // Failure bookkeeping for `runner_status` emission lives
             // here on the consumer's stack — single-threaded access,
@@ -69,11 +69,6 @@ impl SessionManager {
                         events.output(&ev);
                     }
                     Ok(RuntimeOutput::StatusTransition { state, source }) => {
-                        // Direct chats are off-bus; no event log to
-                        // append to. The IdleDetector still runs in
-                        // the forwarder for free — we just drop the
-                        // emission here (see recon notes in issue
-                        // #124).
                         if let Some(ctx) = emit_ctx.as_ref() {
                             let outcome = ctx.try_append_runner_status(state, source);
                             match outcome {
@@ -99,6 +94,12 @@ impl SessionManager {
                                     }
                                 }
                             }
+                        } else {
+                            events.status(&SessionActivityEvent {
+                                session_id: session_id.clone(),
+                                state: state.into(),
+                                source: source.to_string(),
+                            });
                         }
                     }
                     Err(RecvTimeoutError::Timeout) => continue,

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -109,6 +109,16 @@ impl FakeRuntime {
         }
     }
 
+    fn push_status(&self, i: usize, state: RunnerStatus) {
+        let spawns = self.spawns.lock().unwrap();
+        if let Some(tx) = spawns.get(i).and_then(|s| s.tx.as_ref()) {
+            let _ = tx.send(RuntimeOutput::StatusTransition {
+                state,
+                source: "forwarder",
+            });
+        }
+    }
+
     /// Drop the `Sender` for spawn `i` so the forwarder thread
     /// sees `Disconnected` and exits — the manager-side path
     /// that simulates a pane dying cleanly.
@@ -242,6 +252,7 @@ fn mgr_with_fake(shell: Option<String>, fake: Arc<FakeRuntime>) -> Arc<SessionMa
 struct Capture {
     output: Mutex<Vec<OutputEvent>>,
     exit: Mutex<Vec<ExitEvent>>,
+    status: Mutex<Vec<SessionActivityEvent>>,
     activity: Mutex<Vec<RunnerActivityEvent>>,
 }
 impl SessionEvents for Capture {
@@ -250,6 +261,9 @@ impl SessionEvents for Capture {
     }
     fn exit(&self, ev: &ExitEvent) {
         self.exit.lock().unwrap().push(ev.clone());
+    }
+    fn status(&self, ev: &SessionActivityEvent) {
+        self.status.lock().unwrap().push(ev.clone());
     }
     fn runner_activity(&self, ev: &RunnerActivityEvent) {
         self.activity.lock().unwrap().push(ev.clone());
@@ -303,6 +317,30 @@ fn mission() -> Mission {
 
 fn capture() -> Arc<Capture> {
     Arc::new(Capture::default())
+}
+
+fn wait_for_session_status_event(
+    cap: &Capture,
+    session_id: &str,
+    state: SessionActivityState,
+) -> SessionActivityEvent {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        if let Some(ev) = cap
+            .status
+            .lock()
+            .unwrap()
+            .iter()
+            .find(|ev| ev.session_id == session_id && ev.state == state)
+            .cloned()
+        {
+            return ev;
+        }
+        if Instant::now() > deadline {
+            panic!("session/status event never arrived for {session_id} state {state:?}");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
 }
 
 fn has_arg_pair(args: &[String], flag: &str, value: &str) -> bool {
@@ -1374,6 +1412,179 @@ fn spawn_direct_writes_session_with_null_mission_id_and_emits_activity() {
         last.active_sessions, 0,
         "after reap, active_sessions for this runner must be 0"
     );
+}
+
+#[test]
+fn direct_chat_status_transition_emits_session_status_busy() {
+    let pool = pool_with_schema();
+    let now = Utc::now().to_rfc3339();
+    let runner_id = ulid::Ulid::new().to_string();
+    {
+        let conn = pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'directbusy', 'Direct Busy', 'shell', '/bin/cat',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+            params![runner_id, now],
+        )
+        .unwrap();
+    }
+
+    let mut runner = runner("/bin/cat", &[]);
+    runner.id = runner_id;
+    runner.handle = "directbusy".into();
+
+    let fake = fake_runtime();
+    let mgr = mgr_with_fake(None, Arc::clone(&fake));
+    let cap = capture();
+    let spawned = mgr
+        .spawn_direct(
+            &runner,
+            Some("/tmp"),
+            None,
+            None,
+            std::path::Path::new("/tmp"),
+            Arc::clone(&pool),
+            Arc::clone(&cap) as Arc<dyn SessionEvents>,
+            None,
+        )
+        .unwrap();
+
+    fake.push_status(0, RunnerStatus::Busy);
+    let ev = wait_for_session_status_event(&cap, &spawned.id, SessionActivityState::Busy);
+
+    assert_eq!(ev.session_id, spawned.id);
+    assert_eq!(ev.state, SessionActivityState::Busy);
+    assert_eq!(ev.source, "forwarder");
+
+    mgr.kill(&spawned.id).unwrap();
+}
+
+#[test]
+fn direct_chat_status_transition_emits_session_status_idle() {
+    let pool = pool_with_schema();
+    let now = Utc::now().to_rfc3339();
+    let runner_id = ulid::Ulid::new().to_string();
+    {
+        let conn = pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'directidle', 'Direct Idle', 'shell', '/bin/cat',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+            params![runner_id, now],
+        )
+        .unwrap();
+    }
+
+    let mut runner = runner("/bin/cat", &[]);
+    runner.id = runner_id;
+    runner.handle = "directidle".into();
+
+    let fake = fake_runtime();
+    let mgr = mgr_with_fake(None, Arc::clone(&fake));
+    let cap = capture();
+    let spawned = mgr
+        .spawn_direct(
+            &runner,
+            Some("/tmp"),
+            None,
+            None,
+            std::path::Path::new("/tmp"),
+            Arc::clone(&pool),
+            Arc::clone(&cap) as Arc<dyn SessionEvents>,
+            None,
+        )
+        .unwrap();
+
+    fake.push_status(0, RunnerStatus::Idle);
+    let ev = wait_for_session_status_event(&cap, &spawned.id, SessionActivityState::Idle);
+
+    assert_eq!(ev.session_id, spawned.id);
+    assert_eq!(ev.state, SessionActivityState::Idle);
+    assert_eq!(ev.source, "forwarder");
+
+    mgr.kill(&spawned.id).unwrap();
+}
+
+#[test]
+fn mission_status_transition_appends_runner_status_without_session_status_event() {
+    let pool = pool_with_schema();
+    let mission_base = Mission {
+        crew_id: "c".into(),
+        ..mission()
+    };
+    let runner = runner("/bin/cat", &[]);
+    let slot_id = insert_crew_runner(&pool, &mission_base.id, &runner.id);
+    let fresh_mission_id: String = {
+        let conn = pool.get().unwrap();
+        conn.query_row("SELECT id FROM missions LIMIT 1", [], |r| r.get(0))
+            .unwrap()
+    };
+    let mission = Mission {
+        id: fresh_mission_id,
+        ..mission_base
+    };
+    let mut slot = slot_for(&runner);
+    slot.id = slot_id;
+    slot.crew_id = mission.crew_id.clone();
+
+    let app_data = tempfile::tempdir().unwrap();
+    let events_log_path =
+        runner_core::event_log::path::events_path(app_data.path(), &mission.crew_id, &mission.id);
+    let mission_dir =
+        runner_core::event_log::path::mission_dir(app_data.path(), &mission.crew_id, &mission.id);
+
+    let fake = fake_runtime();
+    let mgr = mgr_with_fake(None, Arc::clone(&fake));
+    let cap = capture();
+    let spawned = mgr
+        .spawn(
+            &mission,
+            &runner,
+            &slot,
+            app_data.path(),
+            events_log_path,
+            Arc::clone(&pool),
+            Arc::clone(&cap) as Arc<dyn SessionEvents>,
+            None,
+        )
+        .unwrap();
+
+    fake.push_status(0, RunnerStatus::Busy);
+
+    let log = EventLog::open(&mission_dir).unwrap();
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let event = loop {
+        let entries = log.read_from(0).unwrap();
+        if let Some(event) = entries.into_iter().map(|entry| entry.event).find(|event| {
+            event
+                .signal_type
+                .as_ref()
+                .is_some_and(|ty| ty.as_str() == "runner_status")
+        }) {
+            break event;
+        }
+        if Instant::now() > deadline {
+            panic!("runner_status event never arrived in mission log");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    };
+
+    assert_eq!(event.from, runner.handle);
+    assert_eq!(event.payload["state"], "busy");
+    assert_eq!(event.payload["source"], "forwarder");
+    assert!(
+        cap.status.lock().unwrap().is_empty(),
+        "mission sessions must not emit live session/status events",
+    );
+
+    mgr.kill(&spawned.id).unwrap();
 }
 
 #[test]

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -60,7 +60,12 @@ import {
   readBrandTint,
   STORAGE_APP_BRAND_TINT,
 } from "../lib/settings";
-import type { AppendedEvent, MissionSummary } from "../lib/types";
+import type {
+  AppendedEvent,
+  MissionSummary,
+  SessionActivityEvent,
+  SessionActivityState,
+} from "../lib/types";
 import { StartMissionModal } from "./StartMissionModal";
 import { StartChatModal } from "./StartChatModal";
 import { SettingsModal } from "./SettingsModal";
@@ -140,6 +145,9 @@ export function Sidebar({
   const [directSessions, setDirectSessions] = useState<DirectSessionEntry[]>(
     [],
   );
+  const [directSessionActivity, setDirectSessionActivity] = useState<
+    Record<string, SessionActivityState | undefined>
+  >({});
 
   // Section toggles, persisted so users don't have to re-expand each visit.
   const [missionsOpen, setMissionsOpen] = useState<boolean>(() =>
@@ -293,6 +301,22 @@ export function Sidebar({
     void refreshDirectSessions();
   }, [refreshDirectSessions]);
 
+  useEffect(() => {
+    const visibleIds = new Set(directSessions.map((s) => s.session_id));
+    setDirectSessionActivity((prev) => {
+      let changed = false;
+      const next: Record<string, SessionActivityState | undefined> = {};
+      for (const [id, state] of Object.entries(prev)) {
+        if (!visibleIds.has(id)) {
+          changed = true;
+          continue;
+        }
+        next[id] = state;
+      }
+      return changed ? next : prev;
+    });
+  }, [directSessions]);
+
   // session/exit fires when a running PTY reaps (live → stopped flip).
   // runner/activity fires on every spawn/reap and is our cue that a
   // new direct chat row may have appeared. Both refresh the same list.
@@ -301,9 +325,17 @@ export function Sidebar({
     let unlistenActivity: (() => void) | null = null;
     let unlistenArchived: (() => void) | null = null;
     let unlistenUpdated: (() => void) | null = null;
+    let unlistenStatus: (() => void) | null = null;
     let cancelled = false;
     void Promise.all([
-      listen("session/exit", () => {
+      listen<{ session_id: string }>("session/exit", (event) => {
+        const sessionId = event.payload.session_id;
+        setDirectSessionActivity((prev) => {
+          if (prev[sessionId] == null) return prev;
+          const next = { ...prev };
+          delete next[sessionId];
+          return next;
+        });
         void refreshDirectSessions();
         // A mission slot exiting flips `any_session_live` from true →
         // false (if it was the last live slot). Without this, the
@@ -334,18 +366,26 @@ export function Sidebar({
         // refresh.
         void refreshDirectSessions();
       }),
-    ]).then(([fnExit, fnActivity, fnArchived, fnUpdated]) => {
+      listen<SessionActivityEvent>("session/status", (event) => {
+        setDirectSessionActivity((prev) => ({
+          ...prev,
+          [event.payload.session_id]: event.payload.state,
+        }));
+      }),
+    ]).then(([fnExit, fnActivity, fnArchived, fnUpdated, fnStatus]) => {
       if (cancelled) {
         fnExit();
         fnActivity();
         fnArchived();
         fnUpdated();
+        fnStatus();
         return;
       }
       unlistenExit = fnExit;
       unlistenActivity = fnActivity;
       unlistenArchived = fnArchived;
       unlistenUpdated = fnUpdated;
+      unlistenStatus = fnStatus;
     });
     return () => {
       cancelled = true;
@@ -353,6 +393,7 @@ export function Sidebar({
       unlistenActivity?.();
       unlistenArchived?.();
       unlistenUpdated?.();
+      unlistenStatus?.();
     };
   }, [refreshDirectSessions, refreshMissions]);
 
@@ -681,6 +722,7 @@ export function Sidebar({
                         <SessionRow
                           key={s.session_id}
                           session={s}
+                          activity={directSessionActivity[s.session_id]}
                           selected={s.session_id === currentChatSessionId}
                           renaming={renamingId === s.session_id}
                           onClick={() => openDirectChat(s)}
@@ -951,6 +993,7 @@ function SidebarListRow({
   title,
   mono,
   dim,
+  dotClassName,
   pinned,
   renaming,
   renameValue,
@@ -969,6 +1012,8 @@ function SidebarListRow({
    *  direct chat that can be resumed). Mutes the status dot so the user
    *  can tell which sessions are live at a glance. */
   dim?: boolean;
+  /** Optional explicit status-dot color for rows with richer live state. */
+  dotClassName?: string;
   /** Pinned rows show a Pin icon next to the label. */
   pinned?: boolean;
   /** When true, replaces the label with an inline rename input. */
@@ -988,6 +1033,7 @@ function SidebarListRow({
         title={title}
         mono={mono}
         dim={dim}
+        dotClassName={dotClassName}
         onSubmit={onRenameSubmit}
         onCancel={onRenameCancel}
       />
@@ -1017,7 +1063,7 @@ function SidebarListRow({
       >
         <span
           className={`inline-flex h-1.5 w-1.5 shrink-0 rounded-full ${
-            dim ? "bg-fg-3" : "bg-accent"
+            dotClassName ?? (dim ? "bg-fg-3" : "bg-accent")
           }`}
         />
         {pinned ? (
@@ -1056,6 +1102,7 @@ function SidebarRowRenameInput({
   title,
   mono,
   dim,
+  dotClassName,
   onSubmit,
   onCancel,
 }: {
@@ -1064,6 +1111,7 @@ function SidebarRowRenameInput({
   title?: string;
   mono?: boolean;
   dim?: boolean;
+  dotClassName?: string;
   onSubmit: (next: string) => void;
   onCancel: () => void;
 }) {
@@ -1080,7 +1128,7 @@ function SidebarRowRenameInput({
     >
       <span
         className={`inline-flex h-1.5 w-1.5 shrink-0 rounded-full ${
-          dim ? "bg-fg-3" : "bg-accent"
+          dotClassName ?? (dim ? "bg-fg-3" : "bg-accent")
         }`}
       />
       <input
@@ -1112,8 +1160,34 @@ function SidebarRowRenameInput({
 // SESSION row: adapter from DirectSessionEntry to the shared sidebar
 // row shell. Keeps chat-specific label and rename-null semantics out
 // of the generic visual component.
+type DirectChatDisplayStatus = SessionActivityState | "stopped" | "crashed";
+
+function directChatDisplayStatus(
+  session: DirectSessionEntry,
+  activity: SessionActivityState | undefined,
+): DirectChatDisplayStatus {
+  if (session.status === "stopped" || session.status === "crashed") {
+    return session.status;
+  }
+  return activity === "busy" ? "busy" : "idle";
+}
+
+function directChatDotClassName(status: DirectChatDisplayStatus): string {
+  switch (status) {
+    case "busy":
+      return "bg-accent";
+    case "idle":
+      return "bg-accent/30";
+    case "crashed":
+      return "bg-danger";
+    case "stopped":
+      return "bg-fg-3";
+  }
+}
+
 function SessionRow({
   session,
+  activity,
   selected,
   renaming,
   onClick,
@@ -1122,6 +1196,7 @@ function SessionRow({
   onRenameCancel,
 }: {
   session: DirectSessionEntry;
+  activity: SessionActivityState | undefined;
   selected: boolean;
   renaming: boolean;
   onClick: () => void;
@@ -1134,7 +1209,8 @@ function SessionRow({
     : `${session.display_name} · ${formatStartedAt(session)}`;
   const label = session.title ?? defaultLabel;
   const dim = session.status !== "running";
-  const tooltip = `${session.handle ? `@${session.handle}` : session.display_name} · ${session.status}${
+  const displayStatus = directChatDisplayStatus(session, activity);
+  const tooltip = `${session.handle ? `@${session.handle}` : session.display_name} · ${displayStatus}${
     session.status !== "running" && session.resumable ? " · resumable" : ""
   }${session.pinned ? " · pinned" : ""}`;
 
@@ -1147,6 +1223,7 @@ function SessionRow({
       title={tooltip}
       mono={!!session.handle}
       dim={dim}
+      dotClassName={directChatDotClassName(displayStatus)}
       pinned={session.pinned}
       renaming={renaming}
       renameValue={session.title ?? ""}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -131,6 +131,14 @@ export interface SessionOutputEvent {
   data: string;
 }
 
+export type SessionActivityState = "busy" | "idle";
+
+export interface SessionActivityEvent {
+  session_id: string;
+  state: SessionActivityState;
+  source: string;
+}
+
 export type MissionStatus = "running" | "completed" | "aborted";
 
 export interface Mission {

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -50,7 +50,13 @@ import {
   unmarkArchivingSession,
   useArchivingSession,
 } from "../lib/archivingState";
-import type { Runner, SessionStatus, WarningEvent } from "../lib/types";
+import type {
+  Runner,
+  SessionActivityEvent,
+  SessionActivityState,
+  SessionStatus,
+  WarningEvent,
+} from "../lib/types";
 
 interface ExitEvent {
   session_id: string;
@@ -92,6 +98,8 @@ interface DirectSessionPane {
   exitCode: number | null;
 }
 
+type DirectChatDisplayStatus = SessionActivityState | "stopped" | "crashed";
+
 export default function RunnerChat() {
   const { sessionId: sessionIdParam } = useParams<{
     sessionId: string;
@@ -119,6 +127,9 @@ export default function RunnerChat() {
   // meta line. Pulled from session_list_recent_direct so the chat
   // surface and the sidebar agree on the truth.
   const [chatMeta, setChatMeta] = useState<DirectSessionEntry | null>(null);
+  const [activityBySession, setActivityBySession] = useState<
+    Record<string, SessionActivityState | undefined>
+  >({});
   // chatMeta is async (listRecentDirect → session_get fallback) and is
   // the only source of `archived_at`. Until it resolves we don't know
   // whether the URL points at an archived row, and we can't safely
@@ -176,7 +187,14 @@ export default function RunnerChat() {
   const startedKeyRef = useRef<string | null>(null);
 
   const activeSession = directSessions.find((s) => s.id === sessionId) ?? null;
-  const status = activeSession?.status ?? "running";
+  const status = activeSession?.status ?? chatMeta?.status ?? "running";
+  const latestActivity = sessionId ? activityBySession[sessionId] : undefined;
+  const displayStatus: DirectChatDisplayStatus =
+    status === "stopped" || status === "crashed"
+      ? status
+      : latestActivity === "busy"
+        ? "busy"
+        : "idle";
   const exitCode = activeSession?.exitCode ?? null;
   const backTarget = chatMeta?.handle ? `/runners/${chatMeta.handle}` : "/runners";
   const backLabel = chatMeta?.handle ? "Back to runner" : "Back to runners";
@@ -215,6 +233,15 @@ export default function RunnerChat() {
     });
   }, []);
 
+  const clearActivity = useCallback((id: string) => {
+    setActivityBySession((prev) => {
+      if (prev[id] == null) return prev;
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
+  }, []);
+
   const attach = useCallback(
     (
       id: string,
@@ -241,18 +268,22 @@ export default function RunnerChat() {
     [upsertSession],
   );
 
-  const onTerminalExit = useCallback((ev: ExitEvent) => {
-    const userEnded = killedSessionsRef.current.has(ev.session_id);
-    const nextStatus = ev.success || userEnded ? "stopped" : "crashed";
-    killedSessionsRef.current.delete(ev.session_id);
-    setDirectSessions((prev) =>
-      prev.map((s) =>
-        s.id === ev.session_id
-          ? { ...s, status: nextStatus, exitCode: ev.exit_code }
-          : s,
-      ),
-    );
-  }, []);
+  const onTerminalExit = useCallback(
+    (ev: ExitEvent) => {
+      const userEnded = killedSessionsRef.current.has(ev.session_id);
+      const nextStatus = ev.success || userEnded ? "stopped" : "crashed";
+      killedSessionsRef.current.delete(ev.session_id);
+      clearActivity(ev.session_id);
+      setDirectSessions((prev) =>
+        prev.map((s) =>
+          s.id === ev.session_id
+            ? { ...s, status: nextStatus, exitCode: ev.exit_code }
+            : s,
+        ),
+      );
+    },
+    [clearActivity],
+  );
 
   // Pull runner config only for runner-backed chats. Runtime-only
   // chats render from chatMeta.agent_* instead.
@@ -336,6 +367,34 @@ export default function RunnerChat() {
     };
   }, [sessionId, refreshChatMeta]);
 
+  useEffect(() => {
+    setActivityBySession({});
+  }, [sessionId]);
+
+  useEffect(() => {
+    if (!sessionId || isArchived) {
+      setActivityBySession({});
+      return;
+    }
+    const targetId = sessionId;
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    void listen<SessionActivityEvent>("session/status", (event) => {
+      if (event.payload.session_id !== targetId) return;
+      setActivityBySession({ [targetId]: event.payload.state });
+    }).then((fn) => {
+      if (cancelled) {
+        fn();
+        return;
+      }
+      unlisten = fn;
+    });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [sessionId, isArchived]);
+
   // Sync the active pane's status from the DB-backed chatMeta. attach()
   // seeds new panes with `status: "running"` because the spawn path is
   // its primary caller, but the sidebar's attach path can land on a
@@ -352,6 +411,7 @@ export default function RunnerChat() {
   // agent, which is the right signal that the canvas is live again.
   useEffect(() => {
     if (!chatMeta) return;
+    if (chatMeta.status !== "running") clearActivity(chatMeta.session_id);
     setDirectSessions((prev) =>
       prev.map((s) =>
         s.id === chatMeta.session_id
@@ -359,7 +419,7 @@ export default function RunnerChat() {
           : s,
       ),
     );
-  }, [chatMeta]);
+  }, [chatMeta, clearActivity]);
 
   // Clear `resuming` once the agent has settled on a steady frame.
   // Heuristic: wait for the first output chunk, then for output to
@@ -598,6 +658,7 @@ export default function RunnerChat() {
     if (!sessionId) return;
     const targetId = sessionId;
     killedSessionsRef.current.add(targetId);
+    clearActivity(targetId);
     try {
       // session_kill blocks until the reader thread reaps the child
       // and emits session/exit. The exit listener should flip the
@@ -637,6 +698,7 @@ export default function RunnerChat() {
     const targetId = sessionId;
     setResuming(true);
     setErr(null);
+    clearActivity(targetId);
     try {
       const dims = terminalsRef.current.get(targetId)?.measure() ?? null;
       await api.session.resume(
@@ -705,6 +767,7 @@ export default function RunnerChat() {
     const targetId = sessionId;
     const effectiveStatus = activeSession?.status ?? chatMeta?.status;
     markArchivingSession(targetId);
+    clearActivity(targetId);
     try {
       if (effectiveStatus === "running") {
         // Mark the kill as user-initiated so the exit handler reads it
@@ -736,36 +799,31 @@ export default function RunnerChat() {
   // Header layout mirrors Pencil node `NLa0k` inside `u6woG`:
   // 36px terminal-icon avatar, vertical title stack (handle + DIRECT
   // chip + meta line), and a right cluster of status pill + Stop +
-  // kebab. Status colors come from the runner-status semantics.
-  // 3-way derived state: "resuming" overrides whatever the row says
-  // because it's the user-driven transitional state. Mirrors the
-  // three Pencil frames (running u6woG / stopped vS5ce / resuming
-  // GZhHO).
-  type ChatState = "running" | "stopped" | "crashed" | "resuming";
-  const chatState: ChatState = resuming
-    ? "resuming"
-    : status === "running"
-      ? "running"
-      : status === "crashed"
-        ? "crashed"
-        : "stopped";
+  // kebab. `resuming` is a transitional control state; the steady
+  // display model is busy / idle / stopped / crashed.
+  type ChatState = DirectChatDisplayStatus | "resuming";
+  const chatState: ChatState = resuming ? "resuming" : displayStatus;
   const statusBadgeClass =
-    chatState === "running"
+    chatState === "busy"
       ? "bg-accent/10 text-accent"
-      : chatState === "crashed"
-        ? "bg-danger/10 text-danger"
-        : chatState === "resuming"
-          ? "bg-info/15 text-info"
-          : "bg-line-strong text-fg-2";
+      : chatState === "idle"
+        ? "bg-accent/5 text-fg-2"
+        : chatState === "crashed"
+          ? "bg-danger/10 text-danger"
+          : chatState === "resuming"
+            ? "bg-info/15 text-info"
+            : "bg-line-strong text-fg-2";
   const statusDotClass =
-    chatState === "running"
+    chatState === "busy"
       ? "bg-accent"
-      : chatState === "crashed"
-        ? "bg-danger"
-        : chatState === "resuming"
-          ? "bg-info"
-          : "bg-fg-3";
-  const statusLabel = chatState === "resuming" ? "resuming…" : status;
+      : chatState === "idle"
+        ? "bg-accent/35"
+        : chatState === "crashed"
+          ? "bg-danger"
+          : chatState === "resuming"
+            ? "bg-info"
+            : "bg-fg-3";
+  const statusLabel = chatState === "resuming" ? "resuming…" : displayStatus;
   const titleLabel =
     chatMeta?.title ??
     (chatMeta?.handle
@@ -862,7 +920,7 @@ export default function RunnerChat() {
             <BackButton onClick={() => navigate(backTarget)}>{backLabel}</BackButton>
           ) : chatState === "resuming" ? (
             <ResumingButton />
-          ) : chatState === "running" && sessionId ? (
+          ) : status === "running" && sessionId ? (
             <StopButton onClick={() => void endChat()} />
           ) : sessionId ? (
             // Stopped/crashed → Resume, matching
@@ -1047,7 +1105,7 @@ export default function RunnerChat() {
           // boots. The terminal underneath is hidden via
           // `opacity-0` above so the pill reads on a clean canvas.
           <StartingOverlay label="Starting chat…" />
-        ) : activeSession && chatState !== "running" ? (
+        ) : activeSession && status !== "running" ? (
           <SessionEndedOverlay
             status={status}
             exitCode={exitCode}


### PR DESCRIPTION
## Summary
- add live direct-chat `session/status` events from the PTY forwarder using the existing busy/idle detector
- derive direct-chat header display as `busy | idle | stopped | crashed`, defaulting alive DB `running` rows to `idle`
- update the #130 implementation plan and add Rust coverage that direct chats emit live status while mission sessions still append `runner_status` only

Refs #130.

## Validation
- pnpm exec tsc --noEmit
- pnpm run lint
- cargo fmt --check
- cargo test -p runner direct_chat_status_transition_emits_session_status
- cargo test -p runner mission_status_transition_appends_runner_status_without_session_status_event
- git diff --check
- smoke test passed
- Runner review mission 01KVMQ61MQP1X2JEDD9S0GAJ87 reported clean review; no must-fix findings
