### PR TITLE
refactor(db): repo layer on serde_rusqlite (plan 0021)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3856,6 +3856,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "serde_rusqlite",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
@@ -4291,6 +4292,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_rusqlite"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b741cc5ef185cd96157e762c3bba743c4e94c8dc6af0edb053c48d2b3c27e691"
+dependencies = [
+ "rusqlite",
+ "serde",
 ]
 
 [[package]]

--- a/docs/impls/0021-repo-layer-serde-rusqlite.md
+++ b/docs/impls/0021-repo-layer-serde-rusqlite.md
@@ -1,0 +1,119 @@
+# 0021 — Lite ORM repo layer on serde_rusqlite
+
+> Behavior-preserving reorganization of the persistence layer around persistent objects. No product-visible change, no schema change, no new stored byte formats; the existing test suite is the contract.
+
+## Context
+
+Persistence today is hand-written SQL spread across the command layer. Every table has a hand-rolled `fn row_to_X(&Row) -> rusqlite::Result<X>` mapper (`commands/crew.rs:75`, `commands/mission.rs:80`, `commands/slot.rs:113`, `commands/runner.rs:210`, `commands/session.rs:50`), each repeating the same ceremony: `row.get("col")?` per column, `String → DateTime<Utc>` parsing with a hand-built `FromSqlConversionFailure`, `match`-based enum decoding, and `serde_json::from_str` for JSON-in-TEXT columns. Writes are the mirror image: INSERT/UPDATE strings with positional `params![]` lists that must be kept in sync with the mappers by eye. Statement counts: `commands/mission.rs` 29, `commands/session.rs` 17, `commands/slot.rs` 9, `commands/crew.rs` 6, `commands/runner.rs` 4, plus writers outside the command layer (`session/manager/spawn.rs`, `session/manager/output.rs`, `session/pty_runtime.rs`, `session/codex_capture.rs`, `mcp/tools/crew.rs`) and `db.rs` seeds.
+
+The cost is not the SQL — the queries are fine — it is the by-hand mapping between rows and structs: five mappers, dozens of param lists, and column lists duplicated between SELECTs and mappers with nothing keeping them aligned.
+
+The model types in `model.rs` already derive `Serialize`/`Deserialize` (they double as Tauri IPC DTOs), which is exactly the contract `serde_rusqlite` needs. This plan adds a `repo/` module that owns all row mapping and SQL per table, with mapping derived from serde instead of written by hand.
+
+## Goal
+
+- One `repo::<table>` submodule per persistent object (`crew`, `runner`, `slot`, `mission`, `session`) owning that table's row struct, column list, and CRUD functions.
+- Row↔struct mapping is derived (`from_row`, `to_params_named`), not hand-written. All five `row_to_*` mappers deleted.
+- Callers (`commands/`, `mcp/tools/`, `session/`) do validation and orchestration and call `repo` functions; they no longer contain INSERT/UPDATE SQL or `rusqlite::Row` handling.
+- `db.rs` shrinks to pool, migration runner, schema guard, and seeds.
+- Stored byte formats stay identical to today (timestamps via `to_rfc3339`, JSON via `serde_json::to_string`), so old and new rows are indistinguishable and no migration is needed.
+
+## Non-goals
+
+- No async. The stack stays `rusqlite` + r2d2 + sync Tauri commands; async ORMs (ormlite, SQLx, SeaORM's async core) were evaluated and rejected — they color the whole command layer for zero benefit on a local single-file SQLite DB. `sea-orm-sync` (2.0, rusqlite backend) was the runner-up but is a heavyweight framework and a 6-month-old sync port; `serde_rusqlite` reuses the serde derives the models already have.
+- No query DSL and no schema generation from structs. SQL stays hand-written and visible, just centralized in `repo/`.
+- Migrations stay raw SQL files under `src-tauri/migrations/` run by `db.rs`. Seeds stay SQL.
+- No change to the IPC surface: `model.rs` types keep their exact serde shape, `src/lib/types.ts` untouched, no frontend change.
+- The event log (NDJSON via `runner-core`) is not a database and is untouched.
+- No behavior change anywhere. If a step needs a non-mechanical test change, stop and reassess.
+
+## Decisions
+
+1. **`serde_rusqlite`, thin-repository style.** The crate gives `from_row::<T>(&Row)` / `from_rows`, `to_params_named(&T)` (+ `to_params_named_with_fields` for partial UPDATEs), and `columns_from_statement`. Confirmed type support: `bool ↔ INTEGER`, `Option<T>`, unit-variant enums ↔ TEXT (serde `rename_all` respected — matches `MissionStatus`/`SessionStatus` storing `'running'` etc.), `String`/`i64`/`f64`/`Vec<u8>`. Confirmed limits that shape this plan: `Vec<String>`, `HashMap`, and `serde_json::Value` are NOT usable as single columns; `u64`/`i128` unsupported. Version note: pick the `serde_rusqlite` release whose `rusqlite` dependency matches the workspace's `rusqlite` version exactly, or the `Row` types won't unify.
+2. **Every table gets a `Row` struct in `repo/` — the persistent object.** Even where the model type's serde shape happens to match the table today (Slot, Mission, Session), the repo defines its own `XRow` mirroring columns exactly, with `From<XRow> for X` / `From<&X> for XRow` conversions. Rationale: (a) it decouples the DB representation from the IPC DTO permanently — Runner (`args`/`env` structs vs `args_json`/`env_json` TEXT) and Crew (`orchestrator_policy` JSON TEXT) prove the two shapes diverge; (b) it lets the row structs pin storage-stable serde helpers (decision 3) without touching what the frontend receives; (c) uniformity is the framework — every table has exactly one Row struct + one column list + CRUD functions, no per-table special cases to remember.
+3. **Storage formats are pinned by shared serde helpers in `repo/serde.rs`, byte-identical to today.** `rfc3339` / `rfc3339_opt` serialize `Timestamp` via `to_rfc3339()` (the `+00:00` format every current write path uses) and deserialize via `str::parse` (accepts both RFC3339 offset spellings, so any historical rows are fine). `json_text` / `json_text_opt` are generic `#[serde(with)] `modules serializing any `Serialize + DeserializeOwned` field through `serde_json` to a TEXT column — used by `RunnerRow.args_json: Vec<String>`, `RunnerRow.env_json: HashMap<String, String>`, and `CrewRow.orchestrator_policy: Option<serde_json::Value>` (deprecated per #247/`285530d`: still read, never written — the Row struct keeps it so `SELECT *`-style reads and the serialized `Crew` shape are unaffected).
+4. **Repo functions take `&Connection` (or `&Transaction` via `Deref`), never the pool.** Same convention as today's `crew::get(&conn, id)` — callers own connection acquisition and transaction boundaries, so repo calls compose inside the existing multi-statement transactions in `commands/mission.rs` and `commands/slot.rs` unchanged.
+5. **Column lists are a per-table `const COLUMNS: &[&str]`** used to build SELECT lists and INSERT column/param lists, so the statement and the struct can't drift apart silently. A per-table unit test round-trips a fully-populated Row through INSERT → SELECT → `from_row` to prove the pairing.
+6. **Join DTOs compose from per-table rows; `#[serde(flatten)]` is not trusted for row deserialization.** `SlotWithRunner` and `SessionRow` (session + `handle`/`runtime`/`lead`/`agent_session_key`) are read from JOIN queries today. serde's `flatten` buffers through an internal `Content` type that drops the type hints `serde_rusqlite` needs for `bool`-from-INTEGER and enum decoding — whether it works is version-dependent trivia we don't want to depend on. Instead: joined SELECTs alias each side's columns and the repo builds the DTO from two `from_row_with_columns` calls (or reads the handful of denormalized extras with plain `row.get`), then assembles the existing DTO struct in Rust. The DTO types themselves and their IPC shape don't change.
+7. **Order the migration by blast radius, one phase per table, each phase independently green.** Slot first (smallest real surface, exercises bool/i64/timestamp and the join pattern via `slot_list`), then crew (JSON column + `CrewListItem` join), then runner (both JSON columns + the largest partial-UPDATE surface), then session (most writer call sites, spread across `session/` and `mcp/`), then mission last (biggest file, transaction-heavy paths including the `ensure_first_turn_fits` rollback). A stalled or reverted phase leaves everything before it shipped and everything after it untouched.
+
+## Step 0: Dependency + helpers + spike
+
+Files: `src-tauri/Cargo.toml`, new `src-tauri/src/repo/mod.rs`, new `src-tauri/src/repo/serde.rs`
+
+- Add `serde_rusqlite` (version matched to the workspace `rusqlite` — see decision 1).
+- Create `repo/mod.rs` (module wiring) and `repo/serde.rs` with `rfc3339`, `rfc3339_opt`, `json_text`, `json_text_opt` helper modules.
+- Spike tests against an in-memory DB proving, before any migration: `bool ↔ INTEGER` round-trip; `MissionStatus`/`SessionStatus` ↔ lowercase TEXT; `Option<Timestamp>` via `rfc3339_opt` writing byte-identical strings to `to_rfc3339()` and reading legacy `+00:00` and `Z` spellings; `Vec<String>`/`HashMap`/`Option<Value>` via `json_text` writing byte-identical strings to the current `serde_json::to_string` calls; `to_params_named_with_fields` driving a partial UPDATE.
+
+Validation: `cargo test -p runner repo` green. If any spike fails, resolve here — nothing else has moved yet.
+
+## Step 1: Slot
+
+Files: new `src-tauri/src/repo/slot.rs`, `src-tauri/src/commands/slot.rs`
+
+- `SlotRow` + `COLUMNS` + CRUD (`insert`, `get`, `list_for_crew`, `list_for_runner`, `update`, `delete`, the position/lead helpers behind `slot_reorder`/`slot_set_lead`). Transaction-using callers keep their existing `tx` boundaries (decision 4).
+- `slot_list`'s `SlotWithRunner` join moves to the aliased-columns pattern (decision 6), pulling the runner side via `repo::runner` once that exists — until then it may temporarily call the existing `row_to_runner`; the temporary seam is removed in Step 3.
+  - **As implemented:** today's `slot::list` is not a JOIN — it is two queries (slot rows, then `runner::get` per slot) with a comment explaining the readability trade-off. Preserving behavior exactly meant keeping that two-query shape: Step 1 reads slot rows via `repo::slot::list_for_crew` and keeps calling `commands::runner::get` (the temporary `row_to_runner` seam); Step 3 makes `runner::get` repo-backed, which removes the seam without ever introducing an aliased JOIN here. The aliased-columns pattern is used where a real JOIN already existed (`list_crews_for_runner`, `CrewListItem` previews, session list/direct surfaces).
+- Delete `row_to_slot`.
+
+Validation: `cargo test -p runner`, focused on `commands::slot` + `db` tests.
+
+## Step 2: Crew
+
+Files: new `src-tauri/src/repo/crew.rs`, `src-tauri/src/commands/crew.rs`, `src-tauri/src/mcp/tools/crew.rs`
+
+- `CrewRow` with `orchestrator_policy` behind `json_text_opt` (read-only field, never in INSERT/UPDATE column lists — matches `285530d`), `system_prompt_addendum`, timestamps via `rfc3339`.
+- CRUD for create/update/get/list/delete; `CrewListItem`'s member-preview join stays one query, assembled per decision 6.
+- Validation logic (`validate_crew_goal`, addendum normalization) stays in `commands/crew.rs` — the repo persists, it does not police.
+- Delete `row_to_crew`.
+
+Validation: `cargo test -p runner`, focused on `commands::crew` (goal-cap and addendum tests must pass unchanged).
+
+## Step 3: Runner
+
+Files: new `src-tauri/src/repo/runner.rs`, `src-tauri/src/commands/runner.rs`
+
+- `RunnerRow` with `args_json`/`env_json` behind `json_text` and `From` conversions to/from `model::Runner` (the field-name divergence `args` ↔ `args_json` lives only here).
+- Partial updates use `to_params_named_with_fields` against the existing update semantics (outer-`Option` = leave untouched).
+- Delete `row_to_runner`; remove the temporary seam from Step 1.
+
+Validation: `cargo test -p runner`, focused on `commands::runner` (including the `MAX_SYSTEM_PROMPT_BYTES` tests).
+
+## Step 4: Session
+
+Files: new `src-tauri/src/repo/session.rs`, `src-tauri/src/commands/session.rs`, `src-tauri/src/session/manager/spawn.rs`, `src-tauri/src/session/manager/output.rs`, `src-tauri/src/session/pty_runtime.rs`, `src-tauri/src/session/codex_capture.rs`, `src-tauri/src/mcp/tools/crew.rs`
+
+- `SessionRowDb` (naming avoids the existing `commands::session::SessionRow` DTO) covering the sessions table including `agent_session_key` and the legacy runtime columns exactly as written today.
+- This is the widest phase by call-site count but the statements are small (status flips, pid/stopped_at updates, key capture). Port them mechanically; do not consolidate or "improve" write paths — some run on the PTY hot path and their timing is load-bearing.
+- The `SessionRow` DTO join keeps its shape, assembled per decision 6.
+- Delete `row_to_session`.
+
+Validation: `cargo test -p runner` (manager + session tests are the deep coverage here), plus a manual smoke: direct chat spawn/stop/resume, mission spawn, `agent_session_key` capture visible in the UI.
+
+## Step 5: Mission
+
+Files: new `src-tauri/src/repo/mission.rs`, `src-tauri/src/commands/mission.rs`, `src-tauri/src/mcp/tools/*.rs` (mission tools)
+
+- `MissionRow` (status enum, four timestamp columns of which three nullable) + CRUD covering the 29 statements: start/stop/complete/abort transitions, archive/pin/rename, the `ensure_first_turn_fits` rollback-to-aborted paths, and the list/feed queries.
+- Transaction boundaries in `mission_start`/`mission_reset` stay exactly where they are; repo calls take the `&Transaction`.
+- Delete `row_to_mission`.
+
+Validation: `cargo test -p runner` full; the mission lifecycle tests (including `ensure_first_turn_fits_guards_the_argv_ceiling` and the rollback tests) are the contract.
+
+## Step 6: Sweep and gate
+
+Files: `src-tauri/src/db.rs`, stragglers
+
+- Port `db.rs` seed/test helpers to repo calls where that is a net simplification; leave migration SQL and the schema guard untouched.
+- Gates, enforced by grep in the final review: no `fn row_to_` anywhere; no `INSERT INTO` / `UPDATE ` SQL outside `repo/`, `db.rs` (migrations/seeds/schema-guard), and test fixtures; `commands/` and `session/` contain no `rusqlite::Row` imports.
+
+Validation: `cargo test --workspace`, `pnpm exec tsc --noEmit`, `pnpm run lint`, and a full manual smoke (crew CRUD, runner CRUD, slot reorder, mission start → archive, direct chat, app restart with existing DB — the existing-DB restart specifically proves old-format rows read cleanly).
+
+## Verification
+
+- [ ] `cargo test --workspace` green after every step, not just at the end.
+- [ ] Old databases open cleanly: timestamps in both RFC3339 spellings and all existing JSON TEXT values deserialize (Step 0 spike + Step 6 restart smoke).
+- [ ] New writes are byte-identical to old writes for every column (spot-check with `sqlite3` on a dev DB: insert the same entity via old build and new build, diff the rows).
+- [ ] All five `row_to_*` mappers deleted; grep gates from Step 6 hold.
+- [ ] IPC payloads unchanged: `src/lib/types.ts` untouched and `pnpm exec tsc --noEmit` green with zero frontend edits.
+- [ ] No behavior change: no test modified except mechanically (renamed symbol, moved import).

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,6 +27,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 base64 = "0.22"
 rusqlite = { version = "0.32", features = ["bundled", "chrono", "serde_json"] }
+# Derived row<->struct mapping for the repo layer (impl 0021). 0.36.x is
+# the release whose rusqlite dependency is 0.32, matching the workspace
+# rusqlite exactly so the Row types unify.
+serde_rusqlite = "0.36"
 r2d2 = "0.8"
 r2d2_sqlite = "0.25"
 chrono = { workspace = true }

--- a/src-tauri/src/commands/crew.rs
+++ b/src-tauri/src/commands/crew.rs
@@ -6,7 +6,7 @@
 // + sidecar that used to feed it are gone (feature 20).
 
 use chrono::Utc;
-use rusqlite::{params, Connection, OptionalExtension, Row};
+use rusqlite::Connection;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tauri::State;
@@ -15,7 +15,7 @@ use ulid::Ulid as UlidGen;
 use crate::{
     error::{Error, Result},
     model::{Crew, Timestamp},
-    AppState,
+    repo, AppState,
 };
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
@@ -72,83 +72,24 @@ fn now() -> Timestamp {
     Utc::now()
 }
 
-fn row_to_crew(row: &Row<'_>) -> rusqlite::Result<Crew> {
-    let orchestrator_policy: Option<String> = row.get("orchestrator_policy")?;
-    let created_at: String = row.get("created_at")?;
-    let updated_at: String = row.get("updated_at")?;
-    Ok(Crew {
-        id: row.get("id")?,
-        name: row.get("name")?,
-        purpose: row.get("purpose")?,
-        goal: row.get("goal")?,
-        orchestrator_policy: match orchestrator_policy {
-            Some(s) => Some(serde_json::from_str(&s).map_err(|e| {
-                rusqlite::Error::FromSqlConversionFailure(
-                    0,
-                    rusqlite::types::Type::Text,
-                    Box::new(e),
-                )
-            })?),
-            None => None,
-        },
-        system_prompt_addendum: row.get("system_prompt_addendum")?,
-        created_at: created_at.parse().map_err(|e: chrono::ParseError| {
-            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
-        })?,
-        updated_at: updated_at.parse().map_err(|e: chrono::ParseError| {
-            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
-        })?,
-    })
-}
-
 pub fn list(conn: &Connection) -> Result<Vec<CrewListItem>> {
-    let mut stmt = conn.prepare(
-        "SELECT c.id, c.name, c.purpose, c.goal, c.orchestrator_policy,
-                c.system_prompt_addendum,
-                c.created_at, c.updated_at,
-                (SELECT COUNT(*) FROM slots s WHERE s.crew_id = c.id) AS runner_count
-           FROM crews c
-         ORDER BY c.created_at ASC",
-    )?;
-    let rows: Vec<(Crew, i64)> = stmt
-        .query_map([], |row| {
-            let crew = row_to_crew(row)?;
-            let runner_count: i64 = row.get("runner_count")?;
-            Ok((crew, runner_count))
-        })?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-    drop(stmt);
+    let rows = repo::crew::list_with_runner_count(conn)?;
 
     // Bulk-fetch slot pills for every crew in a single query so the
     // Crews page renders without an N+1 lookup. Ordered by
     // (crew_id, position) so we can group sequentially.
-    let mut members_stmt = conn.prepare(
-        "SELECT s.crew_id, s.slot_handle, s.lead, r.handle AS runner_handle, r.runtime
-           FROM slots s
-           JOIN runners r ON r.id = s.runner_id
-          ORDER BY s.crew_id ASC, s.position ASC",
-    )?;
     let mut members_by_crew: std::collections::HashMap<String, Vec<CrewMemberPreview>> =
         std::collections::HashMap::new();
-    let member_rows = members_stmt.query_map([], |row| {
-        let crew_id: String = row.get("crew_id")?;
-        let slot_handle: String = row.get("slot_handle")?;
-        let runner_handle: String = row.get("runner_handle")?;
-        let runtime: String = row.get("runtime")?;
-        let lead: i64 = row.get("lead")?;
-        Ok((
-            crew_id,
-            CrewMemberPreview {
-                slot_handle,
-                runner_handle,
-                runtime,
-                lead: lead != 0,
-            },
-        ))
-    })?;
-    for entry in member_rows {
-        let (crew_id, member) = entry?;
-        members_by_crew.entry(crew_id).or_default().push(member);
+    for preview in repo::crew::list_member_previews(conn)? {
+        members_by_crew
+            .entry(preview.crew_id)
+            .or_default()
+            .push(CrewMemberPreview {
+                slot_handle: preview.slot_handle,
+                runner_handle: preview.runner_handle,
+                runtime: preview.runtime,
+                lead: preview.lead,
+            });
     }
 
     Ok(rows
@@ -165,16 +106,7 @@ pub fn list(conn: &Connection) -> Result<Vec<CrewListItem>> {
 }
 
 pub fn get(conn: &Connection, id: &str) -> Result<Crew> {
-    conn.query_row(
-        "SELECT id, name, purpose, goal, orchestrator_policy,
-                system_prompt_addendum,
-                created_at, updated_at
-           FROM crews WHERE id = ?1",
-        params![id],
-        row_to_crew,
-    )
-    .optional()?
-    .ok_or_else(|| Error::msg(format!("crew not found: {id}")))
+    repo::crew::get(conn, id)?.ok_or_else(|| Error::msg(format!("crew not found: {id}")))
 }
 
 /// Reject `crew.goal` payloads that would push the composed lead
@@ -214,13 +146,20 @@ pub fn create(conn: &Connection, input: CreateCrewInput) -> Result<Crew> {
     }
     validate_crew_goal(input.goal.as_deref())?;
     let id = new_id();
-    let ts = now().to_rfc3339();
+    let ts = now();
     let addendum = normalize_addendum(input.system_prompt_addendum);
-    conn.execute(
-        "INSERT INTO crews (id, name, purpose, goal,
-                            system_prompt_addendum, created_at, updated_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)",
-        params![id, name, input.purpose, input.goal, addendum, ts],
+    repo::crew::insert(
+        conn,
+        &repo::crew::CrewRow {
+            id: id.clone(),
+            name: name.to_string(),
+            purpose: input.purpose,
+            goal: input.goal,
+            orchestrator_policy: None,
+            system_prompt_addendum: addendum,
+            created_at: ts,
+            updated_at: ts,
+        },
     )?;
     get(conn, &id)
 }
@@ -246,27 +185,28 @@ pub fn update(conn: &Connection, id: &str, input: UpdateCrewInput) -> Result<Cre
         None => existing.system_prompt_addendum,
     };
 
-    let ts = now().to_rfc3339();
-
     // `orchestrator_policy` is deprecated (superseded by
     // `system_prompt_addendum`) and intentionally not written here — the
     // column is retained for existing rows but no longer maintained. See
-    // #247.
-    conn.execute(
-        "UPDATE crews
-            SET name = ?1,
-                purpose = ?2,
-                goal = ?3,
-                system_prompt_addendum = ?4,
-                updated_at = ?5
-          WHERE id = ?6",
-        params![name, purpose, goal, system_prompt_addendum, ts, id],
+    // #247. The repo's update column list excludes it.
+    repo::crew::update(
+        conn,
+        &repo::crew::CrewRow {
+            id: id.to_string(),
+            name,
+            purpose,
+            goal,
+            orchestrator_policy: None,
+            system_prompt_addendum,
+            created_at: existing.created_at,
+            updated_at: now(),
+        },
     )?;
     get(conn, id)
 }
 
 pub fn delete(conn: &Connection, id: &str) -> Result<()> {
-    let affected = conn.execute("DELETE FROM crews WHERE id = ?1", params![id])?;
+    let affected = repo::crew::delete(conn, id)?;
     if affected == 0 {
         return Err(Error::msg(format!("crew not found: {id}")));
     }
@@ -311,6 +251,7 @@ pub async fn crew_delete(state: State<'_, AppState>, id: String) -> Result<()> {
 mod tests {
     use super::*;
     use crate::db;
+    use rusqlite::params;
 
     fn ctx() -> db::DbPool {
         db::open_in_memory().unwrap()

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 use chrono::Utc;
 use runner_core::event_log::{self, EventLog};
 use runner_core::model::{EventDraft, EventKind, KnownSignalType, SignalType};
-use rusqlite::{params, Connection, OptionalExtension, Row};
+use rusqlite::{params, Connection};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tauri::State;
@@ -25,8 +25,8 @@ use ulid::Ulid as UlidGen;
 use crate::{
     commands::{crew, slot},
     error::{Error, Result},
-    model::{Mission, MissionStatus, Timestamp},
-    AppState,
+    model::{Mission, MissionStatus, SessionStatus, Timestamp},
+    repo, AppState,
 };
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -77,66 +77,16 @@ fn all_known_signals() -> Vec<SignalType> {
         .collect()
 }
 
-fn row_to_mission(row: &Row<'_>) -> rusqlite::Result<Mission> {
-    let status: String = row.get("status")?;
-    let started_at: String = row.get("started_at")?;
-    let stopped_at: Option<String> = row.get("stopped_at")?;
-    let pinned_at: Option<String> = row.get("pinned_at")?;
-    let archived_at: Option<String> = row.get("archived_at")?;
-
-    let status = match status.as_str() {
-        "running" => MissionStatus::Running,
-        "completed" => MissionStatus::Completed,
-        "aborted" => MissionStatus::Aborted,
-        other => {
-            return Err(rusqlite::Error::FromSqlConversionFailure(
-                0,
-                rusqlite::types::Type::Text,
-                format!("unknown mission status {other:?}").into(),
-            ))
-        }
-    };
-    let parse_ts = |s: String| -> rusqlite::Result<Timestamp> {
-        s.parse().map_err(|e: chrono::ParseError| {
-            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
-        })
-    };
-
-    Ok(Mission {
-        id: row.get("id")?,
-        crew_id: row.get("crew_id")?,
-        title: row.get("title")?,
-        status,
-        goal_override: row.get("goal_override")?,
-        cwd: row.get("cwd")?,
-        started_at: parse_ts(started_at)?,
-        stopped_at: stopped_at.map(parse_ts).transpose()?,
-        pinned_at: pinned_at.map(parse_ts).transpose()?,
-        archived_at: archived_at.map(parse_ts).transpose()?,
-    })
-}
-
 pub fn list(conn: &Connection, crew_id: Option<&str>) -> Result<Vec<Mission>> {
     // Pinned missions float to the top, then most-recently-started.
-    // Sort key: NULL pinned_at sorts last (DESC), older pinned_at
-    // sorts after newer (last-pinned first feels right for testing).
     //
-    // `archived_at IS NULL` is the single chokepoint that hides
-    // archived missions from every surface that lists missions: the
-    // ⌘K palette, the sidebar tray, the Missions page summary. New
-    // surfaces inherit the filter by going through this helper. To
-    // open an archived mission by direct URL, use `get()` instead —
-    // it intentionally does NOT filter.
-    let sql = "SELECT id, crew_id, title, status, goal_override, cwd,
-                      started_at, stopped_at, pinned_at, archived_at
-                 FROM missions
-                 WHERE (?1 IS NULL OR crew_id = ?1)
-                   AND archived_at IS NULL
-                 ORDER BY pinned_at IS NULL, pinned_at DESC, started_at DESC";
-    let mut stmt = conn.prepare(sql)?;
-    let rows = stmt.query_map(params![crew_id], row_to_mission)?;
-    rows.collect::<rusqlite::Result<Vec<_>>>()
-        .map_err(Into::into)
+    // `archived_at IS NULL` (inside the repo query) is the single
+    // chokepoint that hides archived missions from every surface that
+    // lists missions: the ⌘K palette, the sidebar tray, the Missions
+    // page summary. New surfaces inherit the filter by going through
+    // this helper. To open an archived mission by direct URL, use
+    // `get()` instead — it intentionally does NOT filter.
+    repo::mission::list(conn, crew_id).map_err(Into::into)
 }
 
 /// One row in the Missions page list — the mission's own fields denormalized
@@ -168,15 +118,7 @@ pub fn get(conn: &Connection, id: &str) -> Result<Mission> {
     // Intentionally no `archived_at` filter — opening an archived
     // mission by direct URL has to still resolve so the workspace can
     // render it read-only.
-    conn.query_row(
-        "SELECT id, crew_id, title, status, goal_override, cwd,
-                started_at, stopped_at, pinned_at, archived_at
-           FROM missions WHERE id = ?1",
-        params![id],
-        row_to_mission,
-    )
-    .optional()?
-    .ok_or_else(|| Error::msg(format!("mission not found: {id}")))
+    repo::mission::get(conn, id)?.ok_or_else(|| Error::msg(format!("mission not found: {id}")))
 }
 
 /// Cap on the effective mission goal byte length. The launch prompt
@@ -275,18 +217,20 @@ pub fn start(
 
     let id = new_id();
     let started_at = now();
-    tx.execute(
-        "INSERT INTO missions
-            (id, crew_id, title, status, goal_override, cwd, started_at)
-         VALUES (?1, ?2, ?3, 'running', ?4, ?5, ?6)",
-        params![
-            id,
-            crew.id,
-            title,
-            input.goal_override,
-            input.cwd,
-            started_at.to_rfc3339(),
-        ],
+    repo::mission::insert(
+        &tx,
+        &repo::mission::MissionRow {
+            id: id.clone(),
+            crew_id: crew.id.clone(),
+            title: title.clone(),
+            status: MissionStatus::Running,
+            goal_override: input.goal_override.clone(),
+            cwd: input.cwd.clone(),
+            started_at,
+            stopped_at: None,
+            pinned_at: None,
+            archived_at: None,
+        },
     )?;
 
     let mission_dir = event_log::mission_dir(app_data_dir, &crew.id, &id);
@@ -361,12 +305,7 @@ pub fn stop(conn: &mut Connection, app_data_dir: &Path, id: &str) -> Result<Miss
     // `status='completed' AND archived_at IS NULL` (other than
     // pre-existing rows the migration backfilled).
     let stopped_at = now();
-    let affected = tx.execute(
-        "UPDATE missions
-            SET status = 'completed', stopped_at = ?1, archived_at = ?1
-          WHERE id = ?2 AND status = 'running'",
-        params![stopped_at.to_rfc3339(), id],
-    )?;
+    let affected = repo::mission::complete_and_archive_if_running(&tx, id, stopped_at)?;
     if affected == 0 {
         // Either the id doesn't exist or the mission isn't running anymore
         // (a concurrent stop won the race). Fetch for a precise error.
@@ -651,12 +590,7 @@ async fn mission_start_impl_with_size(
         if let Some(body) = body {
             if let Err(e) = ensure_first_turn_fits(&member.slot.slot_handle, body) {
                 if let Ok(conn) = state.db.get() {
-                    let _ = conn.execute(
-                        "UPDATE missions
-                            SET status = 'aborted', stopped_at = ?1
-                          WHERE id = ?2",
-                        rusqlite::params![Utc::now().to_rfc3339(), out.mission.id],
-                    );
+                    let _ = repo::mission::abort(&conn, &out.mission.id, Utc::now());
                 }
                 return Err(e);
             }
@@ -674,12 +608,7 @@ async fn mission_start_impl_with_size(
             // Couldn't open the log — roll the mission row back. Bus isn't
             // mounted yet, no sessions were spawned, nothing to clean up.
             if let Ok(conn) = state.db.get() {
-                let _ = conn.execute(
-                    "UPDATE missions
-                        SET status = 'aborted', stopped_at = ?1
-                      WHERE id = ?2",
-                    rusqlite::params![Utc::now().to_rfc3339(), out.mission.id],
-                );
+                let _ = repo::mission::abort(&conn, &out.mission.id, Utc::now());
             }
             return Err(e);
         }
@@ -698,12 +627,7 @@ async fn mission_start_impl_with_size(
         Ok(r) => r,
         Err(e) => {
             if let Ok(conn) = state.db.get() {
-                let _ = conn.execute(
-                    "UPDATE missions
-                        SET status = 'aborted', stopped_at = ?1
-                      WHERE id = ?2",
-                    rusqlite::params![Utc::now().to_rfc3339(), out.mission.id],
-                );
+                let _ = repo::mission::abort(&conn, &out.mission.id, Utc::now());
             }
             return Err(e);
         }
@@ -764,16 +688,8 @@ async fn mission_start_impl_with_size(
                 // error. Bus and router aren't mounted yet so no
                 // event-side cleanup.
                 if let Ok(conn) = state.db.get() {
-                    let _ = conn.execute(
-                        "DELETE FROM sessions WHERE mission_id = ?1",
-                        rusqlite::params![out.mission.id],
-                    );
-                    let _ = conn.execute(
-                        "UPDATE missions
-                            SET status = 'aborted', stopped_at = ?1
-                          WHERE id = ?2",
-                        rusqlite::params![Utc::now().to_rfc3339(), out.mission.id],
-                    );
+                    let _ = repo::session::delete_all_for_mission(&conn, &out.mission.id);
+                    let _ = repo::mission::abort(&conn, &out.mission.id, Utc::now());
                 }
                 return Err(e);
             }
@@ -811,16 +727,8 @@ async fn mission_start_impl_with_size(
         // `complete_mission_session_spawn`.
         drop(pendings);
         if let Ok(conn) = state.db.get() {
-            let _ = conn.execute(
-                "DELETE FROM sessions WHERE mission_id = ?1",
-                rusqlite::params![out.mission.id],
-            );
-            let _ = conn.execute(
-                "UPDATE missions
-                    SET status = 'aborted', stopped_at = ?1
-                  WHERE id = ?2",
-                rusqlite::params![Utc::now().to_rfc3339(), out.mission.id],
-            );
+            let _ = repo::session::delete_all_for_mission(&conn, &out.mission.id);
+            let _ = repo::mission::abort(&conn, &out.mission.id, Utc::now());
         }
         return Err(e);
     }
@@ -865,12 +773,11 @@ async fn mission_start_impl_with_size(
                 Ok(crate::session::CompleteSpawnOutcome::Spawned) => {}
                 Ok(crate::session::CompleteSpawnOutcome::Cancelled) => {
                     if let Ok(conn) = pool_for_task.get() {
-                        let _ = conn.execute(
-                            "UPDATE sessions
-                                SET status = 'stopped',
-                                    stopped_at = ?2
-                              WHERE id = ?1",
-                            rusqlite::params![session_id, Utc::now().to_rfc3339()],
+                        let _ = repo::session::set_exit_status(
+                            &conn,
+                            &session_id,
+                            SessionStatus::Stopped,
+                            Utc::now(),
                         );
                     }
                     emitter_for_task.exit(&crate::session::manager::ExitEvent {
@@ -886,12 +793,11 @@ async fn mission_start_impl_with_size(
                          mission={mission_id_for_task} session={session_id} error={e}"
                     );
                     if let Ok(conn) = pool_for_task.get() {
-                        let _ = conn.execute(
-                            "UPDATE sessions
-                                SET status = 'crashed',
-                                    stopped_at = ?2
-                              WHERE id = ?1",
-                            rusqlite::params![session_id, Utc::now().to_rfc3339()],
+                        let _ = repo::session::set_exit_status(
+                            &conn,
+                            &session_id,
+                            SessionStatus::Crashed,
+                            Utc::now(),
                         );
                     }
                     // Tell the workspace the slot died so the pane
@@ -1163,15 +1069,8 @@ pub(crate) async fn mission_pin_impl(
     pinned: bool,
 ) -> Result<Mission> {
     let conn = state.db.get()?;
-    let pinned_at: Option<String> = if pinned {
-        Some(now().to_rfc3339())
-    } else {
-        None
-    };
-    let n = conn.execute(
-        "UPDATE missions SET pinned_at = ?1 WHERE id = ?2",
-        params![pinned_at, id],
-    )?;
+    let pinned_at: Option<Timestamp> = if pinned { Some(now()) } else { None };
+    let n = repo::mission::set_pinned_at(&conn, &id, pinned_at)?;
     if n != 1 {
         return Err(Error::msg(format!("mission not found: {id}")));
     }
@@ -1196,10 +1095,7 @@ pub(crate) async fn mission_rename_impl(
         return Err(Error::msg("mission title must not be empty"));
     }
     let conn = state.db.get()?;
-    let n = conn.execute(
-        "UPDATE missions SET title = ?1 WHERE id = ?2",
-        params![trimmed, id],
-    )?;
+    let n = repo::mission::set_title(&conn, &id, trimmed)?;
     if n != 1 {
         return Err(Error::msg(format!("mission not found: {id}")));
     }
@@ -1272,12 +1168,7 @@ pub(crate) async fn mission_reset_impl(
     // below.
     {
         let conn = state.db.get()?;
-        conn.execute(
-            "UPDATE sessions
-                SET archived_at = ?1
-              WHERE mission_id = ?2 AND archived_at IS NULL",
-            params![now().to_rfc3339(), id],
-        )?;
+        repo::session::archive_all_for_mission(&conn, &id, now())?;
     }
 
     // 4. Wipe the event log + per-mission shim dir so the next spawn
@@ -1311,15 +1202,7 @@ pub(crate) async fn mission_reset_impl(
     let started_at_dt = now();
     {
         let conn = state.db.get()?;
-        let n = conn.execute(
-            "UPDATE missions
-                SET status = 'running',
-                    started_at = ?1,
-                    stopped_at = NULL,
-                    archived_at = NULL
-              WHERE id = ?2",
-            params![started_at_dt.to_rfc3339(), id],
-        )?;
+        let n = repo::mission::reset_to_running(&conn, &id, started_at_dt)?;
         if n != 1 {
             return Err(Error::msg(format!("mission not found: {id}")));
         }
@@ -1410,12 +1293,7 @@ pub(crate) async fn mission_reset_impl(
         if let Some(body) = body {
             if let Err(e) = ensure_first_turn_fits(&member.slot.slot_handle, body) {
                 if let Ok(conn) = state.db.get() {
-                    let _ = conn.execute(
-                        "UPDATE missions
-                            SET status = 'aborted', stopped_at = ?1
-                          WHERE id = ?2",
-                        params![now().to_rfc3339(), id],
-                    );
+                    let _ = repo::mission::abort(&conn, &id, now());
                 }
                 return Err(e);
             }
@@ -1476,13 +1354,8 @@ pub(crate) async fn mission_reset_impl(
                 // the mission. Bus / router aren't mounted yet so no
                 // event-side cleanup.
                 if let Ok(conn) = state.db.get() {
-                    let _ = conn.execute("DELETE FROM sessions WHERE mission_id = ?1", params![id]);
-                    let _ = conn.execute(
-                        "UPDATE missions
-                            SET status = 'aborted', stopped_at = ?1
-                          WHERE id = ?2",
-                        params![now().to_rfc3339(), id],
-                    );
+                    let _ = repo::session::delete_all_for_mission(&conn, &id);
+                    let _ = repo::mission::abort(&conn, &id, now());
                 }
                 return Err(e);
             }
@@ -1507,13 +1380,8 @@ pub(crate) async fn mission_reset_impl(
         // mission stays aborted.
         drop(pendings);
         if let Ok(conn) = state.db.get() {
-            let _ = conn.execute("DELETE FROM sessions WHERE mission_id = ?1", params![id]);
-            let _ = conn.execute(
-                "UPDATE missions
-                    SET status = 'aborted', stopped_at = ?1
-                  WHERE id = ?2",
-                params![now().to_rfc3339(), id],
-            );
+            let _ = repo::session::delete_all_for_mission(&conn, &id);
+            let _ = repo::mission::abort(&conn, &id, now());
         }
         return Err(e);
     }
@@ -1541,12 +1409,11 @@ pub(crate) async fn mission_reset_impl(
                 Ok(crate::session::CompleteSpawnOutcome::Spawned) => {}
                 Ok(crate::session::CompleteSpawnOutcome::Cancelled) => {
                     if let Ok(conn) = pool_for_task.get() {
-                        let _ = conn.execute(
-                            "UPDATE sessions
-                                SET status = 'stopped',
-                                    stopped_at = ?2
-                              WHERE id = ?1",
-                            params![session_id, now().to_rfc3339()],
+                        let _ = repo::session::set_exit_status(
+                            &conn,
+                            &session_id,
+                            SessionStatus::Stopped,
+                            now(),
                         );
                     }
                     emitter_for_task.exit(&crate::session::manager::ExitEvent {
@@ -1562,12 +1429,11 @@ pub(crate) async fn mission_reset_impl(
                          mission={mission_id_for_task} session={session_id} error={e}"
                     );
                     if let Ok(conn) = pool_for_task.get() {
-                        let _ = conn.execute(
-                            "UPDATE sessions
-                                SET status = 'crashed',
-                                    stopped_at = ?2
-                              WHERE id = ?1",
-                            params![session_id, now().to_rfc3339()],
+                        let _ = repo::session::set_exit_status(
+                            &conn,
+                            &session_id,
+                            SessionStatus::Crashed,
+                            now(),
                         );
                     }
                     emitter_for_task.exit(&crate::session::manager::ExitEvent {

--- a/src-tauri/src/commands/runner.rs
+++ b/src-tauri/src/commands/runner.rs
@@ -12,7 +12,7 @@
 use std::collections::HashMap;
 
 use chrono::Utc;
-use rusqlite::{params, Connection, OptionalExtension, Row};
+use rusqlite::{params, Connection, OptionalExtension};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tauri::State;
@@ -21,7 +21,7 @@ use ulid::Ulid as UlidGen;
 use crate::{
     error::{Error, Result},
     model::{Runner, Timestamp},
-    AppState,
+    repo, AppState,
 };
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -207,61 +207,8 @@ pub(super) fn validate_env_keys<S: std::hash::BuildHasher>(
     Ok(())
 }
 
-pub(super) fn row_to_runner(row: &Row<'_>) -> rusqlite::Result<Runner> {
-    let args_raw: Option<String> = row.get("args_json")?;
-    let env_raw: Option<String> = row.get("env_json")?;
-    let created_at: String = row.get("created_at")?;
-    let updated_at: String = row.get("updated_at")?;
-    Ok(Runner {
-        id: row.get("id")?,
-        handle: row.get("handle")?,
-        display_name: row.get("display_name")?,
-        runtime: row.get("runtime")?,
-        command: row.get("command")?,
-        args: match args_raw {
-            Some(s) => serde_json::from_str(&s).map_err(|e| {
-                rusqlite::Error::FromSqlConversionFailure(
-                    0,
-                    rusqlite::types::Type::Text,
-                    Box::new(e),
-                )
-            })?,
-            None => Vec::new(),
-        },
-        working_dir: row.get("working_dir")?,
-        system_prompt: row.get("system_prompt")?,
-        env: match env_raw {
-            Some(s) => serde_json::from_str(&s).map_err(|e| {
-                rusqlite::Error::FromSqlConversionFailure(
-                    0,
-                    rusqlite::types::Type::Text,
-                    Box::new(e),
-                )
-            })?,
-            None => HashMap::new(),
-        },
-        model: row.get("model")?,
-        effort: row.get("effort")?,
-        created_at: created_at.parse().map_err(|e: chrono::ParseError| {
-            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
-        })?,
-        updated_at: updated_at.parse().map_err(|e: chrono::ParseError| {
-            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
-        })?,
-    })
-}
-
-pub(super) const SELECT_COLS: &str = "id, handle, display_name, runtime, command,
-                                       args_json, working_dir, system_prompt, env_json,
-                                       model, effort,
-                                       created_at, updated_at";
-
 pub fn list(conn: &Connection) -> Result<Vec<Runner>> {
-    let sql = format!("SELECT {SELECT_COLS} FROM runners ORDER BY handle ASC");
-    let mut stmt = conn.prepare(&sql)?;
-    let rows = stmt.query_map([], row_to_runner)?;
-    rows.collect::<rusqlite::Result<Vec<_>>>()
-        .map_err(Into::into)
+    repo::runner::list(conn).map_err(Into::into)
 }
 
 /// `list()` + `activity()` for every runner, in one IPC call. The Runners
@@ -282,10 +229,7 @@ pub fn list_with_activity(conn: &Connection) -> Result<Vec<RunnerWithActivity>> 
 }
 
 pub fn get(conn: &Connection, id: &str) -> Result<Runner> {
-    let sql = format!("SELECT {SELECT_COLS} FROM runners WHERE id = ?1");
-    conn.query_row(&sql, params![id], row_to_runner)
-        .optional()?
-        .ok_or_else(|| Error::msg(format!("runner not found: {id}")))
+    repo::runner::get(conn, id)?.ok_or_else(|| Error::msg(format!("runner not found: {id}")))
 }
 
 /// Look up a runner by its `handle`. Used by `/runners/:handle` so the URL
@@ -293,9 +237,7 @@ pub fn get(conn: &Connection, id: &str) -> Result<Runner> {
 /// not ULIDs). Handles are globally unique by schema, so this is exactly
 /// 0 or 1 rows.
 pub fn get_by_handle(conn: &Connection, handle: &str) -> Result<Runner> {
-    let sql = format!("SELECT {SELECT_COLS} FROM runners WHERE handle = ?1");
-    conn.query_row(&sql, params![handle], row_to_runner)
-        .optional()?
+    repo::runner::get_by_handle(conn, handle)?
         .ok_or_else(|| Error::msg(format!("runner not found: @{handle}")))
 }
 
@@ -308,7 +250,7 @@ pub fn create(conn: &Connection, input: CreateRunnerInput) -> Result<Runner> {
     validate_system_prompt(input.system_prompt.as_deref())?;
 
     let id = new_id();
-    let ts = now().to_rfc3339();
+    let ts = now();
     // Apply the form's "Permission mode" segmented control to the
     // args column at create time so the canonical mode flags are
     // persisted on the row, not derived at spawn time. See
@@ -320,38 +262,30 @@ pub fn create(conn: &Connection, input: CreateRunnerInput) -> Result<Runner> {
         &input.args,
         input.permission_mode,
     );
-    let args_json = serde_json::to_string(&args)?;
-    let env_json = serde_json::to_string(&input.env)?;
 
-    conn.execute(
-        "INSERT INTO runners (
-            id, handle, display_name, runtime, command,
-            args_json, working_dir, system_prompt, env_json,
-            model, effort,
-            created_at, updated_at
-         ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?12)",
-        params![
-            id,
-            input.handle,
-            input.display_name,
-            input.runtime,
-            input.command,
-            args_json,
-            input.working_dir,
-            input.system_prompt,
-            env_json,
-            input
+    repo::runner::insert(
+        conn,
+        &repo::runner::RunnerRow {
+            id: id.clone(),
+            handle: input.handle,
+            display_name: input.display_name,
+            runtime: input.runtime,
+            command: input.command,
+            args_json: Some(args),
+            working_dir: input.working_dir,
+            system_prompt: input.system_prompt,
+            env_json: Some(input.env),
+            model: input
                 .model
-                .as_ref()
-                .map(|s| s.trim())
+                .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty()),
-            input
+            effort: input
                 .effort
-                .as_ref()
-                .map(|s| s.trim())
+                .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty()),
-            ts,
-        ],
+            created_at: ts,
+            updated_at: ts,
+        },
     )?;
     get(conn, &id)
 }
@@ -433,36 +367,23 @@ pub fn update(conn: &Connection, id: &str, input: UpdateRunnerInput) -> Result<R
         })
         .unwrap_or(existing.effort);
 
-    let args_json = serde_json::to_string(&args)?;
-    let env_json = serde_json::to_string(&env)?;
-    let ts = now().to_rfc3339();
-
-    conn.execute(
-        "UPDATE runners
-            SET display_name = ?1,
-                runtime = ?2,
-                command = ?3,
-                args_json = ?4,
-                working_dir = ?5,
-                system_prompt = ?6,
-                env_json = ?7,
-                model = ?8,
-                effort = ?9,
-                updated_at = ?10
-          WHERE id = ?11",
-        params![
+    repo::runner::update(
+        conn,
+        &repo::runner::RunnerRow {
+            id: id.to_string(),
+            handle: existing.handle,
             display_name,
             runtime,
             command,
-            args_json,
+            args_json: Some(args),
             working_dir,
             system_prompt,
-            env_json,
+            env_json: Some(env),
             model,
             effort,
-            ts,
-            id,
-        ],
+            created_at: existing.created_at,
+            updated_at: now(),
+        },
     )?;
     get(conn, id)
 }
@@ -497,7 +418,7 @@ pub fn delete(conn: &mut Connection, id: &str) -> Result<()> {
         rows.collect::<rusqlite::Result<Vec<_>>>()?
     };
 
-    let affected = tx.execute("DELETE FROM runners WHERE id = ?1", params![id])?;
+    let affected = repo::runner::delete(&tx, id)?;
     if affected != 1 {
         return Err(Error::msg(format!("runner not found: {id}")));
     }
@@ -515,7 +436,7 @@ pub fn delete(conn: &mut Connection, id: &str) -> Result<()> {
                 )
                 .optional()?;
             if let Some(new_lead) = promote {
-                tx.execute("UPDATE slots SET lead = 1 WHERE id = ?1", params![new_lead])?;
+                repo::slot::promote_to_lead(&tx, &new_lead)?;
             }
         }
         // Close the position gap the cascade left for this crew so

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -12,7 +12,6 @@
 
 use std::sync::Arc;
 
-use rusqlite::{params, OptionalExtension, Row};
 use serde::{Deserialize, Serialize};
 use tauri::{Emitter, State};
 
@@ -20,6 +19,7 @@ use crate::{
     commands::runner,
     error::{Error, Result},
     model::{Session, SessionStatus, Timestamp},
+    repo,
     session::manager::{
         runtime_direct_runner, OutputEvent, SessionEvents, SpawnedSession, TauriSessionEvents,
     },
@@ -47,77 +47,23 @@ pub struct SessionRow {
     pub agent_session_key: Option<String>,
 }
 
-fn row_to_session(row: &Row<'_>) -> rusqlite::Result<SessionRow> {
-    let status: String = row.get("status")?;
-    let started_at: Option<String> = row.get("started_at")?;
-    let stopped_at: Option<String> = row.get("stopped_at")?;
-
-    let status = match status.as_str() {
-        "running" => SessionStatus::Running,
-        "stopped" => SessionStatus::Stopped,
-        "crashed" => SessionStatus::Crashed,
-        other => {
-            return Err(rusqlite::Error::FromSqlConversionFailure(
-                0,
-                rusqlite::types::Type::Text,
-                format!("unknown session status {other:?}").into(),
-            ))
-        }
-    };
-    let parse_ts = |s: String| -> rusqlite::Result<Timestamp> {
-        s.parse().map_err(|e: chrono::ParseError| {
-            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
-        })
-    };
-    Ok(SessionRow {
-        session: Session {
-            id: row.get("id")?,
-            mission_id: row.get("mission_id")?,
-            runner_id: row.get("runner_id")?,
-            slot_id: row.get("slot_id")?,
-            cwd: row.get("cwd")?,
-            status,
-            pid: row.get("pid")?,
-            started_at: started_at.map(parse_ts).transpose()?,
-            stopped_at: stopped_at.map(parse_ts).transpose()?,
-        },
-        handle: row.get("handle")?,
-        runtime: row.get("runtime")?,
-        lead: row.get("lead")?,
-        agent_session_key: row.get("agent_session_key")?,
-    })
-}
-
 pub fn list_for_mission(conn: &rusqlite::Connection, mission_id: &str) -> Result<Vec<SessionRow>> {
-    // Order by the slot-scoped position within this mission's crew so
-    // the UI renders sessions in the same slot order as the Crew
-    // Detail roster. The session's `slot_id` is the direct join key
-    // into `slots`; `handle` is the slot's in-crew handle, and the
-    // template handle is no longer used in mission contexts.
-    // `r.handle` (template) is kept on the row for fallback display
-    // (legacy mission sessions before 0006 have no slot_id).
-    // archived_at IS NULL filters out the dead session rows that
-    // `mission_reset` (and any future archive path) leaves behind: a
-    // reset wipes the run context and inserts fresh PTY rows for the
-    // same (mission_id, slot_id) pair, so without this filter the
-    // sidebar would stack the old stopped row alongside the new
-    // running one for every slot.
-    let mut stmt = conn.prepare(
-        "SELECT s.id, s.mission_id, s.runner_id, s.slot_id, s.cwd, s.status, s.pid,
-                s.started_at, s.stopped_at, s.agent_session_key,
-                COALESCE(sl.slot_handle, r.handle) AS handle,
-                r.runtime AS runtime,
-                COALESCE(sl.lead, 0) AS lead
-           FROM sessions s
-           JOIN runners r ON r.id = s.runner_id
-           LEFT JOIN slots sl ON sl.id = s.slot_id
-          WHERE s.mission_id = ?1
-            AND s.archived_at IS NULL
-          ORDER BY COALESCE(sl.position, 0) ASC, s.started_at ASC",
-    )?;
-    let rows = stmt.query_map(params![mission_id], row_to_session)?;
-    rows.collect::<rusqlite::Result<Vec<_>>>()
-        .map_err(Into::into)
+    // Sessions render in the same slot order as the Crew Detail roster;
+    // `handle` is the slot's in-crew handle with the template handle as
+    // fallback for legacy pre-slot rows, and archived rows (mission
+    // reset leftovers) are filtered out. The ordering, join, and filter
+    // semantics live in `repo::session::list_for_mission`.
+    let rows = repo::session::list_for_mission(conn, mission_id)?;
+    Ok(rows
+        .into_iter()
+        .map(|row| SessionRow {
+            session: row.session,
+            handle: row.handle,
+            runtime: row.runtime,
+            lead: row.lead,
+            agent_session_key: row.agent_session_key,
+        })
+        .collect())
 }
 
 #[tauri::command]
@@ -313,53 +259,48 @@ pub struct DirectSessionEntry {
     pub archived_at: Option<Timestamp>,
 }
 
-fn direct_entry_from_row(row: &Row<'_>) -> rusqlite::Result<DirectSessionEntry> {
-    let status: String = row.get("status")?;
-    let status = match status.as_str() {
-        "running" => SessionStatus::Running,
-        "stopped" => SessionStatus::Stopped,
-        "crashed" => SessionStatus::Crashed,
-        other => {
-            return Err(rusqlite::Error::FromSqlConversionFailure(
-                0,
-                rusqlite::types::Type::Text,
-                format!("unknown session status {other:?}").into(),
-            ))
-        }
-    };
-    let parse_ts = |s: String| -> rusqlite::Result<Timestamp> {
-        s.parse().map_err(|e: chrono::ParseError| {
-            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
-        })
-    };
-    let started_at: Option<String> = row.get("started_at")?;
-    let stopped_at: Option<String> = row.get("stopped_at")?;
-    let archived_at: Option<String> = row.get("archived_at")?;
-    let resumable: i64 = row.get("resumable")?;
-    let pinned: i64 = row.get("pinned")?;
-    let handle: Option<String> = row.get("handle")?;
-    let agent_runtime: String = row.get("agent_runtime")?;
-    let agent_command: String = row.get("agent_command")?;
-    let runner_display_name: Option<String> = row.get("runner_display_name")?;
-    let display_name = runner_display_name
+/// Assemble the IPC entry from a repo direct-session row. `ship_key`
+/// distinguishes the two surfaces: `session_get` returns the raw
+/// `agent_session_key`, while the recent list intentionally ships NULL.
+fn direct_entry_from_repo(
+    d: repo::session::DirectSessionRow,
+    ship_key: bool,
+) -> Result<DirectSessionEntry> {
+    let handle = d.runner_handle;
+    let agent_runtime = d
+        .row
+        .agent_runtime
+        .or(d.runner_runtime)
+        .ok_or_else(|| Error::msg(format!("session {} has no agent_runtime", d.row.id)))?;
+    let agent_command = d
+        .row
+        .agent_command
+        .or(d.runner_command)
+        .ok_or_else(|| Error::msg(format!("session {} has no agent_command", d.row.id)))?;
+    let display_name = d
+        .runner_display_name
         .filter(|_| handle.is_some())
         .unwrap_or_else(|| crate::router::runtime::runtime_display_name(&agent_runtime));
     Ok(DirectSessionEntry {
-        session_id: row.get("session_id")?,
-        runner_id: row.get("runner_id")?,
+        session_id: d.row.id,
+        runner_id: d.row.runner_id,
         handle,
         agent_runtime,
         agent_command,
         display_name,
-        status,
-        title: row.get("title")?,
-        cwd: row.get("cwd")?,
-        started_at: started_at.map(parse_ts).transpose()?,
-        stopped_at: stopped_at.map(parse_ts).transpose()?,
-        resumable: resumable != 0,
-        agent_session_key: row.get("agent_session_key")?,
-        pinned: pinned != 0,
-        archived_at: archived_at.map(parse_ts).transpose()?,
+        status: d.row.status,
+        title: d.row.title,
+        cwd: d.row.cwd,
+        started_at: d.row.started_at,
+        stopped_at: d.row.stopped_at,
+        resumable: d.row.agent_session_key.is_some(),
+        agent_session_key: if ship_key {
+            d.row.agent_session_key
+        } else {
+            None
+        },
+        pinned: d.row.pinned_at.is_some(),
+        archived_at: d.row.archived_at,
     })
 }
 
@@ -368,38 +309,10 @@ pub async fn session_list_recent_direct(
     state: State<'_, AppState>,
 ) -> Result<Vec<DirectSessionEntry>> {
     let conn = state.db.get()?;
-    // Flat list: every un-archived direct session. Sort key:
-    //   1. pinned first (pinned_at NOT NULL)
-    //   2. then running before stopped/crashed
-    //   3. then by most-recent activity (stopped_at if set, else
-    //      started_at)
-    let mut stmt = conn.prepare(
-        "SELECT s.id        AS session_id,
-                s.runner_id AS runner_id,
-                r.handle    AS handle,
-                r.display_name AS runner_display_name,
-                COALESCE(s.agent_runtime, r.runtime) AS agent_runtime,
-                COALESCE(s.agent_command, r.command) AS agent_command,
-                s.status    AS status,
-                s.title     AS title,
-                s.cwd       AS cwd,
-                s.started_at,
-                s.stopped_at,
-                s.archived_at,
-                CASE WHEN s.agent_session_key IS NOT NULL THEN 1 ELSE 0 END AS resumable,
-                NULL AS agent_session_key,
-                CASE WHEN s.pinned_at         IS NOT NULL THEN 1 ELSE 0 END AS pinned
-           FROM sessions s
-           LEFT JOIN runners r ON r.id = s.runner_id
-          WHERE s.mission_id IS NULL
-            AND s.archived_at IS NULL
-          ORDER BY CASE WHEN s.pinned_at IS NOT NULL THEN 0 ELSE 1 END,
-                   CASE WHEN s.status = 'running'    THEN 0 ELSE 1 END,
-                   COALESCE(s.stopped_at, s.started_at) DESC",
-    )?;
-    let rows = stmt.query_map([], direct_entry_from_row)?;
-    rows.collect::<rusqlite::Result<Vec<_>>>()
-        .map_err(Into::into)
+    repo::session::list_recent_direct(&conn)?
+        .into_iter()
+        .map(|d| direct_entry_from_repo(d, /*ship_key*/ false))
+        .collect()
 }
 
 /// Unfiltered single-row lookup for a direct-chat session.
@@ -431,31 +344,9 @@ pub async fn session_get(
 }
 
 fn get_direct(conn: &rusqlite::Connection, session_id: &str) -> Result<Option<DirectSessionEntry>> {
-    let mut stmt = conn.prepare(
-        "SELECT s.id        AS session_id,
-                s.runner_id AS runner_id,
-                r.handle    AS handle,
-                r.display_name AS runner_display_name,
-                COALESCE(s.agent_runtime, r.runtime) AS agent_runtime,
-                COALESCE(s.agent_command, r.command) AS agent_command,
-                s.status    AS status,
-                s.title     AS title,
-                s.cwd       AS cwd,
-                s.started_at,
-                s.stopped_at,
-                s.archived_at,
-                CASE WHEN s.agent_session_key IS NOT NULL THEN 1 ELSE 0 END AS resumable,
-                s.agent_session_key AS agent_session_key,
-                CASE WHEN s.pinned_at         IS NOT NULL THEN 1 ELSE 0 END AS pinned
-           FROM sessions s
-           LEFT JOIN runners r ON r.id = s.runner_id
-          WHERE s.id = ?1
-            AND s.mission_id IS NULL",
-    )?;
-    let row = stmt
-        .query_row(params![session_id], direct_entry_from_row)
-        .optional()?;
-    Ok(row)
+    repo::session::get_direct(conn, session_id)?
+        .map(|d| direct_entry_from_repo(d, /*ship_key*/ true))
+        .transpose()
 }
 
 /// Soft-delete a session: hides it from the SESSION sidebar tray. The row
@@ -474,14 +365,7 @@ pub async fn session_archive(
     session_id: String,
 ) -> Result<()> {
     let conn = state.db.get()?;
-    let now = chrono::Utc::now().to_rfc3339();
-    let updated = conn.execute(
-        "UPDATE sessions
-            SET archived_at = ?2
-          WHERE id = ?1
-            AND status != 'running'",
-        params![session_id, now],
-    )?;
+    let updated = repo::session::archive(&conn, &session_id, chrono::Utc::now())?;
     if updated == 0 {
         return Err(Error::msg(
             "session not found or still running (kill before archiving)".to_string(),
@@ -524,10 +408,7 @@ pub async fn session_rename(
         }
     });
     let conn = state.db.get()?;
-    let updated = conn.execute(
-        "UPDATE sessions SET title = ?2 WHERE id = ?1",
-        params![session_id, normalized],
-    )?;
+    let updated = repo::session::set_title(&conn, &session_id, normalized.as_deref())?;
     if updated == 0 {
         return Err(Error::msg(format!("session not found: {session_id}")));
     }
@@ -554,18 +435,12 @@ pub async fn session_pin(
     pinned: bool,
 ) -> Result<()> {
     let conn = state.db.get()?;
-    let updated = if pinned {
-        let now = chrono::Utc::now().to_rfc3339();
-        conn.execute(
-            "UPDATE sessions SET pinned_at = ?2 WHERE id = ?1",
-            params![session_id, now],
-        )?
+    let pinned_at = if pinned {
+        Some(chrono::Utc::now())
     } else {
-        conn.execute(
-            "UPDATE sessions SET pinned_at = NULL WHERE id = ?1",
-            params![session_id],
-        )?
+        None
     };
+    let updated = repo::session::set_pinned_at(&conn, &session_id, pinned_at)?;
     if updated == 0 {
         return Err(Error::msg(format!("session not found: {session_id}")));
     }
@@ -708,6 +583,7 @@ mod tests {
     use super::*;
     use crate::db;
     use chrono::Utc;
+    use rusqlite::params;
 
     #[test]
     fn paste_image_format_maps_png_and_jpeg_to_pasteboard_classes() {

--- a/src-tauri/src/commands/slot.rs
+++ b/src-tauri/src/commands/slot.rs
@@ -29,7 +29,7 @@ use crate::{
     commands::runner,
     error::{Error, Result},
     model::{Slot, SlotWithRunner, Timestamp},
-    AppState,
+    repo, AppState,
 };
 
 /// One crew that a given runner template is referenced by, plus the
@@ -96,46 +96,16 @@ pub(super) fn repack_positions(conn: &Connection, crew_id: &str) -> Result<()> {
         rows.collect::<rusqlite::Result<Vec<_>>>()?
     };
     for (i, id) in ordered.iter().enumerate() {
-        conn.execute(
-            "UPDATE slots SET position = ?1 WHERE id = ?2",
-            params![-(i as i64) - 1, id],
-        )?;
+        repo::slot::set_position(conn, id, -(i as i64) - 1)?;
     }
     for (position, id) in ordered.iter().enumerate() {
-        conn.execute(
-            "UPDATE slots SET position = ?1 WHERE id = ?2",
-            params![position as i64, id],
-        )?;
+        repo::slot::set_position(conn, id, position as i64)?;
     }
     Ok(())
 }
 
-fn row_to_slot(row: &rusqlite::Row<'_>) -> rusqlite::Result<Slot> {
-    let lead: i64 = row.get("lead")?;
-    let added_at_raw: String = row.get("added_at")?;
-    let added_at: Timestamp = added_at_raw.parse().map_err(|e: chrono::ParseError| {
-        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
-    })?;
-    Ok(Slot {
-        id: row.get("id")?,
-        crew_id: row.get("crew_id")?,
-        runner_id: row.get("runner_id")?,
-        slot_handle: row.get("slot_handle")?,
-        position: row.get("position")?,
-        lead: lead != 0,
-        added_at,
-    })
-}
-
 fn get_slot_internal(conn: &Connection, slot_id: &str) -> Result<Slot> {
-    conn.query_row(
-        "SELECT id, crew_id, runner_id, slot_handle, position, lead, added_at
-           FROM slots WHERE id = ?1",
-        params![slot_id],
-        row_to_slot,
-    )
-    .optional()?
-    .ok_or_else(|| Error::msg(format!("slot not found: {slot_id}")))
+    repo::slot::get(conn, slot_id)?.ok_or_else(|| Error::msg(format!("slot not found: {slot_id}")))
 }
 
 /// Return the slots that belong to a crew, ordered by position, each
@@ -144,15 +114,7 @@ fn get_slot_internal(conn: &Connection, slot_id: &str) -> Result<Slot> {
 /// big alias-mangled JOIN. Pre-release crews are tiny; readability
 /// wins.
 pub fn list(conn: &Connection, crew_id: &str) -> Result<Vec<SlotWithRunner>> {
-    let mut stmt = conn.prepare(
-        "SELECT id, crew_id, runner_id, slot_handle, position, lead, added_at
-           FROM slots
-          WHERE crew_id = ?1
-          ORDER BY position ASC",
-    )?;
-    let slots: Vec<Slot> = stmt
-        .query_map(params![crew_id], row_to_slot)?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
+    let slots = repo::slot::list_for_crew(conn, crew_id)?;
 
     let mut out = Vec::with_capacity(slots.len());
     for slot in slots {
@@ -166,34 +128,19 @@ pub fn list(conn: &Connection, crew_id: &str) -> Result<Vec<SlotWithRunner>> {
 /// across every crew. Drives the Runner Detail "Crews using this
 /// runner" panel.
 pub fn list_crews_for_runner(conn: &Connection, runner_id: &str) -> Result<Vec<CrewMembership>> {
-    let mut stmt = conn.prepare(
-        "SELECT c.id AS crew_id, c.name AS crew_name,
-                sl.id AS slot_id, sl.slot_handle AS slot_handle,
-                sl.lead AS lead,
-                sl.position AS position, sl.added_at AS added_at
-           FROM slots sl
-           JOIN crews c ON c.id = sl.crew_id
-          WHERE sl.runner_id = ?1
-          ORDER BY sl.added_at DESC",
-    )?;
-    let rows = stmt.query_map(params![runner_id], |row| {
-        let added_at_raw: String = row.get("added_at")?;
-        let added_at: Timestamp = added_at_raw.parse().map_err(|e: chrono::ParseError| {
-            rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
-        })?;
-        let lead_int: i64 = row.get("lead")?;
-        Ok(CrewMembership {
-            crew_id: row.get("crew_id")?,
-            crew_name: row.get("crew_name")?,
-            slot_id: row.get("slot_id")?,
-            slot_handle: row.get("slot_handle")?,
-            lead: lead_int != 0,
-            position: row.get("position")?,
-            added_at,
+    let rows = repo::slot::list_for_runner_with_crew_name(conn, runner_id)?;
+    Ok(rows
+        .into_iter()
+        .map(|(slot, crew_name)| CrewMembership {
+            crew_id: slot.crew_id,
+            crew_name,
+            slot_id: slot.id,
+            slot_handle: slot.slot_handle,
+            lead: slot.lead,
+            position: slot.position,
+            added_at: slot.added_at,
         })
-    })?;
-    rows.collect::<rusqlite::Result<Vec<_>>>()
-        .map_err(Into::into)
+        .collect())
 }
 
 /// Append a new slot to `crew_id`'s roster at the next position. The
@@ -217,7 +164,7 @@ pub fn create(
     }
 
     let id = new_id();
-    let ts = now().to_rfc3339();
+    let added_at = now();
     let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
 
     let count: i64 = tx.query_row(
@@ -231,13 +178,18 @@ pub fn create(
         |r| r.get(0),
     )?;
     let is_first = count == 0;
-    let lead: i64 = if is_first { 1 } else { 0 };
 
-    tx.execute(
-        "INSERT INTO slots
-            (id, crew_id, runner_id, slot_handle, position, lead, added_at)
-         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
-        params![id, crew_id, runner_id, slot_handle, next_position, lead, ts],
+    repo::slot::insert(
+        &tx,
+        &repo::slot::SlotRow {
+            id: id.clone(),
+            crew_id: crew_id.to_string(),
+            runner_id: runner_id.to_string(),
+            slot_handle: slot_handle.to_string(),
+            position: next_position,
+            lead: is_first,
+            added_at,
+        },
     )
     .map_err(|e| match e.sqlite_error_code() {
         Some(rusqlite::ErrorCode::ConstraintViolation) => Error::msg(format!(
@@ -275,15 +227,13 @@ pub fn update(
         None => existing.slot_handle.clone(),
     };
 
-    conn.execute(
-        "UPDATE slots SET slot_handle = ?1 WHERE id = ?2",
-        params![slot_handle, slot_id],
-    )
-    .map_err(|e| match e.sqlite_error_code() {
-        Some(rusqlite::ErrorCode::ConstraintViolation) => Error::msg(format!(
-            "slot_handle '{slot_handle}' is already used in this crew"
-        )),
-        _ => e.into(),
+    repo::slot::set_slot_handle(conn, slot_id, &slot_handle).map_err(|e| {
+        match e.sqlite_error_code() {
+            Some(rusqlite::ErrorCode::ConstraintViolation) => Error::msg(format!(
+                "slot_handle '{slot_handle}' is already used in this crew"
+            )),
+            _ => e.into(),
+        }
     })?;
 
     list(conn, &existing.crew_id)?
@@ -301,7 +251,7 @@ pub fn delete(conn: &mut Connection, slot_id: &str) -> Result<()> {
 
     let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
 
-    let affected = tx.execute("DELETE FROM slots WHERE id = ?1", params![slot_id])?;
+    let affected = repo::slot::delete(&tx, slot_id)?;
     if affected != 1 {
         return Err(Error::msg(format!("slot not found: {slot_id}")));
     }
@@ -317,7 +267,7 @@ pub fn delete(conn: &mut Connection, slot_id: &str) -> Result<()> {
             )
             .optional()?;
         if let Some(new_lead) = promote {
-            tx.execute("UPDATE slots SET lead = 1 WHERE id = ?1", params![new_lead])?;
+            repo::slot::promote_to_lead(&tx, &new_lead)?;
         }
     }
 
@@ -345,11 +295,8 @@ pub fn set_lead(conn: &mut Connection, slot_id: &str) -> Result<SlotWithRunner> 
     // Clear the old lead first so no schema-level uniqueness check
     // ever sees two lead=1 rows in the same crew (we removed the
     // partial unique index, but the invariant lives here).
-    tx.execute(
-        "UPDATE slots SET lead = 0 WHERE crew_id = ?1 AND lead = 1",
-        params![crew_id],
-    )?;
-    let affected = tx.execute("UPDATE slots SET lead = 1 WHERE id = ?1", params![slot_id])?;
+    repo::slot::clear_crew_lead(&tx, &crew_id)?;
+    let affected = repo::slot::promote_to_lead(&tx, slot_id)?;
     if affected != 1 {
         return Err(Error::msg(format!("slot not found: {slot_id}")));
     }
@@ -401,16 +348,10 @@ pub fn reorder(
 
     // Two-pass to avoid transient violations of UNIQUE(crew_id, position).
     for (i, id) in current.iter().enumerate() {
-        tx.execute(
-            "UPDATE slots SET position = ?1 WHERE id = ?2",
-            params![-(i as i64) - 1, id],
-        )?;
+        repo::slot::set_position(&tx, id, -(i as i64) - 1)?;
     }
     for (position, id) in ordered_slot_ids.iter().enumerate() {
-        let affected = tx.execute(
-            "UPDATE slots SET position = ?1 WHERE id = ?2",
-            params![position as i64, id],
-        )?;
+        let affected = repo::slot::set_position(&tx, id, position as i64)?;
         if affected != 1 {
             return Err(Error::msg(format!(
                 "slot_reorder: slot {id} not in crew {crew_id}"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -6,6 +6,7 @@ mod event_bus;
 mod mcp;
 mod model;
 mod panic_hook;
+mod repo;
 mod router;
 mod session;
 mod shell_path;

--- a/src-tauri/src/repo/crew.rs
+++ b/src-tauri/src/repo/crew.rs
@@ -1,0 +1,351 @@
+// `crews` table — the top-level container for a team of runners.
+//
+// `orchestrator_policy` is deprecated (#247, superseded by
+// `system_prompt_addendum`): the row struct keeps it so reads and the
+// serialized `Crew` shape are unaffected, but it is excluded from every
+// write column list — the column is never written again.
+
+use rusqlite::{Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use serde_rusqlite::{from_row, to_params_named_with_fields};
+
+use crate::model::{Crew, Timestamp};
+
+use super::{de_err, insert_sql, select_list, ser_err};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CrewRow {
+    pub id: String,
+    pub name: String,
+    pub purpose: Option<String>,
+    pub goal: Option<String>,
+    /// Read-only (#247): kept for existing rows, never in a write list.
+    #[serde(with = "crate::repo::serde::json_text_opt")]
+    pub orchestrator_policy: Option<serde_json::Value>,
+    pub system_prompt_addendum: Option<String>,
+    #[serde(with = "crate::repo::serde::rfc3339")]
+    pub created_at: Timestamp,
+    #[serde(with = "crate::repo::serde::rfc3339")]
+    pub updated_at: Timestamp,
+}
+
+pub const COLUMNS: &[&str] = &[
+    "id",
+    "name",
+    "purpose",
+    "goal",
+    "orchestrator_policy",
+    "system_prompt_addendum",
+    "created_at",
+    "updated_at",
+];
+
+/// Write column list — `COLUMNS` minus the read-only
+/// `orchestrator_policy`.
+const INSERT_COLUMNS: &[&str] = &[
+    "id",
+    "name",
+    "purpose",
+    "goal",
+    "system_prompt_addendum",
+    "created_at",
+    "updated_at",
+];
+
+const UPDATE_FIELDS: &[&str] = &[
+    "name",
+    "purpose",
+    "goal",
+    "system_prompt_addendum",
+    "updated_at",
+    "id",
+];
+
+impl From<CrewRow> for Crew {
+    fn from(r: CrewRow) -> Self {
+        Crew {
+            id: r.id,
+            name: r.name,
+            purpose: r.purpose,
+            goal: r.goal,
+            orchestrator_policy: r.orchestrator_policy,
+            system_prompt_addendum: r.system_prompt_addendum,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        }
+    }
+}
+
+impl From<&Crew> for CrewRow {
+    fn from(c: &Crew) -> Self {
+        CrewRow {
+            id: c.id.clone(),
+            name: c.name.clone(),
+            purpose: c.purpose.clone(),
+            goal: c.goal.clone(),
+            orchestrator_policy: c.orchestrator_policy.clone(),
+            system_prompt_addendum: c.system_prompt_addendum.clone(),
+            created_at: c.created_at,
+            updated_at: c.updated_at,
+        }
+    }
+}
+
+pub fn insert(conn: &Connection, row: &CrewRow) -> rusqlite::Result<()> {
+    conn.execute(
+        &insert_sql("crews", INSERT_COLUMNS),
+        to_params_named_with_fields(row, INSERT_COLUMNS)
+            .map_err(ser_err)?
+            .to_slice()
+            .as_slice(),
+    )?;
+    Ok(())
+}
+
+/// Full-row update of every writable column (the command layer resolves
+/// leave-untouched semantics against the existing row before calling).
+pub fn update(conn: &Connection, row: &CrewRow) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE crews
+            SET name = :name,
+                purpose = :purpose,
+                goal = :goal,
+                system_prompt_addendum = :system_prompt_addendum,
+                updated_at = :updated_at
+          WHERE id = :id",
+        to_params_named_with_fields(row, UPDATE_FIELDS)
+            .map_err(ser_err)?
+            .to_slice()
+            .as_slice(),
+    )
+}
+
+pub fn get(conn: &Connection, id: &str) -> rusqlite::Result<Option<Crew>> {
+    let sql = format!("SELECT {} FROM crews WHERE id = ?1", select_list(COLUMNS));
+    conn.query_row(&sql, rusqlite::params![id], |row| {
+        from_row::<CrewRow>(row).map_err(de_err)
+    })
+    .optional()
+    .map(|opt| opt.map(Crew::from))
+}
+
+/// Every crew with its slot count, ordered by creation time. Feeds
+/// `CrewListItem`.
+pub fn list_with_runner_count(conn: &Connection) -> rusqlite::Result<Vec<(Crew, i64)>> {
+    let sql = format!(
+        "SELECT {},
+                (SELECT COUNT(*) FROM slots s WHERE s.crew_id = c.id) AS runner_count
+           FROM crews c
+         ORDER BY c.created_at ASC",
+        super::qualified_select_list("c", COLUMNS)
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], |row| {
+        let crew = from_row::<CrewRow>(row).map_err(de_err)?;
+        let runner_count: i64 = row.get("runner_count")?;
+        Ok((Crew::from(crew), runner_count))
+    })?;
+    rows.collect()
+}
+
+/// One row per slot across every crew, in (crew_id, position) order —
+/// the bulk member-preview feed for the Crews list cards.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct MemberPreviewRow {
+    pub crew_id: String,
+    pub slot_handle: String,
+    pub runner_handle: String,
+    pub runtime: String,
+    pub lead: bool,
+}
+
+pub fn list_member_previews(conn: &Connection) -> rusqlite::Result<Vec<MemberPreviewRow>> {
+    let mut stmt = conn.prepare(
+        "SELECT s.crew_id, s.slot_handle, s.lead, r.handle AS runner_handle, r.runtime
+           FROM slots s
+           JOIN runners r ON r.id = s.runner_id
+          ORDER BY s.crew_id ASC, s.position ASC",
+    )?;
+    let rows = stmt.query_map([], |row| from_row::<MemberPreviewRow>(row).map_err(de_err))?;
+    rows.collect()
+}
+
+pub fn delete(conn: &Connection, id: &str) -> rusqlite::Result<usize> {
+    conn.execute("DELETE FROM crews WHERE id = ?1", rusqlite::params![id])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+    use chrono::Utc;
+
+    fn full_row() -> CrewRow {
+        let now = Utc::now();
+        CrewRow {
+            id: "c-full".into(),
+            name: "Full crew".into(),
+            purpose: Some("purpose".into()),
+            goal: Some("goal".into()),
+            orchestrator_policy: None, // never written through the repo
+            system_prompt_addendum: Some("squash PRs against main".into()),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn minimal_row() -> CrewRow {
+        let now = Utc::now();
+        CrewRow {
+            id: "c-min".into(),
+            name: "Minimal".into(),
+            purpose: None,
+            goal: None,
+            orchestrator_policy: None,
+            system_prompt_addendum: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn insert_then_get_round_trips_full_and_minimal_rows() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        for row in [full_row(), minimal_row()] {
+            insert(&conn, &row).unwrap();
+            let read = get(&conn, &row.id).unwrap().unwrap();
+            assert_eq!(CrewRow::from(&read), row);
+        }
+    }
+
+    #[test]
+    fn legacy_rows_read_cleanly_including_policy_json_and_z_timestamps() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        // Raw SQL in today's exact stored formats: `Z` timestamps (seed
+        // shape) and a JSON TEXT orchestrator_policy written by the
+        // pre-#247 update path.
+        conn.execute(
+            r#"INSERT INTO crews
+                (id, name, purpose, goal, orchestrator_policy,
+                 system_prompt_addendum, created_at, updated_at)
+             VALUES ('c-legacy', 'Legacy', NULL, 'ship it',
+                     '[{"when":{"signal":"ask_lead"},"do":"inject_stdin"}]',
+                     NULL, '2026-05-03T00:00:00Z', '2026-05-03T00:00:00+00:00')"#,
+            [],
+        )
+        .unwrap();
+
+        let crew = get(&conn, "c-legacy").unwrap().unwrap();
+        assert_eq!(
+            crew.orchestrator_policy,
+            Some(serde_json::json!([
+                {"when": {"signal": "ask_lead"}, "do": "inject_stdin"}
+            ]))
+        );
+        assert_eq!(
+            crew.created_at, crew.updated_at,
+            "both spellings, same instant"
+        );
+        assert_eq!(crew.goal.as_deref(), Some("ship it"));
+    }
+
+    #[test]
+    fn writes_are_byte_identical_to_the_legacy_path() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let row = full_row();
+        insert(&conn, &row).unwrap();
+        let (created_raw, updated_raw): (String, String) = conn
+            .query_row(
+                "SELECT created_at, updated_at FROM crews WHERE id = 'c-full'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(created_raw, row.created_at.to_rfc3339());
+        assert_eq!(updated_raw, row.updated_at.to_rfc3339());
+    }
+
+    #[test]
+    fn orchestrator_policy_is_never_written_by_insert_or_update() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let mut row = full_row();
+        // Even a row struct carrying a policy value must not write it.
+        row.orchestrator_policy = Some(serde_json::json!({"drift": true}));
+        insert(&conn, &row).unwrap();
+        let stored: Option<String> = conn
+            .query_row(
+                "SELECT orchestrator_policy FROM crews WHERE id = 'c-full'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, None, "insert must not write orchestrator_policy");
+
+        // Seed a legacy policy by raw SQL, then update through the repo —
+        // the legacy value must survive untouched.
+        conn.execute(
+            "UPDATE crews SET orchestrator_policy = '{\"keep\":1}' WHERE id = 'c-full'",
+            [],
+        )
+        .unwrap();
+        row.name = "Renamed".into();
+        update(&conn, &row).unwrap();
+        let stored: Option<String> = conn
+            .query_row(
+                "SELECT orchestrator_policy FROM crews WHERE id = 'c-full'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored.as_deref(), Some("{\"keep\":1}"));
+        let name: String = conn
+            .query_row("SELECT name FROM crews WHERE id = 'c-full'", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(name, "Renamed");
+    }
+
+    #[test]
+    fn list_with_runner_count_and_member_previews_match_todays_shapes() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        insert(&conn, &full_row()).unwrap();
+        insert(&conn, &minimal_row()).unwrap();
+        conn.execute(
+            "INSERT INTO runners (id, handle, display_name, runtime, command, created_at, updated_at)
+             VALUES ('r1', 'lead', 'Lead', 'shell', 'sh', '2026-04-22T00:00:00Z', '2026-04-22T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO slots (id, crew_id, runner_id, slot_handle, position, lead, added_at)
+             VALUES ('s1', 'c-full', 'r1', 'lead-slot', 0, 1, '2026-04-22T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+
+        let listed = list_with_runner_count(&conn).unwrap();
+        assert_eq!(listed.len(), 2);
+        let full = listed.iter().find(|(c, _)| c.id == "c-full").unwrap();
+        assert_eq!(full.1, 1);
+        let min = listed.iter().find(|(c, _)| c.id == "c-min").unwrap();
+        assert_eq!(min.1, 0);
+
+        let previews = list_member_previews(&conn).unwrap();
+        assert_eq!(
+            previews,
+            vec![MemberPreviewRow {
+                crew_id: "c-full".into(),
+                slot_handle: "lead-slot".into(),
+                runner_handle: "lead".into(),
+                runtime: "shell".into(),
+                lead: true,
+            }]
+        );
+    }
+}

--- a/src-tauri/src/repo/mission.rs
+++ b/src-tauri/src/repo/mission.rs
@@ -1,0 +1,345 @@
+// `missions` table — the runtime container for a crew run.
+//
+// Lifecycle orchestration (event-log writes, router/bus mounting,
+// rollback decisions) stays in `commands::mission`; this module owns the
+// row struct and the statements. Transaction boundaries are the
+// caller's: every function takes `&Connection` and composes inside the
+// existing `mission_start` / `mission_reset` transactions unchanged.
+
+use rusqlite::{Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use serde_rusqlite::{from_row, to_params_named};
+
+use crate::model::{Mission, MissionStatus, Timestamp};
+
+use super::{de_err, insert_sql, select_list, ser_err};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MissionRow {
+    pub id: String,
+    pub crew_id: String,
+    pub title: String,
+    pub status: MissionStatus,
+    pub goal_override: Option<String>,
+    pub cwd: Option<String>,
+    #[serde(with = "crate::repo::serde::rfc3339")]
+    pub started_at: Timestamp,
+    #[serde(with = "crate::repo::serde::rfc3339_opt")]
+    pub stopped_at: Option<Timestamp>,
+    #[serde(with = "crate::repo::serde::rfc3339_opt")]
+    pub pinned_at: Option<Timestamp>,
+    #[serde(with = "crate::repo::serde::rfc3339_opt")]
+    pub archived_at: Option<Timestamp>,
+}
+
+pub const COLUMNS: &[&str] = &[
+    "id",
+    "crew_id",
+    "title",
+    "status",
+    "goal_override",
+    "cwd",
+    "started_at",
+    "stopped_at",
+    "pinned_at",
+    "archived_at",
+];
+
+impl From<MissionRow> for Mission {
+    fn from(r: MissionRow) -> Self {
+        Mission {
+            id: r.id,
+            crew_id: r.crew_id,
+            title: r.title,
+            status: r.status,
+            goal_override: r.goal_override,
+            cwd: r.cwd,
+            started_at: r.started_at,
+            stopped_at: r.stopped_at,
+            pinned_at: r.pinned_at,
+            archived_at: r.archived_at,
+        }
+    }
+}
+
+impl From<&Mission> for MissionRow {
+    fn from(m: &Mission) -> Self {
+        MissionRow {
+            id: m.id.clone(),
+            crew_id: m.crew_id.clone(),
+            title: m.title.clone(),
+            status: m.status,
+            goal_override: m.goal_override.clone(),
+            cwd: m.cwd.clone(),
+            started_at: m.started_at,
+            stopped_at: m.stopped_at,
+            pinned_at: m.pinned_at,
+            archived_at: m.archived_at,
+        }
+    }
+}
+
+pub fn insert(conn: &Connection, row: &MissionRow) -> rusqlite::Result<()> {
+    conn.execute(
+        &insert_sql("missions", COLUMNS),
+        to_params_named(row).map_err(ser_err)?.to_slice().as_slice(),
+    )?;
+    Ok(())
+}
+
+pub fn get(conn: &Connection, id: &str) -> rusqlite::Result<Option<Mission>> {
+    // Intentionally no `archived_at` filter — opening an archived
+    // mission by direct URL has to still resolve so the workspace can
+    // render it read-only.
+    let sql = format!(
+        "SELECT {} FROM missions WHERE id = ?1",
+        select_list(COLUMNS)
+    );
+    conn.query_row(&sql, rusqlite::params![id], |row| {
+        from_row::<MissionRow>(row).map_err(de_err)
+    })
+    .optional()
+    .map(|opt| opt.map(Mission::from))
+}
+
+/// Non-archived missions, optionally filtered by crew. Pinned missions
+/// float to the top, then most-recently-started. `archived_at IS NULL`
+/// is the single chokepoint that hides archived missions from every
+/// listing surface.
+pub fn list(conn: &Connection, crew_id: Option<&str>) -> rusqlite::Result<Vec<Mission>> {
+    let sql = format!(
+        "SELECT {}
+           FROM missions
+           WHERE (?1 IS NULL OR crew_id = ?1)
+             AND archived_at IS NULL
+           ORDER BY pinned_at IS NULL, pinned_at DESC, started_at DESC",
+        select_list(COLUMNS)
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params![crew_id], |row| {
+        from_row::<MissionRow>(row).map_err(de_err)
+    })?;
+    rows.map(|r| r.map(Mission::from)).collect()
+}
+
+/// Terminal stop: flip `running` -> `completed` and stamp `archived_at`
+/// atomically with the status (a terminal stop is by definition an
+/// archive). The `WHERE status = 'running'` guard makes racing stops
+/// mutually exclusive — the loser updates 0 rows.
+pub fn complete_and_archive_if_running(
+    conn: &Connection,
+    id: &str,
+    stopped_at: Timestamp,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE missions
+            SET status = 'completed', stopped_at = ?1, archived_at = ?1
+          WHERE id = ?2 AND status = 'running'",
+        rusqlite::params![stopped_at.to_rfc3339(), id],
+    )
+}
+
+/// Roll a half-open mission to `aborted` (spawn/mount/first-turn
+/// failures during start or reset).
+pub fn abort(conn: &Connection, id: &str, stopped_at: Timestamp) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE missions
+            SET status = 'aborted', stopped_at = ?1
+          WHERE id = ?2",
+        rusqlite::params![stopped_at.to_rfc3339(), id],
+    )
+}
+
+/// Mission reset: back to `running` with a fresh `started_at`;
+/// `stopped_at` and `archived_at` clear in lockstep with the status flip
+/// so a freshly-reset live mission never vanishes from `list()`.
+pub fn reset_to_running(
+    conn: &Connection,
+    id: &str,
+    started_at: Timestamp,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE missions
+            SET status = 'running',
+                started_at = ?1,
+                stopped_at = NULL,
+                archived_at = NULL
+          WHERE id = ?2",
+        rusqlite::params![started_at.to_rfc3339(), id],
+    )
+}
+
+pub fn set_pinned_at(
+    conn: &Connection,
+    id: &str,
+    pinned_at: Option<Timestamp>,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE missions SET pinned_at = ?1 WHERE id = ?2",
+        rusqlite::params![pinned_at.map(|t| t.to_rfc3339()), id],
+    )
+}
+
+pub fn set_title(conn: &Connection, id: &str, title: &str) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE missions SET title = ?1 WHERE id = ?2",
+        rusqlite::params![title, id],
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+    use chrono::Utc;
+
+    fn seed_crew(conn: &Connection, id: &str) {
+        conn.execute(
+            "INSERT INTO crews (id, name, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?3)",
+            rusqlite::params![id, format!("crew-{id}"), "2026-04-22T00:00:00Z"],
+        )
+        .unwrap();
+    }
+
+    fn full_row() -> MissionRow {
+        let now = Utc::now();
+        MissionRow {
+            id: "m-full".into(),
+            crew_id: "c1".into(),
+            title: "Ship it".into(),
+            status: MissionStatus::Completed,
+            goal_override: Some("override".into()),
+            cwd: Some("/tmp/work".into()),
+            started_at: now,
+            stopped_at: Some(now),
+            pinned_at: Some(now),
+            archived_at: Some(now),
+        }
+    }
+
+    fn minimal_row() -> MissionRow {
+        MissionRow {
+            id: "m-min".into(),
+            crew_id: "c1".into(),
+            title: "Bare".into(),
+            status: MissionStatus::Running,
+            goal_override: None,
+            cwd: None,
+            started_at: Utc::now(),
+            stopped_at: None,
+            pinned_at: None,
+            archived_at: None,
+        }
+    }
+
+    #[test]
+    fn insert_then_get_round_trips_full_and_minimal_rows() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        seed_crew(&conn, "c1");
+        for row in [full_row(), minimal_row()] {
+            insert(&conn, &row).unwrap();
+            let read = get(&conn, &row.id).unwrap().unwrap();
+            assert_eq!(MissionRow::from(&read), row);
+        }
+    }
+
+    #[test]
+    fn legacy_rows_in_both_timestamp_spellings_read_cleanly() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        seed_crew(&conn, "c1");
+        conn.execute(
+            "INSERT INTO missions
+                (id, crew_id, title, status, goal_override, cwd, started_at, stopped_at)
+             VALUES ('m-z', 'c1', 't', 'aborted', NULL, NULL,
+                     '2026-04-22T00:00:00Z', '2026-04-22T01:00:00Z'),
+                    ('m-o', 'c1', 't', 'aborted', NULL, NULL,
+                     '2026-04-22T00:00:00+00:00', '2026-04-22T01:00:00+00:00')",
+            [],
+        )
+        .unwrap();
+        let zulu = get(&conn, "m-z").unwrap().unwrap();
+        let offset = get(&conn, "m-o").unwrap().unwrap();
+        assert_eq!(zulu.started_at, offset.started_at);
+        assert_eq!(zulu.stopped_at, offset.stopped_at);
+        assert_eq!(zulu.status, MissionStatus::Aborted);
+    }
+
+    #[test]
+    fn writes_are_byte_identical_to_the_legacy_path() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        seed_crew(&conn, "c1");
+        let row = minimal_row();
+        insert(&conn, &row).unwrap();
+        let (started_raw, status_raw): (String, String) = conn
+            .query_row(
+                "SELECT started_at, status FROM missions WHERE id = 'm-min'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(started_raw, row.started_at.to_rfc3339());
+        assert_eq!(status_raw, "running");
+    }
+
+    #[test]
+    fn complete_and_archive_only_flips_running_rows() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        seed_crew(&conn, "c1");
+        insert(&conn, &minimal_row()).unwrap();
+
+        let stopped_at = Utc::now();
+        assert_eq!(
+            complete_and_archive_if_running(&conn, "m-min", stopped_at).unwrap(),
+            1
+        );
+        let m = get(&conn, "m-min").unwrap().unwrap();
+        assert_eq!(m.status, MissionStatus::Completed);
+        assert_eq!(m.stopped_at, m.archived_at, "archive stamps atomically");
+
+        // Losing racer: no longer running, 0 rows.
+        assert_eq!(
+            complete_and_archive_if_running(&conn, "m-min", Utc::now()).unwrap(),
+            0
+        );
+    }
+
+    #[test]
+    fn reset_to_running_clears_terminal_stamps() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        seed_crew(&conn, "c1");
+        insert(&conn, &full_row()).unwrap();
+
+        let fresh_start = Utc::now();
+        assert_eq!(reset_to_running(&conn, "m-full", fresh_start).unwrap(), 1);
+        let m = get(&conn, "m-full").unwrap().unwrap();
+        assert_eq!(m.status, MissionStatus::Running);
+        assert_eq!(m.started_at, fresh_start);
+        assert_eq!(m.stopped_at, None);
+        assert_eq!(m.archived_at, None);
+        assert!(m.pinned_at.is_some(), "pin survives a reset");
+    }
+
+    #[test]
+    fn list_hides_archived_and_floats_pinned() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        seed_crew(&conn, "c1");
+        insert(&conn, &full_row()).unwrap(); // archived — hidden
+        insert(&conn, &minimal_row()).unwrap();
+        let mut pinned = minimal_row();
+        pinned.id = "m-pinned".into();
+        pinned.started_at = Utc::now() - chrono::Duration::hours(1);
+        pinned.pinned_at = Some(Utc::now());
+        insert(&conn, &pinned).unwrap();
+
+        let listed = list(&conn, Some("c1")).unwrap();
+        let ids: Vec<&str> = listed.iter().map(|m| m.id.as_str()).collect();
+        assert_eq!(ids, vec!["m-pinned", "m-min"]);
+    }
+}

--- a/src-tauri/src/repo/mod.rs
+++ b/src-tauri/src/repo/mod.rs
@@ -1,0 +1,399 @@
+// Repo layer (impl 0021): one submodule per persistent object, owning that
+// table's row struct, column list, and CRUD statements. Row<->struct mapping
+// is derived through `serde_rusqlite` instead of hand-written mappers; the
+// storage byte formats are pinned by the helpers in `repo::serde` so old and
+// new rows are indistinguishable.
+//
+// Conventions:
+//   - Functions take `&Connection` (or a `&Transaction` via `Deref`), never
+//     the pool — callers own connection acquisition and transaction
+//     boundaries.
+//   - Every module has a `const COLUMNS: &[&str]` naming the table's columns
+//     in row-struct field order; SELECT and INSERT statements are built from
+//     it so the statement and the struct can't drift apart silently.
+//   - Functions return `rusqlite::Result` — the same contract the legacy
+//     `row_to_*` mappers had — so command-layer error shaping (not-found
+//     messages, constraint-violation rewrites) stays where it is.
+//   - Join DTOs are assembled in Rust from per-table reads or aliased
+//     columns; `#[serde(flatten)]` is not used for row deserialization.
+
+pub mod crew;
+pub mod mission;
+pub mod runner;
+pub mod serde;
+pub mod session;
+pub mod slot;
+
+/// Map a serde_rusqlite deserialization error into the same rusqlite error
+/// shape the legacy hand-written mappers produced on bad column data.
+pub(crate) fn de_err(e: serde_rusqlite::Error) -> rusqlite::Error {
+    rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Text, Box::new(e))
+}
+
+/// Map a serde_rusqlite serialization error into rusqlite's ToSql error.
+pub(crate) fn ser_err(e: serde_rusqlite::Error) -> rusqlite::Error {
+    rusqlite::Error::ToSqlConversionFailure(Box::new(e))
+}
+
+/// `col_a, col_b, ...` — SELECT list for a table's COLUMNS.
+pub(crate) fn select_list(columns: &[&str]) -> String {
+    columns.join(", ")
+}
+
+/// `alias.col_a, alias.col_b, ...` — SELECT list for one side of a JOIN.
+/// SQLite reports the bare column name for `alias.col`, so `from_row`
+/// still matches the row-struct fields by name.
+pub(crate) fn qualified_select_list(alias: &str, columns: &[&str]) -> String {
+    columns
+        .iter()
+        .map(|c| format!("{alias}.{c}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+/// `INSERT INTO <table> (cols...) VALUES (:col...)` built from COLUMNS so
+/// the statement and the row struct stay paired.
+pub(crate) fn insert_sql(table: &str, columns: &[&str]) -> String {
+    let placeholders: Vec<String> = columns.iter().map(|c| format!(":{c}")).collect();
+    format!(
+        "INSERT INTO {table} ({}) VALUES ({})",
+        columns.join(", "),
+        placeholders.join(", ")
+    )
+}
+
+#[cfg(test)]
+mod spike_tests {
+    // Step 0 spike: prove every risky mapping against an in-memory DB
+    // before any table is migrated. Each test pins a byte format or a
+    // type-bridge behavior the per-table modules will rely on.
+
+    use std::collections::HashMap;
+
+    use chrono::Utc;
+    use rusqlite::Connection;
+    use serde::{Deserialize, Serialize};
+    use serde_rusqlite::{from_row, to_params_named, to_params_named_with_fields};
+
+    use crate::model::{MissionStatus, SessionStatus, Timestamp};
+
+    #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+    struct SpikeRow {
+        id: String,
+        flag: bool,
+        mission_status: MissionStatus,
+        session_status: SessionStatus,
+        #[serde(with = "crate::repo::serde::rfc3339")]
+        ts: Timestamp,
+        #[serde(with = "crate::repo::serde::rfc3339_opt")]
+        ts_opt: Option<Timestamp>,
+        #[serde(with = "crate::repo::serde::json_text")]
+        args: Vec<String>,
+        #[serde(with = "crate::repo::serde::json_text")]
+        env: HashMap<String, String>,
+        #[serde(with = "crate::repo::serde::json_text_opt")]
+        policy: Option<serde_json::Value>,
+        note: Option<String>,
+    }
+
+    const SPIKE_COLUMNS: &[&str] = &[
+        "id",
+        "flag",
+        "mission_status",
+        "session_status",
+        "ts",
+        "ts_opt",
+        "args",
+        "env",
+        "policy",
+        "note",
+    ];
+
+    fn conn() -> Connection {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE spike (
+                id TEXT PRIMARY KEY,
+                flag INTEGER NOT NULL,
+                mission_status TEXT NOT NULL,
+                session_status TEXT NOT NULL,
+                ts TEXT NOT NULL,
+                ts_opt TEXT,
+                args TEXT NOT NULL,
+                env TEXT NOT NULL,
+                policy TEXT,
+                note TEXT
+            )",
+        )
+        .unwrap();
+        conn
+    }
+
+    fn insert(conn: &Connection, row: &SpikeRow) {
+        conn.execute(
+            &super::insert_sql("spike", SPIKE_COLUMNS),
+            to_params_named(row).unwrap().to_slice().as_slice(),
+        )
+        .unwrap();
+    }
+
+    fn get(conn: &Connection, id: &str) -> SpikeRow {
+        let sql = format!(
+            "SELECT {} FROM spike WHERE id = ?1",
+            super::select_list(SPIKE_COLUMNS)
+        );
+        conn.query_row(&sql, rusqlite::params![id], |row| {
+            from_row::<SpikeRow>(row).map_err(super::de_err)
+        })
+        .unwrap()
+    }
+
+    fn full_row() -> SpikeRow {
+        let now = Utc::now();
+        let mut env = HashMap::new();
+        env.insert("FOO".to_string(), "bar".to_string());
+        env.insert("BAZ".to_string(), "qux".to_string());
+        SpikeRow {
+            id: "full".into(),
+            flag: true,
+            mission_status: MissionStatus::Running,
+            session_status: SessionStatus::Crashed,
+            ts: now,
+            ts_opt: Some(now),
+            args: vec!["--flag".into(), "--val=1".into()],
+            env,
+            policy: Some(serde_json::json!([
+                {"when": {"signal": "ask_lead"}, "do": "inject_stdin"}
+            ])),
+            note: Some("hello".into()),
+        }
+    }
+
+    fn minimal_row() -> SpikeRow {
+        SpikeRow {
+            id: "minimal".into(),
+            flag: false,
+            mission_status: MissionStatus::Aborted,
+            session_status: SessionStatus::Stopped,
+            ts: Utc::now(),
+            ts_opt: None,
+            args: Vec::new(),
+            env: HashMap::new(),
+            policy: None,
+            note: None,
+        }
+    }
+
+    #[test]
+    fn round_trip_fully_populated_row() {
+        let conn = conn();
+        let row = full_row();
+        insert(&conn, &row);
+        assert_eq!(get(&conn, "full"), row);
+    }
+
+    #[test]
+    fn round_trip_null_heavy_row() {
+        let conn = conn();
+        let row = minimal_row();
+        insert(&conn, &row);
+        assert_eq!(get(&conn, "minimal"), row);
+    }
+
+    #[test]
+    fn bool_is_stored_as_integer() {
+        let conn = conn();
+        insert(&conn, &full_row());
+        let (type_of, raw): (String, i64) = conn
+            .query_row(
+                "SELECT typeof(flag), flag FROM spike WHERE id = 'full'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(type_of, "integer");
+        assert_eq!(raw, 1);
+    }
+
+    #[test]
+    fn status_enums_store_lowercase_text() {
+        let conn = conn();
+        insert(&conn, &full_row());
+        insert(&conn, &minimal_row());
+        let (m, s): (String, String) = conn
+            .query_row(
+                "SELECT mission_status, session_status FROM spike WHERE id = 'full'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(m, "running");
+        assert_eq!(s, "crashed");
+        let (m, s): (String, String) = conn
+            .query_row(
+                "SELECT mission_status, session_status FROM spike WHERE id = 'minimal'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(m, "aborted");
+        assert_eq!(s, "stopped");
+    }
+
+    #[test]
+    fn timestamps_write_byte_identical_to_to_rfc3339() {
+        let conn = conn();
+        let row = full_row();
+        insert(&conn, &row);
+        let (ts_raw, ts_opt_raw): (String, String) = conn
+            .query_row("SELECT ts, ts_opt FROM spike WHERE id = 'full'", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(ts_raw, row.ts.to_rfc3339());
+        assert_eq!(ts_opt_raw, row.ts_opt.unwrap().to_rfc3339());
+    }
+
+    #[test]
+    fn timestamps_read_both_legacy_offset_spellings() {
+        let conn = conn();
+        // Raw-SQL inserts in today's two historical spellings: the
+        // `+00:00` form every `to_rfc3339()` write produced, and the `Z`
+        // form used by fixed seed/test timestamps.
+        conn.execute(
+            "INSERT INTO spike
+                (id, flag, mission_status, session_status, ts, ts_opt, args, env, policy, note)
+             VALUES ('offset', 0, 'completed', 'running',
+                     '2026-04-22T01:02:03.456789+00:00', '2026-04-22T01:02:03+00:00',
+                     '[]', '{}', NULL, NULL)",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO spike
+                (id, flag, mission_status, session_status, ts, ts_opt, args, env, policy, note)
+             VALUES ('zulu', 0, 'completed', 'running',
+                     '2026-04-22T01:02:03.456789Z', '2026-04-22T01:02:03Z',
+                     '[]', '{}', NULL, NULL)",
+            [],
+        )
+        .unwrap();
+
+        let offset = get(&conn, "offset");
+        let zulu = get(&conn, "zulu");
+        assert_eq!(
+            offset.ts, zulu.ts,
+            "both spellings parse to the same instant"
+        );
+        assert_eq!(offset.ts_opt, zulu.ts_opt);
+        assert_eq!(
+            offset.ts,
+            "2026-04-22T01:02:03.456789Z".parse::<Timestamp>().unwrap()
+        );
+    }
+
+    #[test]
+    fn json_text_writes_byte_identical_to_serde_json_to_string() {
+        let conn = conn();
+        // Single-entry map so the serialized form is deterministic and the
+        // byte comparison against `serde_json::to_string` is exact.
+        let mut row = full_row();
+        row.id = "json".into();
+        row.env = HashMap::from([("FOO".to_string(), "bar".to_string())]);
+        insert(&conn, &row);
+
+        let (args_raw, env_raw, policy_raw): (String, String, String) = conn
+            .query_row(
+                "SELECT args, env, policy FROM spike WHERE id = 'json'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(args_raw, serde_json::to_string(&row.args).unwrap());
+        assert_eq!(env_raw, serde_json::to_string(&row.env).unwrap());
+        assert_eq!(
+            policy_raw,
+            serde_json::to_string(row.policy.as_ref().unwrap()).unwrap()
+        );
+
+        // Empty collections still serialize (as "[]" / "{}"), matching the
+        // legacy create path that always wrote `serde_json::to_string`.
+        let (args_raw, env_raw): (String, String) = conn
+            .query_row("SELECT args, env FROM spike WHERE id = 'json'", [], |r| {
+                Ok((r.get(0)?, r.get(1)?))
+            })
+            .unwrap();
+        assert_eq!(args_raw, serde_json::to_string(&row.args).unwrap());
+        assert_eq!(env_raw, serde_json::to_string(&row.env).unwrap());
+    }
+
+    #[test]
+    fn json_text_reads_existing_stored_shapes() {
+        let conn = conn();
+        // Raw-SQL insert mirroring today's stored JSON TEXT shapes,
+        // including the seed's args_json literal.
+        conn.execute(
+            r#"INSERT INTO spike
+                (id, flag, mission_status, session_status, ts, ts_opt, args, env, policy, note)
+             VALUES ('legacy', 1, 'running', 'running',
+                     '2026-04-22T00:00:00+00:00', NULL,
+                     '["--ask-for-approval","on-request","--sandbox","workspace-write"]',
+                     '{"FOO":"bar"}',
+                     '[{"when":{"signal":"ask_lead"},"do":"inject_stdin"}]',
+                     NULL)"#,
+            [],
+        )
+        .unwrap();
+        let row = get(&conn, "legacy");
+        assert_eq!(
+            row.args,
+            vec![
+                "--ask-for-approval".to_string(),
+                "on-request".to_string(),
+                "--sandbox".to_string(),
+                "workspace-write".to_string(),
+            ]
+        );
+        assert_eq!(
+            row.env,
+            HashMap::from([("FOO".to_string(), "bar".to_string())])
+        );
+        assert_eq!(
+            row.policy,
+            Some(serde_json::json!([
+                {"when": {"signal": "ask_lead"}, "do": "inject_stdin"}
+            ]))
+        );
+    }
+
+    #[test]
+    fn to_params_named_with_fields_drives_a_partial_update() {
+        let conn = conn();
+        let original = full_row();
+        insert(&conn, &original);
+
+        let mut updated = original.clone();
+        updated.note = Some("rewritten".into());
+        updated.session_status = SessionStatus::Stopped;
+        updated.ts_opt = None;
+        conn.execute(
+            "UPDATE spike
+                SET note = :note, session_status = :session_status, ts_opt = :ts_opt
+              WHERE id = :id",
+            to_params_named_with_fields(&updated, &["note", "session_status", "ts_opt", "id"])
+                .unwrap()
+                .to_slice()
+                .as_slice(),
+        )
+        .unwrap();
+
+        let after = get(&conn, "full");
+        assert_eq!(
+            after, updated,
+            "named fields updated, everything else untouched"
+        );
+        assert_eq!(after.mission_status, original.mission_status);
+        assert_eq!(after.ts, original.ts);
+        assert_eq!(after.args, original.args);
+    }
+}

--- a/src-tauri/src/repo/runner.rs
+++ b/src-tauri/src/repo/runner.rs
@@ -1,0 +1,358 @@
+// `runners` table — global agent templates.
+//
+// The only table where the row shape and the IPC shape diverge by name:
+// the DB stores `args_json` / `env_json` TEXT columns while `model::Runner`
+// exposes `args: Vec<String>` / `env: HashMap`. That divergence lives
+// entirely in this module's `From` conversions.
+//
+// Legacy rows may carry NULL `args_json` / `env_json` (fixture and
+// hand-inserted rows); those read back as empty collections, matching the
+// old `row_to_runner`. Rows written through the repo always serialize the
+// collections (`"[]"` / `"{}"` when empty), matching the legacy
+// create/update paths that always called `serde_json::to_string`.
+
+use std::collections::HashMap;
+
+use rusqlite::{Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use serde_rusqlite::{from_row, to_params_named, to_params_named_with_fields};
+
+use crate::model::{Runner, Timestamp};
+
+use super::{de_err, insert_sql, select_list, ser_err};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RunnerRow {
+    pub id: String,
+    pub handle: String,
+    pub display_name: String,
+    pub runtime: String,
+    pub command: String,
+    #[serde(with = "crate::repo::serde::json_text_opt")]
+    pub args_json: Option<Vec<String>>,
+    pub working_dir: Option<String>,
+    pub system_prompt: Option<String>,
+    #[serde(with = "crate::repo::serde::json_text_opt")]
+    pub env_json: Option<HashMap<String, String>>,
+    pub model: Option<String>,
+    pub effort: Option<String>,
+    #[serde(with = "crate::repo::serde::rfc3339")]
+    pub created_at: Timestamp,
+    #[serde(with = "crate::repo::serde::rfc3339")]
+    pub updated_at: Timestamp,
+}
+
+pub const COLUMNS: &[&str] = &[
+    "id",
+    "handle",
+    "display_name",
+    "runtime",
+    "command",
+    "args_json",
+    "working_dir",
+    "system_prompt",
+    "env_json",
+    "model",
+    "effort",
+    "created_at",
+    "updated_at",
+];
+
+/// `handle` and `created_at` are immutable after create (handle is the
+/// runner's identity in events and policy references), so the update
+/// column list excludes them — same statement shape as the legacy UPDATE.
+const UPDATE_FIELDS: &[&str] = &[
+    "display_name",
+    "runtime",
+    "command",
+    "args_json",
+    "working_dir",
+    "system_prompt",
+    "env_json",
+    "model",
+    "effort",
+    "updated_at",
+    "id",
+];
+
+impl From<RunnerRow> for Runner {
+    fn from(r: RunnerRow) -> Self {
+        Runner {
+            id: r.id,
+            handle: r.handle,
+            display_name: r.display_name,
+            runtime: r.runtime,
+            command: r.command,
+            args: r.args_json.unwrap_or_default(),
+            working_dir: r.working_dir,
+            system_prompt: r.system_prompt,
+            env: r.env_json.unwrap_or_default(),
+            model: r.model,
+            effort: r.effort,
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        }
+    }
+}
+
+impl From<&Runner> for RunnerRow {
+    fn from(r: &Runner) -> Self {
+        RunnerRow {
+            id: r.id.clone(),
+            handle: r.handle.clone(),
+            display_name: r.display_name.clone(),
+            runtime: r.runtime.clone(),
+            command: r.command.clone(),
+            args_json: Some(r.args.clone()),
+            working_dir: r.working_dir.clone(),
+            system_prompt: r.system_prompt.clone(),
+            env_json: Some(r.env.clone()),
+            model: r.model.clone(),
+            effort: r.effort.clone(),
+            created_at: r.created_at,
+            updated_at: r.updated_at,
+        }
+    }
+}
+
+pub fn insert(conn: &Connection, row: &RunnerRow) -> rusqlite::Result<()> {
+    conn.execute(
+        &insert_sql("runners", COLUMNS),
+        to_params_named(row).map_err(ser_err)?.to_slice().as_slice(),
+    )?;
+    Ok(())
+}
+
+/// Full-row update of every mutable column. The command layer resolves the
+/// outer-`Option` (leave-untouched) patch semantics against the existing
+/// row before calling.
+pub fn update(conn: &Connection, row: &RunnerRow) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE runners
+            SET display_name = :display_name,
+                runtime = :runtime,
+                command = :command,
+                args_json = :args_json,
+                working_dir = :working_dir,
+                system_prompt = :system_prompt,
+                env_json = :env_json,
+                model = :model,
+                effort = :effort,
+                updated_at = :updated_at
+          WHERE id = :id",
+        to_params_named_with_fields(row, UPDATE_FIELDS)
+            .map_err(ser_err)?
+            .to_slice()
+            .as_slice(),
+    )
+}
+
+pub fn get(conn: &Connection, id: &str) -> rusqlite::Result<Option<Runner>> {
+    let sql = format!("SELECT {} FROM runners WHERE id = ?1", select_list(COLUMNS));
+    conn.query_row(&sql, rusqlite::params![id], |row| {
+        from_row::<RunnerRow>(row).map_err(de_err)
+    })
+    .optional()
+    .map(|opt| opt.map(Runner::from))
+}
+
+pub fn get_by_handle(conn: &Connection, handle: &str) -> rusqlite::Result<Option<Runner>> {
+    let sql = format!(
+        "SELECT {} FROM runners WHERE handle = ?1",
+        select_list(COLUMNS)
+    );
+    conn.query_row(&sql, rusqlite::params![handle], |row| {
+        from_row::<RunnerRow>(row).map_err(de_err)
+    })
+    .optional()
+    .map(|opt| opt.map(Runner::from))
+}
+
+pub fn list(conn: &Connection) -> rusqlite::Result<Vec<Runner>> {
+    let sql = format!(
+        "SELECT {} FROM runners ORDER BY handle ASC",
+        select_list(COLUMNS)
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], |row| from_row::<RunnerRow>(row).map_err(de_err))?;
+    rows.map(|r| r.map(Runner::from)).collect()
+}
+
+pub fn delete(conn: &Connection, id: &str) -> rusqlite::Result<usize> {
+    conn.execute("DELETE FROM runners WHERE id = ?1", rusqlite::params![id])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+    use chrono::Utc;
+
+    fn full_row() -> RunnerRow {
+        let now = Utc::now();
+        RunnerRow {
+            id: "r-full".into(),
+            handle: "full".into(),
+            display_name: "Full".into(),
+            runtime: "codex".into(),
+            command: "codex".into(),
+            args_json: Some(vec![
+                "--ask-for-approval".into(),
+                "on-request".into(),
+                "--sandbox".into(),
+                "workspace-write".into(),
+            ]),
+            working_dir: Some("/tmp/work".into()),
+            system_prompt: Some("persona".into()),
+            env_json: Some(HashMap::from([("FOO".to_string(), "bar".to_string())])),
+            model: Some("gpt-5".into()),
+            effort: Some("high".into()),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn minimal_row() -> RunnerRow {
+        let now = Utc::now();
+        RunnerRow {
+            id: "r-min".into(),
+            handle: "min".into(),
+            display_name: "Min".into(),
+            runtime: "shell".into(),
+            command: "sh".into(),
+            args_json: Some(Vec::new()),
+            working_dir: None,
+            system_prompt: None,
+            env_json: Some(HashMap::new()),
+            model: None,
+            effort: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn insert_then_get_round_trips_full_and_minimal_rows() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        for row in [full_row(), minimal_row()] {
+            insert(&conn, &row).unwrap();
+            let read = get(&conn, &row.id).unwrap().unwrap();
+            assert_eq!(RunnerRow::from(&read), row);
+        }
+    }
+
+    #[test]
+    fn legacy_rows_with_null_json_columns_read_as_empty_collections() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        // Shape of db.rs fixtures and pre-args rows: no args_json/env_json,
+        // `Z`-spelled timestamps.
+        conn.execute(
+            "INSERT INTO runners (
+                id, handle, display_name, runtime, command, created_at, updated_at
+             ) VALUES ('r-legacy', 'legacy', 'Legacy', 'shell', 'sh',
+                       '2026-04-22T00:00:00Z', '2026-04-22T00:00:00+00:00')",
+            [],
+        )
+        .unwrap();
+        let runner = get(&conn, "r-legacy").unwrap().unwrap();
+        assert!(runner.args.is_empty());
+        assert!(runner.env.is_empty());
+        assert_eq!(runner.created_at, runner.updated_at);
+    }
+
+    #[test]
+    fn legacy_json_text_shapes_read_cleanly() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        // The exact seed args literal and a stored env map.
+        conn.execute(
+            r#"INSERT INTO runners (
+                id, handle, display_name, runtime, command, args_json, env_json,
+                created_at, updated_at
+             ) VALUES ('r-seed', 'seed', 'Seed', 'codex', 'codex',
+                       '["--ask-for-approval","on-request","--sandbox","workspace-write"]',
+                       '{"FOO":"bar"}',
+                       '2026-05-03T00:00:00Z', '2026-05-03T00:00:00Z')"#,
+            [],
+        )
+        .unwrap();
+        let runner = get(&conn, "r-seed").unwrap().unwrap();
+        assert_eq!(
+            runner.args,
+            vec![
+                "--ask-for-approval".to_string(),
+                "on-request".to_string(),
+                "--sandbox".to_string(),
+                "workspace-write".to_string(),
+            ]
+        );
+        assert_eq!(
+            runner.env,
+            HashMap::from([("FOO".to_string(), "bar".to_string())])
+        );
+    }
+
+    #[test]
+    fn writes_are_byte_identical_to_the_legacy_path() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let row = full_row();
+        insert(&conn, &row).unwrap();
+        let (args_raw, env_raw, created_raw): (String, String, String) = conn
+            .query_row(
+                "SELECT args_json, env_json, created_at FROM runners WHERE id = 'r-full'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(
+            args_raw,
+            serde_json::to_string(row.args_json.as_ref().unwrap()).unwrap()
+        );
+        assert_eq!(
+            env_raw,
+            serde_json::to_string(row.env_json.as_ref().unwrap()).unwrap()
+        );
+        assert_eq!(created_raw, row.created_at.to_rfc3339());
+
+        // Empty collections serialize as "[]" / "{}", not NULL — the shape
+        // the legacy create path always wrote.
+        insert(&conn, &minimal_row()).unwrap();
+        let (args_raw, env_raw): (String, String) = conn
+            .query_row(
+                "SELECT args_json, env_json FROM runners WHERE id = 'r-min'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(args_raw, "[]");
+        assert_eq!(env_raw, "{}");
+    }
+
+    #[test]
+    fn update_rewrites_mutable_columns_and_preserves_handle_and_created_at() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let original = full_row();
+        insert(&conn, &original).unwrap();
+
+        let mut updated = original.clone();
+        updated.display_name = "Renamed".into();
+        updated.args_json = Some(vec!["--debug".into()]);
+        updated.model = None;
+        updated.updated_at = Utc::now();
+        // Struct-level drift on immutable fields must not reach the DB.
+        updated.handle = "hijacked".into();
+        update(&conn, &updated).unwrap();
+
+        let read = get(&conn, "r-full").unwrap().unwrap();
+        assert_eq!(read.display_name, "Renamed");
+        assert_eq!(read.args, vec!["--debug".to_string()]);
+        assert_eq!(read.model, None);
+        assert_eq!(read.handle, "full", "handle is not in the update list");
+        assert_eq!(read.created_at, original.created_at);
+        assert_eq!(read.updated_at, updated.updated_at);
+    }
+}

--- a/src-tauri/src/repo/serde.rs
+++ b/src-tauri/src/repo/serde.rs
@@ -1,0 +1,88 @@
+// Storage-format serde helpers for the repo layer (impl 0021).
+//
+// These `#[serde(with)]` modules pin the exact byte formats the legacy
+// hand-written mappers and INSERT/UPDATE paths produced, so rows written
+// through the repo are indistinguishable from rows written before it:
+//
+//   - `rfc3339` / `rfc3339_opt`: serialize `Timestamp` via
+//     `DateTime::to_rfc3339()` (the `+00:00` offset spelling every current
+//     write path uses) and parse back with `str::parse`, which accepts both
+//     historical offset spellings (`+00:00` and `Z`).
+//   - `json_text` / `json_text_opt`: serialize any `Serialize` value through
+//     `serde_json::to_string` into a TEXT column — the same call the legacy
+//     write paths made for `args_json`, `env_json`, and
+//     `orchestrator_policy`.
+
+pub mod rfc3339 {
+    use chrono::{DateTime, Utc};
+    use serde::{de, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &DateTime<Utc>, s: S) -> Result<S::Ok, S::Error> {
+        s.serialize_str(&v.to_rfc3339())
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<DateTime<Utc>, D::Error> {
+        let raw = String::deserialize(d)?;
+        raw.parse().map_err(de::Error::custom)
+    }
+}
+
+pub mod rfc3339_opt {
+    use chrono::{DateTime, Utc};
+    use serde::{de, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(v: &Option<DateTime<Utc>>, s: S) -> Result<S::Ok, S::Error> {
+        match v {
+            Some(t) => s.serialize_some(&t.to_rfc3339()),
+            None => s.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Option<DateTime<Utc>>, D::Error> {
+        let raw: Option<String> = Option::deserialize(d)?;
+        raw.map(|s| s.parse().map_err(de::Error::custom))
+            .transpose()
+    }
+}
+
+// Every JSON TEXT column today is nullable, so production rows go through
+// `json_text_opt`; this non-optional twin is spike-proven (repo::spike_tests)
+// and waiting for the first NOT NULL JSON column.
+#[allow(dead_code)]
+pub mod json_text {
+    use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<T: Serialize, S: Serializer>(v: &T, s: S) -> Result<S::Ok, S::Error> {
+        let text = serde_json::to_string(v).map_err(ser::Error::custom)?;
+        s.serialize_str(&text)
+    }
+
+    pub fn deserialize<'de, T: de::DeserializeOwned, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<T, D::Error> {
+        let text = String::deserialize(d)?;
+        serde_json::from_str(&text).map_err(de::Error::custom)
+    }
+}
+
+pub mod json_text_opt {
+    use serde::{de, ser, Deserialize, Deserializer, Serialize, Serializer};
+
+    pub fn serialize<T: Serialize, S: Serializer>(v: &Option<T>, s: S) -> Result<S::Ok, S::Error> {
+        match v {
+            Some(inner) => {
+                let text = serde_json::to_string(inner).map_err(ser::Error::custom)?;
+                s.serialize_some(&text)
+            }
+            None => s.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, T: de::DeserializeOwned, D: Deserializer<'de>>(
+        d: D,
+    ) -> Result<Option<T>, D::Error> {
+        let raw: Option<String> = Option::deserialize(d)?;
+        raw.map(|text| serde_json::from_str(&text).map_err(de::Error::custom))
+            .transpose()
+    }
+}

--- a/src-tauri/src/repo/session.rs
+++ b/src-tauri/src/repo/session.rs
@@ -1,0 +1,664 @@
+// `sessions` table — one PTY run (mission slot or direct chat).
+//
+// Named `SessionRowDb` to stay clear of the `commands::session::SessionRow`
+// IPC DTO. Covers every column including `agent_session_key` and the
+// legacy `runtime_*` metadata columns exactly as written today.
+//
+// The write functions mirror the legacy statements one-for-one — status
+// flips, pid/stopped_at updates, key capture — because several run on the
+// PTY hot path where statement shape and timing are load-bearing. Do not
+// consolidate them.
+
+use rusqlite::{Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use serde_rusqlite::{from_row, to_params_named};
+
+use crate::model::{Session, SessionStatus, Timestamp};
+
+use super::{de_err, insert_sql, qualified_select_list, select_list, ser_err};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionRowDb {
+    pub id: String,
+    pub mission_id: Option<String>,
+    pub runner_id: Option<String>,
+    pub slot_id: Option<String>,
+    pub cwd: Option<String>,
+    pub status: SessionStatus,
+    pub pid: Option<i64>,
+    #[serde(with = "crate::repo::serde::rfc3339_opt")]
+    pub started_at: Option<Timestamp>,
+    #[serde(with = "crate::repo::serde::rfc3339_opt")]
+    pub stopped_at: Option<Timestamp>,
+    pub agent_session_key: Option<String>,
+    #[serde(with = "crate::repo::serde::rfc3339_opt")]
+    pub archived_at: Option<Timestamp>,
+    pub title: Option<String>,
+    #[serde(with = "crate::repo::serde::rfc3339_opt")]
+    pub pinned_at: Option<Timestamp>,
+    /// PTY-runtime metadata (`pty`, legacy tmux) — not the agent kind;
+    /// that is `agent_runtime`.
+    pub runtime: Option<String>,
+    pub runtime_socket: Option<String>,
+    pub runtime_session: Option<String>,
+    pub runtime_window: Option<String>,
+    pub runtime_pane: Option<String>,
+    pub runtime_cursor: Option<i64>,
+    pub agent_runtime: Option<String>,
+    pub agent_command: Option<String>,
+}
+
+impl SessionRowDb {
+    /// Fresh `running` row with every optional column NULL — spawn sites
+    /// fill in what they persist and leave the rest.
+    pub fn new_running(id: String) -> Self {
+        SessionRowDb {
+            id,
+            mission_id: None,
+            runner_id: None,
+            slot_id: None,
+            cwd: None,
+            status: SessionStatus::Running,
+            pid: None,
+            started_at: None,
+            stopped_at: None,
+            agent_session_key: None,
+            archived_at: None,
+            title: None,
+            pinned_at: None,
+            runtime: None,
+            runtime_socket: None,
+            runtime_session: None,
+            runtime_window: None,
+            runtime_pane: None,
+            runtime_cursor: None,
+            agent_runtime: None,
+            agent_command: None,
+        }
+    }
+}
+
+pub const COLUMNS: &[&str] = &[
+    "id",
+    "mission_id",
+    "runner_id",
+    "slot_id",
+    "cwd",
+    "status",
+    "pid",
+    "started_at",
+    "stopped_at",
+    "agent_session_key",
+    "archived_at",
+    "title",
+    "pinned_at",
+    "runtime",
+    "runtime_socket",
+    "runtime_session",
+    "runtime_window",
+    "runtime_pane",
+    "runtime_cursor",
+    "agent_runtime",
+    "agent_command",
+];
+
+pub fn insert(conn: &Connection, row: &SessionRowDb) -> rusqlite::Result<()> {
+    conn.execute(
+        &insert_sql("sessions", COLUMNS),
+        to_params_named(row).map_err(ser_err)?.to_slice().as_slice(),
+    )?;
+    Ok(())
+}
+
+pub fn get_row(conn: &Connection, id: &str) -> rusqlite::Result<Option<SessionRowDb>> {
+    let sql = format!(
+        "SELECT {} FROM sessions WHERE id = ?1",
+        select_list(COLUMNS)
+    );
+    conn.query_row(&sql, rusqlite::params![id], |row| {
+        from_row::<SessionRowDb>(row).map_err(de_err)
+    })
+    .optional()
+}
+
+pub fn delete(conn: &Connection, id: &str) -> rusqlite::Result<usize> {
+    conn.execute("DELETE FROM sessions WHERE id = ?1", rusqlite::params![id])
+}
+
+pub fn delete_all_for_mission(conn: &Connection, mission_id: &str) -> rusqlite::Result<usize> {
+    conn.execute(
+        "DELETE FROM sessions WHERE mission_id = ?1",
+        rusqlite::params![mission_id],
+    )
+}
+
+/// Persist the runtime-side identity after the PTY forks.
+pub fn update_runtime_metadata(
+    conn: &Connection,
+    id: &str,
+    runtime: &str,
+    runtime_session: &str,
+    pid: Option<i32>,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE sessions
+            SET runtime = ?2,
+                runtime_session = ?3,
+                pid = ?4
+          WHERE id = ?1",
+        rusqlite::params![id, runtime, runtime_session, pid],
+    )
+}
+
+/// Resume an existing row in place: same id, same conversation thread.
+/// A key the resume plan assigned wins; otherwise the stored key is kept.
+pub fn resume_in_place(
+    conn: &Connection,
+    id: &str,
+    started_at: Timestamp,
+    assigned_key: Option<&str>,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE sessions
+            SET status = 'running',
+                pid = NULL,
+                started_at = ?2,
+                stopped_at = NULL,
+                agent_session_key = COALESCE(?3, agent_session_key)
+          WHERE id = ?1",
+        rusqlite::params![id, started_at.to_rfc3339(), assigned_key],
+    )
+}
+
+/// Terminal status flip after a PTY exits (or a pending spawn is
+/// cancelled / fails). `status` is `stopped` or `crashed`.
+pub fn set_exit_status(
+    conn: &Connection,
+    id: &str,
+    status: SessionStatus,
+    stopped_at: Timestamp,
+) -> rusqlite::Result<usize> {
+    let status = match status {
+        SessionStatus::Running => "running",
+        SessionStatus::Stopped => "stopped",
+        SessionStatus::Crashed => "crashed",
+    };
+    conn.execute(
+        "UPDATE sessions
+            SET status = ?1, stopped_at = ?2
+          WHERE id = ?3",
+        rusqlite::params![status, stopped_at.to_rfc3339(), id],
+    )
+}
+
+/// Resume-failure flip: the prior conversation was rejected, so the row
+/// crashes AND forgets its key so the next launch starts fresh.
+pub fn set_crashed_clearing_key(
+    conn: &Connection,
+    id: &str,
+    stopped_at: Timestamp,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE sessions
+            SET status = ?1, stopped_at = ?2,
+                agent_session_key = NULL
+          WHERE id = ?3",
+        rusqlite::params!["crashed", stopped_at.to_rfc3339(), id],
+    )
+}
+
+/// Guarded capture of a codex conversation key. `agent_session_key IS
+/// NULL` so a concurrent writer's key is never clobbered; `started_at`
+/// equality so a stale watcher from a prior incarnation of the row can't
+/// write into a later stop/resume. Returns whether the row was updated.
+pub fn capture_agent_session_key(
+    conn: &Connection,
+    id: &str,
+    agent_session_key: &str,
+    expected_row_started_at: &str,
+) -> rusqlite::Result<bool> {
+    conn.execute(
+        "UPDATE sessions
+            SET agent_session_key = ?2
+          WHERE id = ?1
+            AND agent_session_key IS NULL
+            AND started_at = ?3",
+        rusqlite::params![id, agent_session_key, expected_row_started_at],
+    )
+    .map(|updated| updated > 0)
+}
+
+/// Startup cleanup: demote rows still marked `running` from a prior app
+/// process to `stopped`, preserving any prior `stopped_at`.
+pub fn cleanup_stale_running(conn: &Connection, now: Timestamp) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE sessions
+            SET status = 'stopped',
+                stopped_at = COALESCE(stopped_at, ?1)
+            WHERE status = 'running'",
+        rusqlite::params![now.to_rfc3339()],
+    )
+}
+
+/// Soft-delete: refused for running rows (kill first).
+pub fn archive(conn: &Connection, id: &str, archived_at: Timestamp) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE sessions
+            SET archived_at = ?2
+          WHERE id = ?1
+            AND status != 'running'",
+        rusqlite::params![id, archived_at.to_rfc3339()],
+    )
+}
+
+/// Archive every non-archived session of a mission (mission reset).
+pub fn archive_all_for_mission(
+    conn: &Connection,
+    mission_id: &str,
+    archived_at: Timestamp,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE sessions
+            SET archived_at = ?1
+          WHERE mission_id = ?2 AND archived_at IS NULL",
+        rusqlite::params![archived_at.to_rfc3339(), mission_id],
+    )
+}
+
+pub fn set_title(conn: &Connection, id: &str, title: Option<&str>) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE sessions SET title = ?2 WHERE id = ?1",
+        rusqlite::params![id, title],
+    )
+}
+
+pub fn set_pinned_at(
+    conn: &Connection,
+    id: &str,
+    pinned_at: Option<Timestamp>,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE sessions SET pinned_at = ?2 WHERE id = ?1",
+        rusqlite::params![id, pinned_at.map(|t| t.to_rfc3339())],
+    )
+}
+
+/// One mission session joined with its slot/runner labels — feeds the
+/// `commands::session::SessionRow` IPC DTO.
+#[derive(Debug, Clone)]
+pub struct MissionSessionRow {
+    pub session: Session,
+    pub agent_session_key: Option<String>,
+    pub handle: String,
+    pub runtime: String,
+    pub lead: bool,
+}
+
+fn session_from_row_db(row: SessionRowDb) -> rusqlite::Result<Session> {
+    // Mission-session surfaces INNER JOIN runners, so runner_id is always
+    // present; NULL would mean the query and this assembly drifted apart.
+    let runner_id = row.runner_id.ok_or_else(|| {
+        rusqlite::Error::FromSqlConversionFailure(
+            0,
+            rusqlite::types::Type::Null,
+            "mission session row missing runner_id".into(),
+        )
+    })?;
+    Ok(Session {
+        id: row.id,
+        mission_id: row.mission_id,
+        runner_id,
+        slot_id: row.slot_id,
+        cwd: row.cwd,
+        status: row.status,
+        pid: row.pid,
+        started_at: row.started_at,
+        stopped_at: row.stopped_at,
+    })
+}
+
+/// Non-archived sessions of a mission in slot-roster order, joined with
+/// the slot handle (template handle as fallback for pre-slot rows), the
+/// runner's runtime, and the lead flag. Assembled per decision 6: session
+/// side via `from_row`, denormalized extras via plain `row.get`.
+pub fn list_for_mission(
+    conn: &Connection,
+    mission_id: &str,
+) -> rusqlite::Result<Vec<MissionSessionRow>> {
+    let sql = format!(
+        "SELECT {},
+                COALESCE(sl.slot_handle, r.handle) AS handle,
+                r.runtime AS runner_runtime,
+                COALESCE(sl.lead, 0) AS lead
+           FROM sessions s
+           JOIN runners r ON r.id = s.runner_id
+           LEFT JOIN slots sl ON sl.id = s.slot_id
+          WHERE s.mission_id = ?1
+            AND s.archived_at IS NULL
+          ORDER BY COALESCE(sl.position, 0) ASC, s.started_at ASC",
+        qualified_select_list("s", COLUMNS)
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params![mission_id], |row| {
+        let db_row = from_row::<SessionRowDb>(row).map_err(de_err)?;
+        let handle: String = row.get("handle")?;
+        let runtime: String = row.get("runner_runtime")?;
+        let lead: bool = row.get("lead")?;
+        let agent_session_key = db_row.agent_session_key.clone();
+        Ok(MissionSessionRow {
+            session: session_from_row_db(db_row)?,
+            agent_session_key,
+            handle,
+            runtime,
+            lead,
+        })
+    })?;
+    rows.collect()
+}
+
+/// A direct-chat session row plus the runner-template labels the sidebar
+/// needs. `runner_*` fields are None for runtime-only chats (#195).
+#[derive(Debug, Clone)]
+pub struct DirectSessionRow {
+    pub row: SessionRowDb,
+    pub runner_handle: Option<String>,
+    pub runner_display_name: Option<String>,
+    pub runner_runtime: Option<String>,
+    pub runner_command: Option<String>,
+}
+
+const DIRECT_EXTRAS: &str = "r.handle    AS runner_handle,
+                r.display_name AS runner_display_name,
+                r.runtime   AS runner_runtime,
+                r.command   AS runner_command";
+
+fn direct_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<DirectSessionRow> {
+    Ok(DirectSessionRow {
+        row: from_row::<SessionRowDb>(row).map_err(de_err)?,
+        runner_handle: row.get("runner_handle")?,
+        runner_display_name: row.get("runner_display_name")?,
+        runner_runtime: row.get("runner_runtime")?,
+        runner_command: row.get("runner_command")?,
+    })
+}
+
+/// Flat list of every un-archived direct session. Sort key:
+///   1. pinned first (pinned_at NOT NULL)
+///   2. then running before stopped/crashed
+///   3. then by most-recent activity (stopped_at if set, else started_at)
+pub fn list_recent_direct(conn: &Connection) -> rusqlite::Result<Vec<DirectSessionRow>> {
+    let sql = format!(
+        "SELECT {}, {DIRECT_EXTRAS}
+           FROM sessions s
+           LEFT JOIN runners r ON r.id = s.runner_id
+          WHERE s.mission_id IS NULL
+            AND s.archived_at IS NULL
+          ORDER BY CASE WHEN s.pinned_at IS NOT NULL THEN 0 ELSE 1 END,
+                   CASE WHEN s.status = 'running'    THEN 0 ELSE 1 END,
+                   COALESCE(s.stopped_at, s.started_at) DESC",
+        qualified_select_list("s", COLUMNS)
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map([], direct_row)?;
+    rows.collect()
+}
+
+/// Unfiltered single-row lookup for a direct-chat session — archived rows
+/// ARE returned (the chat page renders them read-only; see the
+/// archived-row tests in `commands::session`). Mission sessions are not:
+/// this surface is for direct chats only.
+pub fn get_direct(conn: &Connection, id: &str) -> rusqlite::Result<Option<DirectSessionRow>> {
+    let sql = format!(
+        "SELECT {}, {DIRECT_EXTRAS}
+           FROM sessions s
+           LEFT JOIN runners r ON r.id = s.runner_id
+          WHERE s.id = ?1
+            AND s.mission_id IS NULL",
+        qualified_select_list("s", COLUMNS)
+    );
+    conn.query_row(&sql, rusqlite::params![id], direct_row)
+        .optional()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+    use chrono::Utc;
+
+    fn seed_runner(conn: &Connection, id: &str, handle: &str) {
+        conn.execute(
+            "INSERT INTO runners (
+                id, handle, display_name, runtime, command, created_at, updated_at
+             ) VALUES (?1, ?2, ?3, 'shell', 'sh', ?4, ?4)",
+            rusqlite::params![
+                id,
+                handle,
+                format!("{handle} display"),
+                "2026-04-22T00:00:00Z"
+            ],
+        )
+        .unwrap();
+    }
+
+    fn full_row() -> SessionRowDb {
+        let now = Utc::now();
+        SessionRowDb {
+            id: "sess-full".into(),
+            mission_id: None,
+            runner_id: Some("r1".into()),
+            slot_id: None,
+            cwd: Some("/tmp/work".into()),
+            status: SessionStatus::Stopped,
+            pid: Some(4242),
+            started_at: Some(now),
+            stopped_at: Some(now),
+            agent_session_key: Some("2f6e0f2e-key".into()),
+            archived_at: Some(now),
+            title: Some("my chat".into()),
+            pinned_at: Some(now),
+            runtime: Some("pty".into()),
+            runtime_socket: Some("sock".into()),
+            runtime_session: Some("rt-sess".into()),
+            runtime_window: Some("w0".into()),
+            runtime_pane: Some("p0".into()),
+            runtime_cursor: Some(7),
+            agent_runtime: Some("codex".into()),
+            agent_command: Some("codex".into()),
+        }
+    }
+
+    fn minimal_row() -> SessionRowDb {
+        SessionRowDb::new_running("sess-min".into())
+    }
+
+    #[test]
+    fn insert_then_get_round_trips_full_and_minimal_rows() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        seed_runner(&conn, "r1", "alpha");
+        for row in [full_row(), minimal_row()] {
+            insert(&conn, &row).unwrap();
+            assert_eq!(get_row(&conn, &row.id).unwrap().unwrap(), row);
+        }
+    }
+
+    #[test]
+    fn legacy_rows_in_todays_stored_formats_read_cleanly() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        seed_runner(&conn, "r1", "alpha");
+        // Both timestamp spellings, a captured agent key, and legacy tmux
+        // runtime metadata — the shapes real upgraded databases carry.
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, cwd, status, pid, started_at, stopped_at,
+                 agent_session_key, runtime, runtime_socket, runtime_session,
+                 runtime_window, runtime_pane, runtime_cursor)
+             VALUES ('sess-legacy', NULL, 'r1', '/tmp', 'crashed', 123,
+                     '2026-04-22T01:02:03.456789+00:00', '2026-04-22T02:00:00Z',
+                     'abcd-uuid', 'tmux', '/tmp/sock', 'tmux-0', '@1', '%1', 42)",
+            [],
+        )
+        .unwrap();
+        let row = get_row(&conn, "sess-legacy").unwrap().unwrap();
+        assert_eq!(row.status, SessionStatus::Crashed);
+        assert_eq!(row.pid, Some(123));
+        assert_eq!(row.agent_session_key.as_deref(), Some("abcd-uuid"));
+        assert_eq!(row.runtime.as_deref(), Some("tmux"));
+        assert_eq!(row.runtime_cursor, Some(42));
+        assert_eq!(
+            row.started_at.unwrap(),
+            "2026-04-22T01:02:03.456789Z".parse::<Timestamp>().unwrap()
+        );
+        assert_eq!(
+            row.stopped_at.unwrap(),
+            "2026-04-22T02:00:00Z".parse::<Timestamp>().unwrap()
+        );
+    }
+
+    #[test]
+    fn writes_are_byte_identical_to_the_legacy_path() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        seed_runner(&conn, "r1", "alpha");
+        let row = full_row();
+        insert(&conn, &row).unwrap();
+        let (started_raw, status_raw): (String, String) = conn
+            .query_row(
+                "SELECT started_at, status FROM sessions WHERE id = 'sess-full'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?)),
+            )
+            .unwrap();
+        assert_eq!(started_raw, row.started_at.unwrap().to_rfc3339());
+        assert_eq!(status_raw, "stopped");
+    }
+
+    #[test]
+    fn capture_agent_session_key_is_guarded_by_null_key_and_started_at() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        seed_runner(&conn, "r1", "alpha");
+        let mut row = minimal_row();
+        let started = Utc::now();
+        row.runner_id = Some("r1".into());
+        row.started_at = Some(started);
+        insert(&conn, &row).unwrap();
+        let started_str = started.to_rfc3339();
+
+        // Stale watcher (wrong started_at) must not write.
+        assert!(!capture_agent_session_key(
+            &conn,
+            "sess-min",
+            "key-a",
+            "1999-01-01T00:00:00+00:00"
+        )
+        .unwrap());
+        // Matching guard writes.
+        assert!(capture_agent_session_key(&conn, "sess-min", "key-a", &started_str).unwrap());
+        // Second writer must not clobber.
+        assert!(!capture_agent_session_key(&conn, "sess-min", "key-b", &started_str).unwrap());
+        let stored: String = conn
+            .query_row(
+                "SELECT agent_session_key FROM sessions WHERE id = 'sess-min'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(stored, "key-a");
+    }
+
+    #[test]
+    fn list_for_mission_matches_todays_dto_shape() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let now = Utc::now().to_rfc3339();
+        seed_runner(&conn, "r1", "template");
+        conn.execute(
+            "INSERT INTO crews (id, name, created_at, updated_at) VALUES ('c1', 'C', ?1, ?1)",
+            rusqlite::params![now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO slots (id, crew_id, runner_id, slot_handle, position, lead, added_at)
+             VALUES ('sl1', 'c1', 'r1', 'coder', 0, 1, ?1)",
+            rusqlite::params![now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO missions (id, crew_id, title, status, started_at)
+             VALUES ('m1', 'c1', 't', 'running', ?1)",
+            rusqlite::params![now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, slot_id, status, started_at, agent_session_key)
+             VALUES ('se1', 'm1', 'r1', 'sl1', 'running', ?1, 'key-1')",
+            rusqlite::params![now],
+        )
+        .unwrap();
+        // Archived row must be filtered out.
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, slot_id, status, started_at, archived_at)
+             VALUES ('se-archived', 'm1', 'r1', 'sl1', 'stopped', ?1, ?1)",
+            rusqlite::params![now],
+        )
+        .unwrap();
+
+        let rows = list_for_mission(&conn, "m1").unwrap();
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.session.id, "se1");
+        assert_eq!(row.session.runner_id, "r1");
+        assert_eq!(row.session.status, SessionStatus::Running);
+        assert_eq!(row.handle, "coder", "slot handle wins over template handle");
+        assert_eq!(row.runtime, "shell");
+        assert!(row.lead);
+        assert_eq!(row.agent_session_key.as_deref(), Some("key-1"));
+    }
+
+    #[test]
+    fn direct_session_surfaces_join_runner_labels_and_keep_archived_semantics() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let now = Utc::now().to_rfc3339();
+        seed_runner(&conn, "r1", "alpha");
+        conn.execute(
+            "INSERT INTO sessions (id, mission_id, runner_id, status, started_at, agent_session_key)
+             VALUES ('d1', NULL, 'r1', 'stopped', ?1, 'resume-key')",
+            rusqlite::params![now],
+        )
+        .unwrap();
+        // Runtime-only chat (#195): no runner row behind it.
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, status, started_at, agent_runtime, agent_command)
+             VALUES ('d2', NULL, NULL, 'running', ?1, 'codex', 'codex')",
+            rusqlite::params![now],
+        )
+        .unwrap();
+        // Archived: hidden from the list, still returned by get_direct.
+        conn.execute(
+            "INSERT INTO sessions (id, mission_id, runner_id, status, started_at, archived_at)
+             VALUES ('d3', NULL, 'r1', 'stopped', ?1, ?1)",
+            rusqlite::params![now],
+        )
+        .unwrap();
+
+        let listed = list_recent_direct(&conn).unwrap();
+        let ids: Vec<&str> = listed.iter().map(|d| d.row.id.as_str()).collect();
+        assert_eq!(ids, vec!["d2", "d1"], "running first, archived hidden");
+        let d1 = listed.iter().find(|d| d.row.id == "d1").unwrap();
+        assert_eq!(d1.runner_handle.as_deref(), Some("alpha"));
+        assert_eq!(d1.runner_runtime.as_deref(), Some("shell"));
+        let d2 = listed.iter().find(|d| d.row.id == "d2").unwrap();
+        assert_eq!(d2.runner_handle, None);
+        assert_eq!(d2.row.agent_runtime.as_deref(), Some("codex"));
+
+        let archived = get_direct(&conn, "d3").unwrap().unwrap();
+        assert!(archived.row.archived_at.is_some());
+    }
+}

--- a/src-tauri/src/repo/slot.rs
+++ b/src-tauri/src/repo/slot.rs
@@ -1,0 +1,286 @@
+// `slots` table — one position in a crew, referencing a Runner template.
+//
+// Invariant enforcement (one lead per crew, dense positions, auto-promote
+// on delete) stays in `commands::slot`; this module owns the row struct,
+// the column list, and the statements.
+
+use rusqlite::{Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
+use serde_rusqlite::{from_row, to_params_named};
+
+use crate::model::{Slot, Timestamp};
+
+use super::{de_err, insert_sql, qualified_select_list, select_list, ser_err};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SlotRow {
+    pub id: String,
+    pub crew_id: String,
+    pub runner_id: String,
+    pub slot_handle: String,
+    pub position: i64,
+    pub lead: bool,
+    #[serde(with = "crate::repo::serde::rfc3339")]
+    pub added_at: Timestamp,
+}
+
+pub const COLUMNS: &[&str] = &[
+    "id",
+    "crew_id",
+    "runner_id",
+    "slot_handle",
+    "position",
+    "lead",
+    "added_at",
+];
+
+impl From<SlotRow> for Slot {
+    fn from(r: SlotRow) -> Self {
+        Slot {
+            id: r.id,
+            crew_id: r.crew_id,
+            runner_id: r.runner_id,
+            slot_handle: r.slot_handle,
+            position: r.position,
+            lead: r.lead,
+            added_at: r.added_at,
+        }
+    }
+}
+
+impl From<&Slot> for SlotRow {
+    fn from(s: &Slot) -> Self {
+        SlotRow {
+            id: s.id.clone(),
+            crew_id: s.crew_id.clone(),
+            runner_id: s.runner_id.clone(),
+            slot_handle: s.slot_handle.clone(),
+            position: s.position,
+            lead: s.lead,
+            added_at: s.added_at,
+        }
+    }
+}
+
+pub fn insert(conn: &Connection, row: &SlotRow) -> rusqlite::Result<()> {
+    conn.execute(
+        &insert_sql("slots", COLUMNS),
+        to_params_named(row).map_err(ser_err)?.to_slice().as_slice(),
+    )?;
+    Ok(())
+}
+
+pub fn get(conn: &Connection, id: &str) -> rusqlite::Result<Option<Slot>> {
+    let sql = format!("SELECT {} FROM slots WHERE id = ?1", select_list(COLUMNS));
+    conn.query_row(&sql, rusqlite::params![id], |row| {
+        from_row::<SlotRow>(row).map_err(de_err)
+    })
+    .optional()
+    .map(|opt| opt.map(Slot::from))
+}
+
+pub fn list_for_crew(conn: &Connection, crew_id: &str) -> rusqlite::Result<Vec<Slot>> {
+    let sql = format!(
+        "SELECT {} FROM slots WHERE crew_id = ?1 ORDER BY position ASC",
+        select_list(COLUMNS)
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params![crew_id], |row| {
+        from_row::<SlotRow>(row).map_err(de_err)
+    })?;
+    rows.map(|r| r.map(Slot::from)).collect()
+}
+
+/// Every slot that references `runner_id`, across every crew, joined with
+/// the crew name. Ordered by `added_at` DESC — drives the Runner Detail
+/// "Crews using this runner" panel.
+pub fn list_for_runner_with_crew_name(
+    conn: &Connection,
+    runner_id: &str,
+) -> rusqlite::Result<Vec<(Slot, String)>> {
+    let sql = format!(
+        "SELECT {}, c.name AS crew_name
+           FROM slots sl
+           JOIN crews c ON c.id = sl.crew_id
+          WHERE sl.runner_id = ?1
+          ORDER BY sl.added_at DESC",
+        qualified_select_list("sl", COLUMNS)
+    );
+    let mut stmt = conn.prepare(&sql)?;
+    let rows = stmt.query_map(rusqlite::params![runner_id], |row| {
+        let slot = from_row::<SlotRow>(row).map_err(de_err)?;
+        let crew_name: String = row.get("crew_name")?;
+        Ok((Slot::from(slot), crew_name))
+    })?;
+    rows.collect()
+}
+
+pub fn set_slot_handle(conn: &Connection, id: &str, slot_handle: &str) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE slots SET slot_handle = ?1 WHERE id = ?2",
+        rusqlite::params![slot_handle, id],
+    )
+}
+
+pub fn set_position(conn: &Connection, id: &str, position: i64) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE slots SET position = ?1 WHERE id = ?2",
+        rusqlite::params![position, id],
+    )
+}
+
+pub fn promote_to_lead(conn: &Connection, id: &str) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE slots SET lead = 1 WHERE id = ?1",
+        rusqlite::params![id],
+    )
+}
+
+/// Clear the current lead flag for a crew. Run before `promote_to_lead`
+/// inside the caller's transaction so no reader ever sees two leads.
+pub fn clear_crew_lead(conn: &Connection, crew_id: &str) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE slots SET lead = 0 WHERE crew_id = ?1 AND lead = 1",
+        rusqlite::params![crew_id],
+    )
+}
+
+pub fn delete(conn: &Connection, id: &str) -> rusqlite::Result<usize> {
+    conn.execute("DELETE FROM slots WHERE id = ?1", rusqlite::params![id])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db;
+    use chrono::Utc;
+
+    fn seed_crew(conn: &Connection, id: &str) {
+        conn.execute(
+            "INSERT INTO crews (id, name, created_at, updated_at)
+             VALUES (?1, ?2, ?3, ?3)",
+            rusqlite::params![id, format!("crew-{id}"), "2026-04-22T00:00:00Z"],
+        )
+        .unwrap();
+    }
+
+    fn seed_runner(conn: &Connection, id: &str, handle: &str) {
+        conn.execute(
+            "INSERT INTO runners (
+                id, handle, display_name, runtime, command, created_at, updated_at
+             ) VALUES (?1, ?2, ?3, 'shell', 'sh', ?4, ?4)",
+            rusqlite::params![
+                id,
+                handle,
+                format!("{handle} display"),
+                "2026-04-22T00:00:00Z"
+            ],
+        )
+        .unwrap();
+    }
+
+    fn full_row() -> SlotRow {
+        SlotRow {
+            id: "s-full".into(),
+            crew_id: "c1".into(),
+            runner_id: "r1".into(),
+            slot_handle: "architect".into(),
+            position: 3,
+            lead: true,
+            added_at: Utc::now(),
+        }
+    }
+
+    fn minimal_row() -> SlotRow {
+        SlotRow {
+            id: "s-min".into(),
+            crew_id: "c1".into(),
+            runner_id: "r1".into(),
+            slot_handle: "worker".into(),
+            position: 0,
+            lead: false,
+            added_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn insert_then_get_round_trips_full_and_minimal_rows() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        seed_crew(&conn, "c1");
+        seed_runner(&conn, "r1", "alpha");
+
+        for row in [full_row(), minimal_row()] {
+            insert(&conn, &row).unwrap();
+            let read = get(&conn, &row.id).unwrap().unwrap();
+            assert_eq!(SlotRow::from(&read), row);
+        }
+    }
+
+    #[test]
+    fn legacy_rows_in_both_timestamp_spellings_read_cleanly() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        seed_crew(&conn, "c1");
+        seed_runner(&conn, "r1", "alpha");
+        // Raw SQL in today's exact stored formats: `Z` (seeds / fixtures)
+        // and `+00:00` (every to_rfc3339 write).
+        conn.execute(
+            "INSERT INTO slots (id, crew_id, runner_id, slot_handle, position, lead, added_at)
+             VALUES ('s-z', 'c1', 'r1', 'zulu', 0, 1, '2026-04-22T00:00:00Z'),
+                    ('s-o', 'c1', 'r1', 'offset', 1, 0, '2026-04-22T00:00:00+00:00')",
+            [],
+        )
+        .unwrap();
+
+        let zulu = get(&conn, "s-z").unwrap().unwrap();
+        let offset = get(&conn, "s-o").unwrap().unwrap();
+        assert_eq!(zulu.added_at, offset.added_at);
+        assert!(zulu.lead);
+        assert!(!offset.lead);
+    }
+
+    #[test]
+    fn writes_are_byte_identical_to_the_legacy_path() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        seed_crew(&conn, "c1");
+        seed_runner(&conn, "r1", "alpha");
+        let row = full_row();
+        insert(&conn, &row).unwrap();
+
+        let (added_at_raw, lead_type, lead_raw): (String, String, i64) = conn
+            .query_row(
+                "SELECT added_at, typeof(lead), lead FROM slots WHERE id = 's-full'",
+                [],
+                |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+            )
+            .unwrap();
+        assert_eq!(added_at_raw, row.added_at.to_rfc3339());
+        assert_eq!(lead_type, "integer");
+        assert_eq!(lead_raw, 1);
+    }
+
+    #[test]
+    fn list_for_runner_with_crew_name_joins_and_orders() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        seed_crew(&conn, "c1");
+        seed_crew(&conn, "c2");
+        seed_runner(&conn, "r1", "shared");
+        conn.execute(
+            "INSERT INTO slots (id, crew_id, runner_id, slot_handle, position, lead, added_at)
+             VALUES ('s1', 'c1', 'r1', 'older', 0, 1, '2026-04-22T00:00:00Z'),
+                    ('s2', 'c2', 'r1', 'newer', 0, 1, '2026-04-23T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+
+        let rows = list_for_runner_with_crew_name(&conn, "r1").unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].0.slot_handle, "newer");
+        assert_eq!(rows[0].1, "crew-c2");
+        assert_eq!(rows[1].0.slot_handle, "older");
+        assert_eq!(rows[1].1, "crew-c1");
+    }
+}

--- a/src-tauri/src/session/codex_capture.rs
+++ b/src-tauri/src/session/codex_capture.rs
@@ -200,15 +200,12 @@ fn persist_capture(
     // that a concurrent path (resume that already had a key) wrote
     // first. Guard with `started_at` so a stale watcher from a prior
     // incarnation of this row cannot write into a later stop/resume.
-    conn.execute(
-        "UPDATE sessions
-            SET agent_session_key = ?2
-          WHERE id = ?1
-            AND agent_session_key IS NULL
-            AND started_at = ?3",
-        params![session_id, agent_session_key, expected_row_started_at],
+    crate::repo::session::capture_agent_session_key(
+        &conn,
+        session_id,
+        agent_session_key,
+        expected_row_started_at,
     )
-    .map(|updated| updated > 0)
     .unwrap_or(false)
 }
 

--- a/src-tauri/src/session/manager/output.rs
+++ b/src-tauri/src/session/manager/output.rs
@@ -127,25 +127,23 @@ impl SessionManager {
                 && !was_killed
                 && started_at.elapsed() < std::time::Duration::from_secs(3);
             let final_status = if success || was_killed {
-                "stopped"
+                crate::model::SessionStatus::Stopped
             } else {
-                "crashed"
+                crate::model::SessionStatus::Crashed
             };
             if let Ok(conn) = pool.get() {
                 if resume_failed {
-                    let _ = conn.execute(
-                        "UPDATE sessions
-                            SET status = ?1, stopped_at = ?2,
-                                agent_session_key = NULL
-                          WHERE id = ?3",
-                        params!["crashed", Utc::now().to_rfc3339(), session_id],
+                    let _ = crate::repo::session::set_crashed_clearing_key(
+                        &conn,
+                        &session_id,
+                        Utc::now(),
                     );
                 } else {
-                    let _ = conn.execute(
-                        "UPDATE sessions
-                            SET status = ?1, stopped_at = ?2
-                          WHERE id = ?3",
-                        params![final_status, Utc::now().to_rfc3339(), session_id],
+                    let _ = crate::repo::session::set_exit_status(
+                        &conn,
+                        &session_id,
+                        final_status,
+                        Utc::now(),
                     );
                 }
             }

--- a/src-tauri/src/session/manager/spawn.rs
+++ b/src-tauri/src/session/manager/spawn.rs
@@ -263,21 +263,14 @@ impl SessionManager {
         let started_at = started_at_dt.to_rfc3339();
         {
             let conn = pool.get()?;
-            conn.execute(
-                "INSERT INTO sessions
-                    (id, mission_id, runner_id, slot_id, cwd, status, pid, started_at,
-                     agent_session_key)
-                 VALUES (?1, ?2, ?3, ?4, ?5, 'running', NULL, ?6, ?7)",
-                params![
-                    session_id,
-                    mission.id,
-                    runner.id,
-                    slot.id,
-                    resolved_cwd,
-                    started_at,
-                    plan.assigned_key
-                ],
-            )?;
+            let mut row = crate::repo::session::SessionRowDb::new_running(session_id.clone());
+            row.mission_id = Some(mission.id.clone());
+            row.runner_id = Some(runner.id.clone());
+            row.slot_id = Some(slot.id.clone());
+            row.cwd = resolved_cwd.clone();
+            row.started_at = Some(started_at_dt);
+            row.agent_session_key = plan.assigned_key.clone();
+            crate::repo::session::insert(&conn, &row)?;
         }
 
         Ok(PendingMissionSpawn {
@@ -413,18 +406,12 @@ impl SessionManager {
         // Persist the runtime-side identity for diagnostics and for
         // the current runtime session row.
         if let Ok(conn) = pool.get() {
-            let _ = conn.execute(
-                "UPDATE sessions
-                    SET runtime = ?2,
-                        runtime_session = ?3,
-                        pid = ?4
-                  WHERE id = ?1",
-                params![
-                    session_id,
-                    rt_session.runtime,
-                    rt_session.session_id,
-                    spawn_pid
-                ],
+            let _ = crate::repo::session::update_runtime_metadata(
+                &conn,
+                &session_id,
+                &rt_session.runtime,
+                &rt_session.session_id,
+                spawn_pid,
             );
         }
 
@@ -565,7 +552,7 @@ impl SessionManager {
             // start from a clean slate. The async mission_start path
             // takes a softer line and marks the row crashed instead.
             if let Ok(conn) = pool.get() {
-                let _ = conn.execute("DELETE FROM sessions WHERE id = ?1", params![session_id]);
+                let _ = crate::repo::session::delete(&conn, &session_id);
             }
             return Err(e);
         }
@@ -712,32 +699,21 @@ impl SessionManager {
             Self::apply_runtime_args(&mut spec, runner, &plan, first_turn.as_deref(), None);
 
         // Insert the row first so a fast-failing spawn doesn't leave
-        // a half-row.
+        // a half-row. Runtime-only chats (no persisted runner template)
+        // carry their agent identity on the row via agent_runtime /
+        // agent_command; runner-backed chats leave those NULL.
         {
             let conn = pool.get()?;
-            conn.execute(
-                "INSERT INTO sessions
-                    (id, mission_id, runner_id, cwd, status, pid, started_at,
-                     agent_session_key, agent_runtime, agent_command)
-                 VALUES (?1, NULL, ?2, ?3, 'running', NULL, ?4, ?5, ?6, ?7)",
-                params![
-                    session_id,
-                    persisted_runner_id,
-                    resolved_cwd,
-                    started_at,
-                    plan.assigned_key,
-                    if persisted_runner_id.is_none() {
-                        Some(runner.runtime.as_str())
-                    } else {
-                        None
-                    },
-                    if persisted_runner_id.is_none() {
-                        Some(runner.command.as_str())
-                    } else {
-                        None
-                    },
-                ],
-            )?;
+            let mut row = crate::repo::session::SessionRowDb::new_running(session_id.clone());
+            row.runner_id = persisted_runner_id.map(str::to_string);
+            row.cwd = resolved_cwd.clone();
+            row.started_at = Some(started_at_dt);
+            row.agent_session_key = plan.assigned_key.clone();
+            if persisted_runner_id.is_none() {
+                row.agent_runtime = Some(runner.runtime.clone());
+                row.agent_command = Some(runner.command.clone());
+            }
+            crate::repo::session::insert(&conn, &row)?;
         }
 
         // Same gate as the mission spawn path — direct chats are
@@ -761,7 +737,7 @@ impl SessionManager {
             Ok(p) => p,
             Err(e) => {
                 if let Ok(conn) = pool.get() {
-                    let _ = conn.execute("DELETE FROM sessions WHERE id = ?1", params![session_id]);
+                    let _ = crate::repo::session::delete(&conn, &session_id);
                 }
                 return Err(Error::msg(format!("spawn {}: {e}", runner.command)));
             }
@@ -786,18 +762,12 @@ impl SessionManager {
         let spawn_pid = self.runtime_pid(&rt_session);
 
         if let Ok(conn) = pool.get() {
-            let _ = conn.execute(
-                "UPDATE sessions
-                    SET runtime = ?2,
-                        runtime_session = ?3,
-                        pid = ?4
-                  WHERE id = ?1",
-                params![
-                    session_id,
-                    rt_session.runtime,
-                    rt_session.session_id,
-                    spawn_pid
-                ],
+            let _ = crate::repo::session::update_runtime_metadata(
+                &conn,
+                &session_id,
+                &rt_session.runtime,
+                &rt_session.session_id,
+                spawn_pid,
             );
         }
 
@@ -924,72 +894,21 @@ impl SessionManager {
         // short-lived connection. We deliberately don't hold the conn
         // across the spawn (which itself grabs a pool slot for the
         // status update).
-        struct Snapshot {
-            runner_id: Option<String>,
-            mission_id: Option<String>,
-            slot_id: Option<String>,
-            cwd: Option<String>,
-            agent_runtime: Option<String>,
-            agent_command: Option<String>,
-            agent_session_key: Option<String>,
-        }
         let snap = {
             let conn = pool.get()?;
-            let mut stmt = conn.prepare(
-                "SELECT runner_id, mission_id, slot_id, cwd, status, archived_at,
-                        agent_runtime, agent_command, agent_session_key
-                   FROM sessions WHERE id = ?1",
-            )?;
-            let row = stmt
-                .query_row(params![session_id], |r| {
-                    Ok((
-                        r.get::<_, Option<String>>("runner_id")?,
-                        r.get::<_, Option<String>>("mission_id")?,
-                        r.get::<_, Option<String>>("slot_id")?,
-                        r.get::<_, Option<String>>("cwd")?,
-                        r.get::<_, String>("status")?,
-                        r.get::<_, Option<String>>("archived_at")?,
-                        r.get::<_, Option<String>>("agent_runtime")?,
-                        r.get::<_, Option<String>>("agent_command")?,
-                        r.get::<_, Option<String>>("agent_session_key")?,
-                    ))
-                })
-                .map_err(|e| match e {
-                    rusqlite::Error::QueryReturnedNoRows => {
-                        Error::msg(format!("session not found: {session_id}"))
-                    }
-                    other => other.into(),
-                })?;
-            let (
-                runner_id,
-                mission_id,
-                slot_id,
-                cwd,
-                status,
-                archived_at,
-                agent_runtime,
-                agent_command,
-                agent_session_key,
-            ) = row;
-            if status == "running" {
+            let row = crate::repo::session::get_row(&conn, session_id)?
+                .ok_or_else(|| Error::msg(format!("session not found: {session_id}")))?;
+            if matches!(row.status, crate::model::SessionStatus::Running) {
                 return Err(Error::msg(format!(
                     "session {session_id} is already running — attach instead"
                 )));
             }
-            if archived_at.is_some() {
+            if row.archived_at.is_some() {
                 return Err(Error::msg(format!(
                     "session {session_id} is archived — un-archive before resuming"
                 )));
             }
-            Snapshot {
-                runner_id,
-                mission_id,
-                slot_id,
-                cwd,
-                agent_runtime,
-                agent_command,
-                agent_session_key,
-            }
+            row
         };
 
         // Purge the prior session's output buffer up front. Two
@@ -1179,15 +1098,11 @@ impl SessionManager {
         // UPDATE in place: same id, same conversation thread.
         {
             let conn = pool.get()?;
-            conn.execute(
-                "UPDATE sessions
-                    SET status = 'running',
-                        pid = NULL,
-                        started_at = ?2,
-                        stopped_at = NULL,
-                        agent_session_key = COALESCE(?3, agent_session_key)
-                  WHERE id = ?1",
-                params![session_id, started_at, plan.assigned_key],
+            crate::repo::session::resume_in_place(
+                &conn,
+                session_id,
+                started_at_dt,
+                plan.assigned_key.as_deref(),
             )?;
         }
 
@@ -1204,12 +1119,11 @@ impl SessionManager {
             Err(e) => {
                 // Roll the row back to stopped so the user can retry.
                 if let Ok(conn) = pool.get() {
-                    let _ = conn.execute(
-                        "UPDATE sessions
-                            SET status = 'stopped',
-                                stopped_at = ?2
-                          WHERE id = ?1",
-                        params![session_id, Utc::now().to_rfc3339()],
+                    let _ = crate::repo::session::set_exit_status(
+                        &conn,
+                        session_id,
+                        crate::model::SessionStatus::Stopped,
+                        Utc::now(),
                     );
                 }
                 return Err(Error::msg(format!("spawn {}: {e}", runner.command)));
@@ -1219,18 +1133,12 @@ impl SessionManager {
         let spawn_pid = self.runtime_pid(&rt_session);
 
         if let Ok(conn) = pool.get() {
-            let _ = conn.execute(
-                "UPDATE sessions
-                    SET runtime = ?2,
-                        runtime_session = ?3,
-                        pid = ?4
-                  WHERE id = ?1",
-                params![
-                    session_id,
-                    rt_session.runtime,
-                    rt_session.session_id,
-                    spawn_pid
-                ],
+            let _ = crate::repo::session::update_runtime_metadata(
+                &conn,
+                session_id,
+                &rt_session.runtime,
+                &rt_session.session_id,
+                spawn_pid,
             );
         }
 

--- a/src-tauri/src/session/pty_runtime.rs
+++ b/src-tauri/src/session/pty_runtime.rs
@@ -620,14 +620,7 @@ pub fn cleanup_stale_running_rows_on_startup(
     let conn = pool
         .get()
         .map_err(|e| rusqlite::Error::ToSqlConversionFailure(Box::new(e)))?;
-    let now = chrono::Utc::now().to_rfc3339();
-    let updated = conn.execute(
-        "UPDATE sessions
-            SET status = 'stopped',
-                stopped_at = COALESCE(stopped_at, ?1)
-            WHERE status = 'running'",
-        rusqlite::params![now],
-    )?;
+    let updated = crate::repo::session::cleanup_stale_running(&conn, chrono::Utc::now())?;
     if updated > 0 {
         log::info!(
             "pty-runtime startup cleanup: demoted {updated} stale running session(s) to stopped"


### PR DESCRIPTION
Executes implementation plan [`docs/impls/0021-repo-layer-serde-rusqlite.md`](docs/impls/0021-repo-layer-serde-rusqlite.md) (included in this PR): a behavior-preserving reorganization of the persistence layer around per-table repo modules, with row↔struct mapping derived through `serde_rusqlite` instead of five hand-written `row_to_*` mappers.

## What changed

- New `src-tauri/src/repo/` with one module per persistent object (`crew`, `runner`, `slot`, `mission`, `session`), each owning its row struct, a `COLUMNS` const that both SELECT and INSERT statements are built from, and the table's CRUD functions.
- `repo/serde.rs` pins storage byte formats: timestamps serialize via `to_rfc3339()` and parse both historical offset spellings (`+00:00` and `Z`); JSON TEXT columns serialize via `serde_json::to_string`. Old and new rows are byte-indistinguishable — no migration, old databases open unchanged.
- All five `row_to_*` mappers deleted. `commands/` and `session/` contain no INSERT/UPDATE SQL and no `rusqlite::Row` imports; join DTOs assemble from aliased columns in Rust (no `#[serde(flatten)]` row deserialization).
- `crew.orchestrator_policy` remains read-only (#247): present in the read column list, excluded from every write list, with a test proving a legacy value survives repo insert/update.
- Session write paths (`manager/spawn.rs`, `manager/output.rs`, `pty_runtime.rs`, `codex_capture.rs`) ported statement-for-statement — no consolidation on the PTY hot path. Existing transaction boundaries in `mission_start`/`mission_reset`/slot commands are untouched.
- `db.rs` seeds intentionally untouched: they write fixed `Z`-spelling timestamps, and porting them would change seed bytes.
- `serde_rusqlite` 0.36.0 pinned to match the workspace's rusqlite 0.32 exactly (single rusqlite in the lockfile).

## Tests

Existing suite is the contract: green after every step, zero tests modified except two mechanical import moves. 26 new repo tests: Step-0 spike proofs (bool↔INTEGER, status enums↔lowercase TEXT, timestamp/JSON byte-stability + legacy-spelling reads, `to_params_named_with_fields` partial UPDATE), per-table round-trips (full + NULL-heavy rows), legacy-format reads via raw-SQL fixtures, and join-DTO shape tests.

## Verification

- `cargo test --workspace`, `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `pnpm exec tsc --noEmit`, `pnpm run lint` — all clean.
- Frontend untouched: zero edits under `src/`, `src/lib/types.ts` unchanged.
- Peer review (@reviewer) clean, no must-fix findings; independently re-ran per-module suites, fmt, clippy `-D warnings`, `git diff --check`.
- Manual smoke on an existing DB passed: legacy rows render, direct chat spawn/stop/resume, mission start → archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)