### PR TITLE
feat(ui): refresh sidebar collapse toggle, hover, and accordion

### DIFF
--- a/design/runners-design.pen
+++ b/design/runners-design.pen
@@ -41098,6 +41098,1036 @@
           ]
         }
       ]
+    },
+    {
+      "type": "frame",
+      "id": "n96Xi",
+      "x": -4568,
+      "y": 5410,
+      "name": "Sidebar toggle — #246 chrome spec",
+      "clip": true,
+      "width": 780,
+      "fill": "#0F1014",
+      "cornerRadius": 12,
+      "stroke": "#272930",
+      "strokeWidth": 1,
+      "strokeAlignment": "inner",
+      "layout": "vertical",
+      "gap": 24,
+      "padding": 32,
+      "children": [
+        {
+          "type": "frame",
+          "id": "Z0xZx",
+          "name": "header",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 6,
+          "children": [
+            {
+              "type": "text",
+              "id": "QW1wA",
+              "name": "title",
+              "fill": "#DCDCE0",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Sidebar collapse toggle",
+              "fontFamily": "Inter",
+              "fontSize": 20,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "aO80s",
+              "name": "subtitle",
+              "fill": "#9A9BA5",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "lucide PanelLeft glyph in the titlebar — one visible control in both states (#246, Codex-style)",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "CK2u9",
+          "name": "glyphStates",
+          "width": "fill_container",
+          "fill": "#15161B",
+          "cornerRadius": 10,
+          "stroke": "#272930",
+          "strokeWidth": 1,
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "gap": 16,
+          "padding": 20,
+          "children": [
+            {
+              "type": "text",
+              "id": "X0VsoT",
+              "name": "h",
+              "fill": "#9A9BA5",
+              "content": "Glyph — two states (drawn at size)",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "n8kqgg",
+              "name": "row",
+              "gap": 40,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "c4MmYw",
+                  "name": "card",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "d2NCj",
+                      "name": "tile",
+                      "width": 130,
+                      "height": 92,
+                      "fill": "#272930",
+                      "cornerRadius": 10,
+                      "stroke": "#272930",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "C9BdbF",
+                          "name": "glyph",
+                          "width": 60,
+                          "height": 46,
+                          "layout": "none",
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 9,
+                              "id": "URwjj",
+                              "x": 0,
+                              "y": 0,
+                              "name": "outer",
+                              "fill": "#00000000",
+                              "width": 60,
+                              "height": 46,
+                              "stroke": "#DCDCE0",
+                              "strokeWidth": 3,
+                              "strokeAlignment": "inner"
+                            },
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": [
+                                6,
+                                0,
+                                0,
+                                6
+                              ],
+                              "id": "sq4Nk",
+                              "x": 3,
+                              "y": 3,
+                              "name": "panel",
+                              "fill": "#DCDCE0",
+                              "width": 16,
+                              "height": 40
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Zw03Q",
+                      "name": "lbl",
+                      "fill": "#DCDCE0",
+                      "content": "Filled leading panel",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "GD2t5",
+                      "name": "sub",
+                      "fill": "#5A5C66",
+                      "content": "Expanded · sidebar shown",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "suHnk",
+                  "name": "card",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "fVUIB",
+                      "name": "tile",
+                      "width": 130,
+                      "height": 92,
+                      "fill": "#15161B",
+                      "cornerRadius": 10,
+                      "stroke": "#272930",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "DPkWy",
+                          "name": "glyph",
+                          "width": 60,
+                          "height": 46,
+                          "layout": "none",
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 9,
+                              "id": "CnXY7",
+                              "x": 0,
+                              "y": 0,
+                              "name": "outer",
+                              "fill": "#00000000",
+                              "width": 60,
+                              "height": 46,
+                              "stroke": "#DCDCE0",
+                              "strokeWidth": 3,
+                              "strokeAlignment": "inner"
+                            },
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 1.5,
+                              "id": "rSKh6",
+                              "x": 19,
+                              "y": 3,
+                              "name": "divider",
+                              "fill": "#DCDCE0",
+                              "width": 3,
+                              "height": 40
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "FBFUd",
+                      "name": "lbl",
+                      "fill": "#DCDCE0",
+                      "content": "Hollow panel-left",
+                      "fontFamily": "Inter",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "J03Pv0",
+                      "name": "sub",
+                      "fill": "#5A5C66",
+                      "content": "Collapsed · sidebar hidden",
+                      "fontFamily": "Inter",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "Lj8PC",
+              "name": "srcnote",
+              "fill": "#5A5C66",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "lucide panel-left ships the hollow state; the filled state matches macOS SF Symbols sidebar.left (no direct lucide equivalent — drawn here).",
+              "lineHeight": 1.35,
+              "fontFamily": "Inter",
+              "fontSize": 11.5,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "DTPuO",
+          "name": "states",
+          "width": "fill_container",
+          "gap": 24,
+          "children": [
+            {
+              "type": "frame",
+              "id": "SK0DB",
+              "name": "Expanded col",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "nyFGI",
+                  "name": "lbl",
+                  "fill": "#9A9BA5",
+                  "content": "Expanded",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "frame",
+                  "id": "zAUmp",
+                  "name": "window",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": 230,
+                  "fill": "#15161B",
+                  "cornerRadius": 10,
+                  "stroke": "#272930",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "h5TFFT",
+                      "name": "body",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "nJkoN",
+                          "name": "sidebar",
+                          "width": 162,
+                          "height": "fill_container",
+                          "fill": "#272930",
+                          "stroke": "#272930",
+                          "strokeWidth": {
+                            "right": 1
+                          },
+                          "strokeAlignment": "inner",
+                          "layout": "vertical",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "Xfjq3",
+                              "name": "titlebar",
+                              "width": "fill_container",
+                              "height": 40,
+                              "gap": 8,
+                              "padding": [
+                                0,
+                                12
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "a3re9L",
+                                  "name": "traffic",
+                                  "gap": 7,
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "ellipse",
+                                      "id": "gBk8F",
+                                      "name": "tl_r",
+                                      "fill": "#FF5F57",
+                                      "width": 11,
+                                      "height": 11
+                                    },
+                                    {
+                                      "type": "ellipse",
+                                      "id": "fudKq",
+                                      "name": "tl_y",
+                                      "fill": "#FEBC2E",
+                                      "width": 11,
+                                      "height": 11
+                                    },
+                                    {
+                                      "type": "ellipse",
+                                      "id": "y3e5W",
+                                      "name": "tl_g",
+                                      "fill": "#28C840",
+                                      "width": 11,
+                                      "height": 11
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "IYXk9",
+                                  "name": "toggle",
+                                  "width": 26,
+                                  "height": 26,
+                                  "fill": "#00000000",
+                                  "cornerRadius": 6,
+                                  "justifyContent": "center",
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "icon",
+                                      "id": "BBE0z",
+                                      "name": "glyph",
+                                      "width": 15,
+                                      "height": 15,
+                                      "icon": "panel-left",
+                                      "library": "lucide",
+                                      "fill": "#9A9BA5"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "xItCi",
+                              "name": "nav",
+                              "width": "fill_container",
+                              "layout": "vertical",
+                              "gap": 5,
+                              "padding": [
+                                2,
+                                10,
+                                10,
+                                10
+                              ],
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "ArcFW",
+                                  "name": "navrow",
+                                  "width": "fill_container",
+                                  "height": 26,
+                                  "fill": "#00000000",
+                                  "cornerRadius": 6,
+                                  "gap": 8,
+                                  "padding": [
+                                    0,
+                                    8
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "cornerRadius": 3,
+                                      "id": "gfb18",
+                                      "name": "ic",
+                                      "fill": "#5A5C66",
+                                      "width": 11,
+                                      "height": 11
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "cornerRadius": 3,
+                                      "id": "P78ce",
+                                      "name": "bar",
+                                      "fill": "#3A3C44",
+                                      "width": "fill_container",
+                                      "height": 6
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "JbMpZ",
+                                  "name": "navrow",
+                                  "width": "fill_container",
+                                  "height": 26,
+                                  "fill": "#333640",
+                                  "cornerRadius": 6,
+                                  "gap": 8,
+                                  "padding": [
+                                    0,
+                                    8
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "cornerRadius": 3,
+                                      "id": "dDRxd",
+                                      "name": "ic",
+                                      "fill": "#DCDCE0",
+                                      "width": 11,
+                                      "height": 11
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "cornerRadius": 3,
+                                      "id": "U21E7N",
+                                      "name": "bar",
+                                      "fill": "#9A9BA5",
+                                      "width": "fill_container",
+                                      "height": 6
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Dm7CB",
+                                  "name": "navrow",
+                                  "width": "fill_container",
+                                  "height": 26,
+                                  "fill": "#00000000",
+                                  "cornerRadius": 6,
+                                  "gap": 8,
+                                  "padding": [
+                                    0,
+                                    8
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "cornerRadius": 3,
+                                      "id": "Q71KL",
+                                      "name": "ic",
+                                      "fill": "#5A5C66",
+                                      "width": 11,
+                                      "height": 11
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "cornerRadius": 3,
+                                      "id": "tTdx5",
+                                      "name": "bar",
+                                      "fill": "#3A3C44",
+                                      "width": "fill_container",
+                                      "height": 6
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "INFH5",
+                                  "name": "navrow",
+                                  "width": "fill_container",
+                                  "height": 26,
+                                  "fill": "#00000000",
+                                  "cornerRadius": 6,
+                                  "gap": 8,
+                                  "padding": [
+                                    0,
+                                    8
+                                  ],
+                                  "alignItems": "center",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "cornerRadius": 3,
+                                      "id": "s7L25",
+                                      "name": "ic",
+                                      "fill": "#5A5C66",
+                                      "width": 11,
+                                      "height": 11
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "cornerRadius": 3,
+                                      "id": "iBSWV",
+                                      "name": "bar",
+                                      "fill": "#3A3C44",
+                                      "width": "fill_container",
+                                      "height": 6
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "QNLpr",
+                          "name": "main",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "fill": "#15161B",
+                          "layout": "vertical",
+                          "gap": 11,
+                          "padding": 16,
+                          "children": [
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 4,
+                              "id": "NpXWO",
+                              "name": "cbar",
+                              "fill": "#3A3C44",
+                              "width": 140,
+                              "height": 9
+                            },
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 4,
+                              "id": "m9K1iW",
+                              "name": "cbar",
+                              "fill": "#26272E",
+                              "width": 220,
+                              "height": 7
+                            },
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 4,
+                              "id": "YVGtx",
+                              "name": "cbar",
+                              "fill": "#26272E",
+                              "width": 190,
+                              "height": 7
+                            },
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 4,
+                              "id": "hPkr8",
+                              "name": "cbar",
+                              "fill": "#26272E",
+                              "width": 210,
+                              "height": 7
+                            },
+                            {
+                              "type": "rectangle",
+                              "cornerRadius": 4,
+                              "id": "QUR8T",
+                              "name": "cbar",
+                              "fill": "#26272E",
+                              "width": 120,
+                              "height": 7
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "EoMu8",
+              "name": "Collapsed col",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "LAUw6",
+                  "name": "lbl",
+                  "fill": "#9A9BA5",
+                  "content": "Collapsed",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "frame",
+                  "id": "Eit5Z",
+                  "name": "window",
+                  "clip": true,
+                  "width": "fill_container",
+                  "height": 230,
+                  "fill": "#15161B",
+                  "cornerRadius": 10,
+                  "stroke": "#272930",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "fcX8E",
+                      "name": "titlebar",
+                      "width": "fill_container",
+                      "height": 40,
+                      "fill": "#15161B",
+                      "gap": 8,
+                      "padding": [
+                        0,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "wcDgQ",
+                          "name": "traffic",
+                          "gap": 7,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "ellipse",
+                              "id": "IQhwz",
+                              "name": "tl_r",
+                              "fill": "#FF5F57",
+                              "width": 11,
+                              "height": 11
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "tjhhW",
+                              "name": "tl_y",
+                              "fill": "#FEBC2E",
+                              "width": 11,
+                              "height": 11
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "FpFtI",
+                              "name": "tl_g",
+                              "fill": "#28C840",
+                              "width": 11,
+                              "height": 11
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "HI25C",
+                          "name": "toggle",
+                          "width": 26,
+                          "height": 26,
+                          "fill": "#00000000",
+                          "cornerRadius": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "aNs7g",
+                              "name": "glyph",
+                              "width": 15,
+                              "height": 15,
+                              "icon": "panel-left",
+                              "library": "lucide",
+                              "fill": "#9A9BA5"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "q64mSJ",
+                      "name": "main",
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "fill": "#15161B",
+                      "layout": "vertical",
+                      "gap": 11,
+                      "padding": 16,
+                      "children": [
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 4,
+                          "id": "rGf9o",
+                          "name": "cbar",
+                          "fill": "#3A3C44",
+                          "width": 140,
+                          "height": 9
+                        },
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 4,
+                          "id": "I2Y01x",
+                          "name": "cbar",
+                          "fill": "#26272E",
+                          "width": 220,
+                          "height": 7
+                        },
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 4,
+                          "id": "gLG3t",
+                          "name": "cbar",
+                          "fill": "#26272E",
+                          "width": 190,
+                          "height": 7
+                        },
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 4,
+                          "id": "Bbxxl",
+                          "name": "cbar",
+                          "fill": "#26272E",
+                          "width": 210,
+                          "height": 7
+                        },
+                        {
+                          "type": "rectangle",
+                          "cornerRadius": 4,
+                          "id": "t0ouQ",
+                          "name": "cbar",
+                          "fill": "#26272E",
+                          "width": 120,
+                          "height": 7
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "G2wwS",
+                      "layoutPosition": "absolute",
+                      "x": 0,
+                      "y": 40,
+                      "name": "edge_hint",
+                      "width": 5,
+                      "height": 190,
+                      "fill": "#00FF9C1F"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dpz2z",
+          "name": "footer",
+          "width": "fill_container",
+          "gap": 24,
+          "children": [
+            {
+              "type": "frame",
+              "id": "arw34",
+              "name": "control",
+              "width": 300,
+              "fill": "#15161B",
+              "cornerRadius": 10,
+              "stroke": "#272930",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "layout": "vertical",
+              "gap": 14,
+              "padding": 18,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "oT0EO",
+                  "name": "h",
+                  "fill": "#9A9BA5",
+                  "content": "The control",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "frame",
+                  "id": "ZMFHS",
+                  "name": "btns",
+                  "gap": 22,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "zBOcQ",
+                      "name": "state",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "DZk6W",
+                          "name": "btn",
+                          "width": 40,
+                          "height": 40,
+                          "fill": "#00000000",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "h2j2y",
+                              "name": "glyph",
+                              "width": 22,
+                              "height": 22,
+                              "icon": "panel-left",
+                              "library": "lucide",
+                              "fill": "#9A9BA5"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "axRY7",
+                          "name": "cap",
+                          "fill": "#5A5C66",
+                          "content": "Default",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "cQBqK",
+                      "name": "state",
+                      "layout": "vertical",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "fRbh4",
+                          "name": "btn",
+                          "width": 40,
+                          "height": 40,
+                          "fill": "#FFFFFF14",
+                          "cornerRadius": 8,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "vV7FD",
+                              "name": "glyph",
+                              "width": 22,
+                              "height": 22,
+                              "icon": "panel-left",
+                              "library": "lucide",
+                              "fill": "#DCDCE0"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "cPkYc",
+                          "name": "cap",
+                          "fill": "#5A5C66",
+                          "content": "Hover",
+                          "fontFamily": "Inter",
+                          "fontSize": 11,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "AM4HN",
+                  "name": "glyphname",
+                  "fill": "#5A5C66",
+                  "content": "lucide · panel-left · 15px",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "PuAoc",
+              "name": "notes",
+              "width": "fill_container",
+              "fill": "#15161B",
+              "cornerRadius": 10,
+              "stroke": "#272930",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "layout": "vertical",
+              "gap": 10,
+              "padding": 18,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "kqrol",
+                  "name": "h",
+                  "fill": "#9A9BA5",
+                  "content": "Behavior",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "VCgc2",
+                  "name": "note",
+                  "fill": "#B8B9C2",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Placement — leading titlebar cluster, right after the traffic lights; the rest of the bar stays draggable.",
+                  "lineHeight": 1.35,
+                  "fontFamily": "Inter",
+                  "fontSize": 12.5,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "IUwfb",
+                  "name": "note",
+                  "fill": "#B8B9C2",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Glyph — lucide PanelLeft, replacing the old ChevronsLeft/Right button at the sidebar bottom (#196).",
+                  "lineHeight": 1.35,
+                  "fontFamily": "Inter",
+                  "fontSize": 12.5,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "HZ3lI",
+                  "name": "note",
+                  "fill": "#B8B9C2",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Persistence — the control lives in the window chrome, so it stays visible in both expanded and collapsed states.",
+                  "lineHeight": 1.35,
+                  "fontFamily": "Inter",
+                  "fontSize": 12.5,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "gmZ17",
+                  "name": "note",
+                  "fill": "#B8B9C2",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Secondary — the left-edge hover preview and “Keep sidebar open” pin are retained (accent strip on the collapsed edge).",
+                  "lineHeight": 1.35,
+                  "fontFamily": "Inter",
+                  "fontSize": 12.5,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "N1tYK",
+                  "name": "note",
+                  "fill": "#B8B9C2",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Shortcut — ⌘S still toggles the sidebar.",
+                  "lineHeight": 1.35,
+                  "fontFamily": "Inter",
+                  "fontSize": 12.5,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "fileToken": "238a5aa3-1778-4702-a0cc-856ec975f9ae"

--- a/src/components/ChatTabGroup.tsx
+++ b/src/components/ChatTabGroup.tsx
@@ -1,29 +1,21 @@
 // Sidebar accordion for a multi-pane tab (impl 0023). A tab with ≥2 member
-// chats renders as a disclosure header (chevron · split icon · name · pin
-// marker) over a left rail wrapping the member rows. Single-member and
-// un-tabbed chats never reach here — they stay flat `SessionRow` leaves.
+// chats renders as a disclosure header (split icon · name · pin marker · a
+// trailing collapse chevron) over a left rail wrapping the member rows.
+// Single-member and un-tabbed chats never reach here — they stay flat
+// `SessionRow` leaves.
 //
 // The members REUSE `SessionRow` so rename, pin, status dot, context menu and
 // the focused-pane accent bar keep working by construction; only the header +
-// rail are new chrome. Collapse is per-tab and persisted (the chevron toggles
-// it on any tab, active or not). The active on-screen tab carries an accent
-// rail and marks its focused member with the selected fill.
+// rail are new chrome. Collapse is per-tab and persisted; clicking the row (or
+// the trailing chevron) toggles it on any tab, active or not. The active
+// on-screen tab carries an accent rail and marks its focused member with the
+// selected fill.
 
-import { useEffect, useRef, useState } from "react";
-
-import {
-  ChevronDown,
-  ChevronRight,
-  Columns2,
-  Columns3,
-  Pin,
-} from "lucide-react";
+import { ChevronDown, Columns2, Columns3, Pin } from "lucide-react";
 
 import type { DirectSessionEntry } from "../lib/api";
 import {
-  activatePaneLayoutForSession,
   findLeaf,
-  setGroupName,
   setTabCollapsed,
   type PaneLayout,
 } from "../lib/paneLayout";
@@ -71,7 +63,6 @@ export function ChatTabGroup({
   onMemberRenameCancel: () => void;
 }) {
   const collapsed = !!layout.collapsed;
-  const [renaming, setRenaming] = useState(false);
 
   const paneFocusedSessionId =
     findLeaf(layout.root, layout.focusedPaneId)?.sessionId ?? null;
@@ -80,68 +71,60 @@ export function ChatTabGroup({
   const name = layout.name ?? memberLabel(nameSource);
   const pinned = members.every((m) => m.pinned);
 
-  const Chevron = collapsed ? ChevronRight : ChevronDown;
   const SplitIcon = members.length >= 3 ? Columns3 : Columns2;
 
   const toggleCollapse = () => {
     setTabCollapsed(members[0].session_id, !(layout.collapsed ?? false));
   };
 
-  const submitRename = (raw: string) => {
-    const next = raw.trim() || null;
-    setRenaming(false);
-    if (next === layout.name) return;
-    // setGroupName writes the active tab, so adopt this one first — renaming a
-    // background tab makes it current, which is the sensible read of "edit it".
-    activatePaneLayoutForSession(members[0].session_id);
-    setGroupName(next);
-  };
-
   return (
     <div className="flex flex-col gap-0.5">
-      <div className="group relative flex items-center gap-2 rounded-md px-2.5 py-1.5 text-xs transition-colors hover:bg-sidebar-selected/60">
+      <div className="group relative flex items-center gap-1.5 rounded-md border border-transparent px-2.5 py-1.5 text-xs transition-colors hover:border-sidebar-selected-border hover:bg-sidebar-selected/40">
+        <button
+          type="button"
+          onClick={() => {
+            // The whole row toggles this tab's expand/collapse, so you
+            // never need to hit the chevron. Opening a collapsed tab also
+            // activates it; collapsing just hides its members in place.
+            const willExpand = collapsed;
+            toggleCollapse();
+            if (willExpand) onActivateTab(nameSource);
+          }}
+          title={name}
+          className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
+        >
+          <SplitIcon
+            aria-hidden
+            className={`h-3 w-3 shrink-0 ${active ? "text-accent" : "text-fg-2"}`}
+          />
+          {pinned ? (
+            <Pin
+              aria-hidden
+              className="h-2.5 w-2.5 shrink-0 -rotate-45 text-fg-3"
+            />
+          ) : null}
+          <span className={`truncate text-fg ${active ? "font-semibold" : ""}`}>
+            {name}
+          </span>
+        </button>
+        {/* Disclosure chevron trails the title. A single glyph that
+            rotates between states (down = open, right = collapsed) so it
+            doesn't visually jump the way swapping two glyphs does. */}
         <button
           type="button"
           onClick={toggleCollapse}
           title={collapsed ? "Expand tab" : "Collapse tab"}
           aria-label={collapsed ? "Expand tab" : "Collapse tab"}
           aria-expanded={!collapsed}
-          className="flex shrink-0 cursor-pointer items-center gap-1.5 text-fg-2 hover:text-fg"
+          className="flex shrink-0 cursor-pointer items-center text-fg-2 hover:text-fg"
         >
-          <Chevron aria-hidden className="h-3 w-3" />
-          <SplitIcon
+          <ChevronDown
             aria-hidden
-            className={`h-3 w-3 ${active ? "text-accent" : "text-fg-2"}`}
+            className={`h-3 w-3 transition-transform ${
+              collapsed ? "-rotate-90" : ""
+            }`}
           />
         </button>
-        {renaming ? (
-          <TabNameInput
-            initial={layout.name ?? ""}
-            placeholder={name}
-            onSubmit={submitRename}
-            onCancel={() => setRenaming(false)}
-          />
-        ) : (
-          <button
-            type="button"
-            onClick={() => onActivateTab(nameSource)}
-            onDoubleClick={() => setRenaming(true)}
-            title={name}
-            className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
-          >
-            {pinned ? (
-              <Pin
-                aria-hidden
-                className="h-2.5 w-2.5 shrink-0 -rotate-45 text-fg-3"
-              />
-            ) : null}
-            <span
-              className={`truncate text-fg ${active ? "font-semibold" : ""}`}
-            >
-              {name}
-            </span>
-          </button>
-        )}
       </div>
       {collapsed ? null : (
         <div
@@ -172,46 +155,5 @@ export function ChatTabGroup({
         </div>
       )}
     </div>
-  );
-}
-
-function TabNameInput({
-  initial,
-  placeholder,
-  onSubmit,
-  onCancel,
-}: {
-  initial: string;
-  placeholder: string;
-  onSubmit: (next: string) => void;
-  onCancel: () => void;
-}) {
-  const [draft, setDraft] = useState(initial);
-  const inputRef = useRef<HTMLInputElement>(null);
-  useEffect(() => {
-    inputRef.current?.focus();
-    inputRef.current?.select();
-  }, []);
-  return (
-    <input
-      ref={inputRef}
-      value={draft}
-      placeholder={placeholder}
-      onChange={(e) => setDraft(e.target.value)}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") {
-          e.preventDefault();
-          onSubmit(draft);
-        } else if (e.key === "Escape") {
-          e.preventDefault();
-          onCancel();
-        }
-      }}
-      onBlur={() => {
-        if (draft.trim() === initial.trim()) onCancel();
-        else onSubmit(draft);
-      }}
-      className="min-w-0 flex-1 bg-transparent text-xs font-semibold text-fg outline-none placeholder:text-fg-3"
-    />
   );
 }

--- a/src/components/PanelToggleGlyph.tsx
+++ b/src/components/PanelToggleGlyph.tsx
@@ -1,0 +1,56 @@
+// Two-state panel-toggle glyph shared by the left sidebar (AppShell) and
+// the right runner rail (RunnerChat / MissionWorkspace), so both toggles
+// read as one family. Drawn to the #246 Pencil spec (node n96Xi): a
+// landscape 60×46 panel — 3px outline, 9px radius, with a filled column /
+// divider one third in from the panel's docked edge.
+//   filled → solid column on the docked edge = panel SHOWN
+//   hollow → thin divider, no fill            = panel HIDDEN
+// `side` mirrors the geometry: "left" hugs the leading edge (sidebar),
+// "right" hugs the trailing edge (runner rail). lucide's PanelLeft/Right
+// are square and use a solid-vs-dashed divider instead, so both states
+// are hand-rolled here to keep the design's aspect ratio and fill.
+// The viewBox carries a 2-unit margin (`-2 -2 64 50`) so the outer stroke
+// isn't flush with the boundary — otherwise it clips/softens when scaled
+// down small.
+export function PanelToggleGlyph({
+  side,
+  filled,
+  className,
+}: {
+  side: "left" | "right";
+  filled: boolean;
+  className?: string;
+}) {
+  return (
+    <svg viewBox="-2 -2 64 50" fill="none" aria-hidden className={className}>
+      <rect
+        x="1.5"
+        y="1.5"
+        width="57"
+        height="43"
+        rx="7.5"
+        stroke="currentColor"
+        strokeWidth={3}
+      />
+      {filled ? (
+        <path
+          d={
+            side === "left"
+              ? "M9 3 H19 V43 H9 Q3 43 3 37 V9 Q3 3 9 3 Z"
+              : "M51 3 H41 V43 H51 Q57 43 57 37 V9 Q57 3 51 3 Z"
+          }
+          fill="currentColor"
+        />
+      ) : (
+        <rect
+          x={side === "left" ? 19 : 38}
+          y="3"
+          width="3"
+          height="40"
+          rx="1.5"
+          fill="currentColor"
+        />
+      )}
+    </svg>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -34,9 +34,6 @@ import {
   AppWindow,
   Archive,
   ChevronDown,
-  ChevronRight,
-  ChevronsLeft,
-  ChevronsRight,
   MessageSquarePlus,
   MoreHorizontal,
   Pin,
@@ -77,6 +74,7 @@ import {
   visibleSessionIds,
 } from "../lib/paneLayout";
 import { ChatTabGroup } from "./ChatTabGroup";
+import { PanelToggleGlyph } from "./PanelToggleGlyph";
 import { useResizableWidth } from "../hooks/useResizableWidth";
 import {
   BRAND_MARK_PINNED_COLOR,
@@ -173,9 +171,9 @@ interface SidebarProps {
   settingsOpen: boolean;
   onSettingsOpenChange: (open: boolean) => void;
   // Collapsed/expanded state lives in AppShell so the global Cmd+S
-  // shortcut can toggle it. The `width` resize state stays local —
-  // it's preserved across collapse/expand cycles so users get their
-  // last full width back when they re-open.
+  // shortcut can toggle it too. The `width` resize state stays local —
+  // it's preserved across collapse/expand cycles so users get their last
+  // full width back when they re-open.
   collapsed: boolean;
   onCollapsedChange: (collapsed: boolean) => void;
   previewOpen: boolean;
@@ -888,11 +886,12 @@ export function Sidebar({
     ],
   );
 
-  // Accordion header (tab name) click: activate the header's OWN tab and open
-  // its focused pane's chat (impl 0023). Unlike openDirectChat this never
-  // routes through the empty-pane fill — a header is "go to this tab", so it
-  // must not pull the tab's chat into whatever empty pane the current split
-  // happens to have. Member-row clicks keep openDirectChat (spec: unchanged).
+  // Accordion header row click: activate the header's OWN tab and open its
+  // focused pane's chat (impl 0023). ChatTabGroup fires this alongside its
+  // expand toggle. Unlike openDirectChat this never routes through the
+  // empty-pane fill — a header is "go to this tab", so it must not pull the
+  // tab's chat into whatever empty pane the current split happens to have.
+  // Member-row clicks keep openDirectChat (spec: unchanged).
   const activateTabChat = useCallback(
     (entry: DirectSessionEntry) => {
       const entryLayout = activatePaneLayoutForSession(entry.session_id);
@@ -973,6 +972,26 @@ export function Sidebar({
 
   const sidebarVisible = !collapsed || previewOpen;
   const sidebarPreview = collapsed && previewOpen;
+  // Keep the panel mounted through the collapse width-animation so it
+  // slides out under the overflow clip instead of blinking away — the
+  // mirror of the expand animation. `contentMounted` lingers true after
+  // `sidebarVisible` flips false; a `width` transitionend then clears it.
+  const [contentMounted, setContentMounted] = useState(sidebarVisible);
+  useEffect(() => {
+    if (sidebarVisible) setContentMounted(true);
+  }, [sidebarVisible]);
+  const showPanel = sidebarVisible || contentMounted;
+  // The collapsed hover-peek renders as a raised, docked overlay with a
+  // rounded right edge (Arc-ish), fading + sliding in on hover. `peeking`
+  // holds that overlay treatment through the fade-out so it stays absolute
+  // (never shoving the main content); pinning it open clears it, as does the
+  // width transitionend once fully closed.
+  const [peeking, setPeeking] = useState(false);
+  useEffect(() => {
+    if (previewOpen) setPeeking(true);
+    else if (!collapsed) setPeeking(false);
+  }, [previewOpen, collapsed]);
+  const peekOverlay = collapsed && (previewOpen || peeking);
 
   return (
     <>
@@ -981,18 +1000,30 @@ export function Sidebar({
         onMouseLeave={
           sidebarPreview ? () => onPreviewOpenChange(false) : undefined
         }
-        style={{ width: sidebarVisible ? width : 0 }}
-        className={`${
-          collapsed
-            ? "absolute left-0 top-0 z-40"
-            : "relative"
-        } ${
-          sidebarPreview ? "shadow-2xl shadow-black/40" : ""
-        } flex h-full shrink-0 select-none flex-col overflow-hidden transition-[width] duration-150 ${
-          sidebarVisible ? "border-r border-line bg-sidebar" : "bg-transparent"
+        onTransitionEnd={(e) => {
+          if (e.propertyName === "width" && !sidebarVisible) {
+            setContentMounted(false);
+            setPeeking(false);
+          }
+        }}
+        style={{
+          width: sidebarVisible ? width : 0,
+          opacity: sidebarVisible ? 1 : 0,
+        }}
+        className={`flex shrink-0 select-none flex-col overflow-hidden transition-[width,opacity] duration-150 ${
+          peekOverlay
+            ? // Collapsed peek: a raised, docked overlay with a rounded right
+              // edge. Kept absolute (via `peeking`) through the fade-out so it
+              // never shoves the main content on the way in or out.
+              "absolute inset-y-0 left-0 z-40 rounded-r-xl border-r border-line bg-sidebar shadow-2xl shadow-black/40"
+            : // Docked: in-flow so the width animation pushes/pulls the main
+              // content symmetrically on both expand and collapse.
+              `relative h-full ${
+                showPanel ? "border-r border-line bg-sidebar" : "bg-transparent"
+              }`
         }`}
       >
-        {sidebarVisible ? (
+        {showPanel ? (
           <div className="flex min-h-0 flex-1 flex-col pb-4">
             <div data-tauri-drag-region className="h-8 shrink-0" />
 
@@ -1029,11 +1060,12 @@ export function Sidebar({
 
             <div className="h-5 shrink-0" />
 
-            {/* Codex-desktop style: Mission and Chat live in one
-                natural scroll column. Sections stack by content
-                height; no pane reserves empty space. */}
-            <div className="min-h-0 flex-1 overflow-y-auto pb-3">
-              <section className="flex flex-col">
+            {/* Mission and Chat get INDEPENDENT scroll regions so a long
+                chat list can't scroll the mission tray out of view. The
+                mission tray is capped and self-scrolls; Chat fills and
+                scrolls the rest. */}
+            <div className="flex min-h-0 flex-1 flex-col pb-3">
+              <section className="flex shrink-0 flex-col">
                 <CollapsibleSectionHeader
                   label="MISSION"
                   open={missionsOpen}
@@ -1042,7 +1074,7 @@ export function Sidebar({
                   plusTitle="Start mission"
                 />
                 {missionsOpen ? (
-                  <div className="flex flex-col gap-0.5 px-3 pt-1">
+                  <div className="flex max-h-[38vh] flex-col gap-0.5 overflow-y-auto px-3 pt-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                     {missions.length === 0 ? (
                       <p className="px-2.5 py-1 text-xs text-fg-3">
                         No live missions.
@@ -1067,7 +1099,7 @@ export function Sidebar({
                 ) : null}
               </section>
 
-              <section className="mt-5 flex flex-col">
+              <section className="mt-5 flex min-h-0 flex-1 flex-col">
                 <CollapsibleSectionHeader
                   label="CHAT"
                   open={sessionsOpen}
@@ -1077,7 +1109,7 @@ export function Sidebar({
                   plusExpanded={creatingChat}
                 />
                 {sessionsOpen ? (
-                  <div className="flex flex-col gap-0.5 px-3 pt-1">
+                  <div className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-3 pt-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                     {chatItems.length === 0 ? (
                       <p className="px-2.5 py-1 text-xs text-fg-3">
                         No chats yet.
@@ -1092,13 +1124,13 @@ export function Sidebar({
 
             {/* Settings row — pinned at the bottom of the sidebar
                 column. Mirrors Pencil node `IJsUO` (sidebar settings).
-                The chevron points toward the action: left collapses
-                an open sidebar, right pins a hover-preview sidebar. */}
-            <div className="flex shrink-0 items-center gap-2 border-t border-line px-3 pt-2">
+                The trailing button collapses the sidebar (or, in a
+                hover-preview, pins it open) via the #246 panel glyph. */}
+            <div className="flex shrink-0 items-center gap-2 border-t border-sidebar-selected-border px-3 pt-2">
               <button
                 type="button"
                 onClick={() => setSettingsOpen(true)}
-                className="flex flex-1 cursor-pointer items-center gap-2.5 rounded border border-transparent px-2.5 py-2 text-left text-fg-2 transition-colors hover:bg-sidebar-selected/60 hover:text-fg focus:bg-sidebar-selected/60 focus:text-fg focus:outline-none"
+                className="flex flex-1 cursor-pointer items-center gap-2.5 rounded border border-transparent px-2.5 py-2 text-left text-fg-2 transition-colors hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg focus:border-sidebar-selected-border focus:bg-sidebar-selected/40 focus:text-fg focus:outline-none"
               >
                 <SettingsIcon aria-hidden className="h-3.5 w-3.5" />
                 <span className="text-[13px]">Settings</span>
@@ -1119,13 +1151,13 @@ export function Sidebar({
                 aria-label={
                   sidebarPreview ? "Keep sidebar open" : "Collapse sidebar"
                 }
-                className="flex h-6 w-6 cursor-pointer items-center justify-center rounded border border-transparent text-fg-3 transition-colors hover:bg-sidebar-selected/60 hover:text-fg focus:bg-sidebar-selected/60 focus:text-fg focus:outline-none"
+                className="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded border border-transparent text-fg-2 transition-colors hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg focus:border-sidebar-selected-border focus:bg-sidebar-selected/40 focus:text-fg focus:outline-none"
               >
-                {sidebarPreview ? (
-                  <ChevronsRight aria-hidden className="h-3.5 w-3.5" />
-                ) : (
-                  <ChevronsLeft aria-hidden className="h-3.5 w-3.5" />
-                )}
+                <PanelToggleGlyph
+                  side="left"
+                  filled={!collapsed}
+                  className="h-[12px] w-[15.4px]"
+                />
               </button>
             </div>
           </div>
@@ -1282,7 +1314,7 @@ function NavRow({
         `flex items-center gap-2 rounded border px-2.5 py-1.5 text-sm transition-colors ${
           isActive
             ? "border-sidebar-selected-border bg-sidebar-selected font-semibold text-fg shadow-sm"
-            : "border-transparent text-fg-2 hover:bg-sidebar-selected/60 hover:text-fg"
+            : "border-transparent text-fg-2 hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg"
         }`
       }
     >
@@ -1305,7 +1337,7 @@ function NewChatNavRow({ onOpen }: { onOpen: () => void }) {
       type="button"
       title="New chat"
       onClick={onOpen}
-      className="group flex w-full cursor-pointer items-center gap-2 rounded border border-transparent px-2.5 py-1.5 text-left text-sm text-fg-2 transition-colors hover:bg-sidebar-selected/60 hover:text-fg focus:bg-sidebar-selected/60 focus:text-fg focus:outline-none"
+      className="group flex w-full cursor-pointer items-center gap-2 rounded border border-transparent px-2.5 py-1.5 text-left text-sm text-fg-2 transition-colors hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg focus:border-sidebar-selected-border focus:bg-sidebar-selected/40 focus:text-fg focus:outline-none"
     >
       <MessageSquarePlus aria-hidden className="h-3 w-3 text-fg-2" />
       <span className="min-w-0 flex-1 truncate">new chat</span>
@@ -1326,7 +1358,7 @@ function SearchNavRow({ onOpen }: { onOpen: () => void }) {
       type="button"
       title="Search"
       onClick={onOpen}
-      className="group flex w-full cursor-pointer items-center gap-2 rounded border border-transparent px-2.5 py-1.5 text-left text-sm text-fg-2 transition-colors hover:bg-sidebar-selected/60 hover:text-fg focus:bg-sidebar-selected/60 focus:text-fg focus:outline-none"
+      className="group flex w-full cursor-pointer items-center gap-2 rounded border border-transparent px-2.5 py-1.5 text-left text-sm text-fg-2 transition-colors hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg focus:border-sidebar-selected-border focus:bg-sidebar-selected/40 focus:text-fg focus:outline-none"
     >
       <Search aria-hidden className="h-3 w-3 text-fg-2" />
       <span className="min-w-0 flex-1 truncate">search</span>
@@ -1356,7 +1388,6 @@ function CollapsibleSectionHeader({
    *  trigger advertises `aria-haspopup="dialog"` + `aria-expanded`. */
   plusExpanded?: boolean;
 }) {
-  const Chevron = open ? ChevronDown : ChevronRight;
   return (
     <div className="flex items-center justify-between gap-2 px-5 pb-1.5">
       <button
@@ -1364,8 +1395,13 @@ function CollapsibleSectionHeader({
         onClick={onToggle}
         className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-[0.15em] text-fg-3 hover:text-fg-2"
       >
-        <Chevron aria-hidden className="h-2.5 w-2.5" />
         <span>{label}</span>
+        <ChevronDown
+          aria-hidden
+          className={`h-2.5 w-2.5 transition-transform ${
+            open ? "" : "-rotate-90"
+          }`}
+        />
       </button>
       <button
         type="button"
@@ -1455,7 +1491,7 @@ function SidebarListRow({
       className={`group relative flex w-full items-center gap-2 rounded border px-2.5 py-1.5 text-left text-xs transition-colors ${
         selected
           ? "border-sidebar-selected-border bg-sidebar-selected font-semibold text-fg shadow-sm"
-          : "border-transparent text-fg-2 hover:bg-sidebar-selected/60 hover:text-fg"
+          : "border-transparent text-fg-2 hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg"
       }`}
     >
       {accentBar ? (

--- a/src/lib/paneLayout.test.ts
+++ b/src/lib/paneLayout.test.ts
@@ -419,8 +419,8 @@ describe("hydrateLayoutSet (cross-window sync)", () => {
     activatePaneLayoutForSession("A"); // view A's tab
     setRouteAnchorSession("A"); // route owns A
 
-    // Renaming the background C/D tab activates it without navigating —
-    // mirrors ChatTabGroup.submitRename. The route anchor must stay A.
+    // Activating the background C/D tab (as setGroupName does when naming it)
+    // must not navigate — the route anchor must stay A.
     activatePaneLayoutForSession("C");
 
     // A remote change moves C elsewhere; A stays in its own tab (index 0).

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -21,8 +21,6 @@ import {
   MoreHorizontal,
   Pin,
   PinOff,
-  PanelRight,
-  PanelRightDashed,
   RotateCcw,
   SquarePen,
   Terminal,
@@ -53,6 +51,7 @@ import { MissionInput } from "../components/MissionInput";
 import { MissionMetaPanel } from "../components/MissionMetaPanel";
 import { MissionResetConfirm } from "../components/MissionResetConfirm";
 import { RunnersRail } from "../components/RunnersRail";
+import { PanelToggleGlyph } from "../components/PanelToggleGlyph";
 import {
   RunnerTerminal,
   type RunnerTerminalHandle,
@@ -843,6 +842,14 @@ export default function MissionWorkspace() {
       // ignore storage errors
     }
   }, [railOpen]);
+  // Show the rail's left divider only once it's fully open, dropping it as a
+  // collapse starts — otherwise the visible border rides the animating edge
+  // and slides across the workspace during the width transition. Mirrors the
+  // RunnerChat side panel.
+  const [railBorderOn, setRailBorderOn] = useState(railOpen);
+  useEffect(() => {
+    if (!railOpen) setRailBorderOn(false);
+  }, [railOpen]);
   // Drag-to-resize width for the rail. Persisted separately from the
   // open/closed flag so collapse → expand restores the last dragged
   // width instead of the hardcoded default. The hook writes
@@ -1040,7 +1047,11 @@ export default function MissionWorkspace() {
               aria-label="Open runners panel"
               className="inline-flex h-7 w-7 items-center justify-center rounded text-fg-2 transition-colors hover:bg-raised hover:text-fg"
             >
-              <PanelRightDashed aria-hidden className="h-4 w-4" />
+              <PanelToggleGlyph
+                side="right"
+                filled={false}
+                className="h-[12.5px] w-[16px]"
+              />
             </button>
           ) : null}
         </div>
@@ -1221,9 +1232,12 @@ export default function MissionWorkspace() {
       <aside
         ref={railAsideRef}
         aria-hidden={!railOpen}
+        onTransitionEnd={(e) => {
+          if (e.propertyName === "width" && railOpen) setRailBorderOn(true);
+        }}
         style={{ width: railOpen ? railWidth : 0 }}
-        className={`relative flex shrink-0 flex-col overflow-hidden bg-panel transition-[width,border-left-width] duration-200 ease-in-out ${
-          railOpen ? "border-l border-line" : "border-l-0"
+        className={`relative flex shrink-0 flex-col overflow-hidden bg-panel transition-[width] duration-200 ease-in-out ${
+          railBorderOn ? "border-l border-line" : "border-l-0"
         }`}
       >
         <div
@@ -1265,7 +1279,11 @@ export default function MissionWorkspace() {
                 aria-label="Collapse panel"
                 className="flex h-7 w-7 cursor-pointer items-center justify-center rounded border border-transparent text-fg-2 transition-colors hover:bg-sidebar-selected/60 hover:text-fg focus:bg-sidebar-selected/60 focus:text-fg focus:outline-none"
               >
-                <PanelRight aria-hidden className="h-4 w-4" />
+                <PanelToggleGlyph
+                  side="right"
+                  filled
+                  className="h-[12.5px] w-[16px]"
+                />
               </button>
             </div>
           </header>

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -16,8 +16,6 @@ import { listen } from "@tauri-apps/api/event";
 import {
   Archive,
   MoreHorizontal,
-  PanelRight,
-  PanelRightDashed,
   Pin,
   PinOff,
   SquarePen,
@@ -50,6 +48,7 @@ import {
   useArchivingVersion,
 } from "../lib/archivingState";
 import { ChatPaneGroup } from "../components/ChatPaneGroup";
+import { PanelToggleGlyph } from "../components/PanelToggleGlyph";
 import { createTerminalRegistry } from "../lib/terminalRegistry";
 import { LayoutPicker } from "../components/LayoutPicker";
 import { StartChatModal } from "../components/StartChatModal";
@@ -1684,11 +1683,14 @@ export default function RunnerChat() {
               aria-label="Open side panel"
               className="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-fg-2 hover:bg-raised hover:text-fg"
             >
-              {/* Dashed-bar variant = "panel exists but is collapsed";
-                  flips to the solid `PanelRight` when the panel is
-                  open. Two clearly distinct states, both Obsidian-
-                  flavored (no chevrons). */}
-              <PanelRightDashed aria-hidden className="h-4 w-4" />
+              {/* Hollow = "panel exists but is collapsed"; flips to the
+                  filled trailing column when the panel is open. Mirror of
+                  the left sidebar toggle (#246), oriented to the right. */}
+              <PanelToggleGlyph
+                side="right"
+                filled={false}
+                className="h-[12.5px] w-[16px]"
+              />
             </button>
           ) : null}
         </div>
@@ -1956,13 +1958,25 @@ function RunnerSidePanel({
     edge: "left",
     targets: [asideRef, innerRef],
   });
+  // Show the left divider only once the panel is fully open, and drop it the
+  // instant a collapse starts. Otherwise the visible border rides the
+  // animating left edge and reads as a gray bar sliding across the main area
+  // during the width transition (the left sidebar dodges this only because
+  // its border color happens to match its own background).
+  const [borderOn, setBorderOn] = useState(open);
+  useEffect(() => {
+    if (!open) setBorderOn(false);
+  }, [open]);
   return (
     <aside
       ref={asideRef}
       aria-hidden={!open}
+      onTransitionEnd={(e) => {
+        if (e.propertyName === "width" && open) setBorderOn(true);
+      }}
       style={{ width: open ? width : 0 }}
-      className={`relative flex shrink-0 flex-col overflow-hidden bg-panel transition-[width,border-left-width] duration-200 ease-in-out ${
-        open ? "border-l border-line" : "border-l-0"
+      className={`relative flex shrink-0 flex-col overflow-hidden bg-panel transition-[width] duration-200 ease-in-out ${
+        borderOn ? "border-l border-line" : "border-l-0"
       }`}
     >
       <div ref={innerRef} style={{ width }} className="flex h-full flex-col">
@@ -1981,7 +1995,11 @@ function RunnerSidePanel({
               aria-label="Collapse panel"
               className="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-fg-2 hover:bg-raised hover:text-fg"
             >
-              <PanelRight aria-hidden className="h-4 w-4" />
+              <PanelToggleGlyph
+                side="right"
+                filled
+                className="h-[12.5px] w-[16px]"
+              />
             </button>
           </div>
         </header>


### PR DESCRIPTION
## Summary

Adopts Codex desktop's panel glyph for the sidebar + runner-rail collapse toggles and polishes the surrounding interactions. Includes the approved Pencil design (`design/runners-design.pen`).

## What changed

- **Shared `PanelToggleGlyph`** (filled/hollow, `side` left/right) — the sidebar Settings-row toggle and the runner-rail toggle both use it instead of chevrons / lucide `PanelRight`.
- **Collapse animation** — the sidebar collapse animates symmetrically (content slides out under the clip). The collapsed **hover-peek** is now a raised, docked overlay with a rounded right edge that fades + slides in/out and never shoves the main content.
- **Arc-style row hover** — sidebar rows get a rounded bordered rectangle on hover (softer fill); the fuller *selected* state stays distinct.
- **Chat-tab accordion** — the whole row toggles expand/collapse, a single trailing chevron rotates between states (no glyph-swap jump), and the hidden double-click group rename is removed.
- **Scroll** — `MISSION` and `CHAT` are independent scroll regions, and the sidebar list scrollbars are hidden so a long chat list can't shift the column.
- **Rail divider** — the runner rail's left divider no longer slides across the workspace on collapse (shown only once the panel is fully open).

## Note on scope vs #246

The persistent-titlebar toggle #246 originally proposed proved unworkable under the app's webview zoom: there's no per-element opt-out for native `setZoom`, and the Codex "shift the traffic lights to follow the icon" approach needs runtime `NSWindow` window-button repositioning that Tauri 2.11 doesn't expose (and that fights `tao`'s own build-time inset). So the toggle stays in the sidebar and this lands as the Codex panel-glyph adoption plus the surrounding polish.

## Checks

- `pnpm exec tsc --noEmit` — clean
- `pnpm run lint` — clean
- `pnpm test` — 70/70 pass
- Visually verified across expanded / collapsed / hover-peek states, both the left sidebar and the runner rail, and the chat-tab accordion.

Fixes #246
