### PR TITLE
Fix Codex session key capture

### DIFF
--- a/docs/impls/0017-codex-session-key-capture.md
+++ b/docs/impls/0017-codex-session-key-capture.md
@@ -1,0 +1,148 @@
+# Codex Session-Key Capture Hardening
+
+## Status
+
+Planned for issue #229.
+
+## Problem
+
+Codex resume can bind a Runner session row to the wrong native Codex conversation. The resume argv path is already correct: when `sessions.agent_session_key` is set, `router::runtime::resume_plan("codex", Some(key))` builds `codex resume <uuid>`. The weak point is the post-spawn capture of that key.
+
+Codex does not currently expose a fresh-spawn flag for caller-assigned session ids. Runner therefore watches `$CODEX_HOME/sessions/YYYY/MM/DD/rollout-*.jsonl`, reads the first `session_meta` row, and persists `payload.id` into `sessions.agent_session_key`. Today that watcher matches by cwd and spawn timestamp, then picks the earliest unclaimed rollout. That is not strong enough when several Codex sessions start close together in the same cwd: if rollout files flush out of spawn order, a watcher can claim a sibling session's native Codex id. The next resume faithfully resumes the wrong conversation.
+
+The safe invariant is: stale or missing resume is acceptable; wrong resume is not.
+
+Claude Code is intentionally separate: Runner can assign the native Claude session id at fresh spawn with `--session-id <uuid>` and later resume it with `--resume <uuid>`. The filesystem capture and prompt-marker workaround in this plan are Codex-only because Codex lacks the equivalent fresh-spawn id flag.
+
+## Goals
+
+- Persist a Codex `agent_session_key` only when capture is unambiguous for that Runner session row.
+- Keep `codex resume <uuid>` using the key from the exact row being resumed.
+- Fail closed: leave `agent_session_key = NULL` when capture cannot prove ownership.
+- Expose the captured key in the direct-chat side panel for debugging and operator confidence.
+
+## Non-Goals
+
+- Do not introduce per-session `CODEX_HOME` yet. It is cleaner in theory, but Codex home carries auth, config, plugins, skills, sqlite state, caches, and session indexes. A per-session home would require a fragile overlay/symlink strategy and is too large for this bug.
+- Do not parse conversation content or user prompts to infer identity.
+
+## Proposed Backend Design
+
+### Capture Inputs
+
+Extend Codex capture so the watcher gets more than cwd and timestamp:
+
+- Runner `session_id`
+- resolved spawn cwd
+- spawn timestamp
+- spawned process pid, when available from `SessionRuntime::status`
+- optional Runner prompt marker derived from the Runner `session_id`
+- database pool
+
+`PtyRuntime::spawn` already stores the child pid in `SessionStatus.pid`. The manager can query `runtime.status(&rt_session)` after spawn and before launching the capture watcher. If pid is unavailable, capture must either use a conservative fallback or leave the key null.
+
+Start a bounded capture attempt after every fresh Codex spawn/resume without an existing `agent_session_key`. Keep that spawn-time attempt because mission starts often deliver the first turn through argv and Codex may create the rollout immediately. Also keep the capture context on the live `SessionHandle` and retry capture after submitted input (`Enter`/paste-submit), which covers empty direct chats where Codex does not create a rollout file until the user sends a real prompt.
+
+When Runner already has a real first-turn body for a fresh Codex spawn, append an inert marker such as `<!-- runner-codex-session-key-capture:<runner-session-id> -->`. Codex records that prompt text into the rollout. If pid-assisted ownership is unavailable and several rollout files share the same cwd/time window, scan matching rollout content for the exact marker and persist only the rollout containing this session's marker. Do not add a marker-only prompt when there is no real first turn, because that would make Codex respond to internal metadata.
+
+### PID-Assisted Rollout Ownership
+
+Prefer pid-assisted matching over earliest-unclaimed matching.
+
+On macOS, the capture thread can inspect the spawned Codex process with `lsof -p <pid>` or an equivalent platform helper and look for an open rollout file under `$CODEX_HOME/sessions/**/rollout-*.jsonl`. Once found, parse the file's first line and validate:
+
+- first JSON line is `type == "session_meta"`
+- `payload.cwd == resolved_cwd`
+- `payload.timestamp >= started_at`
+- `payload.id` is a UUID
+- path is not already claimed by another watcher
+
+Only then write `payload.id` into `sessions.agent_session_key`.
+
+If there are zero candidate rollout files, keep polling until timeout. If there is more than one candidate, do not guess; keep polling briefly for convergence, then leave the key null.
+
+If no pid-owned file is observable but the spawn prompt carried a Runner marker, the content-marker match is the next ownership proof. This is the mission burst workaround: multiple Codex workers can start in the same cwd at the same millisecond, but each first-turn prompt contains a different Runner session marker.
+
+### Fallback Behavior
+
+The existing cwd/timestamp scan can remain only as a guarded fallback, but it must not silently choose among multiple plausible sibling rollouts. Accept a fallback match only when exactly one unclaimed rollout matches the cwd/time window and Runner's database proves the current row is live, unkeyed, still has the spawn's `started_at`, and no other live unkeyed Codex row could share the effective spawn cwd. Treat `NULL` stored cwd as inherited cwd, so a `NULL` sibling and an explicit sibling matching the effective cwd are ambiguous. If any of those checks fail, leave the key null.
+
+This changes the failure mode from "may resume the wrong conversation" to "may start fresh on resume." That is the right tradeoff.
+
+In multi-runner missions where several Codex sessions start in the same cwd at nearly the same time, fallback may leave every affected row as `NULL` if pid-assisted ownership is unavailable. Do not map by slot order or rollout timestamp order; that would reintroduce sibling cross-wiring. A future reliable mission capture path needs caller-assigned Codex session ids or isolated per-session Codex homes.
+
+### Tests
+
+Add focused tests around `codex_capture`:
+
+- Multiple matching rollouts in the same cwd are ambiguous and do not produce a key.
+- Claimed rollout paths are skipped.
+- A single matching rollout still captures.
+- Invalid/non-UUID `payload.id` is rejected.
+
+Add a `SessionManager::resume` test for Codex:
+
+- Insert a stopped Codex direct-chat row with `agent_session_key = <uuid>`.
+- Resume it through the fake runtime.
+- Assert the spawned `SpawnSpec.args` contain `["resume", "<uuid>", ...]` for that same row and do not use another row's key.
+
+## Direct-Chat And Mission Session Visibility
+
+Add the native session key to the direct-chat info panel and mission runner-session rail.
+
+Backend/API shape:
+
+- Add `agent_session_key: Option<String>` to `DirectSessionEntry`.
+- Include `s.agent_session_key AS agent_session_key` in `session_get`.
+- For `session_list_recent_direct`, either include the same field or return `NULL AS agent_session_key` and have `RunnerChat` fetch full metadata with `session_get` for the active chat. Prefer the latter if we want to avoid sending every recent chat's key to the sidebar list.
+- Add `agent_session_key: Option<String>` to mission `SessionRow` and include it in `session_list`.
+
+Frontend:
+
+- Add `agent_session_key: string | null` to `src/lib/api.ts`.
+- In `src/pages/RunnerChat.tsx`, render a `session_key` row in the Runtime card and show the captured key or `NULL`.
+- In `src/components/RunnersRail.tsx`, render `session_key` for each mission runner session and show the captured key or `NULL`.
+- In `src/pages/MissionWorkspace.tsx`, use a bounded `session_list` refresh while running Codex mission rows are missing keys, and listen for a backend `session/updated` event after successful async capture so late first-activity capture refreshes the rail too.
+- In `src/pages/RunnerChat.tsx`, listen for the same `session/updated` event and refetch the active chat metadata when its key is captured.
+- Use the same compact mono, break-all treatment as `cmd` and `cwd`.
+
+Expected UI:
+
+```text
+Runtime
+Codex  CODEX
+
+cmd          codex
+cwd          /Users/jason/go/src/github.com/yicheng47/runner
+session_key 019eef80-62fd-7c50-b451-bffce763f3fc
+```
+
+Pending/failed capture:
+
+```text
+session_key NULL
+```
+
+## Relevant Code
+
+- `src-tauri/src/session/codex_capture.rs`: rollout scanning and `agent_session_key` persistence.
+- `src-tauri/src/session/manager/spawn.rs`: starts Codex capture after fresh spawn/resume without a prior assigned key.
+- `src-tauri/src/session/pty_runtime.rs`: exposes child pid through `SessionRuntime::status`.
+- `src-tauri/src/router/runtime.rs`: builds `codex resume <uuid>`.
+- `src-tauri/src/commands/session.rs`: direct-chat DTO and SQL queries.
+- `src/lib/api.ts`: `DirectSessionEntry` frontend type.
+- `src/pages/RunnerChat.tsx`: direct-chat side panel.
+
+## Validation
+
+- `cargo test -p runner codex_capture`
+- Focused `SessionManager::resume` test for Codex argv binding.
+- `pnpm exec tsc --noEmit`
+- `pnpm run lint`
+
+Manual smoke:
+
+1. Start two Codex direct chats in the same cwd close together.
+2. Confirm each direct-chat side panel shows either its captured `session_key` or `NULL` while capture is pending/failed.
+3. Stop and resume each chat.
+4. Confirm a keyed chat resumes its own conversation; an unkeyed chat starts fresh rather than attaching to a sibling conversation.

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -41,6 +41,10 @@ pub struct SessionRow {
     pub runtime: String,
     /// Whether this runner is the lead for the mission's crew.
     pub lead: bool,
+    /// Native agent conversation key captured from the spawned agent.
+    /// NULL means capture is pending, unavailable, or intentionally
+    /// failed closed.
+    pub agent_session_key: Option<String>,
 }
 
 fn row_to_session(row: &Row<'_>) -> rusqlite::Result<SessionRow> {
@@ -80,6 +84,7 @@ fn row_to_session(row: &Row<'_>) -> rusqlite::Result<SessionRow> {
         handle: row.get("handle")?,
         runtime: row.get("runtime")?,
         lead: row.get("lead")?,
+        agent_session_key: row.get("agent_session_key")?,
     })
 }
 
@@ -99,7 +104,7 @@ pub fn list_for_mission(conn: &rusqlite::Connection, mission_id: &str) -> Result
     // running one for every slot.
     let mut stmt = conn.prepare(
         "SELECT s.id, s.mission_id, s.runner_id, s.slot_id, s.cwd, s.status, s.pid,
-                s.started_at, s.stopped_at,
+                s.started_at, s.stopped_at, s.agent_session_key,
                 COALESCE(sl.slot_handle, r.handle) AS handle,
                 r.runtime AS runtime,
                 COALESCE(sl.lead, 0) AS lead
@@ -270,6 +275,11 @@ pub struct DirectSessionEntry {
     /// distinguish "stopped but resumable" from "stopped and
     /// forgotten" without shipping the raw key down.
     pub resumable: bool,
+    /// Native agent conversation key for the active direct chat.
+    /// `session_list_recent_direct` intentionally returns NULL here;
+    /// `session_get` is the full-detail path RunnerChat uses for the
+    /// visible row.
+    pub agent_session_key: Option<String>,
     /// `true` iff `pinned_at IS NOT NULL`. Pinned rows render with a
     /// pin glyph and sort to the top of the tray.
     pub pinned: bool,
@@ -326,6 +336,7 @@ fn direct_entry_from_row(row: &Row<'_>) -> rusqlite::Result<DirectSessionEntry> 
         started_at: started_at.map(parse_ts).transpose()?,
         stopped_at: stopped_at.map(parse_ts).transpose()?,
         resumable: resumable != 0,
+        agent_session_key: row.get("agent_session_key")?,
         pinned: pinned != 0,
         archived_at: archived_at.map(parse_ts).transpose()?,
     })
@@ -355,6 +366,7 @@ pub async fn session_list_recent_direct(
                 s.stopped_at,
                 s.archived_at,
                 CASE WHEN s.agent_session_key IS NOT NULL THEN 1 ELSE 0 END AS resumable,
+                NULL AS agent_session_key,
                 CASE WHEN s.pinned_at         IS NOT NULL THEN 1 ELSE 0 END AS pinned
            FROM sessions s
            LEFT JOIN runners r ON r.id = s.runner_id
@@ -412,6 +424,7 @@ fn get_direct(conn: &rusqlite::Connection, session_id: &str) -> Result<Option<Di
                 s.stopped_at,
                 s.archived_at,
                 CASE WHEN s.agent_session_key IS NOT NULL THEN 1 ELSE 0 END AS resumable,
+                s.agent_session_key AS agent_session_key,
                 CASE WHEN s.pinned_at         IS NOT NULL THEN 1 ELSE 0 END AS pinned
            FROM sessions s
            LEFT JOIN runners r ON r.id = s.runner_id
@@ -849,6 +862,73 @@ mod tests {
         let row = get_direct(&conn, &id).unwrap().unwrap();
         let got = row.archived_at.expect("archived_at populated").to_rfc3339();
         assert_eq!(got, archived_at);
+    }
+
+    #[test]
+    fn session_get_returns_agent_session_key_for_direct_chat() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let runner_id = seed_runner(&conn);
+        let id = ulid::Ulid::new().to_string();
+        let now = Utc::now().to_rfc3339();
+        let key = uuid::Uuid::new_v4().to_string();
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, status, started_at, agent_session_key)
+             VALUES (?1, NULL, ?2, 'stopped', ?3, ?4)",
+            params![id, runner_id, now, key],
+        )
+        .unwrap();
+
+        let row = get_direct(&conn, &id).unwrap().unwrap();
+        assert_eq!(row.agent_session_key.as_deref(), Some(key.as_str()));
+        assert!(row.resumable);
+    }
+
+    #[test]
+    fn session_list_returns_agent_session_key_for_mission_rows() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let runner_id = seed_runner(&conn);
+        let crew_id = ulid::Ulid::new().to_string();
+        let slot_id = ulid::Ulid::new().to_string();
+        let mission_id = ulid::Ulid::new().to_string();
+        let session_id = ulid::Ulid::new().to_string();
+        let now = Utc::now().to_rfc3339();
+        let key = uuid::Uuid::new_v4().to_string();
+        conn.execute(
+            "INSERT INTO crews (id, name, created_at, updated_at)
+             VALUES (?1, 'C', ?2, ?2)",
+            params![crew_id, now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO slots
+                (id, crew_id, runner_id, slot_handle, position, lead, added_at)
+             VALUES (?1, ?2, ?3, 'coder', 0, 1, ?4)",
+            params![slot_id, crew_id, runner_id, now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO missions
+                (id, crew_id, title, status, started_at)
+             VALUES (?1, ?2, 't', 'running', ?3)",
+            params![mission_id, crew_id, now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, slot_id, status, started_at, agent_session_key)
+             VALUES (?1, ?2, ?3, ?4, 'running', ?5, ?6)",
+            params![session_id, mission_id, runner_id, slot_id, now, key],
+        )
+        .unwrap();
+
+        let rows = list_for_mission(&conn, &mission_id).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].session.id, session_id);
+        assert_eq!(rows[0].handle, "coder");
+        assert_eq!(rows[0].agent_session_key.as_deref(), Some(key.as_str()));
     }
 
     #[test]

--- a/src-tauri/src/session/codex_capture.rs
+++ b/src-tauri/src/session/codex_capture.rs
@@ -65,43 +65,23 @@ fn claimed_rollouts() -> &'static Mutex<HashSet<PathBuf>> {
 /// `session_id` (a Runner sessions row) and writes it into
 /// `agent_session_key`. Returns immediately; no-op if `$HOME/.codex/`
 /// doesn't exist.
-pub fn spawn_capture(
-    session_id: String,
-    mission_id: Option<String>,
-    spawn_cwd: String,
-    started_at: DateTime<Utc>,
-    expected_row_started_at: String,
-    spawn_pid: Option<i32>,
-    prompt_marker: Option<String>,
-    pool: Arc<DbPool>,
-    events: Arc<dyn SessionEvents>,
-) {
-    std::thread::spawn(move || {
-        run(
-            session_id,
-            mission_id,
-            spawn_cwd,
-            started_at,
-            expected_row_started_at,
-            spawn_pid,
-            prompt_marker,
-            pool,
-            events,
-        )
-    });
+pub struct CaptureRequest {
+    pub session_id: String,
+    pub mission_id: Option<String>,
+    pub spawn_cwd: String,
+    pub started_at: DateTime<Utc>,
+    pub expected_row_started_at: String,
+    pub spawn_pid: Option<i32>,
+    pub prompt_marker: Option<String>,
+    pub pool: Arc<DbPool>,
+    pub events: Arc<dyn SessionEvents>,
 }
 
-fn run(
-    session_id: String,
-    mission_id: Option<String>,
-    spawn_cwd: String,
-    started_at: DateTime<Utc>,
-    expected_row_started_at: String,
-    spawn_pid: Option<i32>,
-    prompt_marker: Option<String>,
-    pool: Arc<DbPool>,
-    events: Arc<dyn SessionEvents>,
-) {
+pub fn spawn_capture(request: CaptureRequest) {
+    std::thread::spawn(move || run(request));
+}
+
+fn run(request: CaptureRequest) {
     let Some(home) = std::env::var_os("HOME") else {
         return;
     };
@@ -113,7 +93,7 @@ fn run(
     // Rollout dirs are partitioned by *local* date. The user might
     // start codex right before midnight and the rollout could land in
     // the next day's dir, so probe both.
-    let local_started = started_at.with_timezone(&Local);
+    let local_started = request.started_at.with_timezone(&Local);
     let candidates = [local_started, local_started + chrono::Duration::days(1)];
 
     let deadline = Instant::now() + Duration::from_secs(CAPTURE_TIMEOUT_SECS);
@@ -125,23 +105,23 @@ fn run(
     let mut done: HashSet<PathBuf> = HashSet::new();
 
     loop {
-        let (scan, source) = if let Some(pid) = spawn_pid {
+        let (scan, source) = if let Some(pid) = request.spawn_pid {
             scan_pid_result_or_fallback(
                 open_rollout_paths_for_pid(pid, &sessions_root),
                 &sessions_root,
                 &candidates,
-                &spawn_cwd,
-                started_at,
-                prompt_marker.as_deref(),
+                &request.spawn_cwd,
+                request.started_at,
+                request.prompt_marker.as_deref(),
                 &mut done,
             )
         } else {
             scan_fallback_with_marker(
                 &sessions_root,
                 &candidates,
-                &spawn_cwd,
-                started_at,
-                prompt_marker.as_deref(),
+                &request.spawn_cwd,
+                request.started_at,
+                request.prompt_marker.as_deref(),
                 &mut done,
             )
         };
@@ -150,10 +130,10 @@ fn run(
             CaptureScan::Unique(candidate) => {
                 if source == ScanSource::Fallback
                     && !fallback_row_is_unambiguous(
-                        &pool,
-                        &session_id,
-                        &expected_row_started_at,
-                        &spawn_cwd,
+                        &request.pool,
+                        &request.session_id,
+                        &request.expected_row_started_at,
+                        &request.spawn_cwd,
                     )
                 {
                     return;
@@ -169,10 +149,15 @@ fn run(
                     done.insert(candidate.path);
                     continue;
                 }
-                if persist_capture(&pool, &session_id, &expected_row_started_at, &candidate.id) {
-                    events.updated(&SessionUpdatedEvent {
-                        session_id: session_id.clone(),
-                        mission_id: mission_id.clone(),
+                if persist_capture(
+                    &request.pool,
+                    &request.session_id,
+                    &request.expected_row_started_at,
+                    &candidate.id,
+                ) {
+                    request.events.updated(&SessionUpdatedEvent {
+                        session_id: request.session_id.clone(),
+                        mission_id: request.mission_id.clone(),
                     });
                 }
                 return;
@@ -337,9 +322,9 @@ fn scan_paths(
     paths: impl IntoIterator<Item = PathBuf>,
     spawn_cwd: &str,
     started_at: DateTime<Utc>,
-    mut done: Option<&mut HashSet<PathBuf>>,
+    done: Option<&mut HashSet<PathBuf>>,
 ) -> CaptureScan {
-    let matches = matching_candidates(paths, spawn_cwd, started_at, done.as_deref_mut());
+    let matches = matching_candidates(paths, spawn_cwd, started_at, done);
     let claimed = claimed_rollouts().lock().unwrap();
     select_unique_unclaimed(matches, |path| claimed.contains(path))
 }
@@ -349,9 +334,9 @@ fn scan_paths_with_marker(
     spawn_cwd: &str,
     started_at: DateTime<Utc>,
     prompt_marker: &str,
-    mut done: Option<&mut HashSet<PathBuf>>,
+    done: Option<&mut HashSet<PathBuf>>,
 ) -> (CaptureScan, ScanSource) {
-    let matches = matching_candidates(paths, spawn_cwd, started_at, done.as_deref_mut());
+    let matches = matching_candidates(paths, spawn_cwd, started_at, done);
     let claimed = claimed_rollouts().lock().unwrap();
     let unclaimed: Vec<MatchCandidate> = matches
         .into_iter()
@@ -461,10 +446,7 @@ fn open_rollout_paths_for_pid(pid: i32, sessions_root: &Path) -> std::io::Result
         .arg(pid.to_string())
         .output()?;
     if !output.status.success() {
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("lsof failed for pid {pid}"),
-        ));
+        return Err(std::io::Error::other(format!("lsof failed for pid {pid}")));
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
     let mut paths: Vec<PathBuf> = stdout

--- a/src-tauri/src/session/codex_capture.rs
+++ b/src-tauri/src/session/codex_capture.rs
@@ -371,14 +371,7 @@ fn scan_paths_with_marker(
         );
     }
 
-    if unclaimed.len() > 1 {
-        return (CaptureScan::None, ScanSource::Marker);
-    }
-
-    (
-        select_unique_unclaimed(unclaimed, |_| false),
-        ScanSource::Fallback,
-    )
+    (CaptureScan::None, ScanSource::Marker)
 }
 
 fn matching_candidates(
@@ -830,6 +823,52 @@ mod tests {
         let got = scan_paths_with_marker(vec![a, b], "/repo", started_at, &marker, None);
 
         assert_eq!(got, (CaptureScan::None, ScanSource::Marker));
+    }
+
+    #[test]
+    fn marker_scan_waits_on_single_candidate_when_fallback_owner_is_ambiguous() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let runner_id = ulid::Ulid::new().to_string();
+        let current_id = ulid::Ulid::new().to_string();
+        let sibling_id = ulid::Ulid::new().to_string();
+        let row_started_at = "2026-06-20T12:00:00+00:00";
+        conn.execute(
+            "INSERT INTO runners
+                (id, handle, display_name, runtime, command, created_at, updated_at)
+             VALUES (?1, 'codex-capture', 'Codex Capture', 'codex', 'codex', ?2, ?2)",
+            params![runner_id, row_started_at],
+        )
+        .unwrap();
+        for session_id in [&current_id, &sibling_id] {
+            conn.execute(
+                "INSERT INTO sessions
+                    (id, mission_id, runner_id, cwd, status, started_at, agent_session_key)
+                 VALUES (?1, NULL, ?2, '/repo', 'running', ?3, NULL)",
+                params![session_id, runner_id, row_started_at],
+            )
+            .unwrap();
+        }
+        drop(conn);
+
+        let dir = tempfile::tempdir().unwrap();
+        let started_at = "2026-06-20T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let marker = prompt_marker(&current_id);
+        let path = write_meta(
+            &dir,
+            "rollout-one.jsonl",
+            "019ee58f-fb81-7d53-ab71-06b471bb4247",
+            "/repo",
+            started_at,
+        );
+
+        let got = scan_paths_with_marker(vec![path], "/repo", started_at, &marker, None);
+
+        assert_eq!(got, (CaptureScan::None, ScanSource::Marker));
+        assert!(
+            !fallback_row_is_unambiguous(&pool, &current_id, row_started_at, "/repo"),
+            "same-cwd sibling means pre-marker fallback would permanently fail closed",
+        );
     }
 
     #[test]

--- a/src-tauri/src/session/codex_capture.rs
+++ b/src-tauri/src/session/codex_capture.rs
@@ -11,10 +11,15 @@
 //
 // After every codex spawn that didn't already have an
 // `agent_session_key` on the row, we kick off a short-lived background
-// thread that polls the rollout dirs for a file matching this spawn's
-// cwd + start time. When found, we write `payload.id` into
-// `sessions.agent_session_key`. The next `session_resume` for this row
-// then drives `codex resume <uuid>` via the runtime adapter.
+// thread that first tries to identify the rollout file opened by the
+// spawned pid. When no pid-owned rollout is available, a Runner-owned
+// prompt marker can identify the rollout that belongs to this exact
+// session row. If neither proof exists, the guarded fallback only
+// accepts a single matching cwd + start-time rollout. Ambiguous
+// matches fail closed and leave `sessions.agent_session_key` NULL.
+// The next `session_resume` for this row then drives
+// `codex resume <uuid>` via the runtime adapter when a key was safely
+// captured.
 //
 // The thread is bounded (30s timeout, 400ms poll interval) and best-
 // effort: if the rollout never appears (codex crashed, $HOME differs,
@@ -30,19 +35,27 @@ use std::time::{Duration, Instant};
 use chrono::{DateTime, Datelike, Local, Utc};
 use rusqlite::params;
 
-use crate::db::DbPool;
+use crate::{
+    db::DbPool,
+    session::manager::{SessionEvents, SessionUpdatedEvent},
+};
 
 const CAPTURE_TIMEOUT_SECS: u64 = 30;
 const POLL_INTERVAL_MS: u64 = 400;
+const PROMPT_MARKER_PREFIX: &str = "runner-codex-session-key-capture:";
+
+pub fn prompt_marker(session_id: &str) -> String {
+    format!("<!-- {PROMPT_MARKER_PREFIX}{session_id} -->")
+}
 
 /// Process-shared set of rollout paths that some watcher has already
 /// captured. Two concurrent watchers polling the same date dir might
 /// both see the same rollout file (sibling chats started seconds
 /// apart in the same cwd); without this set the first-match-wins
-/// loop would write the same `payload.id` into both sessions, fusing
+/// loop could write the same `payload.id` into both sessions, fusing
 /// their codex conversations. Inserting here is the
-/// fastest-thread-wins claim — losing watchers fall through to the
-/// next file.
+/// fastest-thread-wins claim; losing watchers keep polling and fail
+/// closed if no unique unclaimed rollout remains.
 fn claimed_rollouts() -> &'static Mutex<HashSet<PathBuf>> {
     static SET: OnceLock<Mutex<HashSet<PathBuf>>> = OnceLock::new();
     SET.get_or_init(|| Mutex::new(HashSet::new()))
@@ -54,14 +67,41 @@ fn claimed_rollouts() -> &'static Mutex<HashSet<PathBuf>> {
 /// doesn't exist.
 pub fn spawn_capture(
     session_id: String,
+    mission_id: Option<String>,
     spawn_cwd: String,
     started_at: DateTime<Utc>,
+    expected_row_started_at: String,
+    spawn_pid: Option<i32>,
+    prompt_marker: Option<String>,
     pool: Arc<DbPool>,
+    events: Arc<dyn SessionEvents>,
 ) {
-    std::thread::spawn(move || run(session_id, spawn_cwd, started_at, pool));
+    std::thread::spawn(move || {
+        run(
+            session_id,
+            mission_id,
+            spawn_cwd,
+            started_at,
+            expected_row_started_at,
+            spawn_pid,
+            prompt_marker,
+            pool,
+            events,
+        )
+    });
 }
 
-fn run(session_id: String, spawn_cwd: String, started_at: DateTime<Utc>, pool: Arc<DbPool>) {
+fn run(
+    session_id: String,
+    mission_id: Option<String>,
+    spawn_cwd: String,
+    started_at: DateTime<Utc>,
+    expected_row_started_at: String,
+    spawn_pid: Option<i32>,
+    prompt_marker: Option<String>,
+    pool: Arc<DbPool>,
+    events: Arc<dyn SessionEvents>,
+) {
     let Some(home) = std::env::var_os("HOME") else {
         return;
     };
@@ -85,83 +125,60 @@ fn run(session_id: String, spawn_cwd: String, started_at: DateTime<Utc>, pool: A
     let mut done: HashSet<PathBuf> = HashSet::new();
 
     loop {
-        for date in &candidates {
-            let dir = sessions_root
-                .join(format!("{:04}", date.year()))
-                .join(format!("{:02}", date.month()))
-                .join(format!("{:02}", date.day()));
-            let entries = match std::fs::read_dir(&dir) {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
-            let mut matches: Vec<(DateTime<Utc>, PathBuf, String)> = Vec::new();
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if done.contains(&path) {
-                    continue;
+        let (scan, source) = if let Some(pid) = spawn_pid {
+            scan_pid_result_or_fallback(
+                open_rollout_paths_for_pid(pid, &sessions_root),
+                &sessions_root,
+                &candidates,
+                &spawn_cwd,
+                started_at,
+                prompt_marker.as_deref(),
+                &mut done,
+            )
+        } else {
+            scan_fallback_with_marker(
+                &sessions_root,
+                &candidates,
+                &spawn_cwd,
+                started_at,
+                prompt_marker.as_deref(),
+                &mut done,
+            )
+        };
+
+        match scan {
+            CaptureScan::Unique(candidate) => {
+                if source == ScanSource::Fallback
+                    && !fallback_row_is_unambiguous(
+                        &pool,
+                        &session_id,
+                        &expected_row_started_at,
+                        &spawn_cwd,
+                    )
+                {
+                    return;
                 }
-                if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-                    done.insert(path);
-                    continue;
-                }
-                let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
-                    done.insert(path);
-                    continue;
-                };
-                if !name.starts_with("rollout-") {
-                    done.insert(path);
-                    continue;
-                }
-                match parse_session_meta(&path, &spawn_cwd, started_at) {
-                    ParseVerdict::Match(meta) => {
-                        matches.push((meta.timestamp, path, meta.id));
-                    }
-                    ParseVerdict::NotOurs => {
-                        // Definitively not this spawn's rollout
-                        // (cwd/timestamp mismatch, or a non-meta
-                        // envelope). Skip it on every later poll.
-                        done.insert(path);
-                    }
-                    ParseVerdict::NotReady => {
-                        // File exists but its first line isn't yet
-                        // parseable (codex created the file but
-                        // hasn't flushed the session_meta line).
-                        // Leave it out of `done` so the next poll
-                        // re-reads it.
-                    }
-                }
-            }
-            loop {
-                let claimed = claimed_rollouts().lock().unwrap();
-                let next =
-                    select_earliest_unclaimed(matches.clone(), |path| claimed.contains(path));
-                drop(claimed);
-                let Some((path, id)) = next else {
-                    break;
-                };
                 // Race guard: another watcher may have already
                 // captured this rollout (sibling chat in the same cwd).
-                // The first to insert into the process-shared set wins;
-                // losers fall through to the next earliest candidate.
-                let claimed = claimed_rollouts().lock().unwrap().insert(path.clone());
+                // The first to insert into the process-shared set wins.
+                let claimed = claimed_rollouts()
+                    .lock()
+                    .unwrap()
+                    .insert(candidate.path.clone());
                 if !claimed {
-                    done.insert(path);
+                    done.insert(candidate.path);
                     continue;
                 }
-                if let Ok(conn) = pool.get() {
-                    // Guard with `agent_session_key IS NULL` so we
-                    // don't clobber a key that a concurrent path
-                    // (resume that already had a key) wrote first.
-                    let _ = conn.execute(
-                        "UPDATE sessions
-                            SET agent_session_key = ?2
-                          WHERE id = ?1
-                            AND agent_session_key IS NULL",
-                        params![session_id, id],
-                    );
+                if persist_capture(&pool, &session_id, &expected_row_started_at, &candidate.id) {
+                    events.updated(&SessionUpdatedEvent {
+                        session_id: session_id.clone(),
+                        mission_id: mission_id.clone(),
+                    });
                 }
                 return;
             }
+            CaptureScan::Ambiguous => return,
+            CaptureScan::None => {}
         }
         if Instant::now() > deadline {
             return;
@@ -170,21 +187,311 @@ fn run(session_id: String, spawn_cwd: String, started_at: DateTime<Utc>, pool: A
     }
 }
 
-type MatchCandidate = (DateTime<Utc>, PathBuf, String);
+fn persist_capture(
+    pool: &DbPool,
+    session_id: &str,
+    expected_row_started_at: &str,
+    agent_session_key: &str,
+) -> bool {
+    let Ok(conn) = pool.get() else { return false };
+    // Guard with `agent_session_key IS NULL` so we don't clobber a key
+    // that a concurrent path (resume that already had a key) wrote
+    // first. Guard with `started_at` so a stale watcher from a prior
+    // incarnation of this row cannot write into a later stop/resume.
+    conn.execute(
+        "UPDATE sessions
+            SET agent_session_key = ?2
+          WHERE id = ?1
+            AND agent_session_key IS NULL
+            AND started_at = ?3",
+        params![session_id, agent_session_key, expected_row_started_at],
+    )
+    .map(|updated| updated > 0)
+    .unwrap_or(false)
+}
 
-/// Earliest unclaimed rollout wins. This best-effort pairing assumes
-/// Codex writes rollout files in spawn order; because Codex does not
-/// accept a caller-provided id, a later sibling that flushes first can
-/// still be mis-claimed.
-fn select_earliest_unclaimed(
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct MatchCandidate {
+    timestamp: DateTime<Utc>,
+    path: PathBuf,
+    id: String,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum CaptureScan {
+    Unique(MatchCandidate),
+    Ambiguous,
+    None,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ScanSource {
+    Pid,
+    Marker,
+    Fallback,
+}
+
+fn scan_pid_result_or_fallback(
+    pid_paths: std::io::Result<Vec<PathBuf>>,
+    sessions_root: &Path,
+    candidates: &[DateTime<Local>],
+    spawn_cwd: &str,
+    started_at: DateTime<Utc>,
+    prompt_marker: Option<&str>,
+    done: &mut HashSet<PathBuf>,
+) -> (CaptureScan, ScanSource) {
+    match pid_paths {
+        Ok(paths) if !paths.is_empty() => (
+            scan_paths(paths, spawn_cwd, started_at, Some(done)),
+            ScanSource::Pid,
+        ),
+        Ok(_) | Err(_) => scan_fallback_with_marker(
+            sessions_root,
+            candidates,
+            spawn_cwd,
+            started_at,
+            prompt_marker,
+            done,
+        ),
+    }
+}
+
+fn scan_fallback_with_marker(
+    sessions_root: &Path,
+    candidates: &[DateTime<Local>],
+    spawn_cwd: &str,
+    started_at: DateTime<Utc>,
+    prompt_marker: Option<&str>,
+    done: &mut HashSet<PathBuf>,
+) -> (CaptureScan, ScanSource) {
+    let paths = rollout_paths_for_dates(sessions_root, candidates);
+    let Some(prompt_marker) = prompt_marker else {
+        return (
+            scan_paths(paths, spawn_cwd, started_at, Some(done)),
+            ScanSource::Fallback,
+        );
+    };
+    scan_paths_with_marker(paths, spawn_cwd, started_at, prompt_marker, Some(done))
+}
+
+fn fallback_row_is_unambiguous(
+    pool: &DbPool,
+    session_id: &str,
+    expected_row_started_at: &str,
+    spawn_cwd: &str,
+) -> bool {
+    let Ok(conn) = pool.get() else { return false };
+    let current_cwd = conn.query_row(
+        "SELECT s.cwd
+           FROM sessions s
+           LEFT JOIN runners r ON r.id = s.runner_id
+          WHERE s.id = ?1
+            AND s.started_at = ?2
+            AND s.status = 'running'
+            AND s.agent_session_key IS NULL
+            AND COALESCE(s.agent_runtime, r.runtime) = 'codex'",
+        params![session_id, expected_row_started_at],
+        |r| r.get::<_, Option<String>>(0),
+    );
+    match current_cwd {
+        Ok(Some(cwd)) if cwd != spawn_cwd => return false,
+        Ok(_) => {}
+        Err(_) => return false,
+    }
+
+    let sibling_count = conn.query_row(
+        "SELECT COUNT(*)
+           FROM sessions s
+           LEFT JOIN runners r ON r.id = s.runner_id
+          WHERE s.status = 'running'
+            AND s.agent_session_key IS NULL
+            AND COALESCE(s.agent_runtime, r.runtime) = 'codex'
+            AND s.id <> ?1
+            AND (
+                s.cwd = ?2
+                OR s.cwd IS NULL
+            )",
+        params![session_id, spawn_cwd],
+        |r| r.get::<_, i64>(0),
+    );
+    sibling_count.map(|count| count == 0).unwrap_or(false)
+}
+
+fn rollout_paths_for_dates(sessions_root: &Path, candidates: &[DateTime<Local>]) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    for date in candidates {
+        let dir = sessions_root
+            .join(format!("{:04}", date.year()))
+            .join(format!("{:02}", date.month()))
+            .join(format!("{:02}", date.day()));
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        paths.extend(entries.flatten().map(|entry| entry.path()));
+    }
+    paths
+}
+
+fn scan_paths(
+    paths: impl IntoIterator<Item = PathBuf>,
+    spawn_cwd: &str,
+    started_at: DateTime<Utc>,
+    mut done: Option<&mut HashSet<PathBuf>>,
+) -> CaptureScan {
+    let matches = matching_candidates(paths, spawn_cwd, started_at, done.as_deref_mut());
+    let claimed = claimed_rollouts().lock().unwrap();
+    select_unique_unclaimed(matches, |path| claimed.contains(path))
+}
+
+fn scan_paths_with_marker(
+    paths: impl IntoIterator<Item = PathBuf>,
+    spawn_cwd: &str,
+    started_at: DateTime<Utc>,
+    prompt_marker: &str,
+    mut done: Option<&mut HashSet<PathBuf>>,
+) -> (CaptureScan, ScanSource) {
+    let matches = matching_candidates(paths, spawn_cwd, started_at, done.as_deref_mut());
+    let claimed = claimed_rollouts().lock().unwrap();
+    let unclaimed: Vec<MatchCandidate> = matches
+        .into_iter()
+        .filter(|candidate| !claimed.contains(&candidate.path))
+        .collect();
+    drop(claimed);
+
+    let marker_matches: Vec<MatchCandidate> = unclaimed
+        .iter()
+        .filter(|candidate| rollout_contains_marker(&candidate.path, prompt_marker))
+        .cloned()
+        .collect();
+    if !marker_matches.is_empty() {
+        return (
+            select_unique_unclaimed(marker_matches, |_| false),
+            ScanSource::Marker,
+        );
+    }
+
+    if unclaimed.len() > 1 {
+        return (CaptureScan::None, ScanSource::Marker);
+    }
+
+    (
+        select_unique_unclaimed(unclaimed, |_| false),
+        ScanSource::Fallback,
+    )
+}
+
+fn matching_candidates(
+    paths: impl IntoIterator<Item = PathBuf>,
+    spawn_cwd: &str,
+    started_at: DateTime<Utc>,
+    mut done: Option<&mut HashSet<PathBuf>>,
+) -> Vec<MatchCandidate> {
+    let mut matches = Vec::new();
+    for path in paths {
+        if done.as_ref().is_some_and(|done| done.contains(&path)) {
+            continue;
+        }
+        if !is_rollout_file(&path) {
+            if let Some(done) = done.as_deref_mut() {
+                done.insert(path);
+            }
+            continue;
+        }
+        match parse_session_meta(&path, spawn_cwd, started_at) {
+            ParseVerdict::Match(meta) => {
+                matches.push(MatchCandidate {
+                    timestamp: meta.timestamp,
+                    path,
+                    id: meta.id,
+                });
+            }
+            ParseVerdict::NotOurs => {
+                // Definitively not this spawn's rollout
+                // (cwd/timestamp mismatch, invalid id, or a non-meta
+                // envelope). Skip it on every later poll.
+                if let Some(done) = done.as_deref_mut() {
+                    done.insert(path);
+                }
+            }
+            ParseVerdict::NotReady => {
+                // File exists but its first line isn't yet parseable
+                // (codex created the file but hasn't flushed the
+                // session_meta line). Leave it out of `done` so the
+                // next poll re-reads it.
+            }
+        }
+    }
+    matches
+}
+
+fn rollout_contains_marker(path: &Path, marker: &str) -> bool {
+    let Ok(file) = std::fs::File::open(path) else {
+        return false;
+    };
+    let reader = BufReader::new(file);
+    reader
+        .lines()
+        .map_while(Result::ok)
+        .any(|line| line.contains(marker))
+}
+
+fn is_rollout_file(path: &Path) -> bool {
+    path.extension().and_then(|e| e.to_str()) == Some("jsonl")
+        && path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|name| name.starts_with("rollout-"))
+}
+
+fn select_unique_unclaimed(
     mut matches: Vec<MatchCandidate>,
     mut is_claimed: impl FnMut(&PathBuf) -> bool,
-) -> Option<(PathBuf, String)> {
-    matches.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
-    matches
-        .into_iter()
-        .find(|(_, path, _)| !is_claimed(path))
-        .map(|(_, path, id)| (path, id))
+) -> CaptureScan {
+    matches.retain(|candidate| !is_claimed(&candidate.path));
+    matches.sort_by(|a, b| {
+        a.timestamp
+            .cmp(&b.timestamp)
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    match matches.len() {
+        0 => CaptureScan::None,
+        1 => CaptureScan::Unique(matches.remove(0)),
+        _ => CaptureScan::Ambiguous,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn open_rollout_paths_for_pid(pid: i32, sessions_root: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let output = std::process::Command::new("lsof")
+        .args(["-Fn", "-p"])
+        .arg(pid.to_string())
+        .output()?;
+    if !output.status.success() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("lsof failed for pid {pid}"),
+        ));
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut paths: Vec<PathBuf> = stdout
+        .lines()
+        .filter_map(|line| line.strip_prefix('n'))
+        .map(PathBuf::from)
+        .filter(|path| path.starts_with(sessions_root) && is_rollout_file(path))
+        .collect();
+    paths.sort();
+    paths.dedup();
+    Ok(paths)
+}
+
+#[cfg(not(target_os = "macos"))]
+fn open_rollout_paths_for_pid(pid: i32, sessions_root: &Path) -> std::io::Result<Vec<PathBuf>> {
+    let _ = (pid, sessions_root);
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "pid-assisted codex rollout capture is only implemented on macOS",
+    ))
 }
 
 struct MatchedSessionMeta {
@@ -257,17 +564,18 @@ fn parse_session_meta(path: &Path, want_cwd: &str, started_after: DateTime<Utc>)
         return ParseVerdict::NotOurs;
     }
     match payload.get("id").and_then(|v| v.as_str()) {
-        Some(id) => ParseVerdict::Match(MatchedSessionMeta {
+        Some(id) if uuid::Uuid::parse_str(id).is_ok() => ParseVerdict::Match(MatchedSessionMeta {
             id: id.to_string(),
             timestamp: ts,
         }),
-        None => ParseVerdict::NotOurs,
+        _ => ParseVerdict::NotOurs,
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db;
     use std::io::Write;
 
     fn write_meta(
@@ -277,7 +585,17 @@ mod tests {
         cwd: &str,
         timestamp: DateTime<Utc>,
     ) -> PathBuf {
-        let path = dir.path().join(name);
+        write_meta_at_dir(dir.path(), name, id, cwd, timestamp)
+    }
+
+    fn write_meta_at_dir(
+        dir: &Path,
+        name: &str,
+        id: &str,
+        cwd: &str,
+        timestamp: DateTime<Utc>,
+    ) -> PathBuf {
+        let path = dir.join(name);
         let mut file = std::fs::File::create(&path).unwrap();
         writeln!(
             file,
@@ -293,6 +611,22 @@ mod tests {
         )
         .unwrap();
         path
+    }
+
+    fn append_user_message(path: &Path, message: &str) {
+        let mut file = std::fs::OpenOptions::new().append(true).open(path).unwrap();
+        writeln!(
+            file,
+            "{}",
+            serde_json::json!({
+                "type": "event_msg",
+                "payload": {
+                    "type": "user_message",
+                    "message": message,
+                }
+            })
+        )
+        .unwrap();
     }
 
     #[test]
@@ -331,19 +665,378 @@ mod tests {
     }
 
     #[test]
-    fn select_earliest_unclaimed_picks_earliest_then_skips_claimed() {
-        let t0 = "2026-06-20T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
-        let early = (t0, PathBuf::from("rollout-early.jsonl"), "id-a".to_string());
-        let late = (
-            t0 + chrono::Duration::seconds(2),
-            PathBuf::from("rollout-late.jsonl"),
-            "id-b".to_string(),
+    fn parse_session_meta_rejects_non_uuid_session_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let started_at = "2026-06-20T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let path = write_meta(
+            &dir,
+            "rollout-invalid.jsonl",
+            "not-a-uuid",
+            "/repo",
+            started_at,
         );
 
-        let got = select_earliest_unclaimed(vec![late.clone(), early.clone()], |_| false);
-        assert_eq!(got, Some((early.1.clone(), "id-a".to_string())));
+        assert!(matches!(
+            parse_session_meta(&path, "/repo", started_at),
+            ParseVerdict::NotOurs
+        ));
+    }
 
-        let got = select_earliest_unclaimed(vec![late.clone(), early.clone()], |p| p == &early.1);
-        assert_eq!(got, Some((late.1.clone(), "id-b".to_string())));
+    fn candidate(timestamp: DateTime<Utc>, path: &str, id: &str) -> MatchCandidate {
+        MatchCandidate {
+            timestamp,
+            path: PathBuf::from(path),
+            id: id.to_string(),
+        }
+    }
+
+    #[test]
+    fn select_unique_unclaimed_accepts_single_match() {
+        let t0 = "2026-06-20T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let only = candidate(t0, "rollout-only.jsonl", "id-a");
+
+        let got = select_unique_unclaimed(vec![only.clone()], |_| false);
+        assert_eq!(got, CaptureScan::Unique(only));
+    }
+
+    #[test]
+    fn select_unique_unclaimed_fails_closed_when_multiple_matches_remain() {
+        let t0 = "2026-06-20T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let early = candidate(t0, "rollout-early.jsonl", "id-a");
+        let late = candidate(
+            t0 + chrono::Duration::seconds(2),
+            "rollout-late.jsonl",
+            "id-b",
+        );
+
+        let got = select_unique_unclaimed(vec![late, early], |_| false);
+        assert_eq!(got, CaptureScan::Ambiguous);
+    }
+
+    #[test]
+    fn select_unique_unclaimed_skips_claimed_paths() {
+        let t0 = "2026-06-20T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let claimed = candidate(t0, "rollout-claimed.jsonl", "id-a");
+        let unclaimed = candidate(
+            t0 + chrono::Duration::seconds(2),
+            "rollout-unclaimed.jsonl",
+            "id-b",
+        );
+
+        let got = select_unique_unclaimed(vec![claimed.clone(), unclaimed.clone()], |path| {
+            path == &claimed.path
+        });
+        assert_eq!(got, CaptureScan::Unique(unclaimed.clone()));
+
+        let got = select_unique_unclaimed(vec![claimed.clone()], |path| path == &claimed.path);
+        assert_eq!(got, CaptureScan::None);
+    }
+
+    #[test]
+    fn scan_paths_accepts_single_matching_rollout() {
+        let dir = tempfile::tempdir().unwrap();
+        let started_at = "2026-06-20T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let id = "019ee58f-fb81-7d53-ab71-06b471bb4247";
+        let path = write_meta(&dir, "rollout-one.jsonl", id, "/repo", started_at);
+
+        match scan_paths(vec![path.clone()], "/repo", started_at, None) {
+            CaptureScan::Unique(candidate) => {
+                assert_eq!(candidate.path, path);
+                assert_eq!(candidate.id, id);
+            }
+            other => panic!("expected unique capture, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scan_paths_fails_closed_for_multiple_matching_rollouts() {
+        let dir = tempfile::tempdir().unwrap();
+        let started_at = "2026-06-20T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let a = write_meta(
+            &dir,
+            "rollout-a.jsonl",
+            "019ee58f-fb81-7d53-ab71-06b471bb4247",
+            "/repo",
+            started_at,
+        );
+        let b = write_meta(
+            &dir,
+            "rollout-b.jsonl",
+            "019ee58f-fb81-7d53-ab71-06b471bb4248",
+            "/repo",
+            started_at + chrono::Duration::milliseconds(1),
+        );
+
+        let got = scan_paths(vec![a, b], "/repo", started_at, None);
+        assert_eq!(got, CaptureScan::Ambiguous);
+    }
+
+    #[test]
+    fn scan_paths_with_marker_disambiguates_matching_rollouts() {
+        let dir = tempfile::tempdir().unwrap();
+        let started_at = "2026-06-20T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let marker = prompt_marker("01KVWZN1KWNGC54E4PDRKPVJSG");
+        let a = write_meta(
+            &dir,
+            "rollout-a.jsonl",
+            "019ee58f-fb81-7d53-ab71-06b471bb4247",
+            "/repo",
+            started_at,
+        );
+        let b = write_meta(
+            &dir,
+            "rollout-b.jsonl",
+            "019ee58f-fb81-7d53-ab71-06b471bb4248",
+            "/repo",
+            started_at + chrono::Duration::milliseconds(1),
+        );
+        append_user_message(&b, &format!("first turn\n\n{marker}"));
+
+        let got = scan_paths_with_marker(vec![a, b.clone()], "/repo", started_at, &marker, None);
+
+        assert_eq!(
+            got,
+            (
+                CaptureScan::Unique(MatchCandidate {
+                    timestamp: started_at + chrono::Duration::milliseconds(1),
+                    path: b,
+                    id: "019ee58f-fb81-7d53-ab71-06b471bb4248".to_string(),
+                }),
+                ScanSource::Marker,
+            )
+        );
+    }
+
+    #[test]
+    fn scan_paths_with_marker_waits_when_siblings_lack_marker() {
+        let dir = tempfile::tempdir().unwrap();
+        let started_at = "2026-06-20T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let marker = prompt_marker("01KVWZN1KWNGC54E4PDRKPVJSG");
+        let a = write_meta(
+            &dir,
+            "rollout-a.jsonl",
+            "019ee58f-fb81-7d53-ab71-06b471bb4247",
+            "/repo",
+            started_at,
+        );
+        let b = write_meta(
+            &dir,
+            "rollout-b.jsonl",
+            "019ee58f-fb81-7d53-ab71-06b471bb4248",
+            "/repo",
+            started_at + chrono::Duration::milliseconds(1),
+        );
+
+        let got = scan_paths_with_marker(vec![a, b], "/repo", started_at, &marker, None);
+
+        assert_eq!(got, (CaptureScan::None, ScanSource::Marker));
+    }
+
+    #[test]
+    fn empty_pid_result_uses_guarded_fallback_scan() {
+        let root = tempfile::tempdir().unwrap();
+        let started_at = "2026-06-20T12:00:00Z".parse::<DateTime<Utc>>().unwrap();
+        let local_started = started_at.with_timezone(&Local);
+        let date_dir = root.path().join("2026").join("06").join("20");
+        std::fs::create_dir_all(&date_dir).unwrap();
+        let id = "019ee58f-fb81-7d53-ab71-06b471bb4247";
+        let path = write_meta_at_dir(&date_dir, "rollout-one.jsonl", id, "/repo", started_at);
+        let mut done = HashSet::new();
+
+        let got = scan_pid_result_or_fallback(
+            Ok(Vec::new()),
+            root.path(),
+            &[local_started],
+            "/repo",
+            started_at,
+            None,
+            &mut done,
+        );
+
+        assert_eq!(
+            got,
+            (
+                CaptureScan::Unique(MatchCandidate {
+                    timestamp: started_at,
+                    path,
+                    id: id.to_string(),
+                }),
+                ScanSource::Fallback,
+            )
+        );
+    }
+
+    #[test]
+    fn persist_capture_requires_matching_row_started_at() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let runner_id = ulid::Ulid::new().to_string();
+        let session_id = ulid::Ulid::new().to_string();
+        let started_a = "2026-06-20T12:00:00+00:00";
+        let started_b = "2026-06-20T12:01:00+00:00";
+        let key_a = "019ee58f-fb81-7d53-ab71-06b471bb4247";
+        let key_b = "019ee58f-fb81-7d53-ab71-06b471bb4248";
+        conn.execute(
+            "INSERT INTO runners
+                (id, handle, display_name, runtime, command, created_at, updated_at)
+             VALUES (?1, 'codex-capture', 'Codex Capture', 'codex', 'codex', ?2, ?2)",
+            params![runner_id, started_a],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, status, started_at, agent_session_key)
+             VALUES (?1, NULL, ?2, 'running', ?3, NULL)",
+            params![session_id, runner_id, started_a],
+        )
+        .unwrap();
+        drop(conn);
+
+        assert!(persist_capture(&pool, &session_id, started_a, key_a));
+        let stored: Option<String> = {
+            let conn = pool.get().unwrap();
+            conn.query_row(
+                "SELECT agent_session_key FROM sessions WHERE id = ?1",
+                params![session_id],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(stored.as_deref(), Some(key_a));
+
+        {
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "UPDATE sessions
+                    SET started_at = ?2,
+                        agent_session_key = NULL
+                  WHERE id = ?1",
+                params![session_id, started_b],
+            )
+            .unwrap();
+        }
+
+        assert!(
+            !persist_capture(&pool, &session_id, started_a, key_b),
+            "stale watcher from started_at A must not write into row incarnation B",
+        );
+        let stored: Option<String> = {
+            let conn = pool.get().unwrap();
+            conn.query_row(
+                "SELECT agent_session_key FROM sessions WHERE id = ?1",
+                params![session_id],
+                |r| r.get(0),
+            )
+            .unwrap()
+        };
+        assert_eq!(stored, None);
+    }
+
+    #[test]
+    fn fallback_row_is_unambiguous_requires_current_row_as_only_possible_owner_for_cwd() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let runner_id = ulid::Ulid::new().to_string();
+        let current_id = ulid::Ulid::new().to_string();
+        let sibling_id = ulid::Ulid::new().to_string();
+        let started = "2026-06-20T12:00:00+00:00";
+        conn.execute(
+            "INSERT INTO runners
+                (id, handle, display_name, runtime, command, created_at, updated_at)
+             VALUES (?1, 'codex-fallback', 'Codex Fallback', 'codex', 'codex', ?2, ?2)",
+            params![runner_id, started],
+        )
+        .unwrap();
+        for id in [&current_id, &sibling_id] {
+            conn.execute(
+                "INSERT INTO sessions
+                    (id, mission_id, runner_id, cwd, status, started_at, agent_session_key)
+                 VALUES (?1, NULL, ?2, '/repo', 'running', ?3, NULL)",
+                params![id, runner_id, started],
+            )
+            .unwrap();
+        }
+        drop(conn);
+
+        assert!(
+            !fallback_row_is_unambiguous(&pool, &current_id, started, "/repo"),
+            "fallback must not persist when a sibling live Codex row could own the rollout",
+        );
+
+        {
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "UPDATE sessions
+                    SET agent_session_key = ?2
+                  WHERE id = ?1",
+                params![sibling_id, "019ee58f-fb81-7d53-ab71-06b471bb4248"],
+            )
+            .unwrap();
+        }
+
+        assert!(
+            fallback_row_is_unambiguous(&pool, &current_id, started, "/repo"),
+            "fallback may persist only when the current row is the sole live unkeyed Codex row",
+        );
+
+        {
+            let conn = pool.get().unwrap();
+            conn.execute(
+                "UPDATE sessions
+                    SET status = 'stopped'
+                  WHERE id = ?1",
+                params![current_id],
+            )
+            .unwrap();
+            conn.execute(
+                "UPDATE sessions
+                    SET agent_session_key = NULL
+                  WHERE id = ?1",
+                params![sibling_id],
+            )
+            .unwrap();
+        }
+
+        assert!(
+            !fallback_row_is_unambiguous(&pool, &current_id, started, "/repo"),
+            "fallback must not persist for a stopped/stale current row even when a sibling is the only live row",
+        );
+    }
+
+    #[test]
+    fn fallback_row_is_unambiguous_treats_null_inherited_cwd_as_possible_same_cwd() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let runner_id = ulid::Ulid::new().to_string();
+        let current_id = ulid::Ulid::new().to_string();
+        let sibling_id = ulid::Ulid::new().to_string();
+        let started = "2026-06-20T12:00:00+00:00";
+        conn.execute(
+            "INSERT INTO runners
+                (id, handle, display_name, runtime, command, created_at, updated_at)
+             VALUES (?1, 'codex-inherited', 'Codex Inherited', 'codex', 'codex', ?2, ?2)",
+            params![runner_id, started],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, cwd, status, started_at, agent_session_key)
+             VALUES (?1, NULL, ?2, NULL, 'running', ?3, NULL)",
+            params![current_id, runner_id, started],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, cwd, status, started_at, agent_session_key)
+             VALUES (?1, NULL, ?2, '/repo', 'running', ?3, NULL)",
+            params![sibling_id, runner_id, started],
+        )
+        .unwrap();
+        drop(conn);
+
+        assert!(
+            !fallback_row_is_unambiguous(&pool, &current_id, started, "/repo"),
+            "fallback must fail closed when an inherited-cwd row and explicit-cwd row could share the rollout cwd",
+        );
     }
 }

--- a/src-tauri/src/session/manager/mod.rs
+++ b/src-tauri/src/session/manager/mod.rs
@@ -664,15 +664,17 @@ impl SessionManager {
             return;
         }
         crate::session::codex_capture::spawn_capture(
-            session_id.to_string(),
-            ctx.mission_id.clone(),
-            ctx.spawn_cwd.clone(),
-            ctx.started_at,
-            ctx.row_started_at.clone(),
-            ctx.spawn_pid,
-            ctx.prompt_marker.clone(),
-            Arc::clone(&ctx.pool),
-            Arc::clone(&ctx.events),
+            crate::session::codex_capture::CaptureRequest {
+                session_id: session_id.to_string(),
+                mission_id: ctx.mission_id.clone(),
+                spawn_cwd: ctx.spawn_cwd.clone(),
+                started_at: ctx.started_at,
+                expected_row_started_at: ctx.row_started_at.clone(),
+                spawn_pid: ctx.spawn_pid,
+                prompt_marker: ctx.prompt_marker.clone(),
+                pool: Arc::clone(&ctx.pool),
+                events: Arc::clone(&ctx.events),
+            },
         );
     }
 

--- a/src-tauri/src/session/manager/mod.rs
+++ b/src-tauri/src/session/manager/mod.rs
@@ -25,7 +25,7 @@ use std::thread;
 use std::time::{Duration, Instant};
 
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use rusqlite::params;
 use serde::Serialize;
 
@@ -231,6 +231,10 @@ fn drop_streak_is_loggable(streak: u64) -> bool {
 pub trait SessionEvents: Send + Sync + 'static {
     fn output(&self, ev: &OutputEvent);
     fn exit(&self, ev: &ExitEvent);
+    /// Persisted session metadata changed without a lifecycle event
+    /// (e.g. async agent_session_key capture). Default no-op so test
+    /// fakes don't have to opt in.
+    fn updated(&self, _ev: &SessionUpdatedEvent) {}
     /// Live direct-chat activity projection. Mission sessions keep using
     /// `runner_status` rows in the mission log instead.
     fn status(&self, _ev: &SessionActivityEvent) {}
@@ -285,7 +289,7 @@ pub struct SessionActivityEvent {
 }
 
 /// Emitter for the real Tauri app — emits `session/output`, `session/exit`,
-/// and `runner/activity`.
+/// `session/updated`, and `runner/activity`.
 pub struct TauriSessionEvents(pub tauri::AppHandle);
 
 impl SessionEvents for TauriSessionEvents {
@@ -296,6 +300,10 @@ impl SessionEvents for TauriSessionEvents {
     fn exit(&self, ev: &ExitEvent) {
         use tauri::Emitter;
         let _ = self.0.emit("session/exit", ev);
+    }
+    fn updated(&self, ev: &SessionUpdatedEvent) {
+        use tauri::Emitter;
+        let _ = self.0.emit("session/updated", ev);
     }
     fn status(&self, ev: &SessionActivityEvent) {
         use tauri::Emitter;
@@ -335,6 +343,12 @@ pub struct ExitEvent {
     pub mission_id: Option<String>,
     pub exit_code: Option<i32>,
     pub success: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionUpdatedEvent {
+    pub session_id: String,
+    pub mission_id: Option<String>,
 }
 
 /// Non-fatal advisory the UI can render as a banner. Emitted on
@@ -394,6 +408,10 @@ struct SessionHandle {
     /// `runtime.resize` / `runtime.stop` for every operation on the
     /// live session.
     runtime_session: RuntimeSession,
+    /// Codex cannot be given a caller-owned session id at launch.
+    /// When this is present, user activity can retry native id
+    /// capture after Codex has actually created its rollout file.
+    codex_capture: Option<CodexCaptureContext>,
     /// Forwarder thread that drains the runtime's `OutputStream`
     /// into `session/output` events. `kill` joins on this so callers
     /// (mission_stop) get the same "no live sessions after we
@@ -407,6 +425,18 @@ struct SessionHandle {
     /// cleanup stalled — observed live as a stuck "Archiving…" pill
     /// on the chat page.
     stop: std::sync::Arc<std::sync::atomic::AtomicBool>,
+}
+
+#[derive(Clone)]
+struct CodexCaptureContext {
+    mission_id: Option<String>,
+    spawn_cwd: String,
+    started_at: DateTime<Utc>,
+    row_started_at: String,
+    spawn_pid: Option<i32>,
+    prompt_marker: Option<String>,
+    pool: Arc<DbPool>,
+    events: Arc<dyn SessionEvents>,
 }
 
 #[derive(Default)]
@@ -528,6 +558,8 @@ pub struct PendingMissionSpawn {
     plan: router::runtime::ResumePlan,
     first_turn_delivered_via_argv: bool,
     resolved_cwd: Option<String>,
+    row_started_at: String,
+    codex_prompt_marker: Option<String>,
     app_data_dir: PathBuf,
     pool: Arc<DbPool>,
 }
@@ -604,6 +636,44 @@ impl SessionManager {
                 handle.forwarder = Some(forwarder);
             }
         }
+    }
+
+    fn codex_capture_context(&self, session_id: &str) -> Option<CodexCaptureContext> {
+        let state = self.session_state(session_id)?;
+        let state = state.lock().unwrap();
+        state
+            .handle
+            .as_ref()
+            .and_then(|handle| handle.codex_capture.clone())
+    }
+
+    fn spawn_codex_capture_if_unkeyed(&self, session_id: &str, ctx: &CodexCaptureContext) {
+        let Ok(conn) = ctx.pool.get() else { return };
+        let should_capture = conn
+            .query_row(
+                "SELECT agent_session_key IS NULL
+                   FROM sessions
+                  WHERE id = ?1
+                    AND started_at = ?2",
+                params![session_id, ctx.row_started_at],
+                |r| r.get::<_, bool>(0),
+            )
+            .unwrap_or(false);
+        drop(conn);
+        if !should_capture {
+            return;
+        }
+        crate::session::codex_capture::spawn_capture(
+            session_id.to_string(),
+            ctx.mission_id.clone(),
+            ctx.spawn_cwd.clone(),
+            ctx.started_at,
+            ctx.row_started_at.clone(),
+            ctx.spawn_pid,
+            ctx.prompt_marker.clone(),
+            Arc::clone(&ctx.pool),
+            Arc::clone(&ctx.events),
+        );
     }
 
     fn live_runtime_session(&self, session_id: &str) -> Result<RuntimeSession> {

--- a/src-tauri/src/session/manager/output.rs
+++ b/src-tauri/src/session/manager/output.rs
@@ -193,6 +193,11 @@ impl SessionManager {
             self.runtime
                 .send_key(&rt_session, "Enter")
                 .map_err(Into::into)
+                .map(|_| {
+                    if let Some(ctx) = self.codex_capture_context(session_id) {
+                        self.spawn_codex_capture_if_unkeyed(session_id, &ctx);
+                    }
+                })
         } else {
             self.runtime
                 .send_bytes(&rt_session, bytes)
@@ -213,9 +218,16 @@ impl SessionManager {
         let rt_session = self.live_runtime_session(session_id)?;
         self.runtime.send_bytes(&rt_session, payload)?;
         std::thread::sleep(std::time::Duration::from_millis(120));
-        self.runtime
+        let result = self
+            .runtime
             .send_key(&rt_session, "Enter")
-            .map_err(Into::into)
+            .map_err(Into::into);
+        if result.is_ok() {
+            if let Some(ctx) = self.codex_capture_context(session_id) {
+                self.spawn_codex_capture_if_unkeyed(session_id, &ctx);
+            }
+        }
+        result
     }
 
     /// Paste a first-turn body and submit it once we've verified the

--- a/src-tauri/src/session/manager/spawn.rs
+++ b/src-tauri/src/session/manager/spawn.rs
@@ -139,6 +139,25 @@ impl SessionManager {
         delivered_via_argv
     }
 
+    fn codex_capture_prompt_marker(
+        runtime: &str,
+        session_id: &str,
+        first_turn: Option<String>,
+    ) -> (Option<String>, Option<String>) {
+        if runtime != "codex" {
+            return (first_turn, None);
+        }
+        let Some(first_turn) = first_turn else {
+            return (None, None);
+        };
+        let marker = crate::session::codex_capture::prompt_marker(session_id);
+        let marked_first_turn = format!("{first_turn}\n\n{marker}");
+        if marked_first_turn.len() > router::runtime::FIRST_TURN_ARGV_MAX_BYTES {
+            return (Some(first_turn), None);
+        }
+        (Some(marked_first_turn), Some(marker))
+    }
+
     /// Sync part of a mission-slot spawn: validates inputs, composes
     /// the `SpawnSpec`, generates the session id, and INSERTs the
     /// `sessions` row. Returns a `PendingMissionSpawn` that
@@ -214,6 +233,8 @@ impl SessionManager {
         }
 
         let session_id = ulid::Ulid::new().to_string();
+        let (first_turn, codex_prompt_marker) =
+            Self::codex_capture_prompt_marker(&runner.runtime, &session_id, first_turn);
         let mut spec = self.base_spawn_spec(
             session_id.clone(),
             runner,
@@ -268,6 +289,8 @@ impl SessionManager {
             plan,
             first_turn_delivered_via_argv,
             resolved_cwd,
+            row_started_at: started_at,
+            codex_prompt_marker,
             app_data_dir: app_data_dir.to_path_buf(),
             pool,
         })
@@ -309,6 +332,8 @@ impl SessionManager {
             plan,
             first_turn_delivered_via_argv,
             resolved_cwd,
+            row_started_at,
+            codex_prompt_marker,
             app_data_dir,
             pool,
         } = pending;
@@ -383,17 +408,40 @@ impl SessionManager {
             return Ok(CompleteSpawnOutcome::Cancelled);
         }
 
+        let spawn_pid = self.runtime_pid(&rt_session);
+
         // Persist the runtime-side identity for diagnostics and for
         // the current runtime session row.
         if let Ok(conn) = pool.get() {
             let _ = conn.execute(
                 "UPDATE sessions
                     SET runtime = ?2,
-                        runtime_session = ?3
+                        runtime_session = ?3,
+                        pid = ?4
                   WHERE id = ?1",
-                params![session_id, rt_session.runtime, rt_session.session_id],
+                params![
+                    session_id,
+                    rt_session.runtime,
+                    rt_session.session_id,
+                    spawn_pid
+                ],
             );
         }
+
+        let codex_capture = if runner.runtime == "codex" && plan.assigned_key.is_none() {
+            capture_cwd(resolved_cwd.clone()).map(|cwd| CodexCaptureContext {
+                mission_id: Some(mission.id.clone()),
+                spawn_cwd: cwd,
+                started_at: spawn_started_at_dt,
+                row_started_at: row_started_at.clone(),
+                spawn_pid,
+                prompt_marker: codex_prompt_marker.clone(),
+                pool: Arc::clone(&pool),
+                events: Arc::clone(&events),
+            })
+        } else {
+            None
+        };
 
         let stop = output.stop_flag();
         let runtime_session_for_log = rt_session.session_id.clone();
@@ -404,6 +452,7 @@ impl SessionManager {
                 mission_id: Some(mission.id.clone()),
                 runner_id: Some(runner.id.clone()),
                 runtime_session: rt_session.clone(),
+                codex_capture: codex_capture.clone(),
                 forwarder: None,
                 stop,
             },
@@ -430,17 +479,8 @@ impl SessionManager {
         );
         self.install_forwarder(&session_id, forwarder);
 
-        // Mirror the codex rollout capture from spawn_direct / resume so
-        // mission-slot spawns also populate agent_session_key for restart.
-        if runner.runtime == "codex" && plan.assigned_key.is_none() {
-            if let Some(cwd) = capture_cwd(resolved_cwd.clone()) {
-                crate::session::codex_capture::spawn_capture(
-                    session_id.clone(),
-                    cwd,
-                    spawn_started_at_dt,
-                    Arc::clone(&pool),
-                );
-            }
+        if let Some(ctx) = codex_capture.as_ref() {
+            self.spawn_codex_capture_if_unkeyed(&session_id, ctx);
         }
 
         emit_runner_activity(&pool, &runner, events.as_ref());
@@ -653,6 +693,8 @@ impl SessionManager {
         let initial_size = cols.zip(rows);
 
         let session_id = ulid::Ulid::new().to_string();
+        let (first_turn, codex_prompt_marker) =
+            Self::codex_capture_prompt_marker(&runner.runtime, &session_id, first_turn);
         let started_at_dt = Utc::now();
         let started_at = started_at_dt.to_rfc3339();
 
@@ -741,15 +783,38 @@ impl SessionManager {
             )));
         }
 
+        let spawn_pid = self.runtime_pid(&rt_session);
+
         if let Ok(conn) = pool.get() {
             let _ = conn.execute(
                 "UPDATE sessions
                     SET runtime = ?2,
-                        runtime_session = ?3
+                        runtime_session = ?3,
+                        pid = ?4
                   WHERE id = ?1",
-                params![session_id, rt_session.runtime, rt_session.session_id],
+                params![
+                    session_id,
+                    rt_session.runtime,
+                    rt_session.session_id,
+                    spawn_pid
+                ],
             );
         }
+
+        let codex_capture = if runner.runtime == "codex" && plan.assigned_key.is_none() {
+            capture_cwd(resolved_cwd.clone()).map(|cwd| CodexCaptureContext {
+                mission_id: None,
+                spawn_cwd: cwd,
+                started_at: spawn_started_at_dt,
+                row_started_at: started_at.clone(),
+                spawn_pid,
+                prompt_marker: codex_prompt_marker.clone(),
+                pool: Arc::clone(&pool),
+                events: Arc::clone(&events),
+            })
+        } else {
+            None
+        };
 
         self.install_handle(
             &session_id,
@@ -758,6 +823,7 @@ impl SessionManager {
                 mission_id: None,
                 runner_id: persisted_runner_id.map(str::to_string),
                 runtime_session: rt_session.clone(),
+                codex_capture: codex_capture.clone(),
                 forwarder: None,
                 stop: output.stop_flag(),
             },
@@ -777,21 +843,8 @@ impl SessionManager {
         );
         self.install_forwarder(&session_id, forwarder);
 
-        // Codex doesn't accept a caller-assigned session id at spawn,
-        // so the runtime adapter leaves `assigned_key = None` for
-        // fresh codex spawns. Kick off a short-lived watcher that
-        // captures codex's auto-generated id from the rollout file
-        // and writes it to `agent_session_key` so the *next* resume
-        // can drive `codex resume <uuid>`.
-        if runner.runtime == "codex" && plan.assigned_key.is_none() {
-            if let Some(cwd) = capture_cwd(resolved_cwd.clone()) {
-                crate::session::codex_capture::spawn_capture(
-                    session_id.clone(),
-                    cwd,
-                    spawn_started_at_dt,
-                    Arc::clone(&pool),
-                );
-            }
+        if let Some(ctx) = codex_capture.as_ref() {
+            self.spawn_codex_capture_if_unkeyed(&session_id, ctx);
         }
 
         if emit_activity {
@@ -1163,15 +1216,38 @@ impl SessionManager {
             }
         };
 
+        let spawn_pid = self.runtime_pid(&rt_session);
+
         if let Ok(conn) = pool.get() {
             let _ = conn.execute(
                 "UPDATE sessions
                     SET runtime = ?2,
-                        runtime_session = ?3
+                        runtime_session = ?3,
+                        pid = ?4
                   WHERE id = ?1",
-                params![session_id, rt_session.runtime, rt_session.session_id],
+                params![
+                    session_id,
+                    rt_session.runtime,
+                    rt_session.session_id,
+                    spawn_pid
+                ],
             );
         }
+
+        let codex_capture = if runner.runtime == "codex" && plan.assigned_key.is_none() {
+            capture_cwd(resolved_cwd.clone()).map(|cwd| CodexCaptureContext {
+                mission_id: snap.mission_id.clone(),
+                spawn_cwd: cwd,
+                started_at: spawn_started_at_dt,
+                row_started_at: started_at.clone(),
+                spawn_pid,
+                prompt_marker: None,
+                pool: Arc::clone(&pool),
+                events: Arc::clone(&events),
+            })
+        } else {
+            None
+        };
 
         self.install_handle(
             session_id,
@@ -1180,6 +1256,7 @@ impl SessionManager {
                 mission_id: snap.mission_id.clone(),
                 runner_id: snap.runner_id.clone(),
                 runtime_session: rt_session.clone(),
+                codex_capture: codex_capture.clone(),
                 forwarder: None,
                 stop: output.stop_flag(),
             },
@@ -1215,20 +1292,8 @@ impl SessionManager {
         );
         self.install_forwarder(session_id, forwarder);
 
-        // Same codex post-spawn capture as `spawn_direct`: when we
-        // respawn a codex chat that has no agent_session_key on the
-        // row yet (every prior codex chat, until this lands), the
-        // adapter starts fresh and the watcher writes the new id so
-        // the *next* resume drives `codex resume <uuid>`.
-        if runner.runtime == "codex" && plan.assigned_key.is_none() {
-            if let Some(cwd) = capture_cwd(resolved_cwd.clone()) {
-                crate::session::codex_capture::spawn_capture(
-                    session_id.to_string(),
-                    cwd,
-                    spawn_started_at_dt,
-                    Arc::clone(&pool),
-                );
-            }
+        if let Some(ctx) = codex_capture.as_ref() {
+            self.spawn_codex_capture_if_unkeyed(session_id, ctx);
         }
 
         if snap.runner_id.is_some() {
@@ -1296,5 +1361,13 @@ impl SessionManager {
             |r| r.get(0),
         );
         count.map(|n| n > 0).unwrap_or(false)
+    }
+
+    fn runtime_pid(&self, rt_session: &RuntimeSession) -> Option<i32> {
+        self.runtime
+            .status(rt_session)
+            .ok()
+            .flatten()
+            .and_then(|status| status.pid)
     }
 }

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -983,14 +983,17 @@ fn codex_mission_spawn_grants_event_log_dir_to_sandbox() {
 
     let spec = fake.last_spawn_spec().expect("spawn was called");
     let mission_dir_arg = mission_dir.to_string_lossy().to_string();
+    let marker = crate::session::codex_capture::prompt_marker(&spawned.id);
     assert!(
         has_arg_pair(&spec.args, "--add-dir", &mission_dir_arg),
         "codex mission spawn must grant mission dir with --add-dir; args = {:?}",
         spec.args,
     );
     assert!(
-        spec.args.iter().any(|arg| arg == &first_turn),
-        "codex mission first turn must ride argv; args = {:?}",
+        spec.args
+            .iter()
+            .any(|arg| arg.contains(&first_turn) && arg.contains(&marker)),
+        "codex mission first turn and capture marker must ride argv; args = {:?}",
         spec.args,
     );
     assert!(
@@ -1133,7 +1136,9 @@ fn codex_resume_skips_first_prompt_injection() {
     let now = Utc::now().to_rfc3339();
     let runner_id = ulid::Ulid::new().to_string();
     let session_id = ulid::Ulid::new().to_string();
+    let sibling_session_id = ulid::Ulid::new().to_string();
     let prior_key = uuid::Uuid::new_v4().to_string();
+    let sibling_key = uuid::Uuid::new_v4().to_string();
     {
         let conn = pool.get().unwrap();
         conn.execute(
@@ -1152,6 +1157,14 @@ fn codex_resume_skips_first_prompt_injection() {
                      agent_session_key)
                  VALUES (?1, NULL, ?2, '/tmp', 'stopped', ?3, ?4)",
             params![session_id, runner_id, now, prior_key],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions
+                    (id, mission_id, runner_id, cwd, status, started_at,
+                     agent_session_key)
+                 VALUES (?1, NULL, ?2, '/tmp', 'stopped', ?3, ?4)",
+            params![sibling_session_id, runner_id, now, sibling_key],
         )
         .unwrap();
     }
@@ -1178,6 +1191,19 @@ fn codex_resume_skips_first_prompt_injection() {
             capture(),
         )
         .unwrap();
+
+    let spec = fake
+        .last_spawn_spec()
+        .expect("codex resume should spawn through FakeRuntime");
+    assert_eq!(
+        spec.args,
+        vec!["resume".to_string(), prior_key.clone()],
+        "codex resume must bind argv to the resumed row's own agent_session_key",
+    );
+    assert!(
+        !spec.args.contains(&sibling_key),
+        "codex resume must not use a sibling row's agent_session_key"
+    );
 
     // FIRST_PROMPT_DELAY = ZERO under cfg(test); a would-be
     // injection would already be visible in fake.bytes_writes() by

--- a/src/components/RunnersRail.tsx
+++ b/src/components/RunnersRail.tsx
@@ -105,6 +105,12 @@ export function RunnersRail({
                 </button>
               </div>
               <div className="text-[11px] text-fg-2">{subtitle}</div>
+              <div className="grid grid-cols-[72px_minmax(0,1fr)] gap-2 border-t border-line/70 pt-2 text-[10px] leading-snug">
+                <span className="text-fg-3">session_key</span>
+                <span className="break-all font-mono text-fg-2">
+                  {s.agent_session_key ?? "NULL"}
+                </span>
+              </div>
             </div>
           );
         })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -41,6 +41,7 @@ export interface SessionRow extends Session {
    *  TUI agents). See docs/impls/archive/0011 §"Per-runtime clear-on-resize". */
   runtime: string;
   lead: boolean;
+  agent_session_key: string | null;
 }
 
 /**
@@ -62,6 +63,7 @@ export interface DirectSessionEntry {
   started_at: string | null;
   stopped_at: string | null;
   resumable: boolean;
+  agent_session_key: string | null;
   pinned: boolean;
   // Set when the session has been archived. `listRecentDirect` filters
   // these at SQL so rows from that endpoint always have `archived_at:

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -114,6 +114,13 @@ export interface WarningEvent {
   message: string;
 }
 
+// Payload for `session/updated` — persisted metadata changed without a
+// lifecycle event, e.g. async Codex session-key capture.
+export interface SessionUpdatedEvent {
+  session_id: string;
+  mission_id: string | null;
+}
+
 // Returned by session_start_direct (and by mission_start's session list).
 // mission_id is null for the direct flavor.
 export interface SpawnedSession {

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -37,6 +37,7 @@ import type {
   Event,
   HumanQuestionPayload,
   Mission,
+  SessionUpdatedEvent,
   WarningEvent,
 } from "../lib/types";
 import { EventFeed } from "../components/EventFeed";
@@ -306,6 +307,89 @@ export default function MissionWorkspace() {
       unlisten?.();
     };
   }, [id]);
+
+  useEffect(() => {
+    if (!id) return;
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    void listen<SessionUpdatedEvent>("session/updated", (event) => {
+      if (event.payload.mission_id !== id) return;
+      void api.session
+        .list(id)
+        .then((rows) => {
+          if (cancelled) return;
+          setSessions(rows);
+        })
+        .catch(() => {
+          // best-effort — the next lifecycle refresh or reload will
+          // reconcile metadata if this request fails
+        });
+    }).then((fn) => {
+      if (cancelled) {
+        fn();
+        return;
+      }
+      unlisten = fn;
+    });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [id]);
+
+  const pendingCodexKeySessionIds = useMemo(
+    () =>
+      sessions
+        .filter(
+          (s) =>
+            s.status === "running" &&
+            s.runtime === "codex" &&
+            !s.agent_session_key,
+        )
+        .map((s) => s.id)
+        .sort()
+        .join("|"),
+    [sessions],
+  );
+
+  useEffect(() => {
+    if (!id || !pendingCodexKeySessionIds || mission?.status !== "running") {
+      return;
+    }
+
+    const MAX_ATTEMPTS = 35;
+    let cancelled = false;
+    let attempts = 0;
+
+    const poll = () => {
+      attempts += 1;
+      void api.session
+        .list(id)
+        .then((rows) => {
+          if (cancelled) return;
+          setSessions(rows);
+          const stillPending = rows.some(
+            (s) =>
+              s.status === "running" &&
+              s.runtime === "codex" &&
+              !s.agent_session_key,
+          );
+          if (!stillPending || attempts >= MAX_ATTEMPTS) {
+            window.clearInterval(interval);
+          }
+        })
+        .catch(() => {
+          if (attempts >= MAX_ATTEMPTS) window.clearInterval(interval);
+        });
+    };
+
+    const interval = window.setInterval(poll, 1000);
+    poll();
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [id, mission?.status, pendingCodexKeySessionIds]);
 
   // Effective mission goal — read from the `mission_goal` event the
   // backend writes at mission_start. This is the only authoritative
@@ -1205,11 +1289,7 @@ function SlotPtyPane({
 
   // Mission slot pane omits the Archive option — archiving a slot's
   // session row would orphan the slot in the workspace. Mission-level
-  // archive lives in the topbar kebab. `resumable` defaults to true:
-  // we don't have agent_session_key on the SessionRow, but mission
-  // sessions almost always carry one (claude-code self-assigns a
-  // UUID on every fresh spawn) and the worst case is friendlier
-  // copy than reality.
+  // archive lives in the topbar kebab.
   //
   // Pane opacity:
   //   - resuming/starting: 0 (canvas hidden, the pill carries the visual)

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -55,6 +55,7 @@ import type {
   SessionActivityEvent,
   SessionActivityState,
   SessionStatus,
+  SessionUpdatedEvent,
   WarningEvent,
 } from "../lib/types";
 
@@ -330,6 +331,8 @@ export default function RunnerChat() {
       const found = rows.find((r) => r.session_id === sessionId);
       if (found) {
         setChatMeta(found);
+        const full = await api.session.get(sessionId);
+        setChatMeta(full ?? found);
         return;
       }
       // Missed in the visible list — could be archived. The
@@ -352,10 +355,81 @@ export default function RunnerChat() {
   }, [refreshChatMeta]);
 
   useEffect(() => {
+    if (!sessionId || !metaLoaded || isArchived) return;
+    if (
+      chatMeta?.agent_runtime !== "codex" ||
+      chatMeta.agent_session_key ||
+      chatMeta.status !== "running"
+    ) {
+      return;
+    }
+
+    const targetId = sessionId;
+    const MAX_ATTEMPTS = 35;
+    let cancelled = false;
+    let attempts = 0;
+
+    const poll = () => {
+      attempts += 1;
+      void api.session
+        .get(targetId)
+        .then((row) => {
+          if (cancelled) return;
+          if (!row) {
+            window.clearInterval(interval);
+            return;
+          }
+          setChatMeta(row);
+          if (row.agent_session_key || attempts >= MAX_ATTEMPTS) {
+            window.clearInterval(interval);
+          }
+        })
+        .catch(() => {
+          if (attempts >= MAX_ATTEMPTS) window.clearInterval(interval);
+        });
+    };
+
+    const interval = window.setInterval(poll, 1000);
+    poll();
+    return () => {
+      cancelled = true;
+      window.clearInterval(interval);
+    };
+  }, [
+    sessionId,
+    metaLoaded,
+    isArchived,
+    chatMeta?.agent_runtime,
+    chatMeta?.agent_session_key,
+    chatMeta?.status,
+  ]);
+
+  useEffect(() => {
     if (!sessionId) return;
     let unlisten: (() => void) | null = null;
     let cancelled = false;
     void listen("session/exit", () => {
+      void refreshChatMeta();
+    }).then((fn) => {
+      if (cancelled) {
+        fn();
+        return;
+      }
+      unlisten = fn;
+    });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [sessionId, refreshChatMeta]);
+
+  useEffect(() => {
+    if (!sessionId) return;
+    const targetId = sessionId;
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    void listen<SessionUpdatedEvent>("session/updated", (event) => {
+      if (event.payload.session_id !== targetId) return;
       void refreshChatMeta();
     }).then((fn) => {
       if (cancelled) {
@@ -1237,6 +1311,14 @@ function RunnerSidePanel({
                         </dd>
                       </>
                     ) : null}
+                    {chatMeta ? (
+                      <>
+                        <dt className="text-fg-3">session_key</dt>
+                        <dd className="break-all font-mono text-fg-2">
+                          {chatMeta.agent_session_key ?? "NULL"}
+                        </dd>
+                      </>
+                    ) : null}
                   </dl>
                 </div>
               </section>
@@ -1281,6 +1363,10 @@ function RunnerSidePanel({
                       </dd>
                     </>
                   ) : null}
+                  <dt className="text-fg-3">session_key</dt>
+                  <dd className="break-all font-mono text-fg-2">
+                    {chatMeta.agent_session_key ?? "NULL"}
+                  </dd>
                 </dl>
               </div>
             </section>


### PR DESCRIPTION
Fixes #229.

Summary:
- Harden Codex native session-key capture so ambiguous same-cwd rollouts fail closed instead of persisting a sibling conversation id.
- Prefer pid-owned rollout detection, then a Codex-only Runner prompt marker for fresh first-turn spawns, then the guarded sole-owner fallback.
- Keep Claude Code on its native assigned-id path; the marker workaround is Codex-only.
- Retry Codex capture after first real input, emit session/updated on successful capture, and refresh direct chat plus mission session UI.
- Expose session_key in direct-chat runtime metadata and the mission runner rail, showing NULL when capture is unavailable.
- Add the implementation plan at docs/impls/0017-codex-session-key-capture.md.

Validation:
- cargo test -p runner codex_capture
- cargo test -p runner codex_mission_spawn_grants_event_log_dir_to_sandbox
- cargo test -p runner mission_spawn_worker_preamble_lands_as_trailing_positional_argv_with_brief
- cargo test -p runner codex_resume_skips_first_prompt_injection
- cargo test -p runner session_get_returns_agent_session_key_for_direct_chat
- cargo test -p runner session_list_returns_agent_session_key_for_mission_rows
- cargo fmt --check
- pnpm exec tsc --noEmit
- pnpm run lint
- cargo test --workspace
- git diff --check

Manual smoke:
- Started a multi-Codex mission after adding the Codex-only marker path and confirmed session_key populates instead of every mission runner staying NULL.