### PR TITLE
fix(mcp): give human-signal payload a typed schema so tool discovery doesn't fail

### DIFF
--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -419,6 +419,11 @@ pub struct PostHumanSignalInput {
     /// Signal type — restricted to the human-originated ones the workspace
     /// UI is allowed to emit. Anything else is rejected.
     pub signal_type: String,
+    /// Free-form JSON object carried with the signal. Annotated so schemars
+    /// emits a schema with an explicit `type`; a bare `serde_json::Value`
+    /// derives a typeless schema (`{}`), which strict MCP clients reject —
+    /// and the rejection drops the entire advertised tool list (#240).
+    #[schemars(with = "std::collections::HashMap<String, serde_json::Value>")]
     pub payload: serde_json::Value,
 }
 

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -126,7 +126,10 @@ mod tests {
             });
             for (field, schema) in props {
                 let obj = schema.as_object().unwrap_or_else(|| {
-                    panic!("{}: inputSchema.properties.{field} is not an object", tool.name)
+                    panic!(
+                        "{}: inputSchema.properties.{field} is not an object",
+                        tool.name
+                    )
                 });
                 assert!(
                     obj.contains_key("type") || obj.contains_key("$ref"),

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -106,4 +106,37 @@ mod tests {
         .collect();
         assert_eq!(names, expected, "MCP tool registry diverged from Phase 2");
     }
+
+    // Regression for #240. A bare `serde_json::Value` field derives a
+    // *typeless* schema (`{}`, plus any doc-comment `description`). Strict MCP
+    // clients reject a property schema that declares neither `type` nor
+    // `$ref`, and because tool discovery validates the whole `tools` array at
+    // once, that single bad schema drops every Runner tool. Assert every tool
+    // input property declares a `type` or `$ref` so a future free-form field
+    // can't silently take the registry down again.
+    #[test]
+    fn every_tool_input_property_declares_a_type() {
+        let router = RunnerMcpHandler::tool_router();
+        for tool in router.list_all() {
+            let Some(props) = tool.input_schema.get("properties") else {
+                continue;
+            };
+            let props = props.as_object().unwrap_or_else(|| {
+                panic!("{}: inputSchema.properties is not an object", tool.name)
+            });
+            for (field, schema) in props {
+                let obj = schema.as_object().unwrap_or_else(|| {
+                    panic!("{}: inputSchema.properties.{field} is not an object", tool.name)
+                });
+                assert!(
+                    obj.contains_key("type") || obj.contains_key("$ref"),
+                    "{}: inputSchema.properties.{field} must declare `type` or `$ref` \
+                     (strict MCP clients reject typeless schemas, dropping the whole \
+                     tool list — #240); got keys {:?}",
+                    tool.name,
+                    obj.keys().collect::<Vec<_>>(),
+                );
+            }
+        }
+    }
 }


### PR DESCRIPTION
## What

`mission_post_human_signal`'s argument struct `PostHumanSignalInput` has a `payload: serde_json::Value` field. `schemars` derives a **typeless** schema for `serde_json::Value` — `{}` (here plus a `description` from the doc comment), with no `type` and no `$ref`.

Strict MCP clients reject any `inputSchema.properties.*` entry that declares neither `type` nor `$ref`. And because tool discovery validates the **entire** advertised `tools` array at once, that one bad property schema drops **every** Runner MCP tool. Symptom in Claude Code:

```
Reconnected to runner, but fetching tools failed: [
  { "code": "custom", "path": ["tools", 11, "inputSchema", "properties", "payload"], "message": "Invalid input" }
]
```

Every other property across all 30 tools already carries a `type` or `$ref`; `payload` was the sole exception.

## Fix

Annotate the field so `schemars` emits a schema with an explicit `type`:

```rust
#[schemars(with = "std::collections::HashMap<String, serde_json::Value>")]
pub payload: serde_json::Value,
```

`payload` now serializes as `{"type":"object","additionalProperties":true,...}`. The Rust type is unchanged (`serde_json::Value`), so deserialization is unaffected; only the advertised schema gains a `type`. Human-signal payloads are JSON objects in practice (passed straight into `EventDraft.payload`), so `type: object` is accurate.

Also adds a regression test, `every_tool_input_property_declares_a_type`, that walks `RunnerMcpHandler::tool_router()` and asserts every tool input property declares a `type` or `$ref` — so a future free-form `serde_json::Value` field can't silently take the whole tool list down again.

## Test plan

- `cargo test --lib mcp::server::tests` — passes.
- Verified the regression test **fails without** the fix (`payload must declare type or $ref ... got keys ["description"]`) and **passes with** it.
- Manual: with Runner running this build, an MCP client's `tools/list` resolves and all `mcp__runner__*` tools load.

Fixes #240
