### PR TITLE
Add sidebar page shortcuts

### DIFF
--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -56,6 +56,8 @@ interface ExitEvent {
 }
 
 const MAX_PENDING_LIVE_EVENTS = 4096;
+const SIDEBAR_TOGGLE_EVENT = "runner:toggle-sidebar";
+const SIDEBAR_NAVIGATE_EVENT = "runner:navigate-sidebar-page";
 
 function normalizePasteImageMime(type: string): PasteImageMimeType | null {
   switch (type.trim().toLowerCase()) {
@@ -455,7 +457,33 @@ export const RunnerTerminal = forwardRef<
         const key = e.key.toLowerCase();
         if (key === "s" || e.key === "\\") {
           e.preventDefault();
-          window.dispatchEvent(new Event("runner:toggle-sidebar"));
+          window.dispatchEvent(new Event(SIDEBAR_TOGGLE_EVENT));
+          return false;
+        }
+        if (
+          !e.altKey &&
+          !e.shiftKey &&
+          (e.key === "[" || e.code === "BracketLeft")
+        ) {
+          e.preventDefault();
+          window.dispatchEvent(
+            new CustomEvent(SIDEBAR_NAVIGATE_EVENT, {
+              detail: { direction: "previous" },
+            }),
+          );
+          return false;
+        }
+        if (
+          !e.altKey &&
+          !e.shiftKey &&
+          (e.key === "]" || e.code === "BracketRight")
+        ) {
+          e.preventDefault();
+          window.dispatchEvent(
+            new CustomEvent(SIDEBAR_NAVIGATE_EVENT, {
+              detail: { direction: "next" },
+            }),
+          );
           return false;
         }
       }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -17,6 +17,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type ComponentType,
@@ -79,6 +80,43 @@ const SIDEBAR_DEFAULT = 240;
 const STORAGE_WIDTH = "runner.sidebar.width";
 const STORAGE_MISSION_OPEN = "runner.sidebar.mission.open";
 const STORAGE_SESSION_OPEN = "runner.sidebar.session.open";
+const SIDEBAR_NAVIGATE_EVENT = "runner:navigate-sidebar-page";
+
+type SidebarNavigationDirection = "previous" | "next";
+
+interface SidebarNavigationEntry {
+  to: string;
+  state?: { sessionStatus: DirectSessionEntry["status"] };
+}
+
+function sidebarNavigationDirectionFromKey(
+  e: KeyboardEvent,
+): SidebarNavigationDirection | null {
+  if (!(e.metaKey || e.ctrlKey)) return null;
+  if (e.altKey || e.shiftKey) return null;
+  if (e.key === "[" || e.code === "BracketLeft") return "previous";
+  if (e.key === "]" || e.code === "BracketRight") return "next";
+  return null;
+}
+
+function sidebarEntryKeyForPath(pathname: string): string | null {
+  if (pathname === "/runners" || pathname.startsWith("/runners/")) {
+    return "/runners";
+  }
+  if (pathname === "/crews" || pathname.startsWith("/crews/")) {
+    return "/crews";
+  }
+  if (pathname.startsWith("/missions/") || pathname.startsWith("/chats/")) {
+    return pathname;
+  }
+  return null;
+}
+
+function isSidebarNavigationDirection(
+  value: unknown,
+): value is SidebarNavigationDirection {
+  return value === "previous" || value === "next";
+}
 
 function getStoredFlag(key: string, fallback: boolean): boolean {
   if (typeof localStorage === "undefined") return fallback;
@@ -205,6 +243,19 @@ export function Sidebar({
   // session id rather than handle.
   const currentChatSessionId = chatMatch?.params.sessionId ?? null;
 
+  const sidebarNavigationEntries = useMemo<SidebarNavigationEntry[]>(
+    () => [
+      { to: "/runners" },
+      { to: "/crews" },
+      ...missions.map((mission) => ({ to: `/missions/${mission.id}` })),
+      ...directSessions.map((session) => ({
+        to: `/chats/${session.session_id}`,
+        state: { sessionStatus: session.status },
+      })),
+    ],
+    [directSessions, missions],
+  );
+
   const refreshMissions = useCallback(async () => {
     try {
       const rows = await api.mission.listSummary();
@@ -221,6 +272,33 @@ export function Sidebar({
   useEffect(() => {
     void refreshMissions();
   }, [refreshMissions]);
+
+  const navigateSidebarPage = useCallback(
+    (direction: SidebarNavigationDirection) => {
+      if (sidebarNavigationEntries.length < 2) return;
+      const currentKey = sidebarEntryKeyForPath(location.pathname);
+      const currentIndex = currentKey
+        ? sidebarNavigationEntries.findIndex((entry) => entry.to === currentKey)
+        : -1;
+      const delta = direction === "next" ? 1 : -1;
+      const nextIndex =
+        currentIndex === -1
+          ? direction === "next"
+            ? 0
+            : sidebarNavigationEntries.length - 1
+          : (currentIndex + delta + sidebarNavigationEntries.length) %
+            sidebarNavigationEntries.length;
+      const entry = sidebarNavigationEntries[nextIndex];
+      const options = entry.state
+        ? {
+            replace: location.pathname === entry.to,
+            state: entry.state,
+          }
+        : { replace: location.pathname === entry.to };
+      navigate(entry.to, options);
+    },
+    [location.pathname, navigate, sidebarNavigationEntries],
+  );
 
   // ⌘K / Ctrl+K opens the command palette. ⌘T / Ctrl+T opens the Start
   // Chat modal (browser/terminal convention: ⌘T = new tab/chat, ⌘N =
@@ -259,6 +337,42 @@ export function Sidebar({
     window.addEventListener("keydown", onKey, { capture: true });
     return () => window.removeEventListener("keydown", onKey, { capture: true });
   }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const direction = sidebarNavigationDirectionFromKey(e);
+      if (!direction) return;
+      const target = e.target as HTMLElement | null;
+      const tag = target?.tagName?.toLowerCase();
+      const isXtermInput = !!target?.closest(".xterm");
+      if (
+        (tag === "input" ||
+          tag === "textarea" ||
+          tag === "select" ||
+          target?.isContentEditable) &&
+        !isXtermInput
+      ) {
+        return;
+      }
+      if (isXtermInput && !e.metaKey) return;
+      e.preventDefault();
+      e.stopPropagation();
+      navigateSidebarPage(direction);
+    };
+    const onNavigate = (event: Event) => {
+      const direction = (event as CustomEvent<{ direction?: unknown }>).detail
+        ?.direction;
+      if (isSidebarNavigationDirection(direction)) {
+        navigateSidebarPage(direction);
+      }
+    };
+    window.addEventListener("keydown", onKey, { capture: true });
+    window.addEventListener(SIDEBAR_NAVIGATE_EVENT, onNavigate);
+    return () => {
+      window.removeEventListener("keydown", onKey, { capture: true });
+      window.removeEventListener(SIDEBAR_NAVIGATE_EVENT, onNavigate);
+    };
+  }, [navigateSidebarPage]);
 
   useEffect(() => {
     let unlistenEvents: (() => void) | null = null;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -81,12 +81,18 @@ const STORAGE_WIDTH = "runner.sidebar.width";
 const STORAGE_MISSION_OPEN = "runner.sidebar.mission.open";
 const STORAGE_SESSION_OPEN = "runner.sidebar.session.open";
 const SIDEBAR_NAVIGATE_EVENT = "runner:navigate-sidebar-page";
+const SIDEBAR_NAVIGATION_HISTORY_LIMIT = 64;
 
 type SidebarNavigationDirection = "previous" | "next";
 
 interface SidebarNavigationEntry {
   to: string;
   state?: { sessionStatus: DirectSessionEntry["status"] };
+}
+
+interface SidebarNavigationHistory {
+  entries: string[];
+  index: number;
 }
 
 function sidebarNavigationDirectionFromKey(
@@ -99,13 +105,7 @@ function sidebarNavigationDirectionFromKey(
   return null;
 }
 
-function sidebarEntryKeyForPath(pathname: string): string | null {
-  if (pathname === "/runners" || pathname.startsWith("/runners/")) {
-    return "/runners";
-  }
-  if (pathname === "/crews" || pathname.startsWith("/crews/")) {
-    return "/crews";
-  }
+function sidebarRuntimeKeyForPath(pathname: string): string | null {
   if (pathname.startsWith("/missions/") || pathname.startsWith("/chats/")) {
     return pathname;
   }
@@ -188,6 +188,10 @@ export function Sidebar({
   const [directSessionActivity, setDirectSessionActivity] = useState<
     Record<string, SessionActivityState | undefined>
   >({});
+  const sidebarNavigationHistoryRef = useRef<SidebarNavigationHistory>({
+    entries: [],
+    index: -1,
+  });
 
   // Section toggles, persisted so users don't have to re-expand each visit.
   const [missionsOpen, setMissionsOpen] = useState<boolean>(() =>
@@ -245,8 +249,6 @@ export function Sidebar({
 
   const sidebarNavigationEntries = useMemo<SidebarNavigationEntry[]>(
     () => [
-      { to: "/runners" },
-      { to: "/crews" },
       ...missions.map((mission) => ({ to: `/missions/${mission.id}` })),
       ...directSessions.map((session) => ({
         to: `/chats/${session.session_id}`,
@@ -273,29 +275,47 @@ export function Sidebar({
     void refreshMissions();
   }, [refreshMissions]);
 
+  useEffect(() => {
+    const currentKey = sidebarRuntimeKeyForPath(location.pathname);
+    if (!currentKey) return;
+    const history = sidebarNavigationHistoryRef.current;
+    if (history.entries[history.index] === currentKey) return;
+
+    const entries = history.entries.slice(0, history.index + 1);
+    if (entries[entries.length - 1] !== currentKey) {
+      entries.push(currentKey);
+    }
+    if (entries.length > SIDEBAR_NAVIGATION_HISTORY_LIMIT) {
+      entries.splice(0, entries.length - SIDEBAR_NAVIGATION_HISTORY_LIMIT);
+    }
+    history.entries = entries;
+    history.index = entries.length - 1;
+  }, [location.pathname]);
+
   const navigateSidebarPage = useCallback(
     (direction: SidebarNavigationDirection) => {
-      if (sidebarNavigationEntries.length < 2) return;
-      const currentKey = sidebarEntryKeyForPath(location.pathname);
-      const currentIndex = currentKey
-        ? sidebarNavigationEntries.findIndex((entry) => entry.to === currentKey)
-        : -1;
+      const history = sidebarNavigationHistoryRef.current;
+      if (history.entries.length < 2 || history.index === -1) return;
+
       const delta = direction === "next" ? 1 : -1;
-      const nextIndex =
-        currentIndex === -1
-          ? direction === "next"
-            ? 0
-            : sidebarNavigationEntries.length - 1
-          : (currentIndex + delta + sidebarNavigationEntries.length) %
-            sidebarNavigationEntries.length;
-      const entry = sidebarNavigationEntries[nextIndex];
-      const options = entry.state
-        ? {
-            replace: location.pathname === entry.to,
-            state: entry.state,
-          }
-        : { replace: location.pathname === entry.to };
-      navigate(entry.to, options);
+      let nextIndex = history.index + delta;
+      while (nextIndex >= 0 && nextIndex < history.entries.length) {
+        const entry = sidebarNavigationEntries.find(
+          (candidate) => candidate.to === history.entries[nextIndex],
+        );
+        if (entry) {
+          history.index = nextIndex;
+          const options = entry.state
+            ? {
+                replace: location.pathname === entry.to,
+                state: entry.state,
+              }
+            : { replace: location.pathname === entry.to };
+          navigate(entry.to, options);
+          return;
+        }
+        nextIndex += delta;
+      }
     },
     [location.pathname, navigate, sidebarNavigationEntries],
   );


### PR DESCRIPTION
## Summary
- Add Cmd/Ctrl + [ and Cmd/Ctrl + ] sidebar page shortcuts for runtime pages
- Switch through mission/chat navigation history instead of moving up/down the sidebar list
- Exclude Runner and Crew menu pages from the shortcut history
- Preserve chat navigation state when navigating back into direct chat rows
- Dispatch the same shortcut from focused xterm sessions so macOS terminal focus still supports it

## Validation
- pnpm exec tsc --noEmit
- pnpm run lint
- nvm exec 22 pnpm run build

Notes: lint still prints the existing Node 18.20.8 warning in this shell; build prints the existing Vite chunk-size warning.