### PR TITLE
Deprecate crew.orchestrator_policy; guard first-turn argv size (#247)

### DIFF
--- a/docs/arch/arch.md
+++ b/docs/arch/arch.md
@@ -634,7 +634,7 @@ crews (
   name TEXT NOT NULL,
   purpose TEXT,                       -- short prose shown in Crew Detail; optional
   goal TEXT,                          -- default mission goal
-  orchestrator_policy TEXT,           -- reserved for future routing policy
+  orchestrator_policy TEXT,           -- DEPRECATED (#247): superseded by system_prompt_addendum; retained but unused
   system_prompt_addendum TEXT,        -- Layer-2 team conventions; nullable
   created_at TEXT, updated_at TEXT
 );

--- a/src-tauri/migrations/0001_init.sql
+++ b/src-tauri/migrations/0001_init.sql
@@ -9,6 +9,8 @@ CREATE TABLE crews (
     name TEXT NOT NULL,
     purpose TEXT,
     goal TEXT,
+    -- DEPRECATED (#247): superseded by system_prompt_addendum. Retained
+    -- for existing rows; no longer written or read into any prompt.
     orchestrator_policy TEXT,
     signal_types TEXT NOT NULL DEFAULT '["mission_goal","human_said","ask_lead","ask_human","human_question","human_response","runner_status","inbox_read"]',
     created_at TEXT NOT NULL,

--- a/src-tauri/src/commands/crew.rs
+++ b/src-tauri/src/commands/crew.rs
@@ -35,7 +35,8 @@ pub struct UpdateCrewInput {
     pub name: Option<String>,
     pub purpose: Option<Option<String>>,
     pub goal: Option<Option<String>>,
-    pub orchestrator_policy: Option<Option<serde_json::Value>>,
+    // `orchestrator_policy` is deprecated (superseded by
+    // `system_prompt_addendum`) and no longer accepted for write. See #247.
     /// Outer None = leave existing untouched; outer Some(inner) =
     /// write inner. Inner Some("") / whitespace-only collapses to
     /// NULL.
@@ -240,38 +241,26 @@ pub fn update(conn: &Connection, id: &str, input: UpdateCrewInput) -> Result<Cre
     let purpose = input.purpose.unwrap_or(existing.purpose);
     let goal = input.goal.unwrap_or(existing.goal);
     validate_crew_goal(goal.as_deref())?;
-    let orchestrator_policy = input
-        .orchestrator_policy
-        .unwrap_or(existing.orchestrator_policy);
     let system_prompt_addendum = match input.system_prompt_addendum {
         Some(inner) => normalize_addendum(inner),
         None => existing.system_prompt_addendum,
     };
 
-    let policy_raw = match orchestrator_policy.as_ref() {
-        Some(v) => Some(serde_json::to_string(v)?),
-        None => None,
-    };
     let ts = now().to_rfc3339();
 
+    // `orchestrator_policy` is deprecated (superseded by
+    // `system_prompt_addendum`) and intentionally not written here — the
+    // column is retained for existing rows but no longer maintained. See
+    // #247.
     conn.execute(
         "UPDATE crews
             SET name = ?1,
                 purpose = ?2,
                 goal = ?3,
-                orchestrator_policy = ?4,
-                system_prompt_addendum = ?5,
-                updated_at = ?6
-          WHERE id = ?7",
-        params![
-            name,
-            purpose,
-            goal,
-            policy_raw,
-            system_prompt_addendum,
-            ts,
-            id,
-        ],
+                system_prompt_addendum = ?4,
+                updated_at = ?5
+          WHERE id = ?6",
+        params![name, purpose, goal, system_prompt_addendum, ts, id],
     )?;
     get(conn, id)
 }

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -201,6 +201,30 @@ fn validate_mission_goal(goal: &str) -> Result<()> {
     Ok(())
 }
 
+/// Guard one composed first-turn body against the positional `[PROMPT]`
+/// argv ceiling (`router::runtime::FIRST_TURN_ARGV_MAX_BYTES`) before a
+/// PTY is spawned. The individual persist-time caps
+/// (`system_prompt` 16 KB, `crew.goal` / `mission_goal` 8 KB) do NOT
+/// compose to this bound — brief + goal alone can reach 24 KB, and
+/// `crew.system_prompt_addendum` (team conventions) is uncapped on top —
+/// so the real invariant has to be enforced on the assembled body, at
+/// the spawn boundary. Otherwise `first_turn_argv` silently drops the
+/// entire first turn in release builds (empty argv) and trips a
+/// `debug_assert!` in debug. See #247.
+fn ensure_first_turn_fits(slot_handle: &str, body: &str) -> Result<()> {
+    let max = crate::router::runtime::FIRST_TURN_ARGV_MAX_BYTES;
+    if body.len() > max {
+        return Err(Error::msg(format!(
+            "composed first-turn prompt for slot `{slot_handle}` is {} bytes; exceeds the \
+             {} KB runtime argv ceiling. Trim this crew's runner brief, mission goal, or team \
+             conventions.",
+            body.len(),
+            max / 1024,
+        )));
+    }
+    Ok(())
+}
+
 pub fn start(
     conn: &mut Connection,
     app_data_dir: &Path,
@@ -617,6 +641,27 @@ async fn mission_start_impl_with_size(
             })
             .collect()
     };
+
+    // Enforce the composed-body argv ceiling before spawning any PTY.
+    // Per-field persist caps don't compose to this bound (see
+    // `ensure_first_turn_fits`); on overflow, roll the half-open mission
+    // back to `aborted` and surface an actionable error rather than
+    // booting an agent with an empty first turn.
+    for (member, body) in roster.iter().zip(&first_turns) {
+        if let Some(body) = body {
+            if let Err(e) = ensure_first_turn_fits(&member.slot.slot_handle, body) {
+                if let Ok(conn) = state.db.get() {
+                    let _ = conn.execute(
+                        "UPDATE missions
+                            SET status = 'aborted', stopped_at = ?1
+                          WHERE id = ?2",
+                        rusqlite::params![Utc::now().to_rfc3339(), out.mission.id],
+                    );
+                }
+                return Err(e);
+            }
+        }
+    }
 
     // Build the router up front (opens the log, validates the lead, holds
     // empty state). It does NOT subscribe to the bus yet — see ordering
@@ -1355,6 +1400,28 @@ pub(crate) async fn mission_reset_impl(
             .collect()
     };
 
+    // Enforce the composed-body argv ceiling before respawning (same
+    // guard as mission_start). A crew edited to oversized brief / goal /
+    // conventions since the original start would otherwise boot agents
+    // with an empty first turn; abort with an actionable error instead.
+    // The mission is already torn down at this point, so `aborted` is the
+    // consistent terminal state.
+    for (member, body) in roster.iter().zip(&first_turns) {
+        if let Some(body) = body {
+            if let Err(e) = ensure_first_turn_fits(&member.slot.slot_handle, body) {
+                if let Ok(conn) = state.db.get() {
+                    let _ = conn.execute(
+                        "UPDATE missions
+                            SET status = 'aborted', stopped_at = ?1
+                          WHERE id = ?2",
+                        params![now().to_rfc3339(), id],
+                    );
+                }
+                return Err(e);
+            }
+        }
+    }
+
     // 7. Build router + spawn fresh PTYs + mount bus. Same ordering
     // contract as mission_start: spawn first so register_sessions has
     // the full handle map before the bus's initial replay fires the
@@ -1806,6 +1873,30 @@ mod tests {
             serde_json::json!({ "state": state }),
         ))
         .unwrap();
+    }
+
+    #[test]
+    fn ensure_first_turn_fits_guards_the_argv_ceiling() {
+        // #247: the composed body must stay under the argv ceiling even
+        // when every per-field persist cap is individually satisfied
+        // (brief 16 KB + goal 8 KB + uncapped team conventions can
+        // together overflow). Bodies at the limit pass; a byte over is
+        // rejected with a slot-named, actionable error.
+        let max = crate::router::runtime::FIRST_TURN_ARGV_MAX_BYTES;
+        ensure_first_turn_fits("lead", &"x".repeat(max))
+            .expect("a body exactly at the ceiling must be accepted");
+
+        let err = ensure_first_turn_fits("reviewer", &"x".repeat(max + 1))
+            .expect_err("a body one byte past the ceiling must be rejected");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("reviewer"),
+            "error must name the slot; got: {msg}"
+        );
+        assert!(
+            msg.contains("argv ceiling"),
+            "error must explain the ceiling; got: {msg}",
+        );
     }
 
     #[test]

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -23,6 +23,10 @@ pub struct Crew {
     pub name: String,
     pub purpose: Option<String>,
     pub goal: Option<String>,
+    /// DEPRECATED (#247): superseded by `system_prompt_addendum` as the
+    /// single crew-level prompt layer. The column is retained for
+    /// existing rows and still read here, but it is no longer written or
+    /// spliced into any prompt. Do not add new reads.
     pub orchestrator_policy: Option<serde_json::Value>,
     /// Layer-2 team conventions text. Spliced between the platform
     /// preamble and the runner persona on mission spawns only;

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -11,7 +11,8 @@
 //
 // What this is not. There is no policy engine, no rule abstraction, no
 // per-crew config in MVP. Handlers are a flat `match signal_type { … }`.
-// `crews.orchestrator_policy` is reserved for v0.x and is not read here.
+// `crews.orchestrator_policy` is deprecated (#247), superseded by
+// `crew.system_prompt_addendum`; it is not read here or spliced anywhere.
 //
 // Per arch §5.5.0 invariant: messages never trigger router actions. Only
 // `EventKind::Signal` reaches the dispatcher; messages flow through the

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,9 @@ export interface Crew {
   name: string;
   purpose: string | null;
   goal: string | null;
+  /** @deprecated (#247) superseded by `system_prompt_addendum` as the
+   *  single crew-level prompt layer. Still returned for existing rows,
+   *  but no longer written or spliced into any prompt. Not editable. */
   orchestrator_policy: unknown | null;
   /** Layer-2 team conventions text. Spliced between the platform
    *  preamble and the runner persona on mission spawns only;
@@ -229,7 +232,7 @@ export interface UpdateCrewInput {
   name?: string;
   purpose?: string | null;
   goal?: string | null;
-  orchestrator_policy?: unknown | null;
+  // orchestrator_policy is deprecated (#247) and no longer writable.
   /** Omit to leave existing untouched; pass null to clear; pass a
    *  non-empty string to set. */
   system_prompt_addendum?: string | null;


### PR DESCRIPTION
Closes #247.

## Background

`crew.orchestrator_policy` was stored and CRUD'd but never injected into any prompt — pure dead config. Issue #247 offered two directions: **wire** it, or **remove** it.

This branch first wired it (spliced as an `== Orchestration ==` section into every lead/worker first turn). But with it actually reaching prompts, it proved **redundant** with `system_prompt_addendum` ("Team conventions"): both are crew-level prose spliced into the same first-turn body, both reach the lead and workers, and neither is enforced by the router — they differ only in a section label. So the decision (per maintainer) is to **collapse to a single crew-level prompt layer** and **deprecate** `orchestrator_policy` rather than wire it.

## Changes

**`refactor(crew)` — deprecate `orchestrator_policy`:**
- Column `crews.orchestrator_policy` is **retained** (no migration drop) but marked deprecated in the migration, the `Crew` model, the router module doc, `arch.md`, and `types.ts`.
- No longer **written**: removed from `crew::update`'s `UPDATE` and from `UpdateCrewInput` (so it is not writable via the command / MCP path).
- No longer **spliced** into any prompt (the `== Orchestration ==` wiring is fully removed).
- Still **read** by `row_to_crew`, so existing rows and the serialized `Crew` shape are unaffected — no API break.

**`fix(mission)` — guard the composed first-turn body against the argv ceiling:**
- Per-field persist caps (`system_prompt` 16 KB, `goal` 8 KB) don't compose to `FIRST_TURN_ARGV_MAX_BYTES` (32 KB), and `system_prompt_addendum` is uncapped — a valid combination can overflow the positional `[PROMPT]` argv, which `first_turn_argv` silently drops (release) or asserts on (debug).
- `ensure_first_turn_fits` now enforces the real invariant on the assembled body at the spawn boundary in **both** `mission_start` and `mission_reset`, aborting with a slot-named, actionable error instead. This is a pre-existing latent overflow, independent of the policy field.

## Testing
- `cargo fmt --check`, `cargo clippy --workspace --all-targets` — clean
- `cargo test --workspace` — 299 + 8 + 13 + 22, 0 failures (includes the new `ensure_first_turn_fits` guard test)
- `pnpm exec tsc --noEmit`, `pnpm run lint` — clean

## Notes
- Follow-up (not in this PR): the "Team conventions" (`system_prompt_addendum`) editor has a latent clear-via-`null` no-op (serde `Option<Option<T>>` treats present-`null` as "leave untouched"). Same trap, worth a separate fix.