### PR TITLE
feat: multi-window (Arc-style duplicate-subject overlay) — impl 0018

### DIFF
--- a/docs/features/12-multi-window.md
+++ b/docs/features/12-multi-window.md
@@ -49,7 +49,7 @@ that story.
   `Mission(id)` or `DirectChat(session_id)`. On any change, it broadcasts
   a `window_focus_map` event so every window has a consistent picture.
 - **Arc-style overlay.** If a window's current subject is also held by
-  another window with an *earlier* `focused_at` timestamp, this window
+  another window with a *later* `focused_at` timestamp, this window
   is the **secondary**. The mission/chat view renders an overlay over
   the main content area:
   - Title: "Open in another window"
@@ -61,15 +61,16 @@ that story.
     (e.g. to `/runners` empty state, or back via router history).
 - **No PTY / xterm mount on the secondary.** xterm has DOM state and
   consumes stdin; double-mounting against one session creates input
-  races. The overlay is what gates the mount: the workspace component
-  skips `mission_attach` / `session_attach` while the overlay is up,
-  and unmounts the terminal if the window flips from primary to
-  secondary mid-session.
-- **Window close behavior.** Closing a non-last window just unregisters
-  it from the focus map; the backend keeps running. Closing the *last*
-  window quits the app (today's behavior). If the primary window for a
-  subject closes, the secondary becomes primary automatically (the
-  earliest `focused_at` among surviving windows wins).
+  races. The overlay is what gates terminal ownership: the workspace
+  may still load mission/session metadata, but it does not mount
+  terminal components or send stdin/resize/start requests while the
+  overlay is up, and unmounts the terminal if the window flips from
+  primary to secondary mid-session.
+- **Window close behavior.** Closing a secondary window unregisters and
+  destroys it; closing `main` keeps today's hide-on-close behavior. Use
+  Quit / `Cmd+Q` to exit the app. If the primary window for a subject
+  closes, the secondary becomes primary automatically (the latest
+  `focused_at` among surviving windows wins).
 
 ### Out of scope (deferred)
 
@@ -112,11 +113,12 @@ that story.
    map and fans it out. Peer-to-peer coordination via the Tauri event
    bus would race on window-spawn and need conflict resolution. Central
    registry is one mutex, one source of truth.
-4. **The overlay gates the mount, not just the display.** A secondary
-   window doesn't merely *hide* the terminal — it never calls
-   `session_attach` / `mission_attach` in the first place. This is what
-   keeps stdin / PTY input single-writer and what makes `mission_attach`
-   idempotent contract still hold (one attached window per mission).
+4. **The overlay gates the terminal mount, not just the display.** A
+   secondary window doesn't merely *hide* the terminal — it does not
+   mount `RunnerTerminal` or send stdin/resize/start requests. Backend
+   lifecycle calls such as `mission_attach` can remain idempotent if
+   they are only ensuring routers/buses exist; the single-writer rule
+   applies to PTY ownership.
 5. **`emit` stays broadcast.** Today `app.emit("…", payload)` reaches
    every webview. That's fine: each window's frontend filters by its
    own current subject. No need to switch to `emit_to(label, …)` for
@@ -181,7 +183,7 @@ that story.
   `null`.
 - A new `<DuplicateSubjectOverlay>` component:
   - Reads the focus map + this window's label and current subject.
-  - If another window has the same subject with an earlier
+  - If another window has the same subject with a later
     `focused_at`, render an absolute-positioned card over the main
     content area: title, subtitle, "Focus that window" button,
     secondary "Stay here" link.
@@ -189,9 +191,9 @@ that story.
     a duplicate view — the overlay should reappear if they navigate away
     and back. (Don't persist a per-subject dismiss flag; keep it simple.)
 - `MissionWorkspace` and `RunnerChat` check `isSecondary` from the
-  focus map and short-circuit `mission_attach` / `session_attach` calls
-  + terminal mount while it's true. They re-attach on flip back to
-  primary.
+  focus map and short-circuit terminal population/mount, stdin,
+  resize, and start paths while it's true. They re-attach terminals on
+  flip back to primary.
 
 ### Phase 4 — new-window affordances
 
@@ -208,26 +210,27 @@ that story.
 
 - Backend tests: unit tests for `WindowRegistry` covering register /
   unregister / set_subject / focus / primary_for, including the
-  "earliest focused_at wins" rule.
+  "most recent focused_at wins" rule.
 - Frontend manual smoke:
   1. Open Runner. `Cmd+N` opens a second window. Both windows are
      functional, can navigate independently.
-  2. Window A opens mission X. Window B opens mission X. Window B
-     shows the overlay (it's the more recent focus). Click "Focus
-     that window" — window A comes forward, window B keeps showing
-     the overlay.
-  3. Click into window B (focus it). Now B is primary, A's mission
+  2. Window A opens mission X. Window B opens mission X. Window B is
+     primary because it is the more recent focus; window A shows the
+     overlay. Click "Focus that window" in A — window B comes forward.
+  3. Click into window A (focus it). Now A is primary, B's mission
      view picks up the overlay. (Focus flip works both directions.)
-  4. In window A (secondary now), navigate to a different mission.
-     A's overlay disappears; B's overlay disappears (B is alone on
+  4. In window B (secondary now), navigate to a different mission.
+     B's overlay disappears; A's overlay disappears (A is alone on
      mission X again, becomes primary).
   5. Open the same direct chat in two windows. Same overlay rules.
      Confirm only one window's xterm is mounted at a time and the
      PTY input lands once.
-  6. Close window A (the primary for mission X). B's overlay
-     disappears, B becomes primary.
-  7. Quit the app (close the last window). On reopen, only the main
-     window comes back (window restoration is out of scope for v1).
+  6. With both windows back on mission X, close window A (the primary
+     for mission X). B's overlay disappears, B becomes primary.
+  7. Close secondary windows. They unregister/destroy. Close `main`.
+     It hides as it does today. Quit via `Cmd+Q` / app menu. On reopen,
+     only the main window comes back (window restoration is out of
+     scope for v1).
 
 ## Verification
 
@@ -243,8 +246,8 @@ that story.
       session. Input lands in exactly one stream.
 - [ ] Closing the primary promotes the secondary to primary; overlay
       disappears.
-- [ ] Closing the last window quits the app. (Today's behavior, not
-      regressed.)
+- [ ] Closing secondary windows destroys them; closing `main` hides the
+      app window; Quit / `Cmd+Q` exits the app.
 - [ ] Backend `window_focus_map` broadcasts after every mutation; the
       frontend reflects it without polling.
 - [ ] `cargo test --workspace` and `pnpm exec tsc --noEmit` clean.

--- a/docs/impls/0018-multi-window.md
+++ b/docs/impls/0018-multi-window.md
@@ -1,0 +1,196 @@
+# Multi-window Frontend (Arc-style duplicate-subject overlay)
+
+## Status
+
+In progress for issue [#122](https://github.com/yicheng47/runner/issues/122). Implements feature spec [docs/features/12-multi-window.md](../features/12-multi-window.md).
+
+## Problem
+
+Runner ships as a single Tauri window (`src-tauri/tauri.conf.json` declares exactly one, label `main`). For an editor whose unit of work is a long-running mission with sub-conversations, that's a constraint: the user can't park mission A on one monitor while mission B runs on another, or watch a feed in one window while tailing a PTY in another.
+
+The backend is already single-source-of-truth: one process, one `SessionManager`, one `RouterRegistry`, one `BusRegistry`, and event emission via `app.emit(...)` already broadcasts to every webview (`event_bus::TauriBusEvents`, `session::manager::TauriSessionEvents`). The missing pieces are entirely about *coordination*: spawning additional webviews, tracking which subject (mission / direct-chat) each window is looking at, and gating PTY attach so two windows never write to the same stdin.
+
+## Goals
+
+- Spawn additional webview windows via `Cmd+N`, a `File → New Window` menu item, an "Open in New Window" sidebar context action, and a `window_open` command.
+- Each window owns an independent `BrowserRouter` history and reports its current subject (mission id / direct-chat session id) to the backend on route change.
+- A backend `WindowRegistry` maps window label → subject + `focused_at`, and broadcasts `window_focus_map` after every mutation.
+- Arc-style overlay: when two windows share a subject, the more-recently-focused window is **primary**; the other(s) render an overlay with "Focus that window" → `set_focus()` on the primary.
+- **PTY / xterm mounts only in the primary**: terminal components and stdin-capable session UI do not mount while a window is secondary; re-attach on flip back to primary. `mission_attach` remains an idempotent backend lifecycle call unless implementation proves it must be primary-only.
+- Closing a secondary unregisters/destroys it; closing the primary promotes the surviving next-most-recent focused window for that subject. The `main` window keeps its existing hide-on-close behavior.
+
+## Non-Goals (v1, deferred)
+
+- Window restoration across app restart (pairs with spec 10 / mission-session persistence).
+- Per-window settings (zoom / font / theme remain app-global).
+- Tab-tearing, shared-PTY render across windows, multi-instance / multi-process.
+- Targeted `emit_to(label, ...)`. Broadcast `emit` stays; each window filters by its own subject (already the case for `event/appended`, `session/output`, etc.).
+
+## Key Constraints Discovered
+
+1. **Capabilities are scoped to `["main"]`.** `src-tauri/capabilities/default.json` lists `"windows": ["main"]`, so a freshly spawned `window-<ulid>` would have **zero** permissions — it couldn't `invoke` a command or `listen` to an event. This must change to a glob (`["main", "window-*"]`). Because windows are created from Rust (`WebviewWindowBuilder`), we do **not** need the JS-side `core:webview:allow-create-webview-window` permission. `core:window:allow-set-focus` is already present, which `window_focus_other` needs.
+
+2. **`app_ready` shows only `main`.** `commands::app::show_main_window` hard-codes `get_webview_window("main")`. Secondary windows start hidden to avoid the white-flash, so the show-after-first-paint command must show the *calling* window. Generalize `app_ready` to take the invoking `tauri::WebviewWindow` and show that.
+
+3. **Frontend is `BrowserRouter` (HTML5 history), not hash router.** A new window loads `index.html`; a deep path like `/missions/<id>` won't resolve through Tauri's asset protocol in release builds. Pass the initial route as a URL **hash fragment** (`index.html#/missions/<id>`) and have a small bootstrap read `location.hash` on mount, `navigate()` to it, and clear the hash. This matches the spec and sidesteps deep-link asset resolution.
+
+4. **`main` close is special-cased.** `lib.rs::run`'s `RunEvent` handler intercepts `CloseRequested` for `label == "main"`, prevents close, and hides. Secondary windows must be allowed to actually close (destroy). Registry cleanup keys off `WindowEvent::Destroyed`, not `CloseRequested`, so it fires for both the genuine close of a secondary and any future real close.
+
+## Proposed Backend Design
+
+### Phase 1 — `WindowRegistry` module (`src-tauri/src/windows.rs`)
+
+New module, mirroring the `Mutex<HashMap<...>>` shape used elsewhere in the crate.
+
+```rust
+pub enum Subject {
+    Mission(String),
+    DirectChat(String), // session_id
+}
+
+pub struct WindowEntry {
+    pub label: String,
+    pub subject: Option<Subject>,
+    pub focused_at: chrono::DateTime<Utc>,
+}
+
+pub struct WindowRegistry { /* Mutex<HashMap<String, WindowEntry>> */ }
+```
+
+`Subject` derives `Serialize`/`Deserialize`/`Clone`/`PartialEq`. Serialize as a tagged enum so the frontend gets `{ "type": "Mission", "value": "..." }` or similar — pick the serde tag shape and mirror it in `src/lib/types.ts`. `WindowEntry` is `Serialize` for the broadcast payload.
+
+Methods:
+
+- `register(label)` — insert with `subject: None`, `focused_at: now()`.
+- `unregister(label)` — remove.
+- `set_subject(label, Option<Subject>)` — update subject; leave `focused_at` untouched (subject change ≠ focus change).
+- `mark_focused(label)` — bump `focused_at = now()`.
+- `snapshot() -> Vec<WindowEntry>` — for the broadcast payload and `window_list_subjects`.
+- `primary_for(&Subject) -> Option<String>` — among windows holding this subject, the one with the **max** `focused_at` is primary.
+
+Primary invariant: **most-recently-focused window owns the subject**. When a window is focused, `focused_at = now()`. A window is secondary when another window holds the same subject with a later `focused_at`. When the primary closes, the next-most-recent survivor becomes primary.
+
+Add to `AppState` (`lib.rs`): `pub windows: Arc<windows::WindowRegistry>`. Construct in `setup`, register `"main"` immediately, and `.manage` it as part of `AppState` (no separate `.manage`).
+
+### Phase 1 (cont.) — Tauri window lifecycle hooks
+
+In `lib.rs::run`'s `RunEvent` match, extend window handling:
+
+- `WindowEvent::Focused(true)` for any label → `registry.mark_focused(label)` then broadcast.
+- `WindowEvent::Destroyed` for any label → `registry.unregister(label)` then broadcast.
+- `WindowEvent::CloseRequested` for `label == "main"` → unchanged (prevent + hide). App quit remains the explicit Quit / `Cmd+Q` path, not close-main-window.
+- `WindowEvent::CloseRequested` for other labels → let it proceed (default destroy); the subsequent `Destroyed` handles unregister.
+
+Broadcast helper: `fn broadcast_focus_map(app: &AppHandle)` → `app.emit("window_focus_map", registry.snapshot())`. Called from every mutation (hooks + commands).
+
+### Phase 2 — Tauri window-opening helper + commands (`src-tauri/src/commands/window.rs`, new module)
+
+Register in `commands/mod.rs` (`pub mod window;`) and add all four to the `generate_handler!` list in `lib.rs`.
+
+- Shared helper `open_window(app: &AppHandle, state: &AppState, initial_route: Option<String>, position: Option<(i32, i32)>) -> Result<String>` — used by both the Tauri command and the Rust menu handler. Keep the window-building logic out of the command wrapper so `on_menu_event` can call the same path via `app.state::<AppState>()`.
+- `window_open(app, state, initial_route: Option<String>, position: Option<(i32, i32)>) -> Result<String>` — thin command wrapper around the shared helper.
+  - Generate label `window-<ulid>` (ULID dep already present).
+  - `WebviewWindowBuilder::new(&app, &label, WebviewUrl::App(url.into()))` where `url` is `"index.html"` or `"index.html#<initial_route>"`.
+  - Mirror `main`'s chrome via builder methods: `.title("Runner")`, `.inner_size(1440.0, 900.0)`, `.title_bar_style(TitleBarStyle::Overlay)`, `.hidden_title(true)`, `.traffic_light_position(Position)`, `.accept_first_mouse(true)`, `.visible(false)` (shown by the generalized `app_ready` after first paint). Apply `position` if provided, else a small cascade offset from the focused window.
+  - `registry.register(&label)`, broadcast, return label.
+- `window_focus_other(app, label: String) -> Result<()>` — `app.get_webview_window(&label).map(|w| w.set_focus())`.
+- `window_report_subject(window: tauri::WebviewWindow, state, subject: Option<Subject>) -> Result<()>` — resolve label from `window.label()`, `registry.set_subject(label, subject)`, broadcast.
+- `window_list_subjects(state) -> Result<Vec<WindowEntry>>` — `registry.snapshot()` for hydrate-on-mount.
+
+Generalize `commands::app::app_ready` to `app_ready(window: tauri::WebviewWindow)` and show/focus the **calling** window instead of hard-coded `"main"`. `show_main_window` stays for the macOS `Reopen` path.
+
+### Phase 2 (cont.) — capabilities
+
+Edit `src-tauri/capabilities/default.json`: `"windows": ["main", "window-*"]`. No new permissions needed (creation is Rust-side; `set-focus`, event listen, and command invoke are already covered by the existing list + `core:default`).
+
+### Backend tests
+
+Unit tests in `windows.rs`:
+
+- `register` / `unregister` round-trip.
+- `set_subject` updates subject without touching `focused_at`.
+- `mark_focused` bumps timestamp; `primary_for` returns the most-recently-focused holder.
+- Promotion: two windows on a subject, primary unregistered → `primary_for` returns the survivor.
+- `None` subjects never count as a duplicate (no overlay for empty windows).
+
+These are pure registry tests (no Tauri runtime), so they run under `cargo test --workspace` like the existing command unit tests.
+
+## Proposed Frontend Design
+
+### Phase 3 — coordination layer (`src/lib/windowFocus.ts`)
+
+- `useCurrentWindowLabel()` — caches `getCurrentWindow().label` at module load (from `@tauri-apps/api/window`).
+- `useWindowFocus()` — subscribes to `window_focus_map` (via `listen`) and exposes the latest `WindowEntry[]`; hydrates once on mount via `api.window.listSubjects()` so it doesn't wait for the first broadcast.
+- `reportSubject(subject: Subject | null)` — debounced wrapper over `window_report_subject`.
+- Derived helper `isSecondaryFor(map, myLabel, subject)` — true when another entry holds the same subject with a later `focused_at` than mine. Returns the primary's label for the overlay subtitle / focus button.
+- `api.window` block added to `src/lib/api.ts`: `open(initialRoute?, position?)`, `focusOther(label)`, `reportSubject(subject)`, `listSubjects()`. `Subject` / `WindowEntry` types added to `src/lib/types.ts`.
+
+### Phase 3 (cont.) — bootstrap initial route
+
+In `App.tsx` (inside the `BrowserRouter`), a tiny `<InitialRouteBootstrap>` effect: on first mount, if `location.hash` is non-empty, `navigate(hash.slice(1), { replace: true })` and clear the hash. Runs once per window. (Alternatively in `main.tsx` before render — but doing it inside the router via `useNavigate` is cleaner.)
+
+### Phase 3 (cont.) — wire subjects + gate attach
+
+- `MissionWorkspace` (`src/pages/MissionWorkspace.tsx`): `reportSubject({ Mission: id })` on mount, `reportSubject(null)` on unmount. Compute `isSecondary` from `useWindowFocus()`. The data-loading portion of the mount effect may still fetch mission/session/event state, and `api.mission.attach(id)` may remain safe/idempotent; the hard gate is terminal ownership. While `isSecondary`, do not auto-populate `openTabs`, do not render `RunnerTerminal`, and do not send stdin/resize/start requests. On flip secondary→primary, attach/mount terminals normally; on flip primary→secondary mid-session, unmount terminals, clear terminal refs, and avoid leaving hidden PTYs mounted. Render `<DuplicateSubjectOverlay>` over the main content area when secondary.
+- `RunnerChat` (`src/pages/RunnerChat.tsx`): `reportSubject({ DirectChat: sessionId })` / `null`; same `isSecondary` gating around the `RunnerTerminal` map and `session_start_direct` / resize path. On flip primary→secondary, unmount the terminal map and reset the local attach/start refs needed for a clean reattach when it becomes primary again. Render the overlay.
+- Other route pages report `null` on mount (or rely on the previous subject being cleared on the unmount of Mission/Chat). Simplest: a shared `useReportSubject(subject)` hook that reports on mount and clears on unmount; non-subject pages call `useReportSubject(null)`.
+
+### Phase 3 (cont.) — `<DuplicateSubjectOverlay>` (`src/components/DuplicateSubjectOverlay.tsx`)
+
+Absolute-positioned card over the content area. Title "Open in another window", subtitle showing the primary window's label / workspace, primary button "Focus that window" → `api.window.focusOther(primaryLabel)`, secondary "Stay here" link that hides the overlay for the current view (no persisted dismiss flag — reappears on navigate-away-and-back, per spec decision 6). Styled to match existing modal/card components (reuse Tailwind tokens from e.g. `SettingsModal`).
+
+### Phase 4 — new-window affordances + shortcut swap
+
+**Shortcut convention (browser/terminal standard): `Cmd+T` = new chat, `Cmd+N` = new window.** Today `Cmd+N` opens the Start Chat modal via the Sidebar keydown handler (`src/components/Sidebar.tsx:249`, `setCreatingChat(true)`, hint `⌘N` at line 913). Rebind:
+
+- **`Cmd+T` → new chat**: in the Sidebar `onKey` handler change the `e.key === "n"` branch to `"t"` (keep `setCreatingChat(true)`); update the `⌘N` hint on `NewChatNavRow` to `⌘T` and the comment at `Sidebar.tsx:224`. Remove `n` from the JS handler entirely so it doesn't double-fire with the menu accelerator below.
+- **`Cmd+N` → new window**: add `File → New Window` to `build_menu` in `lib.rs` with a `Cmd+N` (`CmdOrCtrl+N`) accelerator. macOS adds a `File` submenu (currently absent); route the menu event in `on_menu_event` to the shared `open_window(..., None, None)` helper. Owning the shortcut at the OS/menu level (rather than a JS keydown handler) is cleaner and is why the JS `n` branch is removed. Non-macOS: add `File → New Window` to the existing menu.
+
+> Order note: both changes land together in this phase, so `Cmd+N` is never dead — it's only repurposed once `window_open` (Phase 2) exists.
+
+- **Sidebar context menus**: extend the existing per-row context menus (mission rows, session rows — state already exists at `sessionMenu`) with "Open in New Window" → `api.window.open("/missions/<id>")` or `api.window.open("/chats/<sessionId>")`.
+- **Empty state**: a `Cmd+N` window with no initial route lands on `/runners` (existing default), `subject: None`, no overlay.
+
+### Frontend checks
+
+`pnpm exec tsc --noEmit` and `pnpm run lint` clean.
+
+## Phase 5 — Verification & smoke
+
+Backend: `cargo test --workspace` (registry unit tests + existing suite).
+
+Manual smoke (from spec §Phase 5):
+
+1. `Cmd+N` opens a second functional window; both navigate independently.
+2. Window A opens mission X, window B opens mission X → B is primary, A shows overlay. "Focus that window" from A brings B forward.
+3. Focus A → A becomes primary, B picks up the overlay (flip works both ways).
+4. In secondary B, navigate to a different mission → both overlays clear (A alone on X).
+5. Same direct chat in two windows → same rules; exactly one xterm mounted, PTY input lands once.
+6. With two windows back on X, close the primary for X → survivor's overlay clears, becomes primary.
+7. Close secondary windows → they unregister/destroy; close `main` → app hides as it does today. Quit via `Cmd+Q` / app menu → only `main` returns on reopen (no restoration; deferred).
+
+## Relevant Code
+
+- `src-tauri/src/lib.rs:32-53` — `AppState` (add `windows`).
+- `src-tauri/src/lib.rs:106-244` — `setup` (construct + register `main`).
+- `src-tauri/src/lib.rs:302-342` — `RunEvent` handler (Focused / Destroyed / CloseRequested hooks).
+- `src-tauri/src/lib.rs:246-299` — `generate_handler!` (register window commands).
+- `src-tauri/src/lib.rs:414-469` — `build_menu` (File → New Window).
+- `src-tauri/src/commands/mod.rs` — add `pub mod window;`.
+- `src-tauri/src/commands/app.rs:9-21` — `app_ready` / `show_main_window` (generalize to calling window).
+- `src-tauri/src/commands/mission.rs:906-1033` — `mission_attach` (kept idempotent unless implementation proves it must be primary-only).
+- `src-tauri/capabilities/default.json` — `windows` glob.
+- `src/App.tsx:73-91` — router + initial-route bootstrap.
+- `src/lib/api.ts`, `src/lib/types.ts` — `api.window`, `Subject`, `WindowEntry`.
+- `src/pages/MissionWorkspace.tsx:143-257`, `src/pages/RunnerChat.tsx` — report subject + gate attach + overlay.
+- `src/components/RunnerTerminal.tsx` — mounted/unmounted by the gating logic (no internal change expected).
+- `src/components/Sidebar.tsx:167-436` — context-menu "Open in New Window".
+
+## Implementation Order
+
+1. Backend registry + lifecycle hooks + `AppState` wiring + unit tests (Phase 1).
+2. Backend commands + capabilities + generalized `app_ready` (Phase 2).
+3. Frontend `windowFocus.ts` + types/api + initial-route bootstrap (Phase 3a).
+4. Overlay component + subject reporting + attach gating in Mission/Chat (Phase 3b).
+5. Menu + sidebar affordances (Phase 4).
+6. Typecheck/lint/tests + manual smoke (Phase 5).

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Capability for all app windows",
-  "windows": ["main"],
+  "windows": ["main", "window-*"],
   "permissions": [
     "core:default",
     "core:window:allow-start-dragging",

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -1,4 +1,9 @@
-use tauri::{AppHandle, Manager};
+use tauri::AppHandle;
+// `Manager` is only needed by the macOS-only `show_main_window`
+// (`get_webview_window`); importing it unconditionally trips `unused_imports`
+// under `-D warnings` on other platforms.
+#[cfg(target_os = "macos")]
+use tauri::Manager;
 use tauri_plugin_opener::OpenerExt;
 
 use crate::error::Error;
@@ -16,6 +21,10 @@ pub fn app_ready(window: tauri::WebviewWindow) -> crate::error::Result<()> {
     Ok(())
 }
 
+/// Show + focus the `main` window. Used only by the macOS `Reopen` path
+/// (dock-icon click with no visible windows); `app_ready` shows the calling
+/// window directly, so this is dead code on other platforms.
+#[cfg(target_os = "macos")]
 pub(crate) fn show_main_window(app: &AppHandle) -> crate::error::Result<()> {
     let window = app
         .get_webview_window("main")

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -5,11 +5,15 @@ use crate::error::Error;
 use crate::log_dir_for_build;
 
 /// Called by the frontend after React has mounted and painted its first frame.
-/// Shows the main window — the window starts hidden so the user sees the dock
-/// bounce → fully-rendered window instead of a blank webview.
+/// Shows the **calling** window — every window (main + secondaries) starts
+/// hidden so the user sees the dock bounce → fully-rendered window instead of
+/// a blank webview. Resolving the window from the invoking webview (rather
+/// than hard-coding `main`) is what lets secondary windows reveal themselves.
 #[tauri::command]
-pub fn app_ready(app: AppHandle) -> crate::error::Result<()> {
-    show_main_window(&app)
+pub fn app_ready(window: tauri::WebviewWindow) -> crate::error::Result<()> {
+    window.show().map_err(|e| Error::msg(e.to_string()))?;
+    window.set_focus().map_err(|e| Error::msg(e.to_string()))?;
+    Ok(())
 }
 
 pub(crate) fn show_main_window(app: &AppHandle) -> crate::error::Result<()> {

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -12,3 +12,4 @@ pub mod runner;
 pub mod runtime;
 pub mod session;
 pub mod slot;
+pub mod window;

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -41,6 +41,9 @@ pub fn open_window(
     // Mirror `main`'s chrome (tauri.conf.json) so secondary windows are
     // visually identical. Starts hidden to avoid the white flash; the
     // generalized `app_ready` shows the calling window after first paint.
+    // `mut` is only consumed by the macOS chrome block below — other
+    // platforms have no extra builder methods, hence the conditional allow.
+    #[cfg_attr(not(target_os = "macos"), allow(unused_mut))]
     let mut builder = WebviewWindowBuilder::new(app, &label, url)
         .title("Runner")
         .inner_size(1440.0, 900.0)

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -1,0 +1,135 @@
+// Window lifecycle commands (impl 0018, spec 12).
+//
+// Additional webview windows are built Rust-side via `WebviewWindowBuilder`,
+// so no JS-side `core:webview:allow-create-webview-window` permission is
+// needed — the frontend only ever *invokes* these commands. Each new window
+// mounts the same React bundle; an optional initial route rides as a URL hash
+// fragment that a tiny frontend bootstrap consumes on mount.
+
+use tauri::{AppHandle, Manager, State, WebviewUrl, WebviewWindowBuilder};
+
+use crate::error::{Error, Result};
+use crate::windows::{Subject, WindowEntry};
+use crate::{broadcast_focus_map, AppState};
+
+/// Shared window-building path used by both the `window_open` command and the
+/// `File → New Window` menu handler. Kept out of the command wrapper so
+/// `on_menu_event` can call the same code via `app.state::<AppState>()`.
+pub fn open_window(
+    app: &AppHandle,
+    state: &AppState,
+    initial_route: Option<String>,
+    position: Option<(i32, i32)>,
+) -> Result<String> {
+    let label = format!("window-{}", ulid::Ulid::new());
+
+    // BrowserRouter can't resolve a deep path (`/missions/<id>`) through
+    // Tauri's asset protocol in release builds, so the initial route rides as
+    // a hash fragment that `InitialRouteBootstrap` navigates to on mount.
+    let url = match initial_route {
+        Some(route) if !route.is_empty() => {
+            let route = if route.starts_with('/') {
+                route
+            } else {
+                format!("/{route}")
+            };
+            WebviewUrl::App(format!("index.html#{route}").into())
+        }
+        _ => WebviewUrl::App("index.html".into()),
+    };
+
+    // Mirror `main`'s chrome (tauri.conf.json) so secondary windows are
+    // visually identical. Starts hidden to avoid the white flash; the
+    // generalized `app_ready` shows the calling window after first paint.
+    let mut builder = WebviewWindowBuilder::new(app, &label, url)
+        .title("Runner")
+        .inner_size(1440.0, 900.0)
+        .accept_first_mouse(true)
+        .visible(false);
+
+    #[cfg(target_os = "macos")]
+    {
+        builder = builder
+            .title_bar_style(tauri::TitleBarStyle::Overlay)
+            .hidden_title(true)
+            .traffic_light_position(tauri::LogicalPosition::new(16.0, 22.0));
+    }
+
+    let window = builder.build().map_err(|e| Error::msg(e.to_string()))?;
+
+    // Position: an explicit hint wins; otherwise cascade off the
+    // most-recently-focused existing window so a fresh window doesn't land
+    // exactly on top of the one it was spawned from.
+    if let Some((x, y)) = position {
+        let _ = window.set_position(tauri::LogicalPosition::new(x as f64, y as f64));
+    } else if let Some(reference) = cascade_reference(app, state, &label) {
+        if let Ok(pos) = reference.outer_position() {
+            let _ = window.set_position(tauri::PhysicalPosition::new(pos.x + 32, pos.y + 32));
+        }
+    }
+
+    state.windows.register(&label);
+    broadcast_focus_map(app);
+    Ok(label)
+}
+
+/// Anchor window for the cascade offset: the most-recently-focused window that
+/// already exists (excluding the one being built).
+fn cascade_reference(
+    app: &AppHandle,
+    state: &AppState,
+    new_label: &str,
+) -> Option<tauri::WebviewWindow> {
+    let label = state
+        .windows
+        .snapshot()
+        .into_iter()
+        .filter(|e| e.label != new_label)
+        .max_by(|a, b| a.focused_at.cmp(&b.focused_at))
+        .map(|e| e.label)?;
+    app.get_webview_window(&label)
+}
+
+/// Open a new webview window. Returns the new window's label. Thin wrapper
+/// around `open_window` so the menu handler and the command share one path.
+#[tauri::command]
+pub fn window_open(
+    app: AppHandle,
+    state: State<AppState>,
+    initial_route: Option<String>,
+    position: Option<(i32, i32)>,
+) -> Result<String> {
+    open_window(&app, &state, initial_route, position)
+}
+
+/// Bring another window to the front — the overlay's "Focus that window"
+/// action. `core:window:allow-set-focus` is already granted.
+#[tauri::command]
+pub fn window_focus_other(app: AppHandle, label: String) -> Result<()> {
+    let window = app
+        .get_webview_window(&label)
+        .ok_or_else(|| Error::msg(format!("window {label} not found")))?;
+    window.set_focus().map_err(|e| Error::msg(e.to_string()))?;
+    Ok(())
+}
+
+/// The frontend reports its current subject on every route change. Label is
+/// resolved from the invoking webview, not trusted from the caller.
+#[tauri::command]
+pub fn window_report_subject(
+    window: tauri::WebviewWindow,
+    state: State<AppState>,
+    app: AppHandle,
+    subject: Option<Subject>,
+) -> Result<()> {
+    state.windows.set_subject(window.label(), subject);
+    broadcast_focus_map(&app);
+    Ok(())
+}
+
+/// Snapshot of the focus map, so a freshly-mounted window can hydrate without
+/// waiting for the next broadcast.
+#[tauri::command]
+pub fn window_list_subjects(state: State<AppState>) -> Result<Vec<WindowEntry>> {
+    Ok(state.windows.snapshot())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -339,6 +339,15 @@ pub fn run() {
                 } if label == "main" => {
                     api.prevent_close();
                     hide_main_window_on_close(app_handle);
+                    // main hides rather than destroys, so it never emits
+                    // `Destroyed` to unregister. Demote it (impl 0018) so a
+                    // visible duplicate window becomes primary and mounts its
+                    // PTY; main keeps its subject, so reopening + focusing it
+                    // reclaims ownership via the `Focused(true)` hook.
+                    if let Some(state) = app_handle.try_state::<AppState>() {
+                        state.windows.mark_hidden(&label);
+                    }
+                    broadcast_focus_map(app_handle);
                 }
                 // Any window gaining focus becomes primary for whatever
                 // subject it's on (spec decision 2). Secondary windows close

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod panic_hook;
 mod router;
 mod session;
 mod shell_path;
+mod windows;
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -50,6 +51,11 @@ pub struct AppState {
     /// MCP server lifecycle handle (impl 0013). Unix socket listener
     /// that external clients connect to via the `runner-mcp` bridge.
     pub mcp: Arc<mcp::McpHandle>,
+    /// Cross-window coordination map (impl 0018). Tracks which subject
+    /// (mission / direct chat) each webview window is looking at + when it
+    /// was last focused, so exactly one window owns a duplicated subject's
+    /// PTY. `main` is registered in `setup`.
+    pub windows: Arc<windows::WindowRegistry>,
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -180,6 +186,12 @@ pub fn run() {
             let buses = event_bus::BusRegistry::new();
             let routers = router::RouterRegistry::new();
             let mcp_handle = Arc::new(mcp::McpHandle::new());
+            // Window registry seeded with `main` — it exists before any
+            // frontend reports a subject, and the snapshot must reflect it
+            // from the first broadcast. Shared with `McpState` so the
+            // MCP-reconstructed `AppState` sees the same map.
+            let window_registry = Arc::new(windows::WindowRegistry::new());
+            window_registry.register("main");
             let mcp_state = mcp::state::McpState {
                 db: Arc::clone(&pool),
                 app_data_dir: app_data_dir.clone(),
@@ -187,6 +199,7 @@ pub fn run() {
                 buses: Arc::clone(&buses),
                 routers: Arc::clone(&routers),
                 mcp: Arc::clone(&mcp_handle),
+                windows: Arc::clone(&window_registry),
                 app_handle: app.handle().clone(),
             };
             if let Err(e) = mcp_handle.start(&app_data_dir.join("mcp.sock"), mcp_state) {
@@ -200,6 +213,7 @@ pub fn run() {
                 buses,
                 routers,
                 mcp: mcp_handle,
+                windows: window_registry,
             };
 
             // Mount router + bus for every `running` mission before
@@ -237,6 +251,11 @@ pub fn run() {
                 if ev.id() == "runner_logs_reveal" {
                     if let Err(e) = commands::app::reveal_logs_dir(app) {
                         log::error!("reveal logs failed: {e}");
+                    }
+                } else if ev.id() == "window_new" {
+                    let state = app.state::<AppState>();
+                    if let Err(e) = commands::window::open_window(app, state.inner(), None, None) {
+                        log::error!("new window failed: {e}");
                     }
                 }
             });
@@ -296,6 +315,10 @@ pub fn run() {
             commands::mcp::mcp_integration_status,
             commands::mcp::mcp_set_integration,
             commands::mcp::mcp_config_snippet,
+            commands::window::window_open,
+            commands::window::window_focus_other,
+            commands::window::window_report_subject,
+            commands::window::window_list_subjects,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
@@ -316,6 +339,30 @@ pub fn run() {
                 } if label == "main" => {
                     api.prevent_close();
                     hide_main_window_on_close(app_handle);
+                }
+                // Any window gaining focus becomes primary for whatever
+                // subject it's on (spec decision 2). Secondary windows close
+                // for real (no main-style prevent), and the `Destroyed`
+                // unregister below promotes the next-most-recent survivor.
+                tauri::RunEvent::WindowEvent {
+                    label,
+                    event: tauri::WindowEvent::Focused(true),
+                    ..
+                } => {
+                    if let Some(state) = app_handle.try_state::<AppState>() {
+                        state.windows.mark_focused(&label);
+                    }
+                    broadcast_focus_map(app_handle);
+                }
+                tauri::RunEvent::WindowEvent {
+                    label,
+                    event: tauri::WindowEvent::Destroyed,
+                    ..
+                } => {
+                    if let Some(state) = app_handle.try_state::<AppState>() {
+                        state.windows.unregister(&label);
+                    }
+                    broadcast_focus_map(app_handle);
                 }
                 tauri::RunEvent::ExitRequested { .. } => {
                     stop_running_sessions_on_quit(app_handle);
@@ -340,6 +387,20 @@ pub fn run() {
                 _ => {}
             }
         });
+}
+
+/// Broadcast the current window→subject map to every webview. Called after
+/// every registry mutation (lifecycle hooks + window commands) so all windows
+/// converge on a consistent picture of who owns what. Broadcast, not
+/// targeted: each window filters by its own subject (spec decision 5).
+pub(crate) fn broadcast_focus_map(app: &AppHandle) {
+    let Some(state) = app.try_state::<AppState>() else {
+        return;
+    };
+    let snapshot = state.windows.snapshot();
+    if let Err(e) = app.emit("window_focus_map", snapshot) {
+        log::error!("broadcast window_focus_map failed: {e}");
+    }
 }
 
 fn hide_main_window_on_close(app_handle: &AppHandle) {
@@ -418,6 +479,14 @@ fn build_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
         .item(&reveal_logs)
         .build()?;
 
+    // File → New Window owns Cmd+N at the OS/menu level (impl 0018). The
+    // accelerator is handled by the menu, not a JS keydown handler, so the
+    // shortcut works regardless of webview focus and can't double-fire.
+    let new_window = MenuItemBuilder::with_id("window_new", "New Window")
+        .accelerator("CmdOrCtrl+N")
+        .build(app)?;
+    let file_menu = SubmenuBuilder::new(app, "File").item(&new_window).build()?;
+
     #[cfg(target_os = "macos")]
     {
         let pkg = app.package_info();
@@ -459,12 +528,21 @@ fn build_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
             .build()?;
 
         MenuBuilder::new(app)
-            .items(&[&app_menu, &edit_menu, &view_menu, &window_menu, &help_menu])
+            .items(&[
+                &app_menu,
+                &file_menu,
+                &edit_menu,
+                &view_menu,
+                &window_menu,
+                &help_menu,
+            ])
             .build()
     }
     #[cfg(not(target_os = "macos"))]
     {
-        MenuBuilder::new(app).items(&[&help_menu]).build()
+        MenuBuilder::new(app)
+            .items(&[&file_menu, &help_menu])
+            .build()
     }
 }
 

--- a/src-tauri/src/mcp/state.rs
+++ b/src-tauri/src/mcp/state.rs
@@ -5,7 +5,7 @@ use tauri::AppHandle;
 
 use crate::{
     db::DbPool, event_bus::BusRegistry, mcp::McpHandle, router::RouterRegistry,
-    session::SessionManager, AppState,
+    session::SessionManager, windows::WindowRegistry, AppState,
 };
 
 #[derive(Clone)]
@@ -16,6 +16,7 @@ pub(crate) struct McpState {
     pub buses: Arc<BusRegistry>,
     pub routers: Arc<RouterRegistry>,
     pub mcp: Arc<McpHandle>,
+    pub windows: Arc<WindowRegistry>,
     pub app_handle: AppHandle,
 }
 
@@ -28,6 +29,7 @@ impl McpState {
             buses: Arc::clone(&self.buses),
             routers: Arc::clone(&self.routers),
             mcp: Arc::clone(&self.mcp),
+            windows: Arc::clone(&self.windows),
         }
     }
 }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -94,6 +94,19 @@ impl WindowRegistry {
         self.mark_focused_at(label, Utc::now());
     }
 
+    /// Demote a window's focus rank to the floor without dropping its subject.
+    ///
+    /// `main` is hidden (not destroyed) on close, so it never emits
+    /// `Destroyed` and stays registered. A *hidden* window must not keep
+    /// owning a duplicated subject over a *visible* one — otherwise the
+    /// visible window is stuck secondary with no terminal. Demoting
+    /// `focused_at` lets any visible holder outrank it, while preserving the
+    /// subject so a later reshow + `Focused(true)` reclaims primary. A hidden
+    /// sole-holder still wins `primary_for` (nothing visible to hand off to).
+    pub fn mark_hidden(&self, label: &str) {
+        self.mark_focused_at(label, DateTime::<Utc>::MIN_UTC);
+    }
+
     /// Snapshot of every registered window, for the `window_focus_map`
     /// broadcast and the `window_list_subjects` hydrate-on-mount path.
     pub fn snapshot(&self) -> Vec<WindowEntry> {
@@ -231,6 +244,45 @@ mod tests {
         // Primary closes → the survivor is promoted.
         reg.unregister("main");
         assert_eq!(reg.primary_for(&subject), Some("window-a".to_string()));
+    }
+
+    #[test]
+    fn mark_hidden_demotes_below_visible_holder_but_keeps_subject() {
+        let reg = WindowRegistry::new();
+        let subject = Subject::Mission("m1".into());
+        reg.register_at("main", ts(500));
+        reg.register_at("window-a", ts(300));
+        reg.set_subject("main", Some(subject.clone()));
+        reg.set_subject("window-a", Some(subject.clone()));
+        // main focused most recently → primary.
+        assert_eq!(reg.primary_for(&subject), Some("main".to_string()));
+
+        // main hidden on close → demoted; the visible window-a takes over.
+        reg.mark_hidden("main");
+        assert_eq!(reg.primary_for(&subject), Some("window-a".to_string()));
+
+        // Subject preserved so a reshow + focus can reclaim ownership.
+        let main_entry = reg
+            .snapshot()
+            .into_iter()
+            .find(|e| e.label == "main")
+            .expect("main still registered");
+        assert_eq!(main_entry.subject, Some(subject.clone()));
+
+        // Reshow + focus → main reclaims primary.
+        reg.mark_focused_at("main", ts(600));
+        assert_eq!(reg.primary_for(&subject), Some("main".to_string()));
+    }
+
+    #[test]
+    fn mark_hidden_sole_holder_stays_primary() {
+        let reg = WindowRegistry::new();
+        let subject = Subject::Mission("m1".into());
+        reg.register_at("main", ts(500));
+        reg.set_subject("main", Some(subject.clone()));
+        // No visible duplicate to hand off to → hidden main remains primary.
+        reg.mark_hidden("main");
+        assert_eq!(reg.primary_for(&subject), Some("main".to_string()));
     }
 
     #[test]

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -1,0 +1,260 @@
+// Cross-window coordination registry (impl 0018, spec 12).
+//
+// Runner is a single backend process that can drive several Tauri webview
+// windows at once. The backend stays the single source of truth: one
+// `SessionManager`, one `RouterRegistry`, one `BusRegistry`. The only thing
+// the windows need to *coordinate* is which subject (mission / direct chat)
+// each is looking at, so two windows never write to the same PTY stdin.
+//
+// This module owns that map. Each window reports its current `Subject` and
+// its focus events; the registry computes, per subject, which window is
+// **primary** — the most-recently-focused holder. Everything else (the
+// Arc-style overlay, the terminal-mount gate) derives from that single rule.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// What a window is currently looking at. Granularity is mission-id /
+/// session-id, not full URL — two windows on the same mission but different
+/// inner tabs are still "looking at the same mission" (spec decision 1).
+///
+/// Serialized adjacently-tagged so the frontend sees
+/// `{ "type": "Mission", "value": "<id>" }`. Mirrored by `Subject` in
+/// `src/lib/types.ts`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", content = "value")]
+pub enum Subject {
+    Mission(String),
+    DirectChat(String),
+}
+
+/// One window's row in the registry. `focused_at` is the tiebreak that
+/// decides primary ownership: among windows holding the same subject, the
+/// largest `focused_at` wins.
+#[derive(Debug, Clone, Serialize)]
+pub struct WindowEntry {
+    pub label: String,
+    pub subject: Option<Subject>,
+    pub focused_at: DateTime<Utc>,
+}
+
+/// `Mutex<HashMap<label, WindowEntry>>`, mirroring the shape used by the
+/// other in-memory registries in this crate (`BusRegistry`, `RouterRegistry`).
+pub struct WindowRegistry {
+    entries: Mutex<HashMap<String, WindowEntry>>,
+}
+
+impl WindowRegistry {
+    pub fn new() -> Self {
+        WindowRegistry {
+            entries: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Insert a freshly-created window with no subject. Called the moment a
+    /// window is built (Rust-side) so the snapshot reflects it before the
+    /// webview's frontend has reported anything.
+    pub fn register(&self, label: &str) {
+        self.register_at(label, Utc::now());
+    }
+
+    /// Remove a window. Keyed off `WindowEvent::Destroyed` so it fires for the
+    /// genuine close of a secondary window. The surviving most-recent holder
+    /// of that subject (if any) becomes primary automatically.
+    pub fn unregister(&self, label: &str) {
+        self.entries.lock().unwrap().remove(label);
+    }
+
+    /// Update a window's subject without touching `focused_at` — navigating
+    /// between routes is not a focus change. Upserts so a report that races
+    /// ahead of `register` still lands.
+    pub fn set_subject(&self, label: &str, subject: Option<Subject>) {
+        let mut map = self.entries.lock().unwrap();
+        match map.get_mut(label) {
+            Some(entry) => entry.subject = subject,
+            None => {
+                map.insert(
+                    label.to_string(),
+                    WindowEntry {
+                        label: label.to_string(),
+                        subject,
+                        focused_at: Utc::now(),
+                    },
+                );
+            }
+        }
+    }
+
+    /// Bump a window's `focused_at` to now — the OS told us this window came
+    /// forward, so it now owns whatever subject it's on (spec decision 2).
+    pub fn mark_focused(&self, label: &str) {
+        self.mark_focused_at(label, Utc::now());
+    }
+
+    /// Snapshot of every registered window, for the `window_focus_map`
+    /// broadcast and the `window_list_subjects` hydrate-on-mount path.
+    pub fn snapshot(&self) -> Vec<WindowEntry> {
+        let mut out: Vec<WindowEntry> = self.entries.lock().unwrap().values().cloned().collect();
+        // Stable order so the broadcast payload is deterministic across
+        // mutations (HashMap iteration order is not).
+        out.sort_by(|a, b| a.label.cmp(&b.label));
+        out
+    }
+
+    /// The primary window for a subject: among windows currently holding it,
+    /// the one with the max `focused_at`. `None` if no window holds it.
+    pub fn primary_for(&self, subject: &Subject) -> Option<String> {
+        self.entries
+            .lock()
+            .unwrap()
+            .values()
+            .filter(|e| e.subject.as_ref() == Some(subject))
+            .max_by(|a, b| a.focused_at.cmp(&b.focused_at))
+            .map(|e| e.label.clone())
+    }
+
+    // --- internals / test seams -----------------------------------------
+
+    fn register_at(&self, label: &str, focused_at: DateTime<Utc>) {
+        self.entries.lock().unwrap().insert(
+            label.to_string(),
+            WindowEntry {
+                label: label.to_string(),
+                subject: None,
+                focused_at,
+            },
+        );
+    }
+
+    /// `mark_focused` with an explicit timestamp. Upserts: a focus event for a
+    /// window we somehow never registered still produces an entry rather than
+    /// being dropped. Split out so tests can assert ordering without sleeping.
+    fn mark_focused_at(&self, label: &str, focused_at: DateTime<Utc>) {
+        let mut map = self.entries.lock().unwrap();
+        match map.get_mut(label) {
+            Some(entry) => entry.focused_at = focused_at,
+            None => {
+                map.insert(
+                    label.to_string(),
+                    WindowEntry {
+                        label: label.to_string(),
+                        subject: None,
+                        focused_at,
+                    },
+                );
+            }
+        }
+    }
+}
+
+impl Default for WindowRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    fn ts(secs: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(secs, 0).single().expect("valid ts")
+    }
+
+    #[test]
+    fn register_unregister_round_trip() {
+        let reg = WindowRegistry::new();
+        reg.register("main");
+        assert_eq!(reg.snapshot().len(), 1);
+        assert_eq!(reg.snapshot()[0].label, "main");
+        assert!(reg.snapshot()[0].subject.is_none());
+
+        reg.unregister("main");
+        assert!(reg.snapshot().is_empty());
+    }
+
+    #[test]
+    fn set_subject_preserves_focused_at() {
+        let reg = WindowRegistry::new();
+        reg.register_at("main", ts(100));
+        reg.set_subject("main", Some(Subject::Mission("m1".into())));
+
+        let snap = reg.snapshot();
+        assert_eq!(snap[0].subject, Some(Subject::Mission("m1".into())));
+        // subject change is not a focus change — timestamp untouched.
+        assert_eq!(snap[0].focused_at, ts(100));
+    }
+
+    #[test]
+    fn mark_focused_bumps_timestamp() {
+        let reg = WindowRegistry::new();
+        reg.register_at("main", ts(100));
+        reg.mark_focused_at("main", ts(200));
+        assert_eq!(reg.snapshot()[0].focused_at, ts(200));
+    }
+
+    #[test]
+    fn primary_for_returns_most_recently_focused_holder() {
+        let reg = WindowRegistry::new();
+        reg.register_at("main", ts(100));
+        reg.register_at("window-a", ts(100));
+        let subject = Subject::Mission("m1".into());
+        reg.set_subject("main", Some(subject.clone()));
+        reg.set_subject("window-a", Some(subject.clone()));
+
+        // main focused later → main is primary.
+        reg.mark_focused_at("main", ts(300));
+        reg.mark_focused_at("window-a", ts(200));
+        assert_eq!(reg.primary_for(&subject), Some("main".to_string()));
+
+        // window-a now focused later → it takes over.
+        reg.mark_focused_at("window-a", ts(400));
+        assert_eq!(reg.primary_for(&subject), Some("window-a".to_string()));
+    }
+
+    #[test]
+    fn primary_promotes_survivor_when_primary_closes() {
+        let reg = WindowRegistry::new();
+        let subject = Subject::DirectChat("s1".into());
+        reg.register_at("main", ts(100));
+        reg.register_at("window-a", ts(100));
+        reg.set_subject("main", Some(subject.clone()));
+        reg.set_subject("window-a", Some(subject.clone()));
+        reg.mark_focused_at("main", ts(500)); // main is primary
+        reg.mark_focused_at("window-a", ts(200));
+        assert_eq!(reg.primary_for(&subject), Some("main".to_string()));
+
+        // Primary closes → the survivor is promoted.
+        reg.unregister("main");
+        assert_eq!(reg.primary_for(&subject), Some("window-a".to_string()));
+    }
+
+    #[test]
+    fn none_subject_never_counts_as_primary() {
+        let reg = WindowRegistry::new();
+        reg.register_at("main", ts(100));
+        reg.register_at("window-a", ts(200)); // both subject: None
+                                              // An empty window is never the "primary" of anything — querying any
+                                              // subject returns None, so the overlay never fires for blank windows.
+        assert_eq!(reg.primary_for(&Subject::Mission("m1".into())), None);
+        assert_eq!(reg.primary_for(&Subject::DirectChat("s1".into())), None);
+    }
+
+    #[test]
+    fn subject_serializes_adjacently_tagged() {
+        let json = serde_json::to_value(Subject::Mission("m1".into())).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({ "type": "Mission", "value": "m1" })
+        );
+        let json = serde_json::to_value(Subject::DirectChat("s1".into())).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({ "type": "DirectChat", "value": "s1" })
+        );
+    }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,11 @@
 import { useEffect } from "react";
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  Navigate,
+  useNavigate,
+} from "react-router-dom";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { AppShell } from "./components/AppShell";
@@ -73,6 +79,7 @@ export default function App() {
   return (
     <UpdateProvider>
       <BrowserRouter>
+        <InitialRouteBootstrap />
         <Routes>
           <Route element={<AppShell />}>
             <Route path="/" element={<Navigate to="/runners" replace />} />
@@ -88,4 +95,22 @@ export default function App() {
       </BrowserRouter>
     </UpdateProvider>
   );
+}
+
+// Secondary windows are opened at `index.html#/missions/<id>` because
+// BrowserRouter can't resolve a deep path through Tauri's asset protocol in
+// release builds (impl 0018 constraint 3). On first mount, consume the hash
+// fragment: navigate to it and clear the hash so a reload doesn't re-trigger.
+// Runs once per window; a window opened with no initial route has no hash and
+// this is a no-op.
+function InitialRouteBootstrap() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    const hash = window.location.hash;
+    if (hash.length > 1) {
+      navigate(hash.slice(1), { replace: true });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return null;
 }

--- a/src/components/DuplicateSubjectOverlay.tsx
+++ b/src/components/DuplicateSubjectOverlay.tsx
@@ -1,0 +1,75 @@
+// Arc-style duplicate-subject overlay (impl 0018, spec 12).
+//
+// When two windows look at the same mission / direct chat, the
+// most-recently-focused one is primary and owns the PTY; the other(s) render
+// this card over the content area. It's a soft hint, not a modal: the
+// terminal mount is gated by `isSecondary` regardless, so "Stay here" only
+// hides the card (to read the feed / metadata underneath) — it does not grant
+// this window terminal ownership. Dismissal isn't persisted, so navigating
+// away and back to the duplicated subject re-shows it (spec decision 6).
+
+import { AppWindow } from "lucide-react";
+
+import { api } from "../lib/api";
+
+export function DuplicateSubjectOverlay({
+  kind,
+  primaryLabel,
+  onStayHere,
+}: {
+  /** Which surface is duplicated — tailors the copy. */
+  kind: "mission" | "chat";
+  /** Label of the primary window, target of "Focus that window". Null only
+   *  in the transient window before the focus map names a primary. */
+  primaryLabel: string | null;
+  onStayHere: () => void;
+}) {
+  const noun = kind === "mission" ? "mission" : "chat";
+  return (
+    <>
+      <div className="pointer-events-none absolute inset-0 z-20 bg-bg/70 backdrop-blur-sm" />
+      <div className="absolute inset-0 z-30 flex items-center justify-center p-6">
+        <div className="flex w-full max-w-md flex-col items-center gap-4 rounded-xl border border-line bg-panel p-6 text-center shadow-[0_8px_30px_rgba(0,0,0,0.67)]">
+          <div className="flex h-11 w-11 items-center justify-center rounded-lg border border-line bg-bg text-accent">
+            <AppWindow aria-hidden className="h-5 w-5" />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <h2 className="text-[15px] font-semibold text-fg">
+              Open in another window
+            </h2>
+            <p className="text-[13px] leading-relaxed text-fg-2">
+              Another window is already driving this {noun}. Only one window can
+              own the terminal at a time, so this view is read-only until you
+              focus it here.
+            </p>
+          </div>
+          <div className="flex items-center gap-3 pt-0.5">
+            <button
+              type="button"
+              onClick={() => {
+                if (primaryLabel) {
+                  void api.window.focusOther(primaryLabel).catch(() => {
+                    // best-effort; the target window may have just closed,
+                    // in which case the focus map will promote this one.
+                  });
+                }
+              }}
+              disabled={!primaryLabel}
+              className="flex cursor-pointer items-center gap-2 rounded-md bg-accent px-3.5 py-2 text-[13px] font-semibold text-bg transition-colors hover:bg-accent/90 disabled:cursor-default disabled:opacity-50"
+            >
+              <AppWindow aria-hidden className="h-3.5 w-3.5" />
+              Focus that window
+            </button>
+            <button
+              type="button"
+              onClick={onStayHere}
+              className="cursor-pointer text-[13px] text-fg-2 underline-offset-2 transition-colors hover:text-fg hover:underline"
+            >
+              Stay here
+            </button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -30,6 +30,7 @@ import {
 } from "react-router-dom";
 import { listen } from "@tauri-apps/api/event";
 import {
+  AppWindow,
   Archive,
   ChevronDown,
   ChevronRight,
@@ -221,8 +222,11 @@ export function Sidebar({
     void refreshMissions();
   }, [refreshMissions]);
 
-  // ⌘K / Ctrl+K opens the command palette. ⌘N / Ctrl+N opens the
-  // Start Chat modal. Skip while editing text controls so shortcuts
+  // ⌘K / Ctrl+K opens the command palette. ⌘T / Ctrl+T opens the Start
+  // Chat modal (browser/terminal convention: ⌘T = new tab/chat, ⌘N =
+  // new window). ⌘N is owned by the File → New Window menu accelerator
+  // (impl 0018) at the OS level, so it's deliberately absent here to
+  // avoid a double-fire. Skip while editing text controls so shortcuts
   // don't hijack form input. xterm's hidden textarea is not an editor
   // field from the app's point of view, so Meta shortcuts still win
   // there; Ctrl shortcuts stay with the PTY/TUI.
@@ -246,7 +250,7 @@ export function Sidebar({
         e.preventDefault();
         e.stopPropagation();
         setPaletteOpen(true);
-      } else if (e.key === "n" || e.key === "N") {
+      } else if (e.key === "t" || e.key === "T") {
         e.preventDefault();
         e.stopPropagation();
         setCreatingChat(true);
@@ -833,6 +837,14 @@ export function Sidebar({
             setRenamingId(sessionMenu.session.session_id);
             closeSessionMenu();
           }}
+          onOpenInNewWindow={() => {
+            void api.window
+              .open(`/chats/${sessionMenu.session.session_id}`)
+              .catch((e) =>
+                console.error("sidebar: open chat in new window failed", e),
+              );
+            closeSessionMenu();
+          }}
           onArchive={() => {
             void archiveSession(sessionMenu.session);
             closeSessionMenu();
@@ -852,6 +864,14 @@ export function Sidebar({
           }}
           onRename={() => {
             setRenamingMissionId(missionMenu.mission.id);
+            closeMissionMenu();
+          }}
+          onOpenInNewWindow={() => {
+            void api.window
+              .open(`/missions/${missionMenu.mission.id}`)
+              .catch((e) =>
+                console.error("sidebar: open mission in new window failed", e),
+              );
             closeMissionMenu();
           }}
           onArchive={() => {
@@ -910,7 +930,7 @@ function NewChatNavRow({ onOpen }: { onOpen: () => void }) {
       <MessageSquarePlus aria-hidden className="h-3 w-3 text-fg-2" />
       <span className="min-w-0 flex-1 truncate">new chat</span>
       <span className="shrink-0 rounded border border-line bg-bg px-1.5 py-px font-mono text-[10px] leading-tight text-fg-3 opacity-0 transition-opacity group-hover:opacity-100 group-focus:opacity-100">
-        ⌘N
+        ⌘T
       </span>
     </button>
   );
@@ -1331,6 +1351,7 @@ function RowContextMenu({
   onClose,
   onPin,
   onRename,
+  onOpenInNewWindow,
   onArchive,
 }: {
   pinned: boolean;
@@ -1339,6 +1360,7 @@ function RowContextMenu({
   onClose: () => void;
   onPin: () => void;
   onRename: () => void;
+  onOpenInNewWindow: () => void;
   onArchive: () => void;
 }) {
   const ref = useRef<HTMLDivElement>(null);
@@ -1382,6 +1404,11 @@ function RowContextMenu({
         onClick={onPin}
       />
       <ContextMenuItem icon={SquarePen} label="Rename" onClick={onRename} />
+      <ContextMenuItem
+        icon={AppWindow}
+        label="Open in New Window"
+        onClick={onOpenInNewWindow}
+      />
       <ContextMenuItem
         icon={Archive}
         label="Archive"

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -28,9 +28,11 @@ import type {
   SpawnedSession,
   StartMissionInput,
   StartMissionOutput,
+  Subject,
   UpdateCrewInput,
   UpdateRunnerInput,
   UpdateSlotInput,
+  WindowEntry,
 } from "./types";
 
 /** Session row joined with the runner's handle for UI labels. */
@@ -232,5 +234,28 @@ export const api = {
         cols,
         rows,
       }),
+  },
+  window: {
+    /** Open a new webview window, optionally pre-navigated to a route
+     *  (carried as a URL hash fragment) and positioned. Returns the new
+     *  window's label. */
+    open: (
+      initialRoute?: string | null,
+      position?: [number, number] | null,
+    ) =>
+      invoke<string>("window_open", {
+        initialRoute: initialRoute ?? null,
+        position: position ?? null,
+      }),
+    /** Bring another window to the front (the overlay's "Focus that
+     *  window" action). */
+    focusOther: (label: string) =>
+      invoke<void>("window_focus_other", { label }),
+    /** Report this window's current subject; the backend recomputes the
+     *  focus map and broadcasts it. */
+    reportSubject: (subject: Subject | null) =>
+      invoke<void>("window_report_subject", { subject }),
+    /** Snapshot of the focus map for hydrate-on-mount. */
+    listSubjects: () => invoke<WindowEntry[]>("window_list_subjects"),
   },
 };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -374,3 +374,20 @@ export interface PostHumanSignalInput {
   signal_type: "human_said" | "human_response";
   payload: HumanSaidPayload | HumanResponsePayload;
 }
+
+// --- Multi-window coordination (impl 0018) -------------------------------
+// Hand-synced with src-tauri/src/windows.rs. `Subject` is the adjacently-
+// tagged serde shape (`#[serde(tag = "type", content = "value")]`), so
+// `{ type: "Mission", value: "<missionId>" }` on the wire.
+
+export type Subject =
+  | { type: "Mission"; value: string }
+  | { type: "DirectChat"; value: string };
+
+// One window's row in the backend WindowRegistry. `focused_at` is RFC3339;
+// the most-recently-focused holder of a subject is its primary.
+export interface WindowEntry {
+  label: string;
+  subject: Subject | null;
+  focused_at: Timestamp;
+}

--- a/src/lib/windowFocus.ts
+++ b/src/lib/windowFocus.ts
@@ -1,0 +1,158 @@
+// Frontend coordination layer for multi-window (impl 0018, spec 12).
+//
+// The backend WindowRegistry is the source of truth: it tracks which subject
+// (mission / direct chat) each window holds and when each was last focused,
+// and broadcasts `window_focus_map` after every mutation. This module is the
+// thin React-side mirror: report this window's subject, subscribe to the map,
+// and derive "am I the secondary for my subject?" — which gates terminal
+// ownership in MissionWorkspace / RunnerChat.
+
+import { useEffect, useState } from "react";
+
+import { listen } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+import { api } from "./api";
+import type { Subject, WindowEntry } from "./types";
+
+// The current window's label never changes, so resolve it once at module
+// load. Wrapped in try/catch for the dev browser preview (no Tauri runtime),
+// where it stays null and every coordination check no-ops.
+let cachedLabel: string | null = null;
+try {
+  cachedLabel = getCurrentWindow().label;
+} catch {
+  cachedLabel = null;
+}
+
+/** This window's Tauri label (`main` or `window-<ulid>`), or null off-Tauri. */
+export function useCurrentWindowLabel(): string | null {
+  return cachedLabel;
+}
+
+/**
+ * Subscribe to the backend focus map. Hydrates once on mount via
+ * `window_list_subjects` so a freshly-opened window doesn't wait for the next
+ * broadcast, then tracks `window_focus_map` broadcasts live.
+ */
+export function useWindowFocus(): WindowEntry[] {
+  const [map, setMap] = useState<WindowEntry[]>([]);
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+
+    api.window
+      .listSubjects()
+      .then((entries) => {
+        // Don't clobber a broadcast that may have already landed; only seed
+        // if we're still empty.
+        if (!cancelled) setMap((prev) => (prev.length === 0 ? entries : prev));
+      })
+      .catch(() => {
+        // best-effort; the next broadcast populates the map
+      });
+
+    void listen<WindowEntry[]>("window_focus_map", (event) => {
+      if (!cancelled) setMap(event.payload);
+    }).then((fn) => {
+      if (cancelled) {
+        fn();
+        return;
+      }
+      unlisten = fn;
+    });
+
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, []);
+  return map;
+}
+
+// Debounced subject reporting. Route changes can fire several times in quick
+// succession (unmount-null then mount-subject when navigating between two
+// missions); coalescing so only the final state hits the backend keeps the
+// focus map from thrashing. Last write wins, which is the correct end state.
+let reportTimer: ReturnType<typeof setTimeout> | null = null;
+let pendingSubject: Subject | null = null;
+
+/** Debounced wrapper over `window_report_subject`. */
+export function reportSubject(subject: Subject | null): void {
+  if (!cachedLabel) return; // off-Tauri: nothing to coordinate
+  pendingSubject = subject;
+  if (reportTimer !== null) clearTimeout(reportTimer);
+  reportTimer = setTimeout(() => {
+    reportTimer = null;
+    void api.window.reportSubject(pendingSubject).catch((e) => {
+      console.error("reportSubject failed", e);
+    });
+  }, 80);
+}
+
+/**
+ * Report `subject` on mount and clear it (report null) on unmount. Subject
+ * pages (MissionWorkspace, RunnerChat) call this; the unmount-clear is what
+ * lets the focus map go empty when the user navigates to a non-subject page
+ * that doesn't report anything itself.
+ */
+export function useReportSubject(subject: Subject | null): void {
+  // Key by content, not object identity, so the effect re-fires only on a
+  // real subject change rather than every render.
+  const key = subject ? `${subject.type}:${subject.value}` : "null";
+  useEffect(() => {
+    reportSubject(subject);
+    return () => {
+      reportSubject(null);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key]);
+}
+
+function sameSubject(a: Subject | null, b: Subject | null): boolean {
+  if (!a || !b) return false;
+  return a.type === b.type && a.value === b.value;
+}
+
+export interface SecondaryState {
+  /** True when another window holds the same subject with a later
+   *  `focused_at` than this one — this window must not own the PTY. */
+  secondary: boolean;
+  /** Label of the primary window (the most-recently-focused other holder),
+   *  for the overlay's "Focus that window" target. Null when not secondary. */
+  primaryLabel: string | null;
+}
+
+/**
+ * Derive whether `myLabel` is the secondary window for `subject`. A window is
+ * secondary iff some *other* window holds the same subject with a strictly
+ * later `focused_at`. The primary is that most-recently-focused other holder.
+ *
+ * `focused_at` is parsed to epoch-ms rather than string-compared: chrono's
+ * RFC3339 uses variable fractional-second widths, so lexicographic order can
+ * disagree with chronological order.
+ */
+export function isSecondaryFor(
+  map: WindowEntry[],
+  myLabel: string | null,
+  subject: Subject | null,
+): SecondaryState {
+  if (!myLabel || !subject) return { secondary: false, primaryLabel: null };
+  const mine = map.find((e) => e.label === myLabel);
+  // Unknown self (broadcast hasn't included us yet) → treat as the earliest
+  // possible focus, so any existing holder wins until we hear otherwise.
+  const myFocus = mine ? Date.parse(mine.focused_at) : -Infinity;
+
+  let primaryLabel: string | null = null;
+  let primaryFocus = myFocus;
+  for (const entry of map) {
+    if (entry.label === myLabel) continue;
+    if (!sameSubject(entry.subject, subject)) continue;
+    const focus = Date.parse(entry.focused_at);
+    if (focus > primaryFocus) {
+      primaryFocus = focus;
+      primaryLabel = entry.label;
+    }
+  }
+  return { secondary: primaryLabel !== null, primaryLabel };
+}

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -38,8 +38,16 @@ import type {
   HumanQuestionPayload,
   Mission,
   SessionUpdatedEvent,
+  Subject,
   WarningEvent,
 } from "../lib/types";
+import { DuplicateSubjectOverlay } from "../components/DuplicateSubjectOverlay";
+import {
+  isSecondaryFor,
+  useCurrentWindowLabel,
+  useReportSubject,
+  useWindowFocus,
+} from "../lib/windowFocus";
 import { EventFeed } from "../components/EventFeed";
 import { MissionInput } from "../components/MissionInput";
 import { MissionMetaPanel } from "../components/MissionMetaPanel";
@@ -132,6 +140,34 @@ export default function MissionWorkspace() {
   // fallback chain and `workspaceDimsFromContainer` for the cell-size
   // measurement step.
   const paneContainerRef = useRef<HTMLDivElement | null>(null);
+
+  // Multi-window coordination (impl 0018). This window reports the mission as
+  // its subject; if another window holds the same mission with a later focus,
+  // we're the secondary and must not own the PTY — no terminal mount, no
+  // stdin/resize/start. The mission/session metadata still loads so the feed
+  // and overlay can render.
+  const focusMap = useWindowFocus();
+  const myWindowLabel = useCurrentWindowLabel();
+  const subject = useMemo<Subject | null>(
+    () => (id ? { type: "Mission", value: id } : null),
+    [id],
+  );
+  useReportSubject(subject);
+  const { secondary: isSecondary, primaryLabel } = isSecondaryFor(
+    focusMap,
+    myWindowLabel,
+    subject,
+  );
+  const [overlayDismissed, setOverlayDismissed] = useState(false);
+  // Re-show the overlay when the subject changes or this window (re)gains
+  // secondary status — e.g. another window steals focus mid-session.
+  useEffect(() => {
+    setOverlayDismissed(false);
+  }, [id, isSecondary]);
+  const showDuplicateOverlay = isSecondary && !overlayDismissed;
+  // Force the feed view while secondary: the PTY tabs/panes don't render, so
+  // a non-feed activeTab would otherwise leave a blank content area.
+  const feedActive = isSecondary || activeTab === "feed";
 
   // Combined: subscribe to `event/appended` BEFORE running the
   // events_replay query, then merge both into a single ULID-deduped
@@ -953,7 +989,11 @@ export default function MissionWorkspace() {
           </div>
         </div>
         <div className="flex items-center gap-2">
-          {mission?.status === "running" && !resumingAll ? (
+          {/* Secondary windows (impl 0018) are read-only: Resume/Reset
+              respawn PTYs, Stop kills them, Archive ends the mission — all
+              of which act on PTYs the primary window owns. Hide the whole
+              action cluster while secondary; focus the primary to act. */}
+          {mission?.status === "running" && !resumingAll && !isSecondary ? (
             <>
               {anySessionStopped ? (
                 <ResumeButton
@@ -1035,16 +1075,18 @@ export default function MissionWorkspace() {
         <div className="flex flex-1 min-h-0 flex-col">
           <div className="flex h-[38px] items-end gap-1 border-b border-line bg-panel px-6">
             <TabButton
-              active={activeTab === "feed"}
+              active={feedActive}
               onClick={selectFeed}
               shortcut="⌘1"
             >
               feed
             </TabButton>
             {/* Archived missions render feed only — skip the per-PTY
-                tabs so no xterm canvas ever mounts. The Pane block
+                tabs so no xterm canvas ever mounts. Secondary windows
+                (impl 0018) likewise show feed only: the duplicated
+                terminal lives in the primary window. The Pane block
                 below applies the same gate. */}
-            {!isArchived
+            {!isArchived && !isSecondary
               ? openTabs
                   .map((tabId) => sessions.find((s) => s.id === tabId))
                   .filter((s): s is SessionRow => s !== undefined)
@@ -1070,20 +1112,25 @@ export default function MissionWorkspace() {
                 that keeps the React/xterm instances alive while making
                 the visible session unambiguous. The terminal activation
                 effect refits + replays after the pane is shown. */}
-            <Pane active={activeTab === "feed"}>
+            <Pane active={feedActive}>
               <EventFeed
                 missionId={mission.id}
                 events={events}
                 resolvedAsks={resolvedAsks}
                 askersByQuestion={askersByQuestion}
-                active={activeTab === "feed"}
+                active={feedActive}
                 onError={setError}
               />
+              {/* Secondary windows can't send input: human_said is
+                  injected into the lead's PTY stdin by the router, which
+                  the primary owns (impl 0018). Disable while secondary. */}
               <MissionInput
                 missionId={mission.id}
                 leadHandle={leadHandle}
                 handles={handles}
-                disabled={mission.status !== "running" || !allSessionsLive}
+                disabled={
+                  mission.status !== "running" || !allSessionsLive || isSecondary
+                }
                 onError={setError}
               />
               {/* Pause overlay fires whenever *any* slot is stopped.
@@ -1097,8 +1144,11 @@ export default function MissionWorkspace() {
               {mission.status === "running" &&
               !allSessionsLive &&
               !resumingAll &&
-              !archivingMission ? (
+              !archivingMission &&
+              !isSecondary ? (
                 // Scrim is rendered by the overlay itself (issue #173).
+                // Hidden while secondary (impl 0018) so its Resume/Archive
+                // buttons can't act on PTYs the primary owns.
                 <MissionPausedCard
                   anySessionLive={anySessionLive}
                   onResumeMission={() => void resumeMission()}
@@ -1107,10 +1157,14 @@ export default function MissionWorkspace() {
               ) : null}
             </Pane>
 
-            {/* Skip per-session PTY panes for archived missions so
-                no xterm canvas ever mounts. The feed Pane stays
+            {/* Skip per-session PTY panes for archived missions and for
+                secondary windows (impl 0018) so no xterm canvas ever
+                mounts and we never write to a PTY the primary owns. On
+                flip primary→secondary this unmounts the terminals (and
+                clears their refs via the register callback); on flip
+                back, they remount and re-attach. The feed Pane stays
                 rendered above as the only surface. */}
-            {!isArchived
+            {!isArchived && !isSecondary
               ? openTabs
                   .map((tabId) => sessions.find((s) => s.id === tabId))
                   .filter((s): s is SessionRow => s !== undefined)
@@ -1142,6 +1196,17 @@ export default function MissionWorkspace() {
                 the resuming-all overlay (slot panes gate
                 forcedResuming on !archivingMission). */}
             {archivingMission ? <ArchivingOverlay withScrim /> : null}
+            {/* Arc-style duplicate-subject overlay (impl 0018). Sits
+                above the panes; gates nothing itself (the PTY mount is
+                gated by `isSecondary`) — "Stay here" only hides the
+                card so the user can read the feed underneath. */}
+            {showDuplicateOverlay ? (
+              <DuplicateSubjectOverlay
+                kind="mission"
+                primaryLabel={primaryLabel}
+                onStayHere={() => setOverlayDismissed(true)}
+              />
+            ) : null}
           </div>
         </div>
       )}

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -51,12 +51,20 @@ import {
   unmarkArchivingSession,
   useArchivingSession,
 } from "../lib/archivingState";
+import { DuplicateSubjectOverlay } from "../components/DuplicateSubjectOverlay";
+import {
+  isSecondaryFor,
+  useCurrentWindowLabel,
+  useReportSubject,
+  useWindowFocus,
+} from "../lib/windowFocus";
 import type {
   Runner,
   SessionActivityEvent,
   SessionActivityState,
   SessionStatus,
   SessionUpdatedEvent,
+  Subject,
   WarningEvent,
 } from "../lib/types";
 
@@ -208,6 +216,28 @@ export default function RunnerChat() {
   // End / Archive — the row is terminal and the operator can only
   // read the meta + go back to the runner.
   const isArchived = chatMeta?.archived_at != null;
+
+  // Multi-window coordination (impl 0018). Report this chat as the window's
+  // subject; if another window holds the same session with a later focus,
+  // we're secondary and must not mount a terminal or send stdin/resize/start.
+  const focusMap = useWindowFocus();
+  const myWindowLabel = useCurrentWindowLabel();
+  const subject: Subject | null = sessionId
+    ? { type: "DirectChat", value: sessionId }
+    : null;
+  useReportSubject(subject);
+  const { secondary: isSecondary, primaryLabel } = isSecondaryFor(
+    focusMap,
+    myWindowLabel,
+    subject,
+  );
+  const [overlayDismissed, setOverlayDismissed] = useState(false);
+  // Re-show the overlay on subject change or when this window (re)gains
+  // secondary status (another window stole focus mid-session).
+  useEffect(() => {
+    setOverlayDismissed(false);
+  }, [sessionId, isSecondary]);
+  const showDuplicateOverlay = isSecondary && !overlayDismissed;
 
   // Render-gate without the flash. The two branches below
   // (chatMeta still loading, or terminals haven't upserted yet) gate
@@ -696,7 +726,6 @@ export default function RunnerChat() {
   // ever runs the deterministic attach path.
   useEffect(() => {
     const requestKey = sessionId ?? "";
-    if (startedKeyRef.current === requestKey) return;
     // Wait for chatMeta to resolve before attaching. Without this
     // gate, the brief window between mount and the first
     // refreshChatMeta resolution would attach a PTY listener even
@@ -704,6 +733,19 @@ export default function RunnerChat() {
     // briefly subscribing to session/output + calling
     // outputSnapshot before the read-only branch takes over.
     if (!metaLoaded) return;
+    // Secondary windows (impl 0018) don't own the PTY: drop any pane we
+    // mounted (flip primary→secondary mid-session unmounts RunnerTerminal so
+    // it stops forwarding stdin) and reset the attach + transitional refs so
+    // a flip back to primary re-attaches cleanly. Leaving startedKeyRef null
+    // is what lets that re-attach fire.
+    if (isSecondary) {
+      startedKeyRef.current = null;
+      setDirectSessions((prev) => (prev.length === 0 ? prev : []));
+      setResuming(false);
+      setStarting(false);
+      return;
+    }
+    if (startedKeyRef.current === requestKey) return;
     startedKeyRef.current = requestKey;
     setErr(null);
     // Skip attach for archived rows: the workspace renders read-only,
@@ -727,6 +769,7 @@ export default function RunnerChat() {
     sessionId,
     state?.sessionStatus,
     isArchived,
+    isSecondary,
     metaLoaded,
     chatMeta,
     chatMeta?.started_at,
@@ -996,6 +1039,11 @@ export default function RunnerChat() {
             // Archived rows are terminal: no Resume / Stop / Archive.
             // Only surface the navigation escape hatch.
             <BackButton onClick={() => navigate(backTarget)}>{backLabel}</BackButton>
+          ) : isSecondary ? (
+            // Secondary window (impl 0018): the primary owns the PTY, so no
+            // Stop/Resume here — those call session_kill / session_resume.
+            // Focus the primary (via the overlay) to act on this chat.
+            <BackButton onClick={() => navigate(backTarget)}>{backLabel}</BackButton>
           ) : chatState === "resuming" ? (
             <ResumingButton />
           ) : status === "running" && sessionId ? (
@@ -1019,7 +1067,7 @@ export default function RunnerChat() {
               the mission topbar's `MissionKebab`. Hidden for archived
               rows: Pin/Rename make no sense for a terminal row, and
               Archive is a no-op. */}
-          {sessionId && chatMeta && !isArchived ? (
+          {sessionId && chatMeta && !isArchived && !isSecondary ? (
             <ChatKebab
               pinned={chatMeta.pinned}
               open={kebabOpen}
@@ -1113,6 +1161,11 @@ export default function RunnerChat() {
               </span>
             </div>
           </div>
+        ) : isSecondary ? (
+          // Secondary window (impl 0018): the primary owns the PTY, so we
+          // mount no terminal here. The duplicate-subject overlay below
+          // covers this area with the "Focus that window" affordance.
+          null
         ) : directSessions.length === 0 ? (
           // Same delayed-pill treatment as the metaLoaded gate above —
           // the terminal map hasn't upserted the active session pane
@@ -1170,7 +1223,22 @@ export default function RunnerChat() {
             );
           })
         )}
-        {archiving ? (
+        {showDuplicateOverlay ? (
+          // Duplicate-subject overlay (impl 0018) wins over the
+          // transitional overlays: this window doesn't own the PTY, so
+          // "Resuming…" / "Starting…" / "Session ended" would be
+          // misleading here.
+          <DuplicateSubjectOverlay
+            kind="chat"
+            primaryLabel={primaryLabel}
+            onStayHere={() => setOverlayDismissed(true)}
+          />
+        ) : isSecondary ? (
+          // Overlay dismissed but still secondary: never surface the
+          // SessionEnded card's Resume/Archive actions — they call
+          // session_resume / session_kill on a PTY the primary owns.
+          null
+        ) : archiving ? (
           // Archiving wins over the resume + start + ended overlays
           // — the session is on its way out, so reading "Resuming…"
           // / "Starting…" / "Session ended" mid-flight would be


### PR DESCRIPTION
Implements multi-window support per [docs/impls/0018-multi-window.md](docs/impls/0018-multi-window.md) and spec [docs/features/12-multi-window.md](docs/features/12-multi-window.md). Closes #122.

## What

Runner can now drive multiple Tauri webview windows from the one backend process. Each window has its own `BrowserRouter` history and reports its current subject (mission id / direct-chat session id) to the backend. A `WindowRegistry` maps window → subject + `focused_at` and broadcasts `window_focus_map` after every mutation.

**Primary invariant:** the most-recently-focused window owns a duplicated mission / direct-chat subject. Secondary windows do **not** mount `RunnerTerminal` and cannot send stdin/resize/start or mission/chat lifecycle actions — so exactly one window writes to a given PTY.

## How

**Backend**
- `src-tauri/src/windows.rs` — `WindowRegistry` (`register`/`unregister`/`set_subject`/`mark_focused`/`snapshot`/`primary_for`); `Subject` is adjacently-tagged serde (`{type,value}`). 7 unit tests cover the focus/primary/promotion rules.
- `src-tauri/src/commands/window.rs` — `window_open` (+ shared `open_window` helper), `window_focus_other`, `window_report_subject`, `window_list_subjects`.
- `lib.rs` — `AppState.windows`; `main` registered at setup; `Focused(true)`→mark_focused and `Destroyed`→unregister hooks (both broadcast); `File → New Window` menu owning `Cmd+N`.
- `app_ready` generalized to show the **calling** window; capabilities globbed to `["main","window-*"]`.

**Frontend**
- `src/lib/windowFocus.ts` — focus-map subscription, debounced subject reporting, `isSecondaryFor` (parses `focused_at` to epoch-ms; chrono RFC3339 fractional widths vary, so no string compare).
- `src/components/DuplicateSubjectOverlay.tsx` — "Focus that window" / "Stay here" (non-persisted dismiss).
- `MissionWorkspace` / `RunnerChat` — report subject, gate terminal mount + all mutating controls on `!isSecondary`. `App.tsx` consumes the initial-route hash fragment.
- Sidebar — `Cmd+T` opens new chat (was `Cmd+N`); "Open in New Window" added to mission/session row menus.

## Out of scope (deferred, per spec)

Window restoration across restart, per-window settings, tab-tearing, shared-PTY render, targeted `emit_to`.

## Validation

- `cargo test --workspace`: 336 passed (incl. 7 new `windows::` tests)
- `cargo fmt --check` + `cargo clippy --workspace --all-targets`: clean
- `pnpm exec tsc --noEmit` + `pnpm run lint`: clean
- Working-tree peer review: two must-fix findings (secondary-window controls were still live) fixed; clean re-review.

**Not done:** live multi-window GUI smoke (can't be driven headlessly). Run the 7-step smoke in impl 0018 §Phase 5 before merge.