### PR TITLE
Fix picker dropdowns closing on select

### DIFF
--- a/src/components/StartChatModal.tsx
+++ b/src/components/StartChatModal.tsx
@@ -7,7 +7,7 @@
 // owns Escape + backdrop close; only the inner dropdown needs its
 // own dismiss handlers.
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { ChevronDown, X } from "lucide-react";
@@ -38,6 +38,9 @@ export function StartChatModal({
   onClose,
   onStarted,
 }: StartChatModalProps) {
+  const formId = useId();
+  const titleInputId = `${formId}-title`;
+  const cwdInputId = `${formId}-cwd`;
   const [runners, setRunners] = useState<Runner[]>([]);
   const [runtimes, setRuntimes] = useState<RuntimeDefinition[]>([]);
   const [mode, setModeState] = useState<ChatMode>(() => readStartChatMode());
@@ -397,10 +400,12 @@ export function StartChatModal({
         )}
 
         <Field
+          htmlFor={titleInputId}
           label="Chat name"
           subtitle="Optional. Leave blank to use the default label."
         >
           <input
+            id={titleInputId}
             value={title}
             onChange={(e) => {
               setTitle(e.target.value);
@@ -413,9 +418,10 @@ export function StartChatModal({
           />
         </Field>
 
-        <Field label="Working directory">
+        <Field label="Working directory" htmlFor={cwdInputId}>
           <div className="flex items-center gap-2">
             <input
+              id={cwdInputId}
               value={cwd}
               onChange={(e) => setCwd(e.target.value)}
               placeholder={
@@ -442,20 +448,28 @@ export function StartChatModal({
 function Field({
   label,
   subtitle,
+  htmlFor,
   children,
 }: {
   label: string;
   subtitle?: string;
+  htmlFor?: string;
   children: React.ReactNode;
 }) {
   return (
-    <label className="flex flex-col gap-1.5">
-      <span className="text-xs font-semibold text-fg">{label}</span>
+    <div className="flex flex-col gap-1.5">
+      {htmlFor ? (
+        <label htmlFor={htmlFor} className="text-xs font-semibold text-fg">
+          {label}
+        </label>
+      ) : (
+        <span className="text-xs font-semibold text-fg">{label}</span>
+      )}
       {children}
       {subtitle ? (
         <span className="text-[11px] text-fg-3">{subtitle}</span>
       ) : null}
-    </label>
+    </div>
   );
 }
 

--- a/src/components/StartChatModal.tsx
+++ b/src/components/StartChatModal.tsx
@@ -39,6 +39,8 @@ export function StartChatModal({
   onStarted,
 }: StartChatModalProps) {
   const formId = useId();
+  const runnerPickerButtonId = `${formId}-runner`;
+  const runtimePickerButtonId = `${formId}-runtime`;
   const titleInputId = `${formId}-title`;
   const cwdInputId = `${formId}-cwd`;
   const [runners, setRunners] = useState<Runner[]>([]);
@@ -328,9 +330,10 @@ export function StartChatModal({
         </div>
 
         {mode === "runner" ? (
-          <Field label="Runner">
+          <Field label="Runner" htmlFor={runnerPickerButtonId}>
             <div ref={runnerPickerRef} className="relative">
               <button
+                id={runnerPickerButtonId}
                 type="button"
                 disabled={submitting || runners.length === 0}
                 onClick={() => setRunnerPickerOpen((v) => !v)}
@@ -387,8 +390,9 @@ export function StartChatModal({
             ) : null}
           </Field>
         ) : (
-          <Field label="Agent runtime">
+          <Field label="Agent runtime" htmlFor={runtimePickerButtonId}>
             <StyledSelect
+              id={runtimePickerButtonId}
               value={runtimeName}
               options={runtimes.map((runtime) => ({
                 value: runtime.name,

--- a/src/components/StartMissionModal.tsx
+++ b/src/components/StartMissionModal.tsx
@@ -36,6 +36,7 @@ export function StartMissionModal({
   initialCrewId = null,
 }: StartMissionModalProps) {
   const formId = useId();
+  const crewPickerButtonId = `${formId}-crew`;
   const titleInputId = `${formId}-title`;
   const goalInputId = `${formId}-goal`;
   const cwdInputId = `${formId}-cwd`;
@@ -214,9 +215,10 @@ export function StartMissionModal({
           </div>
         ) : null}
 
-        <Field label="Crew">
+        <Field label="Crew" htmlFor={crewPickerButtonId}>
           <div ref={crewPickerRef} className="relative">
             <button
+              id={crewPickerButtonId}
               type="button"
               disabled={submitting || crews.length === 0}
               onClick={() => setCrewPickerOpen((v) => !v)}

--- a/src/components/StartMissionModal.tsx
+++ b/src/components/StartMissionModal.tsx
@@ -6,7 +6,7 @@
 // either way; the modal surfaces that error inline so an empty-crew
 // pick is recoverable without closing.
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useId, useMemo, useRef, useState } from "react";
 
 import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import { ChevronDown, ChevronRight, X } from "lucide-react";
@@ -35,6 +35,10 @@ export function StartMissionModal({
   onStarted,
   initialCrewId = null,
 }: StartMissionModalProps) {
+  const formId = useId();
+  const titleInputId = `${formId}-title`;
+  const goalInputId = `${formId}-goal`;
+  const cwdInputId = `${formId}-cwd`;
   const [crews, setCrews] = useState<CrewListItem[]>([]);
   const [crewId, setCrewId] = useState<string>("");
   const [crewPickerOpen, setCrewPickerOpen] = useState(false);
@@ -272,10 +276,12 @@ export function StartMissionModal({
         </Field>
 
         <Field
+          htmlFor={titleInputId}
           label="Mission title"
           subtitle="Short label shown in the missions list and event log."
         >
           <input
+            id={titleInputId}
             value={title}
             onChange={(e) => setTitle(e.target.value)}
             placeholder="e.g. Wire up event bus watcher"
@@ -285,6 +291,7 @@ export function StartMissionModal({
         </Field>
 
         <Field
+          htmlFor={goalInputId}
           label="Goal"
           subtitle={
             lead
@@ -293,6 +300,7 @@ export function StartMissionModal({
           }
         >
           <textarea
+            id={goalInputId}
             value={goal}
             onChange={(e) => setGoal(e.target.value)}
             placeholder={selectedCrew?.goal ?? "Describe what to do…"}
@@ -302,9 +310,10 @@ export function StartMissionModal({
           />
         </Field>
 
-        <Field label="Working directory">
+        <Field label="Working directory" htmlFor={cwdInputId}>
           <div className="flex items-center gap-2">
             <input
+              id={cwdInputId}
               value={cwd}
               onChange={(e) => setCwd(e.target.value)}
               placeholder="/Users/you/projects/foo (optional)"
@@ -352,22 +361,30 @@ export function StartMissionModal({
 function Field({
   label,
   subtitle,
+  htmlFor,
   children,
 }: {
   label: string;
   subtitle?: string;
+  htmlFor?: string;
   children: React.ReactNode;
 }) {
   return (
-    <label className="flex flex-col gap-1.5">
-      <span className="text-xs font-semibold text-fg">
-        {label}
-      </span>
+    <div className="flex flex-col gap-1.5">
+      {htmlFor ? (
+        <label htmlFor={htmlFor} className="text-xs font-semibold text-fg">
+          {label}
+        </label>
+      ) : (
+        <span className="text-xs font-semibold text-fg">
+          {label}
+        </span>
+      )}
       {children}
       {subtitle ? (
         <span className="text-[11px] text-fg-3">{subtitle}</span>
       ) : null}
-    </label>
+    </div>
   );
 }
 

--- a/src/components/ui/StyledSelect.tsx
+++ b/src/components/ui/StyledSelect.tsx
@@ -27,6 +27,7 @@ export interface StyledSelectOption {
 }
 
 export function StyledSelect({
+  id,
   value,
   options,
   onChange,
@@ -34,6 +35,7 @@ export function StyledSelect({
   buttonLabel,
   disabled,
 }: {
+  id?: string;
   value: string;
   options: StyledSelectOption[];
   onChange: (v: string) => void;
@@ -60,6 +62,7 @@ export function StyledSelect({
   return (
     <div ref={rootRef} className={className ?? "min-w-[160px]"}>
       <button
+        id={id}
         type="button"
         onClick={() => {
           if (disabled) return;


### PR DESCRIPTION
## Summary
- Avoid wrapping picker dropdown buttons in label elements in the start chat and start mission modals.
- Preserve explicit label associations for normal input and textarea fields with ids and htmlFor.

## Tests
- pnpm exec tsc --noEmit
- pnpm run lint

Fixes #221