### PR TITLE
fix(ui): seed direct chat status as busy

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1169,7 +1169,7 @@ function directChatDisplayStatus(
   if (session.status === "stopped" || session.status === "crashed") {
     return session.status;
   }
-  return activity === "busy" ? "busy" : "idle";
+  return activity ?? "busy";
 }
 
 function directChatDotClassName(status: DirectChatDisplayStatus): string {

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -100,6 +100,14 @@ interface DirectSessionPane {
 
 type DirectChatDisplayStatus = SessionActivityState | "stopped" | "crashed";
 
+function directChatDisplayStatus(
+  status: SessionStatus,
+  activity: SessionActivityState | undefined,
+): DirectChatDisplayStatus {
+  if (status === "stopped" || status === "crashed") return status;
+  return activity ?? "busy";
+}
+
 export default function RunnerChat() {
   const { sessionId: sessionIdParam } = useParams<{
     sessionId: string;
@@ -189,12 +197,7 @@ export default function RunnerChat() {
   const activeSession = directSessions.find((s) => s.id === sessionId) ?? null;
   const status = activeSession?.status ?? chatMeta?.status ?? "running";
   const latestActivity = sessionId ? activityBySession[sessionId] : undefined;
-  const displayStatus: DirectChatDisplayStatus =
-    status === "stopped" || status === "crashed"
-      ? status
-      : latestActivity === "busy"
-        ? "busy"
-        : "idle";
+  const displayStatus = directChatDisplayStatus(status, latestActivity);
   const exitCode = activeSession?.exitCode ?? null;
   const backTarget = chatMeta?.handle ? `/runners/${chatMeta.handle}` : "/runners";
   const backLabel = chatMeta?.handle ? "Back to runner" : "Back to runners";


### PR DESCRIPTION
## Summary
- Seed running direct chats with missing activity as busy in RunnerChat
- Apply the same busy-until-idle fallback to Sidebar chat rows
- Preserve stopped/crashed terminal states and keep user typing out of activity state

## Validation
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check

Reviewer reported a clean working-tree review before PR creation.