### PR TITLE
fix(ui): sync multi-pane tab layout across windows

### DIFF
--- a/src/lib/paneLayout.test.ts
+++ b/src/lib/paneLayout.test.ts
@@ -21,6 +21,7 @@ import {
   resetPaneLayoutsForTest,
   serializeLayout,
   serializeLayoutSet,
+  setRouteAnchorSession,
   setSizesPure,
   setTabCollapsed,
   subscribePaneLayout,
@@ -307,14 +308,16 @@ describe("setTabCollapsed", () => {
 
 describe("hydrateLayoutSet (cross-window sync)", () => {
   afterEach(() => {
+    vi.useRealTimers();
     resetPaneLayoutsForTest();
   });
 
-  it("replaces the store with a set broadcast from another window and notifies subscribers", () => {
-    // Local state: a single tab on chat A.
-    applyPreset("single", "A", ["A"]);
+  it("converges tab membership from another window and notifies subscribers", () => {
+    // Local state: one tab {A,B}, focused on A (this window's active tab).
+    applyPreset("cols-2", "A", ["A", "B"]);
 
-    // A remote window's serialized set: two tabs, second one active.
+    // A remote window's serialized set: our tab plus a second one it made
+    // active.
     const remote = serializeLayoutSet(
       [
         applyPresetPure("cols-2", "A", ["A", "B"]),
@@ -336,8 +339,118 @@ describe("hydrateLayoutSet (cross-window sync)", () => {
     expect(tabs).toHaveLength(2);
     expect(slotSessions(tabs[0])).toEqual(["A", "B"]);
     expect(slotSessions(tabs[1])).toEqual(["C", "D"]);
-    // The remote active tab wins so every window agrees on the front tab.
-    expect(getPaneLayout()).toBe(tabs[1]);
+  });
+
+  it("keeps this window on its route tab instead of adopting the sender's active tab", () => {
+    // This window's route owns A (its tab is {A,B}).
+    applyPreset("cols-2", "A", ["A", "B"]);
+    setRouteAnchorSession("A");
+
+    // Sender's set puts A's tab at index 1 and makes {C,D} (index 0) active,
+    // so neither the sender's activeIndex nor a positional clamp lands on it.
+    const remote = serializeLayoutSet(
+      [
+        applyPresetPure("cols-2", "C", ["C", "D"]),
+        applyPresetPure("cols-2", "A", ["A", "B"]),
+      ],
+      0,
+    );
+
+    hydrateLayoutSet(remote);
+
+    // Active tab tracks the route session A, so a local closePane/focusPane
+    // can't hit the wrong tab.
+    expect(slotSessions(getPaneLayout())).toEqual(["A", "B"]);
+    expect(getPaneLayout()).toBe(getPaneLayouts()[1]);
+  });
+
+  it("anchors on the route session, not a remotely-changed focused pane", () => {
+    // Route owns A; its tab is {A,B}, focused on A.
+    applyPreset("cols-2", "A", ["A", "B"]);
+    setRouteAnchorSession("A");
+
+    // A remote change moves the tab's focused pane to B (focus is synced).
+    const tabAB = applyPresetPure("cols-2", "A", ["A", "B"]);
+    const bLeaf = leaves(tabAB.root).find((l) => l.sessionId === "B")!;
+    hydrateLayoutSet(
+      serializeLayoutSet([{ ...tabAB, focusedPaneId: bLeaf.id }], 0),
+    );
+
+    // Then a second remote change splits B into its own tab while A stays put.
+    hydrateLayoutSet(
+      serializeLayoutSet(
+        [
+          applyPresetPure("single", "A", ["A"]),
+          applyPresetPure("cols-2", "B", ["B", "X"]),
+        ],
+        1,
+      ),
+    );
+
+    // The window follows A (its route), not the remotely-moved focus on B.
+    expect(getPaneLayout()).toBe(getPaneLayouts()[0]);
+    expect(visibleSessionIds(getPaneLayout().root)).toEqual(["A"]);
+  });
+
+  it("follows the anchored session when a remote change moves its tab", () => {
+    // Two tabs; this window's route owns A and is looking at A's tab.
+    applyPreset("cols-2", "A", ["A"]);
+    applyPreset("cols-2", "B", ["B"]);
+    activatePaneLayoutForSession("A");
+    setRouteAnchorSession("A");
+    expect(visibleSessionIds(getPaneLayout().root)).toEqual(["A"]);
+
+    // Remote regroups A and B into a single pair; the separate tabs are gone.
+    const remote = serializeLayoutSet(
+      [applyPresetPure("cols-2", "B", ["B", "A"])],
+      0,
+    );
+    hydrateLayoutSet(remote);
+
+    // Active tab tracks A into the merged pair rather than falling out of it.
+    expect(getPaneLayouts()).toHaveLength(1);
+    expect(visibleSessionIds(getPaneLayout().root)).toContain("A");
+  });
+
+  it("does not let a background-tab activation rewrite the route anchor", () => {
+    // Route owns A; a separate background tab holds C/D.
+    applyPreset("cols-2", "A", ["A", "B"]);
+    applyPreset("cols-2", "C", ["C", "D"]);
+    activatePaneLayoutForSession("A"); // view A's tab
+    setRouteAnchorSession("A"); // route owns A
+
+    // Renaming the background C/D tab activates it without navigating —
+    // mirrors ChatTabGroup.submitRename. The route anchor must stay A.
+    activatePaneLayoutForSession("C");
+
+    // A remote change moves C elsewhere; A stays in its own tab (index 0).
+    const remote = serializeLayoutSet(
+      [
+        applyPresetPure("cols-2", "A", ["A", "B"]),
+        applyPresetPure("cols-2", "C", ["C", "X"]),
+      ],
+      1,
+    );
+    hydrateLayoutSet(remote);
+
+    // Anchored on A, not the just-activated C, so we stay on A's tab.
+    expect(getPaneLayout()).toBe(getPaneLayouts()[0]);
+    expect(slotSessions(getPaneLayout())).toEqual(["A", "B"]);
+  });
+
+  it("marks hydrated members fresh so the vanished-session sweep spares them", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    applyPreset("single", "A", ["A"]);
+
+    // Remote fills a pane with a chat this window's row cache hasn't seen.
+    const remote = serializeLayoutSet(
+      [applyPresetPure("cols-2", "A", ["A", "just-made-elsewhere"])],
+      0,
+    );
+    hydrateLayoutSet(remote);
+
+    expect(isFreshlyAssigned("just-made-elsewhere")).toBe(true);
   });
 
   it("converges collapsed state from the broadcasting window", () => {

--- a/src/lib/paneLayout.test.ts
+++ b/src/lib/paneLayout.test.ts
@@ -581,3 +581,51 @@ describe("serializeLayout / deserializeLayout", () => {
     expect(restored!.focusedPaneId).toBe(leaves(restored!.root)[0].id);
   });
 });
+
+describe("cold-start hydration", () => {
+  const STORAGE_KEY = "runner.chat.layout";
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.doUnmock("@tauri-apps/api/window");
+    vi.doUnmock("@tauri-apps/api/event");
+    vi.resetModules();
+  });
+
+  it("loads the shared persisted set in a secondary window", async () => {
+    // The env's localStorage is a partial shim; back it with a Map so both
+    // the seed write and the freshly-imported module see the same store.
+    const store = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+      setItem: (k: string, v: string) => void store.set(k, String(v)),
+      removeItem: (k: string) => void store.delete(k),
+      clear: () => store.clear(),
+    });
+
+    // The main window persisted a grouped tab; now a secondary window opens.
+    localStorage.setItem(
+      STORAGE_KEY,
+      serializeLayoutSet([applyPresetPure("cols-2", "A", ["A", "B"])], 0),
+    );
+    vi.resetModules();
+    vi.doMock("@tauri-apps/api/window", () => ({
+      getCurrentWindow: () => ({ label: "window-secondary" }),
+    }));
+    vi.doMock("@tauri-apps/api/event", () => ({
+      emit: () => Promise.resolve(),
+      listen: () => Promise.resolve(() => {}),
+    }));
+
+    const mod = await import("./paneLayout");
+
+    // Even though a secondary window never WRITES localStorage, it now reads
+    // the shared set on cold start, so the tab structure shows immediately.
+    const tabs = mod.getPaneLayouts();
+    expect(tabs).toHaveLength(1);
+    expect(mod.leaves(tabs[0].root).map((l) => l.sessionId)).toEqual([
+      "A",
+      "B",
+    ]);
+  });
+});

--- a/src/lib/paneLayout.test.ts
+++ b/src/lib/paneLayout.test.ts
@@ -12,6 +12,7 @@ import {
   getPaneLayout,
   getPaneLayouts,
   getPaneLayoutsForTest,
+  hydrateLayoutSet,
   isGroupActiveFor,
   isFreshlyAssigned,
   leaves,
@@ -19,8 +20,10 @@ import {
   removeSessionPure,
   resetPaneLayoutsForTest,
   serializeLayout,
+  serializeLayoutSet,
   setSizesPure,
   setTabCollapsed,
+  subscribePaneLayout,
   visibleSessionIds,
   type PaneLayout,
   type PaneSplit,
@@ -298,6 +301,71 @@ describe("setTabCollapsed", () => {
     setTabCollapsed("missing", true);
     setTabCollapsed(7, true);
 
+    expect(getPaneLayouts()).toBe(before);
+  });
+});
+
+describe("hydrateLayoutSet (cross-window sync)", () => {
+  afterEach(() => {
+    resetPaneLayoutsForTest();
+  });
+
+  it("replaces the store with a set broadcast from another window and notifies subscribers", () => {
+    // Local state: a single tab on chat A.
+    applyPreset("single", "A", ["A"]);
+
+    // A remote window's serialized set: two tabs, second one active.
+    const remote = serializeLayoutSet(
+      [
+        applyPresetPure("cols-2", "A", ["A", "B"]),
+        applyPresetPure("cols-2", "C", ["C", "D"]),
+      ],
+      1,
+    );
+
+    let notified = 0;
+    const unsub = subscribePaneLayout(() => {
+      notified += 1;
+    });
+    const applied = hydrateLayoutSet(remote);
+    unsub();
+
+    expect(applied).toBe(true);
+    expect(notified).toBe(1);
+    const tabs = getPaneLayouts();
+    expect(tabs).toHaveLength(2);
+    expect(slotSessions(tabs[0])).toEqual(["A", "B"]);
+    expect(slotSessions(tabs[1])).toEqual(["C", "D"]);
+    // The remote active tab wins so every window agrees on the front tab.
+    expect(getPaneLayout()).toBe(tabs[1]);
+  });
+
+  it("converges collapsed state from the broadcasting window", () => {
+    applyPreset("cols-2", "A", ["A", "B"]);
+    expect(getPaneLayouts()[0].collapsed ?? false).toBe(false);
+
+    const remote = serializeLayoutSet(
+      [{ ...applyPresetPure("cols-2", "A", ["A", "B"]), collapsed: true }],
+      0,
+    );
+    hydrateLayoutSet(remote);
+
+    expect(getPaneLayouts()[0].collapsed).toBe(true);
+  });
+
+  it("no-ops and returns false on a malformed payload", () => {
+    applyPreset("cols-2", "A", ["A", "B"]);
+    const before = getPaneLayouts();
+
+    let notified = 0;
+    const unsub = subscribePaneLayout(() => {
+      notified += 1;
+    });
+    expect(hydrateLayoutSet("not json")).toBe(false);
+    expect(hydrateLayoutSet("null")).toBe(false);
+    unsub();
+
+    expect(notified).toBe(0);
     expect(getPaneLayouts()).toBe(before);
   });
 });

--- a/src/lib/paneLayout.ts
+++ b/src/lib/paneLayout.ts
@@ -550,6 +550,13 @@ let layouts: PaneLayout[] = persisted?.layouts ?? [singleLayout()];
 let activeIndex = persisted?.activeIndex ?? 0;
 const listeners = new Set<() => void>();
 
+// The chat this window owns via its route — the last non-null session passed
+// to `setRouteAnchorSession` (only RunnerChat's URL effect calls it). This is
+// the anchor for cross-window hydration: it is local to this window and,
+// unlike a tab's `focusedPaneId`, never carried in the synced payload, so a
+// remote change can't move it off the tab it renders.
+let routeAnchorSession: string | null = null;
+
 function currentLayout(): PaneLayout {
   return layouts[activeIndex] ?? layouts[0] ?? singleLayout();
 }
@@ -628,7 +635,36 @@ function broadcastLayoutSet(): void {
 export function hydrateLayoutSet(raw: string): boolean {
   const parsed = deserializeLayoutSet(raw);
   if (!parsed) return false;
-  applyLayoutSet(parsed.layouts, parsed.activeIndex);
+
+  // Tab membership / sizes / collapsed / names converge, but activeIndex is
+  // per-window view state bound to this window's route. Adopting the
+  // sender's would repoint `currentLayout()` away from the tab this window
+  // renders, so a local `closePane`/`focusPane`/`setGroupName` would mutate
+  // the wrong tab. Keep our own active tab: re-find, in the incoming set,
+  // the tab showing our route session (`routeAnchorSession` — local, and
+  // not part of the synced payload, unlike a tab's focused pane). Fall back
+  // to clamping our index into range when we don't own a route yet.
+  const anchor = routeAnchorSession;
+  const anchoredIndex =
+    anchor !== null
+      ? parsed.layouts.findIndex((l) => leafForSession(l.root, anchor))
+      : -1;
+  const nextActive =
+    anchoredIndex >= 0
+      ? anchoredIndex
+      : Math.min(activeIndex, parsed.layouts.length - 1);
+
+  // Members may be sessions this window's row cache hasn't observed yet (a
+  // chat just created in another window). Mark them fresh so RunnerChat's
+  // vanished-session sweep leaves them alone until the rows catch up,
+  // instead of evicting them and broadcasting the stale layout back.
+  for (const l of parsed.layouts) {
+    for (const sid of visibleSessionIds(l.root)) {
+      freshAssignments.set(sid, Date.now());
+    }
+  }
+
+  applyLayoutSet(parsed.layouts, nextActive);
   return true;
 }
 
@@ -674,6 +710,17 @@ export function usePaneLayouts(): PaneLayout[] {
   );
 }
 
+/**
+ * Record the chat this window owns via its route, for cross-window hydration
+ * to anchor on. Only RunnerChat's URL effect should call this — generic tab
+ * activations (a sidebar pick, renaming a background tab) reactivate a tab
+ * without owning it as the route, and must not move the anchor. Keeps the
+ * last non-null id so navigating to a non-chat surface doesn't drop it.
+ */
+export function setRouteAnchorSession(sessionId: string | null): void {
+  if (sessionId !== null) routeAnchorSession = sessionId;
+}
+
 export function activatePaneLayoutForSession(
   sessionId: string | null,
 ): PaneLayout {
@@ -692,6 +739,7 @@ export function resetPaneLayoutsForTest(
   const normalized = normalizeLayoutSet(nextLayouts, nextActiveIndex);
   layouts = normalized.layouts;
   activeIndex = normalized.activeIndex;
+  routeAnchorSession = null;
   freshAssignments.clear();
   for (const l of listeners) l();
 }
@@ -802,9 +850,12 @@ export function closePane(paneId: string): PaneLayout {
   return currentLayout();
 }
 
-/** Record live gutter sizes without notifying subscribers — the panel lib
- *  owns the visual truth during a drag; this only keeps the model (and
- *  the persisted copy) current. Fires on drag end, not per frame. */
+/** Record live gutter sizes without notifying local subscribers — the panel
+ *  lib owns the visual truth during a drag; this only keeps the model (and
+ *  the persisted copy) current. Fires on drag end, not per frame. Sizes are
+ *  part of the serialized payload, so it also broadcasts: other windows are
+ *  not mid-drag and reconverge on the new sizes, and the main window's
+ *  localStorage picks up a resize made in a secondary window. */
 export function recordSplitSizes(
   splitId: string,
   sizes: [number, number],
@@ -820,4 +871,5 @@ export function recordSplitSizes(
   };
   walk(currentLayout().root);
   persistLayoutSet();
+  broadcastLayoutSet();
 }

--- a/src/lib/paneLayout.ts
+++ b/src/lib/paneLayout.ts
@@ -441,10 +441,13 @@ try {
   windowLabel = null;
 }
 
-// Persist for the main window only: localStorage is shared by every
-// webview window, and secondary windows' labels (`window-<ulid>`) don't
-// survive a relaunch — persisting theirs would only clobber the main
-// window's pane tabs. Off-Tauri there is a single "window", so persist.
+// localStorage is shared by every webview window. WRITES stay main-window
+// only: secondary windows' labels (`window-<ulid>`) don't survive a relaunch,
+// so persisting theirs would only clobber the main window's pane tabs (a
+// secondary's live changes still reach storage — they broadcast, the main
+// window hydrates and persists). READS, however, are open to every window so
+// a freshly-opened one cold-starts from the current structure instead of a
+// blank single pane. Off-Tauri there is a single "window", so it persists.
 const persistToStorage = windowLabel === null || windowLabel === "main";
 
 // ---- module store -------------------------------------------------------
@@ -497,11 +500,13 @@ export function serializeLayoutSet(
   } satisfies PersistedLayoutSet);
 }
 
+// Read the shared persisted set for ANY window (see `persistToStorage`):
+// secondary windows load the main window's structure on cold start, then
+// track live changes over the broadcast channel.
 function readPersistedLayoutSet(): {
   layouts: PaneLayout[];
   activeIndex: number;
 } | null {
-  if (!persistToStorage) return null;
   try {
     const raw = localStorage.getItem(STORAGE_LAYOUT);
     return raw ? deserializeLayoutSet(raw) : null;

--- a/src/lib/paneLayout.ts
+++ b/src/lib/paneLayout.ts
@@ -14,6 +14,7 @@
 
 import { useSyncExternalStore } from "react";
 
+import { emit, listen } from "@tauri-apps/api/event";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 
 export type PresetKind =
@@ -430,17 +431,21 @@ export function deserializeLayout(raw: string): PaneLayout | null {
   }
 }
 
+// This window's Tauri label (`main` or `window-<ulid>`), resolved once at
+// module load. Null off-Tauri (dev browser preview), where the cross-window
+// broadcast/listen below all no-op.
+let windowLabel: string | null = null;
+try {
+  windowLabel = getCurrentWindow().label;
+} catch {
+  windowLabel = null;
+}
+
 // Persist for the main window only: localStorage is shared by every
 // webview window, and secondary windows' labels (`window-<ulid>`) don't
 // survive a relaunch — persisting theirs would only clobber the main
-// window's pane tabs.
-let persistToStorage = false;
-try {
-  persistToStorage = getCurrentWindow().label === "main";
-} catch {
-  // Dev browser preview — single "window", persist normally.
-  persistToStorage = true;
-}
+// window's pane tabs. Off-Tauri there is a single "window", so persist.
+const persistToStorage = windowLabel === null || windowLabel === "main";
 
 // ---- module store -------------------------------------------------------
 
@@ -481,7 +486,7 @@ function deserializeLayoutSet(
   }
 }
 
-function serializeLayoutSet(
+export function serializeLayoutSet(
   layouts: PaneLayout[],
   activeIndex: number,
 ): string {
@@ -554,7 +559,11 @@ function findLayoutIndexForSession(sessionId: string | null): number {
   return layouts.findIndex((layout) => leafForSession(layout.root, sessionId));
 }
 
-function setLayoutSet(
+// Commit a new layout set to the in-window store: normalize, swap in the
+// fresh arrays, persist (main window only), and notify subscribers. Does
+// NOT broadcast — the remote-hydration path reuses this so a received
+// change never echoes back out.
+function applyLayoutSet(
   nextLayouts: PaneLayout[],
   nextActiveIndex: number,
 ): void {
@@ -565,11 +574,71 @@ function setLayoutSet(
   for (const l of listeners) l();
 }
 
+function setLayoutSet(
+  nextLayouts: PaneLayout[],
+  nextActiveIndex: number,
+): void {
+  applyLayoutSet(nextLayouts, nextActiveIndex);
+  broadcastLayoutSet();
+}
+
 function setCurrent(next: PaneLayout): void {
   if (next === currentLayout()) return;
   const nextLayouts = [...layouts];
   nextLayouts[activeIndex] = next;
   setLayoutSet(nextLayouts, activeIndex);
+}
+
+// ---- cross-window sync (issue #258) -------------------------------------
+//
+// The store is per window and in-memory, so a tab/pane change in one window
+// left the others stale. Mirror how pins converge: every mutation through
+// `setLayoutSet` broadcasts the serialized set over a frontend Tauri event,
+// and every window reloads it. The change carries its origin window label so
+// a window ignores its own echo (Tauri `emit` also delivers to the sender);
+// the hydrate path reuses `applyLayoutSet`, which never re-broadcasts, so
+// there is no feedback loop.
+
+const LAYOUT_CHANGED_EVENT = "chat/layout-changed";
+
+interface LayoutChangedEvent {
+  /** Tauri label of the window that made the change; receivers drop their
+   *  own echo by comparing it to their own label. */
+  origin: string;
+  /** Serialized `PersistedLayoutSet` — the same payload localStorage holds. */
+  set: string;
+}
+
+function broadcastLayoutSet(): void {
+  if (windowLabel === null) return; // off-Tauri: nothing to sync
+  void emit(LAYOUT_CHANGED_EVENT, {
+    origin: windowLabel,
+    set: serializeLayoutSet(layouts, activeIndex),
+  } satisfies LayoutChangedEvent).catch(() => {
+    // best-effort; other windows converge on the next change
+  });
+}
+
+/**
+ * Apply a layout set received from another window: hydrate the in-memory
+ * store and notify subscribers, without re-broadcasting (echo guard). No-op
+ * and returns false on a malformed payload. Exported for the sync listener
+ * and its unit test.
+ */
+export function hydrateLayoutSet(raw: string): boolean {
+  const parsed = deserializeLayoutSet(raw);
+  if (!parsed) return false;
+  applyLayoutSet(parsed.layouts, parsed.activeIndex);
+  return true;
+}
+
+if (windowLabel !== null) {
+  void listen<LayoutChangedEvent>(LAYOUT_CHANGED_EVENT, (event) => {
+    if (event.payload.origin === windowLabel) return; // ignore own echo
+    hydrateLayoutSet(event.payload.set);
+  }).catch(() => {
+    // Tauri unavailable — cross-window sync simply no-ops.
+  });
 }
 
 export function getPaneLayout(sessionId: string | null = null): PaneLayout {

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -69,6 +69,7 @@ import {
   leaves,
   removeSessionFromLayout,
   setGroupName,
+  setRouteAnchorSession,
   usePaneLayout,
   visibleSessionIds,
   type PaneLeaf,
@@ -301,6 +302,9 @@ export default function RunnerChat() {
   // group stays intact in the background until a member is opened again.
   const layout = usePaneLayout(sessionId);
   useEffect(() => {
+    // This is the authoritative route signal: record the session this window
+    // owns so cross-window layout hydration anchors on it (paneLayout.ts).
+    setRouteAnchorSession(sessionId);
     activatePaneLayoutForSession(sessionId);
   }, [sessionId]);
   const splitActive = isGroupActiveFor(layout, sessionId);


### PR DESCRIPTION
## Summary

Fixes #258 — a multi-pane tab/pane layout change made in one window now converges to every other open window, and a newly-opened window shows the existing structure, the way pins already do.

The pane/tab layout store (`src/lib/paneLayout.ts`) was **per-window and in-memory**: `setLayoutSet` only notified in-window `useSyncExternalStore` subscribers, and its only persistence was the **main-window-only, write-only** localStorage key `runner.chat.layout`. No Tauri emit/listen, no BroadcastChannel, no DB round-trip — so split/group/regroup/collapse in window A never reached window B, and a freshly-opened window started blank.

## Approach

Mirror the pins convergence path, kept **frontend-only** since tabs are frontend-only (impl 0023):

- `setLayoutSet` splits into `applyLayoutSet` (normalize → swap → persist → notify) and a thin `setLayoutSet` that also calls `broadcastLayoutSet()`.
- `broadcastLayoutSet` emits the serialized `PersistedLayoutSet` over a `chat/layout-changed` Tauri event, tagged with the origin window label.
- Every window listens, **ignores its own echo** (Tauri `emit` delivers to the sender too) by comparing `origin` to its own label, then hydrates via `hydrateLayoutSet` → `applyLayoutSet`, which **never re-broadcasts** → no feedback loop.
- **Cold start**: localStorage is shared across webview windows, so reads are open to every window (writes stay main-only). A newly-opened secondary window loads the main window's persisted structure immediately, then tracks live changes over the broadcast channel. Its own edits still reach storage via broadcast → main hydrate → main persist, so there is no clobbering.
- **Off-Tauri (dev browser)**: the window label resolves once in a try/catch (null); the emit and the module-load listener both no-op.

### What converges vs. what stays per-window

Tab **membership, pane→session assignments, split sizes, collapsed state, and group names** converge. The **active tab (`activeIndex`) stays per-window**: it is view state bound to each window's route, and local mutators (`closePane`/`focusPane`/`setGroupName`) target `currentLayout()`. On hydrate, a window keeps its own active tab by re-finding, in the incoming set, the tab holding **its route session** — recorded via a dedicated `setRouteAnchorSession` called only from RunnerChat's URL effect (so a sidebar pick or background-tab rename can't move the anchor). Anchoring on the route session rather than a tab's `focusedPaneId` matters because focus itself is synced.

Two supporting fixes surfaced in review:
- Hydrated members are marked **fresh** so RunnerChat's vanished-session sweep doesn't evict a chat just created in another window before this window's row refresh sees it (which would rebroadcast the stale layout).
- `recordSplitSizes` now **broadcasts** on drag-end so sizes converge and a secondary-window resize reaches the main window's localStorage.

## Scope

Fixes **only** #258. Does not touch #259 (duplicate-subject / conflict overlay). No Rust changes.

## Checks

- `pnpm exec tsc --noEmit` — clean
- `pnpm run lint` — clean
- `pnpm exec vitest run` — 70 passed (9 sync cases: membership convergence, route-anchor preservation, anchor-vs-synced-focus, background-tab anchor isolation, follow-anchor-on-move, fresh-marking, collapsed convergence, malformed no-op, secondary-window cold start)

Reviewed on the working-tree diff across rounds before/while this PR was open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)