### PR TITLE
Fix JPEG terminal image paste

### DIFF
--- a/docs/impls/archive/0006-image-paste.md
+++ b/docs/impls/archive/0006-image-paste.md
@@ -47,40 +47,43 @@ End-to-end pipeline:
 
 1. `RunnerTerminal.tsx` `onPaste` (capture phase on xterm's hidden
    `<textarea>`):
-   - Iterate `clipboardData.items`, find the first with
-     `type === "image/png"`, get the `File` via `getAsFile()`. We
-     filter to PNG only — see "PNG-only" below.
+   - Iterate `clipboardData.items`, find the first supported image
+     file, get the `File` via `getAsFile()`, and preserve the image
+     MIME type. The original fix filtered to PNG only; #234 extended
+     the allowlist to PNG and JPEG, with extension fallback for copied
+     files whose MIME is unavailable.
    - `preventDefault()` + `stopImmediatePropagation()` so xterm.js's
      bubble-phase text-paste handler doesn't also run.
    - `await file.arrayBuffer()` → `Uint8Array` (the original bytes
      WebKit captured when it built the JS event, before the
      downstream pbpaste sees the corrupted clipboard).
-   - `await api.session.pasteImage(bytes)` — Rust side restores
-     NSPasteboard.
+   - `await api.session.pasteImage(bytes, mimeType)` — Rust side
+     restores NSPasteboard.
    - `await api.session.injectStdin(sid, "\x16")` — agent CLI now
      sees Ctrl-V, reads NSPasteboard, gets the real bytes, renders
      its `[Image x]` placeholder.
 
-2. New Rust command `session_paste_image(bytes)`
+2. Rust command `session_paste_image(bytes, mimeType)`
    (`src-tauri/src/commands/session.rs`):
    - Writes `bytes` to a `tempfile::NamedTempFile` in `$TMPDIR` with
-     prefix `runner-paste-` and suffix `.png`. `NamedTempFile` is
-     deleted on `Drop`, so the file is gone before the command
-     returns — pasted screenshots can be sensitive, shouldn't
-     accumulate, and the OS reaper isn't load-bearing.
+     prefix `runner-paste-` and a suffix chosen from the MIME type
+     (`.png` or `.jpg`). `NamedTempFile` is deleted on `Drop`, so the
+     file is gone before the command returns — pasted screenshots can
+     be sensitive, shouldn't accumulate, and the OS reaper isn't
+     load-bearing.
    - On macOS, runs:
 
      ```
      osascript -e 'set the clipboard to (read POSIX file "<path>" as «class PNGf»)'
      ```
 
-     `«class PNGf»` is the four-char OSType code for PNG; the
-     statement reads the file as PNG bytes and writes them to
-     NSPasteboard's `public.png` representation, overwriting whatever
-     icon WebKit left there. The path is interpolated via Rust's
-     `{:?}` debug format so paths with spaces or quotes survive (the
-     escape syntax `\\` / `\"` is shared between Rust string literals
-     and AppleScript string literals).
+     `«class PNGf»` is the four-char OSType code for PNG; JPEG uses
+     `«class JPEG»`. The statement reads the file as image bytes and
+     writes them to the matching NSPasteboard representation,
+     overwriting whatever icon WebKit left there. The path is
+     interpolated via Rust's `{:?}` debug format so paths with spaces
+     or quotes survive (the escape syntax `\\` / `\"` is shared
+     between Rust string literals and AppleScript string literals).
    - On non-macOS the command is a no-op — the embedded webview's
      paste behavior on Linux / Windows hasn't been audited and the
      runner doesn't ship there yet.
@@ -90,21 +93,11 @@ End-to-end pipeline:
 
 3. Wired into the Tauri invoke handler in `lib.rs`.
 
-Plain-text pastes are unchanged: when no clipboard item has an
-`image/png` type, the handler returns early without `preventDefault`,
-and xterm.js's bubble-phase paste handler runs normally.
+Plain-text pastes are unchanged: when no clipboard item has a supported image type, the handler returns early without `preventDefault`, and xterm.js's bubble-phase paste handler runs normally.
 
-## PNG-only
+## Format allowlist
 
-The AppleScript writes the bytes verbatim into the `public.png`
-pasteboard flavor. If we let a JPEG or GIF through, NSPasteboard
-would end up with `public.png` populated by non-PNG bytes — the agent
-would attach an image that fails to decode. The frontend filter to
-`image/png` and the doc-comment in the Rust command both call this
-out; broadening to JPEG / GIF / WebP needs either a per-MIME OSType
-map (`«class JPEG»`, `«class GIFf»`, etc.) or a transcode step in
-Rust. Out of scope for v1; macOS screenshots are PNG, which is the
-common-case paste.
+The AppleScript writes the bytes verbatim into the selected pasteboard flavor, so the MIME must map to the correct OSType. The current allowlist is PNG (`«class PNGf»`) and JPEG (`«class JPEG»`, including `.jpg` / `.jpeg` copied-file fallbacks). GIF/WebP would need more OSType mappings or a transcode step before they can be allowed through.
 
 ## Considered: `arboard` / `tauri-plugin-clipboard-manager`
 

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -161,39 +161,58 @@ pub async fn session_output_snapshot(
     Ok(state.sessions.output_snapshot(&session_id))
 }
 
-/// Restore NSPasteboard for a PNG paste that came in through the
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PasteImageFormat {
+    extension: &'static str,
+    pasteboard_class: &'static str,
+}
+
+fn paste_image_format(mime_type: &str) -> Result<PasteImageFormat> {
+    let normalized = mime_type.trim().to_ascii_lowercase();
+    match normalized.as_str() {
+        "image/png" => Ok(PasteImageFormat {
+            extension: "png",
+            pasteboard_class: "PNGf",
+        }),
+        "image/jpeg" | "image/jpg" => Ok(PasteImageFormat {
+            extension: "jpg",
+            pasteboard_class: "JPEG",
+        }),
+        _ => Err(Error::msg(format!(
+            "unsupported clipboard image type {mime_type:?}"
+        ))),
+    }
+}
+
+/// Restore NSPasteboard for an image paste that came in through the
 /// webview, so the agent CLI's NSPasteboard read returns the real
 /// bytes and renders its native `[Image x]` placeholder in the prompt.
 ///
 /// Why: when the user presses Cmd+V over the WKWebView, WebKit
 /// materializes the image clipboard item into a `File` object (a temp
-/// file under the hood). As a side effect NSPasteboard's `public.png`
-/// representation becomes the OS-rendered icon of that temp file
-/// rather than the original screenshot bytes. The agent CLI's
-/// subsequent clipboard read then returns the icon, not the screenshot
-/// (#79).
+/// file under the hood). As a side effect NSPasteboard's image
+/// representation can become the OS-rendered icon of that temp file
+/// rather than the original image bytes. The agent CLI's subsequent
+/// clipboard read then returns the icon, not the copied image (#79).
 ///
 /// Fix: the frontend grabs the original bytes off the `ClipboardEvent`
-/// File before they reach the child process, ships them here, we
-/// write them to a `NamedTempFile`, and use `osascript` to repopulate
-/// NSPasteboard with the real bytes. The frontend then injects Ctrl-V
-/// (`\x16`); the agent's existing paste-attach flow runs unchanged.
-///
-/// PNG-only. AppleScript writes the bytes verbatim into the
-/// `public.png` pasteboard flavor, so non-PNG payloads would end up
-/// labeled PNG with non-PNG bytes. The frontend filters to
-/// `image/png` for the same reason. JPEG/GIF/WebP support is a
-/// follow-up that would need either a per-MIME OSType map or a
-/// transcode step.
+/// File before they reach the child process, ships them here with the
+/// image MIME type, we write them to a `NamedTempFile`, and use
+/// `osascript` to repopulate NSPasteboard with the matching image
+/// flavor. The frontend then injects Ctrl-V (`\x16`); the agent's
+/// existing paste-attach flow runs unchanged.
 ///
 /// macOS-only; on other platforms this is a no-op (the embedded
 /// webview's paste behavior on Linux/Windows hasn't been audited and
 /// the runner doesn't ship there yet).
 #[tauri::command]
-pub async fn session_paste_image(bytes: Vec<u8>) -> Result<()> {
+pub async fn session_paste_image(bytes: Vec<u8>, mime_type: String) -> Result<()> {
+    let format = paste_image_format(&mime_type)?;
+
     #[cfg(not(target_os = "macos"))]
     {
         let _ = bytes;
+        let _ = format;
         Ok(())
     }
 
@@ -206,23 +225,25 @@ pub async fn session_paste_image(bytes: Vec<u8>) -> Result<()> {
         // cleanup is cheaper and matches the value's lifetime:
         // osascript reads the bytes into NSPasteboard synchronously,
         // and after that we don't need the file.
+        let suffix = format!(".{}", format.extension);
         let mut tmp = tempfile::Builder::new()
             .prefix("runner-paste-")
-            .suffix(".png")
+            .suffix(&suffix)
             .tempfile_in(std::env::temp_dir())?;
         tmp.write_all(&bytes)?;
         tmp.flush()?;
 
         let path_str = tmp.path().to_string_lossy();
         // AppleScript: read the temp file's bytes and write them to
-        // NSPasteboard's `public.png` representation. `«class PNGf»`
-        // is the four-char OSType code for PNG. The `{:?}` debug
-        // format quotes the path with `\\` / `\"` escapes that
-        // AppleScript also accepts, so paths with spaces or quotes
-        // pass through safely.
+        // NSPasteboard's matching image representation. The
+        // `pasteboard_class` values are fixed OSType codes selected
+        // from the MIME allowlist above. The `{:?}` debug format
+        // quotes the path with `\\` / `\"` escapes that AppleScript
+        // also accepts, so paths with spaces or quotes pass through
+        // safely.
         let script = format!(
-            "set the clipboard to (read POSIX file {:?} as «class PNGf»)",
-            path_str
+            "set the clipboard to (read POSIX file {:?} as «class {}»)",
+            path_str, format.pasteboard_class
         );
         let status = std::process::Command::new("osascript")
             .arg("-e")
@@ -687,6 +708,41 @@ mod tests {
     use super::*;
     use crate::db;
     use chrono::Utc;
+
+    #[test]
+    fn paste_image_format_maps_png_and_jpeg_to_pasteboard_classes() {
+        assert_eq!(
+            paste_image_format("image/png").unwrap(),
+            PasteImageFormat {
+                extension: "png",
+                pasteboard_class: "PNGf",
+            }
+        );
+        assert_eq!(
+            paste_image_format("image/jpeg").unwrap(),
+            PasteImageFormat {
+                extension: "jpg",
+                pasteboard_class: "JPEG",
+            }
+        );
+    }
+
+    #[test]
+    fn paste_image_format_normalizes_case_and_jpg_alias() {
+        assert_eq!(
+            paste_image_format(" IMAGE/JPG ").unwrap(),
+            PasteImageFormat {
+                extension: "jpg",
+                pasteboard_class: "JPEG",
+            }
+        );
+    }
+
+    #[test]
+    fn paste_image_format_rejects_unsupported_image_types() {
+        let err = paste_image_format("image/gif").unwrap_err().to_string();
+        assert!(err.contains("unsupported clipboard image type"));
+    }
 
     /// Mirrors the SELECT in `session_list_recent_direct` so we can
     /// exercise the ORDER BY without a Tauri State. Returns

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -343,6 +343,19 @@ fn wait_for_session_status_event(
     }
 }
 
+fn join_forwarder_for_test(mgr: &SessionManager, session_id: &str) {
+    let forwarder = mgr.session_state(session_id).and_then(|state| {
+        let mut state = state.lock().unwrap();
+        state
+            .handle
+            .as_mut()
+            .and_then(|handle| handle.forwarder.take())
+    });
+    if let Some(forwarder) = forwarder {
+        forwarder.join().unwrap();
+    }
+}
+
 fn has_arg_pair(args: &[String], flag: &str, value: &str) -> bool {
     args.windows(2).any(|w| w[0] == flag && w[1] == value)
 }
@@ -1583,24 +1596,22 @@ fn mission_status_transition_appends_runner_status_without_session_status_event(
         .unwrap();
 
     fake.push_status(0, RunnerStatus::Busy);
+    fake.close_spawn(0);
+    join_forwarder_for_test(&mgr, &spawned.id);
 
     let log = EventLog::open(&mission_dir).unwrap();
-    let deadline = Instant::now() + Duration::from_secs(2);
-    let event = loop {
-        let entries = log.read_from(0).unwrap();
-        if let Some(event) = entries.into_iter().map(|entry| entry.event).find(|event| {
+    let event = log
+        .read_from(0)
+        .unwrap()
+        .into_iter()
+        .map(|entry| entry.event)
+        .find(|event| {
             event
                 .signal_type
                 .as_ref()
                 .is_some_and(|ty| ty.as_str() == "runner_status")
-        }) {
-            break event;
-        }
-        if Instant::now() > deadline {
-            panic!("runner_status event never arrived in mission log");
-        }
-        std::thread::sleep(Duration::from_millis(20));
-    };
+        })
+        .expect("runner_status event should be appended before the forwarder exits");
 
     assert_eq!(event.from, runner.handle);
     assert_eq!(event.payload["state"], "busy");
@@ -1609,8 +1620,6 @@ fn mission_status_transition_appends_runner_status_without_session_status_event(
         cap.status.lock().unwrap().is_empty(),
         "mission sessions must not emit live session/status events",
     );
-
-    mgr.kill(&spawned.id).unwrap();
 }
 
 #[test]

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -25,7 +25,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import "@xterm/xterm/css/xterm.css";
 
-import { api } from "../lib/api";
+import { api, type PasteImageMimeType } from "../lib/api";
 import {
   readTerminalCursorStyle,
   readTerminalFontFamily,
@@ -56,6 +56,32 @@ interface ExitEvent {
 }
 
 const MAX_PENDING_LIVE_EVENTS = 4096;
+
+function normalizePasteImageMime(type: string): PasteImageMimeType | null {
+  switch (type.trim().toLowerCase()) {
+    case "image/png":
+      return "image/png";
+    case "image/jpeg":
+    case "image/jpg":
+      return "image/jpeg";
+    default:
+      return null;
+  }
+}
+
+function inferPasteImageMime(
+  itemType: string,
+  file: File,
+): PasteImageMimeType | null {
+  const fromType =
+    normalizePasteImageMime(itemType) ?? normalizePasteImageMime(file.type);
+  if (fromType) return fromType;
+
+  const name = file.name.toLowerCase();
+  if (name.endsWith(".png")) return "image/png";
+  if (name.endsWith(".jpg") || name.endsWith(".jpeg")) return "image/jpeg";
+  return null;
+}
 
 interface RunnerTerminalProps {
   sessionId: string;
@@ -456,16 +482,17 @@ export const RunnerTerminal = forwardRef<
     // Image paste support. We can't trust the OS clipboard across the
     // WKWebView boundary: when the user presses Cmd+V over the webview,
     // WebKit materializes the image into a `File` (a temp file under
-    // the hood), and as a side effect NSPasteboard's `public.png`
-    // representation becomes the *icon* for that temp file rather than
-    // the original screenshot bytes. So the agent CLI's own
-    // `pbpaste -Prefer png` (triggered by Ctrl-V) gets a generic file
-    // icon instead of what the user copied (#79).
+    // the hood), and as a side effect NSPasteboard's image
+    // representation can become the *icon* for that temp file rather
+    // than the original image bytes. So the agent CLI's own clipboard
+    // image read (triggered by Ctrl-V) gets a generic file icon instead
+    // of what the user copied (#79).
     //
     // Fix: read the bytes off the `ClipboardEvent`'s File ourselves
-    // (still the original screenshot at that point), ship them to Rust,
-    // which writes them back to NSPasteboard's `public.png` so the
-    // agent's existing pbpaste-based flow returns the real bytes.
+    // (still the original image at that point), ship them to Rust with
+    // the image MIME type, which writes them back to the matching
+    // NSPasteboard flavor so the agent's existing pbpaste-based flow
+    // returns the real bytes.
     // Then inject Ctrl-V (`\x16`) — claude-code / codex see Ctrl-V as
     // they would in a host terminal, attach the image with their
     // native `[Image x]` placeholder. Pure-text pastes fall through
@@ -475,28 +502,28 @@ export const RunnerTerminal = forwardRef<
       if (!sid || disabledRef.current) return;
       const items = e.clipboardData?.items;
       if (!items) return;
-      // PNG-only for now. The clipboard-restore path writes the
-      // bytes verbatim into NSPasteboard's `public.png` flavor, so
-      // non-PNG payloads would end up labeled PNG with non-PNG bytes
-      // and decode as garbage in the agent. macOS screenshots are
-      // PNG; JPEG/GIF/WebP support needs either a per-MIME OSType
-      // map or a transcode step — out of scope for v1 (#79
-      // follow-up).
       let imageFile: File | null = null;
+      let imageMimeType: PasteImageMimeType | null = null;
       for (let i = 0; i < items.length; i += 1) {
         const it = items[i];
-        if (it.type === "image/png") {
-          imageFile = it.getAsFile();
-          if (imageFile) break;
-        }
+        if (it.kind !== "file") continue;
+        const file = it.getAsFile();
+        if (!file) continue;
+        const mimeType = inferPasteImageMime(it.type, file);
+        if (!mimeType) continue;
+        imageFile = file;
+        imageMimeType = mimeType;
+        break;
       }
-      if (!imageFile) return;
+      if (!imageFile || !imageMimeType) return;
+      const file = imageFile;
+      const mimeType = imageMimeType;
       e.preventDefault();
       e.stopImmediatePropagation();
       void (async () => {
         try {
-          const buf = await imageFile.arrayBuffer();
-          await api.session.pasteImage(new Uint8Array(buf));
+          const buf = await file.arrayBuffer();
+          await api.session.pasteImage(new Uint8Array(buf), mimeType);
           await api.session.injectStdin(sid, "\x16");
         } catch (err) {
           onErrorRef.current?.(String(err));

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -73,6 +73,8 @@ export interface DirectSessionEntry {
   archived_at: string | null;
 }
 
+export type PasteImageMimeType = "image/png" | "image/jpeg";
+
 export interface RuntimeDefinition {
   name: string;
   display_name: string;
@@ -201,9 +203,10 @@ export const api = {
       invoke<void>("session_resize", { sessionId, cols, rows }),
     outputSnapshot: (sessionId: string) =>
       invoke<SessionOutputEvent[]>("session_output_snapshot", { sessionId }),
-    pasteImage: (bytes: Uint8Array) =>
+    pasteImage: (bytes: Uint8Array, mimeType: PasteImageMimeType) =>
       invoke<void>("session_paste_image", {
         bytes: Array.from(bytes),
+        mimeType,
       }),
     startDirect: (
       runnerId: string,


### PR DESCRIPTION
Fixes #234.

Summary:
- Accept PNG and JPEG image clipboard/file items in RunnerTerminal, including .png/.jpg/.jpeg extension fallback when MIME is missing.
- Pass the selected image MIME through the Tauri paste-image API.
- Restore macOS NSPasteboard using explicit PNGf/JPEG mappings and reject unsupported image types instead of forcing PNG.
- Update the archived image-paste implementation note.

Validation:
- cargo fmt
- make lint
- make test (passed with escalation for the MCP Unix-socket bind test)
- git diff --check
- Clean working-tree review from @reviewer in Runner.