### PR TITLE
fix(ui): treat the active split-view chat group as one pinned unit

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -57,6 +57,12 @@ import {
   unmarkArchivingSession,
 } from "../lib/archivingState";
 import {
+  clusterActiveGroupRows,
+  groupPinTargets,
+  pinnedSessionIds,
+  shouldInheritPinOnAdd,
+} from "../lib/groupPinning";
+import {
   assignSessionToPane,
   findLeaf,
   focusPane,
@@ -273,22 +279,38 @@ export function Sidebar({
   // non-member chat is open, the sidebar reads classic single-selection.
   const paneLayout = usePaneLayout();
   const chatGroupActive = isGroupActiveFor(paneLayout, currentChatSessionId);
-  const paneOpenSessionIds = chatGroupActive
-    ? new Set(visibleSessionIds(paneLayout.root))
+  const activeGroupSessionIds = useMemo(
+    () => (chatGroupActive ? visibleSessionIds(paneLayout.root) : null),
+    [chatGroupActive, paneLayout],
+  );
+  const paneOpenSessionIds = activeGroupSessionIds
+    ? new Set(activeGroupSessionIds)
     : null;
   const focusedPaneSessionId = chatGroupActive
     ? (findLeaf(paneLayout.root, paneLayout.focusedPaneId)?.sessionId ?? null)
     : null;
 
+  // The CHAT list renders active-group members as one contiguous block in
+  // pane order, anchored where the group's best-sorted member sits — an
+  // unrelated pinned chat can't interleave between two members. Pure
+  // list-rendering logic; the backend sort stays group-blind.
+  const chatRows = useMemo(
+    () =>
+      activeGroupSessionIds
+        ? clusterActiveGroupRows(directSessions, activeGroupSessionIds)
+        : directSessions,
+    [directSessions, activeGroupSessionIds],
+  );
+
   const sidebarNavigationEntries = useMemo<SidebarNavigationEntry[]>(
     () => [
       ...missions.map((mission) => ({ to: `/missions/${mission.id}` })),
-      ...directSessions.map((session) => ({
+      ...chatRows.map((session) => ({
         to: `/chats/${session.session_id}`,
         state: { sessionStatus: session.status },
       })),
     ],
-    [directSessions, missions],
+    [chatRows, missions],
   );
 
   const refreshMissions = useCallback(async () => {
@@ -663,16 +685,30 @@ export function Sidebar({
     [missions, refreshMissions, setRenamingMissionId],
   );
 
+  // Pin/unpin on a member of the active on-screen group applies to every
+  // member, so the group moves between sidebar clusters as one unit.
+  // Chats outside the active group keep single-session behavior.
   const togglePin = useCallback(
     async (session: DirectSessionEntry) => {
+      const layout = getPaneLayout();
+      const groupIds = isGroupActiveFor(layout, currentChatSessionId)
+        ? visibleSessionIds(layout.root)
+        : [];
+      const nextPinned = !session.pinned;
+      const targets = groupPinTargets(
+        session.session_id,
+        groupIds,
+        pinnedSessionIds(directSessions),
+        nextPinned,
+      );
       try {
-        await api.session.pin(session.session_id, !session.pinned);
+        await Promise.all(targets.map((id) => api.session.pin(id, nextPinned)));
         await refreshDirectSessions();
       } catch (e) {
         console.error("sidebar: session_pin failed", e);
       }
     },
-    [refreshDirectSessions],
+    [currentChatSessionId, directSessions, refreshDirectSessions],
   );
 
   const archiveSession = useCallback(
@@ -784,7 +820,26 @@ export function Sidebar({
             chatLayout.focusedPaneId,
           );
           if (groupOnScreen && focusedLeaf && focusedLeaf.sessionId === null) {
+            // Read members before the assign fills the focused pane.
+            const memberIds = visibleSessionIds(chatLayout.root);
             assignSessionToPane(chatLayout.focusedPaneId, entry.session_id);
+            // A chat added to a group with a pinned member inherits the
+            // pin, so the group stays one sidebar cluster (add never
+            // unpins).
+            if (
+              shouldInheritPinOnAdd(
+                memberIds,
+                pinnedSessionIds(directSessions),
+                entry.session_id,
+              )
+            ) {
+              void api.session
+                .pin(entry.session_id, true)
+                .then(() => refreshDirectSessions())
+                .catch((e) =>
+                  console.error("sidebar: session_pin on group add failed", e),
+                );
+            }
           }
         }
       }
@@ -794,7 +849,13 @@ export function Sidebar({
         replace: location.pathname === target,
       });
     },
-    [navigate, location.pathname, currentChatSessionId],
+    [
+      navigate,
+      location.pathname,
+      currentChatSessionId,
+      directSessions,
+      refreshDirectSessions,
+    ],
   );
 
   // CHAT `+` button — opens the StartChat modal (GH #104). The modal is
@@ -925,12 +986,12 @@ export function Sidebar({
                 />
                 {sessionsOpen ? (
                   <div className="flex flex-col gap-0.5 px-3 pt-1">
-                    {directSessions.length === 0 ? (
+                    {chatRows.length === 0 ? (
                       <p className="px-2.5 py-1 text-xs text-fg-3">
                         No chats yet.
                       </p>
                     ) : (
-                      directSessions.map((s) => (
+                      chatRows.map((s) => (
                         <SessionRow
                           key={s.session_id}
                           session={s}

--- a/src/lib/groupPinning.test.ts
+++ b/src/lib/groupPinning.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  clusterActiveGroupRows,
+  groupPinTargets,
+  pinnedSessionIds,
+  shouldInheritPinOnAdd,
+} from "./groupPinning";
+
+function rows(...ids: string[]): { session_id: string }[] {
+  return ids.map((session_id) => ({ session_id }));
+}
+
+function order(list: readonly { session_id: string }[]): string[] {
+  return list.map((r) => r.session_id);
+}
+
+describe("pinnedSessionIds", () => {
+  it("collects the pinned rows' ids", () => {
+    const ids = pinnedSessionIds([
+      { session_id: "A", pinned: true },
+      { session_id: "B", pinned: false },
+      { session_id: "C", pinned: true },
+    ]);
+    expect([...ids].sort()).toEqual(["A", "C"]);
+  });
+});
+
+describe("shouldInheritPinOnAdd", () => {
+  it("pins the new chat when an existing member is pinned", () => {
+    expect(shouldInheritPinOnAdd(["A", "B"], new Set(["B"]), "C")).toBe(true);
+  });
+
+  it("no-ops when no member is pinned (never unpins on add)", () => {
+    expect(shouldInheritPinOnAdd(["A", "B"], new Set(), "C")).toBe(false);
+    // Even an already-pinned chat joining an unpinned group keeps its pin
+    // untouched — the decision is only ever "write pin", never "unpin".
+    expect(shouldInheritPinOnAdd(["A"], new Set(["C"]), "C")).toBe(false);
+  });
+
+  it("skips the write when the new chat is already pinned", () => {
+    expect(shouldInheritPinOnAdd(["A"], new Set(["A", "C"]), "C")).toBe(false);
+  });
+
+  it("ignores the new chat itself among the members", () => {
+    // Defensive: caller passed the post-assign member list.
+    expect(shouldInheritPinOnAdd(["A", "C"], new Set(), "C")).toBe(false);
+  });
+
+  it("no-ops with no existing members", () => {
+    expect(shouldInheritPinOnAdd([], new Set(["X"]), "C")).toBe(false);
+  });
+});
+
+describe("groupPinTargets", () => {
+  it("fans a pin out to every unpinned member of the active group", () => {
+    expect(groupPinTargets("A", ["A", "B", "C"], new Set(), true)).toEqual([
+      "A",
+      "B",
+      "C",
+    ]);
+  });
+
+  it("fans an unpin out to every pinned member", () => {
+    expect(
+      groupPinTargets("B", ["A", "B"], new Set(["A", "B"]), false),
+    ).toEqual(["A", "B"]);
+  });
+
+  it("skips members already in the target state (drifted group converges)", () => {
+    expect(
+      groupPinTargets("B", ["A", "B", "C"], new Set(["A"]), true),
+    ).toEqual(["B", "C"]);
+  });
+
+  it("targets only the toggled chat when it is not in the active group", () => {
+    expect(groupPinTargets("X", ["A", "B"], new Set(), true)).toEqual(["X"]);
+  });
+
+  it("targets only the toggled chat when no group is active", () => {
+    expect(groupPinTargets("X", [], new Set(["X"]), false)).toEqual(["X"]);
+  });
+});
+
+describe("clusterActiveGroupRows", () => {
+  it("renders members as one block in pane order at the highest-sorted member", () => {
+    // Sidebar sort: P (pinned) first, then B, X, A. Group [A, B] anchors
+    // at B's slot (the group's best-sorted member) in pane order A, B.
+    const input = rows("P", "B", "X", "A");
+    expect(order(clusterActiveGroupRows(input, ["A", "B"]))).toEqual([
+      "P",
+      "A",
+      "B",
+      "X",
+    ]);
+  });
+
+  it("preserves non-members' relative order", () => {
+    const input = rows("X", "A", "Y", "Z", "B");
+    expect(order(clusterActiveGroupRows(input, ["B", "A"]))).toEqual([
+      "X",
+      "B",
+      "A",
+      "Y",
+      "Z",
+    ]);
+  });
+
+  it("keeps an unpinned group below the pinned cluster", () => {
+    // P1/P2 pinned, group members A/B unpinned: the anchor is A (best
+    // member), so the block must not climb above the pinned rows.
+    const input = rows("P1", "P2", "A", "X", "B");
+    expect(order(clusterActiveGroupRows(input, ["A", "B"]))).toEqual([
+      "P1",
+      "P2",
+      "A",
+      "B",
+      "X",
+    ]);
+  });
+
+  it("clusters inside the pinned section when the group is pinned", () => {
+    // Group A/B pinned with an unrelated pinned chat P between them:
+    // P stops interleaving but keeps its pinned-cluster spot.
+    const input = rows("A", "P", "B", "X");
+    expect(order(clusterActiveGroupRows(input, ["A", "B"]))).toEqual([
+      "A",
+      "B",
+      "P",
+      "X",
+    ]);
+  });
+
+  it("returns the input unchanged when fewer than two members are listed", () => {
+    const input = rows("A", "X", "B");
+    expect(clusterActiveGroupRows(input, [])).toBe(input);
+    expect(clusterActiveGroupRows(input, ["A"])).toBe(input);
+    expect(clusterActiveGroupRows(input, ["A", "GONE"])).toBe(input);
+  });
+
+  it("ignores member ids missing from the rows (e.g. empty pane slots)", () => {
+    const input = rows("X", "B", "A");
+    expect(order(clusterActiveGroupRows(input, ["A", "GONE", "B"]))).toEqual([
+      "X",
+      "A",
+      "B",
+    ]);
+  });
+});

--- a/src/lib/groupPinning.ts
+++ b/src/lib/groupPinning.ts
@@ -1,0 +1,85 @@
+// Pin semantics for the on-screen chat group (spec 34 follow-up): the
+// active split group behaves as ONE pinned unit in the sidebar. Three
+// concerns, all pure so they unit-test like paneLayout's ops:
+//   - a chat added to a group with a pinned member inherits the pin,
+//   - pin/unpin on a member fans out to every member,
+//   - the CHAT list renders members as one contiguous block.
+// Group membership stays in the frontend layout store; the recent-direct
+// sort SQL is intentionally group-blind.
+
+interface PinnableRow {
+  session_id: string;
+  pinned: boolean;
+}
+
+export function pinnedSessionIds(
+  rows: readonly PinnableRow[],
+): Set<string> {
+  return new Set(rows.filter((r) => r.pinned).map((r) => r.session_id));
+}
+
+/**
+ * Whether a chat just added to the active group should inherit a pin:
+ * true when any existing member is pinned and the new chat isn't
+ * already. Never asks to unpin — adding to an unpinned group leaves the
+ * new chat's pin state alone.
+ */
+export function shouldInheritPinOnAdd(
+  existingMemberIds: readonly string[],
+  pinnedIds: ReadonlySet<string>,
+  newSessionId: string,
+): boolean {
+  return (
+    !pinnedIds.has(newSessionId) &&
+    existingMemberIds.some(
+      (id) => id !== newSessionId && pinnedIds.has(id),
+    )
+  );
+}
+
+/**
+ * Sessions to write when toggling a chat's pin to `nextPinned`. A member
+ * of the active group drags every member with it (skipping ones already
+ * in the target state, so drifted pre-fix groups converge); a chat
+ * outside the active group keeps single-session behavior.
+ */
+export function groupPinTargets(
+  toggledSessionId: string,
+  activeGroupSessionIds: readonly string[],
+  pinnedIds: ReadonlySet<string>,
+  nextPinned: boolean,
+): string[] {
+  if (!activeGroupSessionIds.includes(toggledSessionId)) {
+    return [toggledSessionId];
+  }
+  return activeGroupSessionIds.filter(
+    (id) => pinnedIds.has(id) !== nextPinned,
+  );
+}
+
+/**
+ * Reorder the recent-direct rows so active-group members render as one
+ * contiguous block in pane order, anchored where the group's
+ * highest-sorted member already sits. Non-members keep their relative
+ * order, and because the anchor is the best-sorted member, a fully
+ * unpinned group can never float up into the pinned cluster. Returns
+ * the input unchanged when fewer than two members are in the list.
+ */
+export function clusterActiveGroupRows<T extends { session_id: string }>(
+  rows: readonly T[],
+  activeGroupSessionIds: readonly string[],
+): readonly T[] {
+  const memberIds = new Set(activeGroupSessionIds);
+  const byId = new Map(rows.map((r) => [r.session_id, r]));
+  const block = activeGroupSessionIds
+    .map((id) => byId.get(id))
+    .filter((r): r is T => r !== undefined);
+  if (block.length < 2) return rows;
+  const anchor = rows.findIndex((r) => memberIds.has(r.session_id));
+  const out: T[] = [];
+  rows.forEach((r, i) => {
+    if (i === anchor) out.push(...block);
+    else if (!memberIds.has(r.session_id)) out.push(r);
+  });
+  return out;
+}

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -72,6 +72,10 @@ import {
   type PresetKind,
 } from "../lib/paneLayout";
 import {
+  pinnedSessionIds,
+  shouldInheritPinOnAdd,
+} from "../lib/groupPinning";
+import {
   isSecondaryFor,
   useCurrentWindowLabel,
   useReportSubjects,
@@ -129,6 +133,27 @@ interface DirectSessionPane {
   label: string;
   status: SessionStatus;
   exitCode: number | null;
+}
+
+// A chat spawned into a group with a pinned member inherits the pin so
+// the sidebar keeps the group in one cluster (never unpins on add).
+// Fresh fetch rather than this page's `recentRows`: pins toggled from
+// the sidebar don't flow into that cache. The sidebar reorders off the
+// `session/updated` emit from session_pin.
+async function inheritGroupPin(
+  existingMemberIds: string[],
+  newSessionId: string,
+): Promise<void> {
+  try {
+    const rows = await api.session.listRecentDirect();
+    if (
+      shouldInheritPinOnAdd(existingMemberIds, pinnedSessionIds(rows), newSessionId)
+    ) {
+      await api.session.pin(newSessionId, true);
+    }
+  } catch (e) {
+    console.error("RunnerChat: group pin inherit failed", e);
+  }
 }
 
 type DirectChatDisplayStatus = SessionActivityState | "stopped" | "crashed";
@@ -1745,8 +1770,11 @@ export default function RunnerChat() {
           const target = paneModalTarget;
           setPaneModalTarget(null);
           if (target) {
+            // Read members before the assign fills the target pane.
+            const memberIds = visibleSessionIds(getPaneLayout().root);
             assignSessionToPane(target, spawned.id);
             focusPane(target);
+            void inheritGroupPin(memberIds, spawned.id);
           }
           navigate(`/chats/${spawned.id}`, {
             state: { sessionStatus: "running" },


### PR DESCRIPTION
## Problem

Adding a chat to a split-view group whose existing member is pinned left the new chat's session unpinned, so the sidebar tore the group apart: the pinned member sat in the pinned cluster while the new member landed in the unpinned section. Even with both pinned, the pinned cluster sorts by running-status + recent activity with no group awareness, so an unrelated pinned chat could render between two group members.

## Fix

The active on-screen group (spec 34) now behaves as ONE pinned unit in the sidebar, via pure helpers in `src/lib/groupPinning.ts`:

- **Pin inheritance** — a chat added to the active group inherits the pin when any existing member is pinned (both add paths: empty-pane StartChatModal in `RunnerChat`, sidebar pick into the focused empty pane). Never unpins on add; the pin persists after the group dissolves (intended).
- **Group pin semantics** — pin/unpin from the sidebar row menu on a member of the active group applies to every member (members already in the target state are skipped, so drifted groups converge). Chats outside the active group keep single-session behavior.
- **Sidebar adjacency** — the CHAT list renders active-group members as one contiguous block in pane order, anchored where the group's highest-sorted member sits. Anchoring at the best-sorted member keeps an unpinned group below the pinned cluster. Cmd+Shift+[/] navigation follows the same clustered order.

No backend changes: `session_pin` already emits `session/updated` (the sidebar's refresh cue) and the `list_recent_direct` sort SQL stays group-blind.

## Tests

17 new vitest cases in `src/lib/groupPinning.test.ts`: inheritance decision, fan-out target set, clustering (contiguity, anchor, non-member order, pinned-cluster boundary).

Checks: `pnpm exec vitest run` 37/37 · `tsc --noEmit` clean · `eslint` clean · `cargo test --workspace` 377/377. Peer-reviewed clean by @reviewer in working-tree mode before the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)