### PR TITLE
Add copy controls for session keys

### DIFF
--- a/src/components/MissionMetaPanel.tsx
+++ b/src/components/MissionMetaPanel.tsx
@@ -1,8 +1,8 @@
 // Right-rail variant for the mission workspace — read-only display of
-// the effective mission goal (snapshotted into the `mission_goal`
-// event at mission_start), `mission.cwd`, the crew handle (link),
-// and a relative-time "started" row. Toggle into this view via the
-// icon strip in the rail header.
+// the mission id, effective mission goal (snapshotted into the
+// `mission_goal` event at mission_start), `mission.cwd`, the crew
+// handle (link), and a relative-time "started" row. Toggle into this
+// view via the icon strip in the rail header.
 //
 // Editing is intentionally not in v1: goal + cwd are baked into the
 // lead's launch prompt at `mission_start`, so post-start edits don't
@@ -14,6 +14,7 @@ import { Link } from "react-router-dom";
 import { Clock3, Users } from "lucide-react";
 import { revealItemInDir } from "@tauri-apps/plugin-opener";
 
+import { CopyValueButton } from "./ui/CopyValueButton";
 import type { Crew, Mission } from "../lib/types";
 
 interface MissionMetaPanelProps {
@@ -53,6 +54,15 @@ export function MissionMetaPanel({
       <div className="text-[10px] font-semibold uppercase tracking-[0.15em] text-fg-3">
         Mission detail
       </div>
+
+      <Section label="Mission ID">
+        <span className="flex min-w-0 items-start gap-1.5">
+          <span className="min-w-0 flex-1 break-all font-mono text-[11px] text-fg-2">
+            {mission.id}
+          </span>
+          <CopyValueButton value={mission.id} label="Copy mission ID" />
+        </span>
+      </Section>
 
       <Section label="Goal">
         {missionGoal === null ? (
@@ -99,12 +109,6 @@ export function MissionMetaPanel({
       </Section>
 
       <div className="h-px w-full bg-line" />
-
-      <Section label="Mission ID">
-        <span className="break-all font-mono text-[11px] text-fg-2">
-          {mission.id}
-        </span>
-      </Section>
     </div>
   );
 }

--- a/src/components/RunnersRail.tsx
+++ b/src/components/RunnersRail.tsx
@@ -6,6 +6,7 @@
 
 import { Terminal } from "lucide-react";
 
+import { CopyValueButton } from "./ui/CopyValueButton";
 import type { SessionRow } from "../lib/api";
 
 interface RunnersRailProps {
@@ -107,9 +108,15 @@ export function RunnersRail({
               <div className="text-[11px] text-fg-2">{subtitle}</div>
               <div className="grid grid-cols-[72px_minmax(0,1fr)] gap-2 border-t border-line/70 pt-2 text-[10px] leading-snug">
                 <span className="text-fg-3">session_key</span>
-                <span className="break-all font-mono text-fg-2">
-                  {s.agent_session_key ?? "NULL"}
-                </span>
+                <div className="flex min-w-0 items-start gap-1.5">
+                  <span className="min-w-0 flex-1 break-all font-mono text-fg-2">
+                    {s.agent_session_key ?? "NULL"}
+                  </span>
+                  <CopyValueButton
+                    value={s.agent_session_key}
+                    label={`Copy @${s.handle} session_key`}
+                  />
+                </div>
               </div>
             </div>
           );

--- a/src/components/ui/CopyValueButton.tsx
+++ b/src/components/ui/CopyValueButton.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+interface CopyValueButtonProps {
+  value: string | null | undefined;
+  label: string;
+}
+
+export function CopyValueButton({ value, label }: CopyValueButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const resetTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimer.current !== null) window.clearTimeout(resetTimer.current);
+    };
+  }, []);
+
+  if (!value) return null;
+
+  const copyValue = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(true);
+      if (resetTimer.current !== null) window.clearTimeout(resetTimer.current);
+      resetTimer.current = window.setTimeout(() => setCopied(false), 1500);
+    } catch (e) {
+      console.error("CopyValueButton: clipboard write failed", e);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      aria-label={label}
+      title={copied ? "Copied" : label}
+      onClick={(e) => {
+        e.stopPropagation();
+        void copyValue();
+      }}
+      onKeyDown={(e) => e.stopPropagation()}
+      className="inline-flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-fg-3 transition-colors hover:bg-line/60 hover:text-fg focus:bg-line/60 focus:text-fg focus:outline-none"
+    >
+      {copied ? (
+        <Check aria-hidden className="h-3 w-3" />
+      ) : (
+        <Copy aria-hidden className="h-3 w-3" />
+      )}
+    </button>
+  );
+}

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -34,6 +34,7 @@ import {
   ResumingButton,
   StopButton,
 } from "../components/ui/SessionControl";
+import { CopyValueButton } from "../components/ui/CopyValueButton";
 import {
   ArchivingOverlay,
   ResumingOverlay,
@@ -1314,8 +1315,14 @@ function RunnerSidePanel({
                     {chatMeta ? (
                       <>
                         <dt className="text-fg-3">session_key</dt>
-                        <dd className="break-all font-mono text-fg-2">
-                          {chatMeta.agent_session_key ?? "NULL"}
+                        <dd className="flex min-w-0 items-start gap-1.5">
+                          <span className="min-w-0 flex-1 break-all font-mono text-fg-2">
+                            {chatMeta.agent_session_key ?? "NULL"}
+                          </span>
+                          <CopyValueButton
+                            value={chatMeta.agent_session_key}
+                            label="Copy session_key"
+                          />
                         </dd>
                       </>
                     ) : null}
@@ -1364,8 +1371,14 @@ function RunnerSidePanel({
                     </>
                   ) : null}
                   <dt className="text-fg-3">session_key</dt>
-                  <dd className="break-all font-mono text-fg-2">
-                    {chatMeta.agent_session_key ?? "NULL"}
+                  <dd className="flex min-w-0 items-start gap-1.5">
+                    <span className="min-w-0 flex-1 break-all font-mono text-fg-2">
+                      {chatMeta.agent_session_key ?? "NULL"}
+                    </span>
+                    <CopyValueButton
+                      value={chatMeta.agent_session_key}
+                      label="Copy session_key"
+                    />
                   </dd>
                 </dl>
               </div>


### PR DESCRIPTION
Summary:
- Add a compact shared copy icon button for clipboard values.
- Add copy controls beside direct chat and mission runner rail session_key displays.
- Add copyable Mission ID to the Mission Info panel without showing redundant session keys.

Validation:
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check

Review:
- Peer reviewer reported no must-fix findings.