### PR TITLE
Restore last mission terminal tab

### DIFF
--- a/docs/features/33-mission-last-terminal-tab.md
+++ b/docs/features/33-mission-last-terminal-tab.md
@@ -1,0 +1,40 @@
+# 33 — Mission last terminal tab
+
+> Tracking issue: [#236](https://github.com/yicheng47/runner/issues/236)
+> Priority: P2.
+
+## Motivation
+
+Mission workspaces currently reopen on the feed even when the operator was actively working in a runner PTY before navigating away. Returning to a mission should restore the last runner terminal used for that mission so context switching does not force an extra tab selection.
+
+## Scope
+
+### In scope
+
+- Remember the last selected mission PTY session id per mission.
+- Restore that PTY tab after mission and session rows load.
+- Reopen the remembered PTY tab in the tab strip before selecting it.
+- Fall back to feed when the remembered session id is missing, archived, no longer belongs to the mission, or the mission is archived.
+- Keep explicit tab actions unchanged: feed click shows feed, terminal click selects and remembers the PTY, and closing the active PTY returns to feed.
+
+### Out of scope
+
+- Backend persistence for tab state.
+- Remembering arbitrary split-view or future pane layouts.
+- Restoring archived mission PTYs.
+
+## Implementation Notes
+
+- Persistence is mission-scoped and local to the frontend through `localStorage`.
+- Session ids are validated against `session_list` rows before restore; rows hidden by archive/reset naturally fail validation.
+- Reset and archive clear the stored terminal id because they invalidate the prior session rows.
+
+## Verification
+
+- [ ] Returning to a mission restores the last selected runner terminal tab.
+- [ ] The restored terminal tab exists in the tab strip before selection.
+- [ ] Stale stored session ids fall back to feed without selecting another session.
+- [ ] Archived missions render feed/read-only only.
+- [ ] Feed click, terminal click, and active terminal close behavior remain unchanged.
+- [ ] `pnpm exec tsc --noEmit` passes.
+- [ ] `pnpm run lint` passes.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -40,6 +40,9 @@ links to its tracking issue.
   — add OpenCode as a first-class runtime for direct chats, runner
   templates, and missions with conservative model/prompt support
   before permission/resume mappings.
+- [33 — Mission last terminal tab](./33-mission-last-terminal-tab.md)
+  — remember the last selected runner terminal inside each mission
+  and restore it on workspace remount when the session is still valid.
 
 ## Archive
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -223,30 +223,37 @@ export function Sidebar({
 
   // ⌘K / Ctrl+K opens the command palette. ⌘N / Ctrl+N opens the
   // Start Chat modal. Skip while editing text controls so shortcuts
-  // don't hijack form input.
+  // don't hijack form input. xterm's hidden textarea is not an editor
+  // field from the app's point of view, so Meta shortcuts still win
+  // there; Ctrl shortcuts stay with the PTY/TUI.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
       if (!(e.metaKey || e.ctrlKey)) return;
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName?.toLowerCase();
+      const isXtermInput = !!target?.closest(".xterm");
       if (
-        tag === "input" ||
-        tag === "textarea" ||
-        tag === "select" ||
-        target?.isContentEditable
+        (tag === "input" ||
+          tag === "textarea" ||
+          tag === "select" ||
+          target?.isContentEditable) &&
+        !isXtermInput
       ) {
         return;
       }
+      if (isXtermInput && !e.metaKey) return;
       if (e.key === "k" || e.key === "K") {
         e.preventDefault();
+        e.stopPropagation();
         setPaletteOpen(true);
       } else if (e.key === "n" || e.key === "N") {
         e.preventDefault();
+        e.stopPropagation();
         setCreatingChat(true);
       }
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    window.addEventListener("keydown", onKey, { capture: true });
+    return () => window.removeEventListener("keydown", onKey, { capture: true });
   }, []);
 
   useEffect(() => {

--- a/src/lib/missionLastTerminal.ts
+++ b/src/lib/missionLastTerminal.ts
@@ -1,0 +1,33 @@
+const STORAGE_PREFIX = "runner.mission.lastTerminal.";
+
+function storageKey(missionId: string): string {
+  return `${STORAGE_PREFIX}${missionId}`;
+}
+
+export function getLastMissionTerminalId(missionId: string): string | null {
+  try {
+    const value = localStorage.getItem(storageKey(missionId));
+    return value && value.trim() ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setLastMissionTerminalId(
+  missionId: string,
+  sessionId: string,
+): void {
+  try {
+    localStorage.setItem(storageKey(missionId), sessionId);
+  } catch {
+    // ignore quota / disabled-storage errors
+  }
+}
+
+export function clearLastMissionTerminalId(missionId: string): void {
+  try {
+    localStorage.removeItem(storageKey(missionId));
+  } catch {
+    // ignore quota / disabled-storage errors
+  }
+}

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -65,6 +65,11 @@ import { useDelayedFlag } from "../lib/useDelayedFlag";
 import { useResizableWidth } from "../hooks/useResizableWidth";
 import { useTerminalBg } from "../lib/useTerminalBg";
 import {
+  clearLastMissionTerminalId,
+  getLastMissionTerminalId,
+  setLastMissionTerminalId,
+} from "../lib/missionLastTerminal";
+import {
   markArchivingMission,
   unmarkArchivingMission,
   useArchivingMission,
@@ -204,10 +209,38 @@ export default function MissionWorkspace() {
             if (!cancelled) setCrew(c);
           })
           .catch((e) => console.error("MissionWorkspace: crew_get failed", e));
-        // Auto-open every slot's PTY tab on mount. The user can close
-        // individual tabs via the × on each tab; if they close them
-        // all and re-mount, the mount path opens them again.
-        setOpenTabs(ss.map((s) => s.id));
+        const rememberedSessionId = getLastMissionTerminalId(id);
+        const rememberedSession =
+          m.archived_at == null && rememberedSessionId
+            ? ss.find(
+                (s) => s.id === rememberedSessionId && s.mission_id === id,
+              )
+            : undefined;
+        if (m.archived_at != null) {
+          clearLastMissionTerminalId(id);
+          setOpenTabs([]);
+          setActiveTab("feed");
+        } else {
+          // Auto-open every slot's PTY tab on mount. The user can close
+          // individual tabs via the × on each tab; if they close them
+          // all and re-mount, the mount path opens them again. Keep
+          // the remembered tab in the strip before selecting it so a
+          // future change to lazy-open tabs can't select a hidden pane.
+          const nextOpenTabs = ss.map((s) => s.id);
+          if (
+            rememberedSession &&
+            !nextOpenTabs.includes(rememberedSession.id)
+          ) {
+            nextOpenTabs.push(rememberedSession.id);
+          }
+          setOpenTabs(nextOpenTabs);
+          if (rememberedSession) {
+            setActiveTab(rememberedSession.id);
+          } else {
+            if (rememberedSessionId) clearLastMissionTerminalId(id);
+            setActiveTab("feed");
+          }
+        }
         ingest(evs);
       } catch (e) {
         if (!cancelled) setError(String(e));
@@ -470,6 +503,7 @@ export default function MissionWorkspace() {
     if (!mission) return;
     markArchivingMission(mission.id);
     try {
+      clearLastMissionTerminalId(mission.id);
       await api.mission.archive(mission.id);
       navigate("/runners");
     } catch (e) {
@@ -509,7 +543,9 @@ export default function MissionWorkspace() {
       });
       setEvents(fresh);
       // Fresh slots = open all PTY tabs.
+      clearLastMissionTerminalId(mission.id);
       setOpenTabs(rows.map((s) => s.id));
+      setActiveTab("feed");
       setResetConfirmOpen(false);
     } catch (e) {
       setError(String(e));
@@ -612,6 +648,61 @@ export default function MissionWorkspace() {
   // any UX off `status === 'completed'` because the migration may
   // later widen archive to include other terminal states.
   const isArchived = mission?.archived_at != null;
+
+  useEffect(() => {
+    if (!id || loading || !mission || mission.id !== id) return;
+    if (isArchived) {
+      clearLastMissionTerminalId(id);
+      setActiveTab("feed");
+      setOpenTabs((prev) => (prev.length === 0 ? prev : []));
+      return;
+    }
+
+    const validSessionIds = new Set(
+      sessions
+        .filter((s) => s.mission_id === id)
+        .map((s) => s.id),
+    );
+    const rememberedSessionId = getLastMissionTerminalId(id);
+    if (rememberedSessionId && !validSessionIds.has(rememberedSessionId)) {
+      clearLastMissionTerminalId(id);
+    }
+    if (activeTab !== "feed" && !validSessionIds.has(activeTab)) {
+      setActiveTab("feed");
+    }
+    setOpenTabs((prev) => {
+      const next = prev.filter((tabId) => validSessionIds.has(tabId));
+      return next.length === prev.length ? prev : next;
+    });
+  }, [activeTab, id, isArchived, loading, mission, sessions]);
+
+  const selectFeed = useCallback(() => {
+    setActiveTab("feed");
+  }, []);
+
+  const selectPty = useCallback(
+    (sessionId: string) => {
+      if (!id || isArchived) return;
+      const session = sessions.find(
+        (s) => s.id === sessionId && s.mission_id === id,
+      );
+      if (!session) {
+        const rememberedSessionId = getLastMissionTerminalId(id);
+        if (rememberedSessionId === sessionId) {
+          clearLastMissionTerminalId(id);
+        }
+        setActiveTab("feed");
+        return;
+      }
+      setOpenTabs((prev) =>
+        prev.includes(sessionId) ? prev : [...prev, sessionId],
+      );
+      setLastMissionTerminalId(id, sessionId);
+      setActiveTab(sessionId);
+    },
+    [id, isArchived, sessions],
+  );
+
   const shortcutTabs = useMemo<Array<"feed" | string>>(() => {
     if (isArchived) return ["feed"];
     const slotTabs = openTabs
@@ -629,12 +720,13 @@ export default function MissionWorkspace() {
       if (!target) return;
       e.preventDefault();
       e.stopPropagation();
-      setActiveTab(target);
+      if (target === "feed") selectFeed();
+      else selectPty(target);
     };
     window.addEventListener("keydown", onKeyDown, { capture: true });
     return () =>
       window.removeEventListener("keydown", onKeyDown, { capture: true });
-  }, [shortcutTabs]);
+  }, [selectFeed, selectPty, shortcutTabs]);
 
   // Project ask_human → human_question pairings + human_response
   // resolutions out of the feed. Mirrors the router's reconstruct_from_log
@@ -681,17 +773,23 @@ export default function MissionWorkspace() {
     return map;
   }, [events]);
 
-  const onOpenPty = useCallback((sessionId: string) => {
-    setOpenTabs((prev) =>
-      prev.includes(sessionId) ? prev : [...prev, sessionId],
-    );
-    setActiveTab(sessionId);
-  }, []);
+  const onOpenPty = useCallback(
+    (sessionId: string) => {
+      selectPty(sessionId);
+    },
+    [selectPty],
+  );
 
-  const onCloseTab = useCallback((sessionId: string) => {
-    setOpenTabs((prev) => prev.filter((id) => id !== sessionId));
-    setActiveTab((prev) => (prev === sessionId ? "feed" : prev));
-  }, []);
+  const onCloseTab = useCallback(
+    (sessionId: string) => {
+      setOpenTabs((prev) => prev.filter((id) => id !== sessionId));
+      if (id && getLastMissionTerminalId(id) === sessionId) {
+        clearLastMissionTerminalId(id);
+      }
+      setActiveTab((prev) => (prev === sessionId ? "feed" : prev));
+    },
+    [id],
+  );
 
   const handles = sessions.map((s) => s.handle);
   const startedAt = mission ? formatRelativeTime(mission.started_at) : "";
@@ -938,7 +1036,7 @@ export default function MissionWorkspace() {
           <div className="flex h-[38px] items-end gap-1 border-b border-line bg-panel px-6">
             <TabButton
               active={activeTab === "feed"}
-              onClick={() => setActiveTab("feed")}
+              onClick={selectFeed}
               shortcut="⌘1"
             >
               feed
@@ -955,7 +1053,7 @@ export default function MissionWorkspace() {
                       key={s.id}
                       handle={s.handle}
                       active={activeTab === s.id}
-                      onClick={() => setActiveTab(s.id)}
+                      onClick={() => selectPty(s.id)}
                       onClose={() => onCloseTab(s.id)}
                       shortcut={index < 8 ? `⌘${index + 2}` : undefined}
                     />


### PR DESCRIPTION
## Summary
- remember the last selected PTY session per mission and restore it on workspace remount when still valid
- reopen/validate the remembered PTY tab before selection and clear stale values on reset/archive/close/missing rows
- let Cmd+K/Cmd+N Meta shortcuts work while xterm is focused without stealing Ctrl shortcuts from the PTY
- add the missing feature spec for issue #236

## Validation
- human smoke test passed
- reviewer clean review with no must-fix findings
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check HEAD
- make test passed pre-PR after rerun outside sandbox for the Unix-socket MCP test

Closes #236