### PR TITLE
refactor(db): remove deprecated crews.orchestrator_policy column

### DIFF
--- a/src-tauri/migrations/0008_drop_crews_orchestrator_policy.sql
+++ b/src-tauri/migrations/0008_drop_crews_orchestrator_policy.sql
@@ -1,0 +1,9 @@
+-- Drop `crews.orchestrator_policy` — deprecated in #247 (superseded by
+-- `system_prompt_addendum`) and since then read-only: never written and
+-- spliced into no prompt. Removing the column is behavior-neutral; the
+-- frozen legacy values on existing rows are intentionally discarded.
+--
+-- SQLite 3.35+ supports `ALTER TABLE ... DROP COLUMN` directly; the
+-- bundled rusqlite is fine.
+
+ALTER TABLE crews DROP COLUMN orchestrator_policy;

--- a/src-tauri/src/commands/crew.rs
+++ b/src-tauri/src/commands/crew.rs
@@ -35,8 +35,6 @@ pub struct UpdateCrewInput {
     pub name: Option<String>,
     pub purpose: Option<Option<String>>,
     pub goal: Option<Option<String>>,
-    // `orchestrator_policy` is deprecated (superseded by
-    // `system_prompt_addendum`) and no longer accepted for write. See #247.
     /// Outer None = leave existing untouched; outer Some(inner) =
     /// write inner. Inner Some("") / whitespace-only collapses to
     /// NULL.
@@ -155,7 +153,6 @@ pub fn create(conn: &Connection, input: CreateCrewInput) -> Result<Crew> {
             name: name.to_string(),
             purpose: input.purpose,
             goal: input.goal,
-            orchestrator_policy: None,
             system_prompt_addendum: addendum,
             created_at: ts,
             updated_at: ts,
@@ -185,10 +182,6 @@ pub fn update(conn: &Connection, id: &str, input: UpdateCrewInput) -> Result<Cre
         None => existing.system_prompt_addendum,
     };
 
-    // `orchestrator_policy` is deprecated (superseded by
-    // `system_prompt_addendum`) and intentionally not written here — the
-    // column is retained for existing rows but no longer maintained. See
-    // #247. The repo's update column list excludes it.
     repo::crew::update(
         conn,
         &repo::crew::CrewRow {
@@ -196,7 +189,6 @@ pub fn update(conn: &Connection, id: &str, input: UpdateCrewInput) -> Result<Cre
             name,
             purpose,
             goal,
-            orchestrator_policy: None,
             system_prompt_addendum,
             created_at: existing.created_at,
             updated_at: now(),

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -72,6 +72,9 @@ fn init_connection(conn: &mut Connection) -> rusqlite::Result<()> {
 // 0007: makes direct-chat `sessions.runner_id` nullable and adds
 // `agent_runtime` / `agent_command` so runtime-only chats can resume
 // without a persisted runner template (#195).
+// 0008: drops `crews.orchestrator_policy`. Deprecated in #247
+// (superseded by `system_prompt_addendum`) and read-only since; it
+// fed no prompt and was never written, so the drop is behavior-neutral.
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, include_str!("../migrations/0001_init.sql")),
     (2, include_str!("../migrations/0002_persona_only_seeds.sql")),
@@ -91,6 +94,10 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (
         7,
         include_str!("../migrations/0007_direct_runtime_sessions.sql"),
+    ),
+    (
+        8,
+        include_str!("../migrations/0008_drop_crews_orchestrator_policy.sql"),
     ),
 ];
 
@@ -478,14 +485,6 @@ mod tests {
     fn json_blob_columns_roundtrip() {
         let pool = open_in_memory().unwrap();
         let conn = pool.get().unwrap();
-        insert_crew(&conn, "c1");
-
-        let policy = serde_json::json!([{"when": {"signal": "ask_lead"}, "do": "inject_stdin"}]);
-        conn.execute(
-            "UPDATE crews SET orchestrator_policy = ?1 WHERE id = 'c1'",
-            params![policy.to_string()],
-        )
-        .unwrap();
 
         let env = serde_json::json!({"FOO": "bar", "BAZ": "qux"});
         let args = serde_json::json!(["--flag", "--val=1"]);
@@ -497,18 +496,6 @@ mod tests {
             params![args.to_string(), env.to_string(), "2026-04-22T00:00:00Z"],
         )
         .unwrap();
-
-        let policy_raw: String = conn
-            .query_row(
-                "SELECT orchestrator_policy FROM crews WHERE id = 'c1'",
-                [],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(
-            serde_json::from_str::<serde_json::Value>(&policy_raw).unwrap(),
-            policy
-        );
 
         let (args_raw, env_raw): (String, String) = conn
             .query_row(

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -23,11 +23,6 @@ pub struct Crew {
     pub name: String,
     pub purpose: Option<String>,
     pub goal: Option<String>,
-    /// DEPRECATED (#247): superseded by `system_prompt_addendum` as the
-    /// single crew-level prompt layer. The column is retained for
-    /// existing rows and still read here, but it is no longer written or
-    /// spliced into any prompt. Do not add new reads.
-    pub orchestrator_policy: Option<serde_json::Value>,
     /// Layer-2 team conventions text. Spliced between the platform
     /// preamble and the runner persona on mission spawns only;
     /// direct chats ignore it. NULL / empty = no splice. See #54.
@@ -58,13 +53,13 @@ pub struct Runner {
     /// Optional pinned model name (e.g. `claude-opus-4-7`,
     /// `gpt-5`). When set, the runtime adapter passes it through as
     /// the agent CLI's model flag (claude-code: `--model`). NULL =
-    /// inherit the agent's own default. See migration 0008.
+    /// inherit the agent's own default. Column lives in `0001_init.sql`.
     #[serde(default)]
     pub model: Option<String>,
     /// Optional thinking-effort hint (e.g. `xhigh`, `high`,
     /// `medium`). claude-code accepts an effort flag; codex's
     /// equivalent is wired in the runtime adapter. NULL = inherit
-    /// the agent's own default. See migration 0008.
+    /// the agent's own default. Column lives in `0001_init.sql`.
     #[serde(default)]
     pub effort: Option<String>,
     pub created_at: Timestamp,

--- a/src-tauri/src/repo/crew.rs
+++ b/src-tauri/src/repo/crew.rs
@@ -1,9 +1,4 @@
 // `crews` table — the top-level container for a team of runners.
-//
-// `orchestrator_policy` is deprecated (#247, superseded by
-// `system_prompt_addendum`): the row struct keeps it so reads and the
-// serialized `Crew` shape are unaffected, but it is excluded from every
-// write column list — the column is never written again.
 
 use rusqlite::{Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
@@ -19,9 +14,6 @@ pub struct CrewRow {
     pub name: String,
     pub purpose: Option<String>,
     pub goal: Option<String>,
-    /// Read-only (#247): kept for existing rows, never in a write list.
-    #[serde(with = "crate::repo::serde::json_text_opt")]
-    pub orchestrator_policy: Option<serde_json::Value>,
     pub system_prompt_addendum: Option<String>,
     #[serde(with = "crate::repo::serde::rfc3339")]
     pub created_at: Timestamp,
@@ -30,19 +22,6 @@ pub struct CrewRow {
 }
 
 pub const COLUMNS: &[&str] = &[
-    "id",
-    "name",
-    "purpose",
-    "goal",
-    "orchestrator_policy",
-    "system_prompt_addendum",
-    "created_at",
-    "updated_at",
-];
-
-/// Write column list — `COLUMNS` minus the read-only
-/// `orchestrator_policy`.
-const INSERT_COLUMNS: &[&str] = &[
     "id",
     "name",
     "purpose",
@@ -68,7 +47,6 @@ impl From<CrewRow> for Crew {
             name: r.name,
             purpose: r.purpose,
             goal: r.goal,
-            orchestrator_policy: r.orchestrator_policy,
             system_prompt_addendum: r.system_prompt_addendum,
             created_at: r.created_at,
             updated_at: r.updated_at,
@@ -83,7 +61,6 @@ impl From<&Crew> for CrewRow {
             name: c.name.clone(),
             purpose: c.purpose.clone(),
             goal: c.goal.clone(),
-            orchestrator_policy: c.orchestrator_policy.clone(),
             system_prompt_addendum: c.system_prompt_addendum.clone(),
             created_at: c.created_at,
             updated_at: c.updated_at,
@@ -93,8 +70,8 @@ impl From<&Crew> for CrewRow {
 
 pub fn insert(conn: &Connection, row: &CrewRow) -> rusqlite::Result<()> {
     conn.execute(
-        &insert_sql("crews", INSERT_COLUMNS),
-        to_params_named_with_fields(row, INSERT_COLUMNS)
+        &insert_sql("crews", COLUMNS),
+        to_params_named_with_fields(row, COLUMNS)
             .map_err(ser_err)?
             .to_slice()
             .as_slice(),
@@ -187,7 +164,6 @@ mod tests {
             name: "Full crew".into(),
             purpose: Some("purpose".into()),
             goal: Some("goal".into()),
-            orchestrator_policy: None, // never written through the repo
             system_prompt_addendum: Some("squash PRs against main".into()),
             created_at: now,
             updated_at: now,
@@ -201,7 +177,6 @@ mod tests {
             name: "Minimal".into(),
             purpose: None,
             goal: None,
-            orchestrator_policy: None,
             system_prompt_addendum: None,
             created_at: now,
             updated_at: now,
@@ -220,30 +195,22 @@ mod tests {
     }
 
     #[test]
-    fn legacy_rows_read_cleanly_including_policy_json_and_z_timestamps() {
+    fn legacy_rows_read_cleanly_including_z_timestamps() {
         let pool = db::open_in_memory().unwrap();
         let conn = pool.get().unwrap();
-        // Raw SQL in today's exact stored formats: `Z` timestamps (seed
-        // shape) and a JSON TEXT orchestrator_policy written by the
-        // pre-#247 update path.
+        // Raw SQL in today's exact stored formats: mixed `Z` (seed shape)
+        // and `+00:00` timestamp spellings must both parse.
         conn.execute(
             r#"INSERT INTO crews
-                (id, name, purpose, goal, orchestrator_policy,
-                 system_prompt_addendum, created_at, updated_at)
-             VALUES ('c-legacy', 'Legacy', NULL, 'ship it',
-                     '[{"when":{"signal":"ask_lead"},"do":"inject_stdin"}]',
-                     NULL, '2026-05-03T00:00:00Z', '2026-05-03T00:00:00+00:00')"#,
+                (id, name, purpose, goal, system_prompt_addendum,
+                 created_at, updated_at)
+             VALUES ('c-legacy', 'Legacy', NULL, 'ship it', NULL,
+                     '2026-05-03T00:00:00Z', '2026-05-03T00:00:00+00:00')"#,
             [],
         )
         .unwrap();
 
         let crew = get(&conn, "c-legacy").unwrap().unwrap();
-        assert_eq!(
-            crew.orchestrator_policy,
-            Some(serde_json::json!([
-                {"when": {"signal": "ask_lead"}, "do": "inject_stdin"}
-            ]))
-        );
         assert_eq!(
             crew.created_at, crew.updated_at,
             "both spellings, same instant"
@@ -266,48 +233,6 @@ mod tests {
             .unwrap();
         assert_eq!(created_raw, row.created_at.to_rfc3339());
         assert_eq!(updated_raw, row.updated_at.to_rfc3339());
-    }
-
-    #[test]
-    fn orchestrator_policy_is_never_written_by_insert_or_update() {
-        let pool = db::open_in_memory().unwrap();
-        let conn = pool.get().unwrap();
-        let mut row = full_row();
-        // Even a row struct carrying a policy value must not write it.
-        row.orchestrator_policy = Some(serde_json::json!({"drift": true}));
-        insert(&conn, &row).unwrap();
-        let stored: Option<String> = conn
-            .query_row(
-                "SELECT orchestrator_policy FROM crews WHERE id = 'c-full'",
-                [],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(stored, None, "insert must not write orchestrator_policy");
-
-        // Seed a legacy policy by raw SQL, then update through the repo —
-        // the legacy value must survive untouched.
-        conn.execute(
-            "UPDATE crews SET orchestrator_policy = '{\"keep\":1}' WHERE id = 'c-full'",
-            [],
-        )
-        .unwrap();
-        row.name = "Renamed".into();
-        update(&conn, &row).unwrap();
-        let stored: Option<String> = conn
-            .query_row(
-                "SELECT orchestrator_policy FROM crews WHERE id = 'c-full'",
-                [],
-                |r| r.get(0),
-            )
-            .unwrap();
-        assert_eq!(stored.as_deref(), Some("{\"keep\":1}"));
-        let name: String = conn
-            .query_row("SELECT name FROM crews WHERE id = 'c-full'", [], |r| {
-                r.get(0)
-            })
-            .unwrap();
-        assert_eq!(name, "Renamed");
     }
 
     #[test]

--- a/src-tauri/src/repo/serde.rs
+++ b/src-tauri/src/repo/serde.rs
@@ -10,8 +10,7 @@
 //     historical offset spellings (`+00:00` and `Z`).
 //   - `json_text` / `json_text_opt`: serialize any `Serialize` value through
 //     `serde_json::to_string` into a TEXT column — the same call the legacy
-//     write paths made for `args_json`, `env_json`, and
-//     `orchestrator_policy`.
+//     write paths made for `args_json` and `env_json`.
 
 pub mod rfc3339 {
     use chrono::{DateTime, Utc};

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -11,8 +11,8 @@
 //
 // What this is not. There is no policy engine, no rule abstraction, no
 // per-crew config in MVP. Handlers are a flat `match signal_type { … }`.
-// `crews.orchestrator_policy` is deprecated (#247), superseded by
-// `crew.system_prompt_addendum`; it is not read here or spliced anywhere.
+// The crew-level prompt layer is `crew.system_prompt_addendum`, spliced
+// on mission spawns — not read or acted on here.
 //
 // Per arch §5.5.0 invariant: messages never trigger router actions. Only
 // `EventKind::Signal` reaches the dispatcher; messages flow through the

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,10 +14,6 @@ export interface Crew {
   name: string;
   purpose: string | null;
   goal: string | null;
-  /** @deprecated (#247) superseded by `system_prompt_addendum` as the
-   *  single crew-level prompt layer. Still returned for existing rows,
-   *  but no longer written or spliced into any prompt. Not editable. */
-  orchestrator_policy: unknown | null;
   /** Layer-2 team conventions text. Spliced between the platform
    *  preamble and the runner persona on mission spawns only;
    *  direct chats ignore it. NULL / empty = no splice. See #54. */
@@ -232,7 +228,6 @@ export interface UpdateCrewInput {
   name?: string;
   purpose?: string | null;
   goal?: string | null;
-  // orchestrator_policy is deprecated (#247) and no longer writable.
   /** Omit to leave existing untouched; pass null to clear; pass a
    *  non-empty string to set. */
   system_prompt_addendum?: string | null;

--- a/tests/fixtures/crews/build-squad.seed.sh
+++ b/tests/fixtures/crews/build-squad.seed.sh
@@ -71,13 +71,12 @@ sqlite3 "$DB_PATH" <<SQL
 PRAGMA foreign_keys = ON;
 BEGIN;
 
-INSERT OR REPLACE INTO crews (id, name, purpose, goal, orchestrator_policy, created_at, updated_at)
+INSERT OR REPLACE INTO crews (id, name, purpose, goal, created_at, updated_at)
 VALUES (
   '$CREW_ID',
   'Build squad',
   'Plan, build, and review a single feature end-to-end. Architect dispatches, implementer ships, reviewer gates merge.',
   'Definition of done = code merged behind a green test suite and a clean review pass, with a one-paragraph human-readable summary posted as a broadcast.',
-  NULL,
   '$NOW',
   '$NOW'
 );


### PR DESCRIPTION
Follow-up to #247: remove the deprecated `orchestrator_policy` column from the crews persistence layer.

## Context
`orchestrator_policy` was deprecated in #247 (superseded by `system_prompt_addendum`) but only made read-only — the DB column, the row struct field, and the serialized shape were all kept on the READ path. It is spliced into no prompt and is never written, so removing it entirely is **behavior-neutral**.

## Changes
- **Migration** `0008_drop_crews_orchestrator_policy.sql` — forward-only `ALTER TABLE crews DROP COLUMN`, mirroring the `0006` signal-types-drop idiom; registered as version 8 in `db.rs`.
- **`repo/crew.rs`** — dropped the field from `CrewRow`, `COLUMNS`, both `From` impls, and test constructors; collapsed the now-identical `INSERT_COLUMNS` into `COLUMNS` (it existed solely to exclude this column); removed the obsolete `orchestrator_policy_is_never_written_by_insert_or_update` test; trimmed the policy bits from the legacy-rows read test.
- **`model.rs`**, **`commands/crew.rs`**, **`router/mod.rs`**, **`repo/serde.rs`** — removed the struct field, both `None` construction sites, and the stale reference comments.
- **`db.rs`** — stripped the `orchestrator_policy` half of `json_blob_columns_roundtrip` (kept `args_json`/`env_json` coverage).
- **`src/lib/types.ts`** — removed the field from `Crew` + the deprecated comment in `UpdateCrewInput`.
- **`build-squad.seed.sh`** — dropped the column from the crews INSERT.

## Migration safety
The drop is destructive of the frozen legacy values on existing rows — intended and desired. Both paths are verified by `migrations_bootstrap_all_tables`, which applies `0001→0008` sequentially, so `0008`'s `DROP` runs against a table that already has the column (the existing-DB upgrade path).

## Checks
- `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo test --workspace` green (333+ tests, 0 failed)
- `pnpm exec tsc --noEmit`, `pnpm run lint` clean
- `rg orchestrator_policy` returns no code hits outside the frozen `0001_init.sql` and the new `0008` drop migration