### PR TITLE
Fix mission terminal bracketed paste snapshot replay

### DIFF
--- a/src-tauri/src/session/manager/mod.rs
+++ b/src-tauri/src/session/manager/mod.rs
@@ -76,6 +76,22 @@ const CLAUDE_LAUNCH_GATE_GRACE: Duration = Duration::from_millis(1500);
 #[cfg(test)]
 const CLAUDE_LAUNCH_GATE_GRACE: Duration = Duration::from_millis(0);
 
+fn scan_mode_transition(bytes: &[u8], patterns: &[(&[u8], bool)]) -> Option<bool> {
+    let mut latest: Option<(usize, bool)> = None;
+    for (needle, state) in patterns {
+        if bytes.len() < needle.len() {
+            continue;
+        }
+        if let Some(pos) = bytes.windows(needle.len()).rposition(|w| w == *needle) {
+            latest = match latest {
+                Some((p, _)) if p >= pos => latest,
+                _ => Some((pos, *state)),
+            };
+        }
+    }
+    latest.map(|(_, state)| state)
+}
+
 /// Returns the resulting alt-screen state if `bytes` contains one or
 /// more enter/exit alt-screen escapes; `None` when no such escape is
 /// present. Recognized escapes: `\x1b[?1049h` / `\x1b[?1049l` (the
@@ -94,19 +110,12 @@ fn scan_alt_screen_transition(bytes: &[u8]) -> Option<bool> {
         (b"\x1b[?47h", true),
         (b"\x1b[?47l", false),
     ];
-    let mut latest: Option<(usize, bool)> = None;
-    for (needle, state) in PATTERNS {
-        if bytes.len() < needle.len() {
-            continue;
-        }
-        if let Some(pos) = bytes.windows(needle.len()).rposition(|w| w == *needle) {
-            latest = match latest {
-                Some((p, _)) if p >= pos => latest,
-                _ => Some((pos, *state)),
-            };
-        }
-    }
-    latest.map(|(_, state)| state)
+    scan_mode_transition(bytes, PATTERNS)
+}
+
+fn scan_bracketed_paste_transition(bytes: &[u8]) -> Option<bool> {
+    const PATTERNS: &[(&[u8], bool)] = &[(b"\x1b[?2004h", true), (b"\x1b[?2004l", false)];
+    scan_mode_transition(bytes, PATTERNS)
 }
 
 /// Inputs the forwarder consumer needs to translate a
@@ -406,6 +415,7 @@ struct SessionState {
     output_buffer: VecDeque<OutputEvent>,
     output_seq: u64,
     alt_screen_on: bool,
+    bracketed_paste_on: bool,
     resuming: bool,
     killed: bool,
 }
@@ -416,6 +426,7 @@ impl SessionState {
             && self.output_buffer.is_empty()
             && self.output_seq == 0
             && !self.alt_screen_on
+            && !self.bracketed_paste_on
             && !self.resuming
             && !self.killed
     }

--- a/src-tauri/src/session/manager/output.rs
+++ b/src-tauri/src/session/manager/output.rs
@@ -56,11 +56,11 @@ impl SessionManager {
                 }
                 match output.recv_timeout(Duration::from_millis(500)) {
                     Ok(RuntimeOutput::Stream(bytes)) => {
-                        // Track alt-screen mode before recording so
+                        // Track terminal modes before recording so
                         // that the very next `output_snapshot` (if
                         // one races in here) reflects the latest
                         // state the agent just emitted.
-                        manager_t.update_alt_screen_state(&session_id, &bytes);
+                        manager_t.update_terminal_mode_state(&session_id, &bytes);
                         let ev = manager_t.record_output(
                             &session_id,
                             mission_id.as_deref(),
@@ -251,25 +251,35 @@ impl SessionManager {
         };
         let state = state.lock().unwrap();
         let mut events: Vec<OutputEvent> = state.output_buffer.iter().cloned().collect();
-        // For sessions currently inside an alt-screen, prepend a
-        // synthetic chunk carrying the `\x1b[?1049h` enter escape.
+        // For sessions currently inside terminal modes that xterm
+        // reset clears, prepend a synthetic chunk restoring them.
         // Long-running TUI sessions (claude-code, codex) lose the
         // original enter-alt-screen escape from the bounded
         // 4096-chunk buffer over time, so a re-attach that just
         // replays the remaining chunks lands mid-alt-screen content
         // into xterm's main screen — visible as stacked redraws in
         // scrollback and a blank alt-screen pane on route remount.
-        // seq=0 sits below every real event's
-        // monotonic seq so the frontend's `seq <= lastWrittenSeq`
-        // filter doesn't drop it on re-replay.
+        // Bracketed paste has the same problem after RunnerTerminal
+        // calls `reset()`: without replaying `\x1b[?2004h`, xterm
+        // sends multiline clipboard text as raw Enter-delimited
+        // keystrokes. seq=0 sits below every real event's monotonic
+        // seq so the frontend's `seq <= lastWrittenSeq` filter
+        // doesn't drop it on re-replay.
+        let mut synthetic_prefix = Vec::new();
         if state.alt_screen_on {
+            synthetic_prefix.extend_from_slice(b"\x1b[?1049h");
+        }
+        if state.bracketed_paste_on {
+            synthetic_prefix.extend_from_slice(b"\x1b[?2004h");
+        }
+        if !synthetic_prefix.is_empty() {
             events.insert(
                 0,
                 OutputEvent {
                     session_id: session_id.into(),
                     mission_id: None,
                     seq: 0,
-                    data: BASE64.encode(b"\x1b[?1049h"),
+                    data: BASE64.encode(synthetic_prefix),
                 },
             );
         }
@@ -286,6 +296,7 @@ impl SessionManager {
             state.output_buffer.clear();
             state.output_seq = 0;
             state.alt_screen_on = false;
+            state.bracketed_paste_on = false;
         }
         self.prune_empty_session_state(session_id);
     }
@@ -302,19 +313,19 @@ impl SessionManager {
             let mut state = state.lock().unwrap();
             state.output_buffer.clear();
             // Resume forks a new child; whether it'll be in alt-screen
-            // depends on the new process's own startup. Clear the state
-            // so it re-derives from the new child's emitted bytes
+            // or bracketed-paste mode depends on the new process's own
+            // startup. Clear the state so it re-derives from emitted bytes
             // instead of inheriting the prior child's mode.
             state.alt_screen_on = false;
+            state.bracketed_paste_on = false;
         }
         self.prune_empty_session_state(session_id);
     }
 
-    /// Update the per-session alt-screen flag from a raw runtime
-    /// chunk. We scan for the four mode-switch escapes (1049h/l +
-    /// 47h/l) and take the *latest* match in the chunk as the
-    /// resulting state. No-op when the chunk contains no
-    /// mode-switch escape.
+    /// Update per-session terminal mode flags from a raw runtime
+    /// chunk. We take the *latest* match in the chunk as the resulting
+    /// state for each tracked mode. No-op when the chunk contains no
+    /// tracked mode-switch escape.
     ///
     /// Boundary caveat: an escape could be split across two
     /// adjacent chunks if the PTY reader's buffer slice happens to
@@ -323,12 +334,19 @@ impl SessionManager {
     /// the worst case is one missed transition — the next emitted
     /// transition picks up the right state. If this turns out to
     /// matter we can carry a small tail buffer across chunks.
-    fn update_alt_screen_state(&self, session_id: &str, bytes: &[u8]) {
-        if let Some(new_state) = scan_alt_screen_transition(bytes) {
-            self.session_state_or_insert(session_id)
-                .lock()
-                .unwrap()
-                .alt_screen_on = new_state;
+    fn update_terminal_mode_state(&self, session_id: &str, bytes: &[u8]) {
+        let alt_screen = scan_alt_screen_transition(bytes);
+        let bracketed_paste = scan_bracketed_paste_transition(bytes);
+        if alt_screen.is_none() && bracketed_paste.is_none() {
+            return;
+        }
+        let state = self.session_state_or_insert(session_id);
+        let mut state = state.lock().unwrap();
+        if let Some(new_state) = alt_screen {
+            state.alt_screen_on = new_state;
+        }
+        if let Some(new_state) = bracketed_paste {
+            state.bracketed_paste_on = new_state;
         }
     }
 

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -2221,6 +2221,27 @@ fn scan_alt_screen_detects_modern_and_legacy_escapes() {
 }
 
 #[test]
+fn scan_bracketed_paste_detects_enable_and_disable_escapes() {
+    assert_eq!(scan_bracketed_paste_transition(b"hello world"), None);
+    assert_eq!(
+        scan_bracketed_paste_transition(b"ready\x1b[?2004h"),
+        Some(true)
+    );
+    assert_eq!(
+        scan_bracketed_paste_transition(b"\x1b[?2004lprompt"),
+        Some(false)
+    );
+    assert_eq!(
+        scan_bracketed_paste_transition(b"\x1b[?2004hon\x1b[?2004loff"),
+        Some(false)
+    );
+    assert_eq!(
+        scan_bracketed_paste_transition(b"\x1b[?2004l\x1b[?2004h"),
+        Some(true)
+    );
+}
+
+#[test]
 fn output_snapshot_prepends_alt_screen_enter_when_session_in_alt_screen() {
     let pool = pool_with_schema();
     let fake = fake_runtime();
@@ -2282,6 +2303,113 @@ fn output_snapshot_prepends_alt_screen_enter_when_session_in_alt_screen() {
         snapshot2.first().map(|e| e.seq),
         Some(0),
         "main-screen sessions must not prepend the alt-screen enter"
+    );
+}
+
+#[test]
+fn output_snapshot_prepends_bracketed_paste_enable_when_session_has_it_enabled() {
+    let pool = pool_with_schema();
+    let fake = fake_runtime();
+    let mgr = SessionManager::new(
+        crate::shell_path::LoginShellEnv::default(),
+        Arc::clone(&fake) as Arc<dyn SessionRuntime>,
+    );
+    let runner = runner("/bin/sh", &["-c", "true"]);
+    {
+        let conn = pool.get().unwrap();
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'r', 'r', 'shell', '/bin/sh',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+            params![runner.id, now],
+        )
+        .unwrap();
+    }
+    let spawned = mgr
+        .spawn_direct(
+            &runner,
+            Some("/tmp"),
+            None,
+            None,
+            std::path::Path::new("/tmp"),
+            Arc::clone(&pool),
+            capture(),
+            None,
+        )
+        .unwrap();
+
+    fake.push_output(0, b"\x1b[?2004hprompt ready");
+    std::thread::sleep(Duration::from_millis(50));
+
+    let snapshot = mgr.output_snapshot(&spawned.id);
+    assert!(!snapshot.is_empty(), "snapshot should contain chunks");
+    assert_eq!(snapshot[0].seq, 0);
+    assert_eq!(
+        BASE64.decode(&snapshot[0].data).unwrap(),
+        b"\x1b[?2004h",
+        "synthetic prepend must restore bracketed-paste mode"
+    );
+
+    fake.push_output(0, b"\x1b[?2004lplain prompt");
+    std::thread::sleep(Duration::from_millis(50));
+    let snapshot2 = mgr.output_snapshot(&spawned.id);
+    assert_ne!(
+        snapshot2.first().map(|e| e.seq),
+        Some(0),
+        "sessions with bracketed paste disabled must not prepend the enable escape"
+    );
+}
+
+#[test]
+fn output_snapshot_combines_alt_screen_and_bracketed_paste_prefixes() {
+    let pool = pool_with_schema();
+    let fake = fake_runtime();
+    let mgr = SessionManager::new(
+        crate::shell_path::LoginShellEnv::default(),
+        Arc::clone(&fake) as Arc<dyn SessionRuntime>,
+    );
+    let runner = runner("/bin/sh", &["-c", "true"]);
+    {
+        let conn = pool.get().unwrap();
+        let now = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'r', 'r', 'shell', '/bin/sh',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+            params![runner.id, now],
+        )
+        .unwrap();
+    }
+    let spawned = mgr
+        .spawn_direct(
+            &runner,
+            Some("/tmp"),
+            None,
+            None,
+            std::path::Path::new("/tmp"),
+            Arc::clone(&pool),
+            capture(),
+            None,
+        )
+        .unwrap();
+
+    fake.push_output(0, b"\x1b[?1049h\x1b[?2004hpainted prompt");
+    std::thread::sleep(Duration::from_millis(50));
+
+    let snapshot = mgr.output_snapshot(&spawned.id);
+    assert!(!snapshot.is_empty(), "snapshot should contain chunks");
+    assert_eq!(snapshot[0].seq, 0);
+    assert_eq!(
+        BASE64.decode(&snapshot[0].data).unwrap(),
+        b"\x1b[?1049h\x1b[?2004h",
+        "synthetic prepend must restore every tracked terminal mode"
     );
 }
 


### PR DESCRIPTION
Fixes #223.

Summary:
- Track bracketed paste mode from PTY output alongside alt-screen state.
- Synthesize bracketed paste enable in session snapshots after xterm reset/replay.
- Add focused scanner and snapshot replay tests.

Validation:
- cargo fmt
- cargo test -p runner bracketed_paste
- cargo test -p runner output_snapshot_prepends
- git diff --check
- Manual smoke test confirmed by Jason