### PR TITLE
Fix orphaned mission slot sessions

### DIFF
--- a/src-tauri/src/commands/crew.rs
+++ b/src-tauri/src/commands/crew.rs
@@ -6,7 +6,7 @@
 // + sidecar that used to feed it are gone (feature 20).
 
 use chrono::Utc;
-use rusqlite::Connection;
+use rusqlite::{params, Connection};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tauri::State;
@@ -197,11 +197,44 @@ pub fn update(conn: &Connection, id: &str, input: UpdateCrewInput) -> Result<Cre
     get(conn, id)
 }
 
-pub fn delete(conn: &Connection, id: &str) -> Result<()> {
-    let affected = repo::crew::delete(conn, id)?;
+fn non_archived_mission_ids_for_crew(
+    conn: &Connection,
+    crew_id: &str,
+) -> rusqlite::Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT id
+           FROM missions
+          WHERE crew_id = ?1
+            AND archived_at IS NULL
+          ORDER BY started_at ASC",
+    )?;
+    let ids = stmt
+        .query_map(params![crew_id], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(ids)
+}
+
+pub fn delete(conn: &mut Connection, id: &str) -> Result<()> {
+    let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    let mission_ids = non_archived_mission_ids_for_crew(&tx, id)?;
+    if !mission_ids.is_empty() {
+        return Err(Error::msg(format!(
+            "crew {id} has non-archived missions; archive them before deleting this crew: {}",
+            mission_ids.join(", ")
+        )));
+    }
+    tx.execute(
+        "DELETE FROM sessions
+          WHERE mission_id IN (
+              SELECT id FROM missions WHERE crew_id = ?1
+          )",
+        params![id],
+    )?;
+    let affected = repo::crew::delete(&tx, id)?;
     if affected == 0 {
         return Err(Error::msg(format!("crew not found: {id}")));
     }
+    tx.commit()?;
     Ok(())
 }
 
@@ -235,8 +268,8 @@ pub async fn crew_update(
 
 #[tauri::command]
 pub async fn crew_delete(state: State<'_, AppState>, id: String) -> Result<()> {
-    let conn = state.db.get()?;
-    delete(&conn, &id)
+    let mut conn = state.db.get()?;
+    delete(&mut conn, &id)
 }
 
 #[cfg(test)]
@@ -373,7 +406,7 @@ mod tests {
         // slot rows but leave the runner intact for other crews (or a
         // future direct chat).
         let pool = ctx();
-        let conn = pool.get().unwrap();
+        let mut conn = pool.get().unwrap();
         let crew = create(
             &conn,
             CreateCrewInput {
@@ -398,7 +431,7 @@ mod tests {
         )
         .unwrap();
 
-        delete(&conn, &crew.id).unwrap();
+        delete(&mut conn, &crew.id).unwrap();
         let slot_count: i64 = conn
             .query_row(
                 "SELECT COUNT(*) FROM slots WHERE crew_id = ?1",
@@ -413,6 +446,108 @@ mod tests {
             .unwrap();
         assert_eq!(slot_count, 0);
         assert_eq!(runner_count, 1, "runner outlives the crew");
+    }
+
+    #[test]
+    fn delete_refuses_crew_with_any_non_archived_mission() {
+        let pool = ctx();
+        let mut conn = pool.get().unwrap();
+        let crew = create(
+            &conn,
+            CreateCrewInput {
+                name: "Busy".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO missions (id, crew_id, title, status, started_at)
+             VALUES ('m-live', ?1, 'Live', 'running', '2026-04-22T00:00:00Z')",
+            params![crew.id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO missions
+                (id, crew_id, title, status, started_at, stopped_at)
+             VALUES ('m-aborted', ?1, 'Aborted', 'aborted',
+                     '2026-04-22T00:01:00Z', '2026-04-22T00:02:00Z')",
+            params![crew.id],
+        )
+        .unwrap();
+
+        let err = delete(&mut conn, &crew.id).unwrap_err().to_string();
+        assert!(err.contains("non-archived missions"));
+        assert!(err.contains("m-live"));
+        assert!(err.contains("m-aborted"));
+        let crew_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM crews WHERE id = ?1",
+                params![crew.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(crew_count, 1, "crew must survive a refused delete");
+    }
+
+    #[test]
+    fn delete_removes_archived_mission_sessions_before_deleting_crew() {
+        let pool = ctx();
+        let mut conn = pool.get().unwrap();
+        let crew = create(
+            &conn,
+            CreateCrewInput {
+                name: "Archived".into(),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO runners (
+                id, handle, display_name, runtime, command,
+                created_at, updated_at
+             ) VALUES ('r1', 'reviewer', 'Reviewer', 'shell', 'sh',
+                       '2026-04-22T00:00:00Z', '2026-04-22T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO missions
+                (id, crew_id, title, status, started_at, stopped_at, archived_at)
+             VALUES ('m-archived', ?1, 'Done', 'completed',
+                     '2026-04-22T00:00:00Z', '2026-04-22T01:00:00Z',
+                     '2026-04-22T01:00:00Z')",
+            params![crew.id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, slot_id, status, started_at)
+             VALUES ('s-archived', 'm-archived', 'r1', 'slot-reviewer',
+                     'stopped', '2026-04-22T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+
+        delete(&mut conn, &crew.id).unwrap();
+        let session_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE id = 's-archived'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let mission_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM missions WHERE id = 'm-archived'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(session_count, 0, "app layer deletes mission sessions first");
+        assert_eq!(
+            mission_count, 0,
+            "crew delete still removes archived missions"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/runner.rs
+++ b/src-tauri/src/commands/runner.rs
@@ -388,6 +388,36 @@ pub fn update(conn: &Connection, id: &str, input: UpdateRunnerInput) -> Result<R
     get(conn, id)
 }
 
+fn unarchived_direct_session_ids_for_runner(
+    conn: &Connection,
+    runner_id: &str,
+) -> rusqlite::Result<Vec<String>> {
+    let mut stmt = conn.prepare(
+        "SELECT id
+           FROM sessions
+          WHERE runner_id = ?1
+            AND mission_id IS NULL
+            AND slot_id IS NULL
+            AND archived_at IS NULL
+          ORDER BY started_at ASC",
+    )?;
+    let ids = stmt
+        .query_map(params![runner_id], |row| row.get::<_, String>(0))?
+        .collect::<rusqlite::Result<Vec<_>>>()?;
+    Ok(ids)
+}
+
+pub(crate) fn ensure_delete_allowed(conn: &Connection, id: &str) -> Result<()> {
+    let session_ids = unarchived_direct_session_ids_for_runner(conn, id)?;
+    if !session_ids.is_empty() {
+        return Err(Error::msg(format!(
+            "runner {id} has unarchived chats; archive them before deleting this runner: {}",
+            session_ids.join(", ")
+        )));
+    }
+    Ok(())
+}
+
 // Global delete: removes the runner template row and lets the
 // `ON DELETE CASCADE` on `slots` strip every slot that referenced
 // the runner. A single runner template might have been referenced by
@@ -400,6 +430,7 @@ pub fn update(conn: &Connection, id: &str, input: UpdateRunnerInput) -> Result<R
 // (0..N-1).
 pub fn delete(conn: &mut Connection, id: &str) -> Result<()> {
     let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    ensure_delete_allowed(&tx, id)?;
 
     // Distinct crews that referenced this runner, plus whether ANY of
     // its slots in that crew was lead (so we know to auto-promote
@@ -418,6 +449,7 @@ pub fn delete(conn: &mut Connection, id: &str) -> Result<()> {
         rows.collect::<rusqlite::Result<Vec<_>>>()?
     };
 
+    tx.execute("DELETE FROM sessions WHERE runner_id = ?1", params![id])?;
     let affected = repo::runner::delete(&tx, id)?;
     if affected != 1 {
         return Err(Error::msg(format!("runner not found: {id}")));
@@ -494,7 +526,11 @@ pub fn activity(conn: &Connection, runner_id: &str) -> Result<RunnerActivity> {
     let direct_session_id: Option<String> = conn
         .query_row(
             "SELECT id FROM sessions
-              WHERE runner_id = ?1 AND status = 'running' AND mission_id IS NULL
+              WHERE runner_id = ?1
+                AND status = 'running'
+                AND mission_id IS NULL
+                AND slot_id IS NULL
+                AND archived_at IS NULL
               ORDER BY started_at DESC
               LIMIT 1",
             params![runner_id],
@@ -560,12 +596,14 @@ pub async fn runner_update(
 
 #[tauri::command]
 pub async fn runner_delete(state: State<'_, AppState>, id: String) -> Result<()> {
-    // Reap every live PTY for this runner BEFORE the DB delete.
-    // `sessions.runner_id` is `ON DELETE CASCADE`, so the row drop nukes
-    // the session record — but the in-memory SessionManager still holds
-    // the live child + reader thread. Without `kill_all_for_runner`, the
-    // PTY lingers as a daemon attached to nothing and the Mac's TTY count
-    // climbs every time the user deletes a runner with an open chat.
+    {
+        let conn = state.db.get()?;
+        ensure_delete_allowed(&conn, &id)?;
+    }
+    // Reap every live PTY for this runner before the DB delete. The
+    // command-layer delete removes session rows explicitly, but the
+    // in-memory SessionManager still owns child processes and reader
+    // threads until they are killed.
     state.sessions.kill_all_for_runner(&id)?;
     let mut conn = state.db.get()?;
     delete(&mut conn, &id)
@@ -684,6 +722,117 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM runners", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn delete_refuses_runner_with_unarchived_direct_chat() {
+        let pool = ctx();
+        let mut conn = pool.get().unwrap();
+        let r = make(&conn, "alpha");
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, slot_id, status, started_at)
+             VALUES ('direct-live', NULL, ?1, NULL, 'stopped',
+                     '2026-04-22T00:00:00Z')",
+            params![r.id],
+        )
+        .unwrap();
+
+        let err = delete(&mut conn, &r.id).unwrap_err().to_string();
+        assert!(err.contains("unarchived chats"));
+        let runner_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM runners WHERE id = ?1",
+                params![r.id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let session_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE id = 'direct-live'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(runner_count, 1, "runner must survive refused delete");
+        assert_eq!(session_count, 1, "chat must survive refused delete");
+    }
+
+    #[test]
+    fn delete_removes_runner_sessions_before_runner_row() {
+        let pool = ctx();
+        let mut conn = pool.get().unwrap();
+        let r = make(&conn, "alpha");
+        conn.execute(
+            "INSERT INTO crews (id, name, created_at, updated_at)
+             VALUES ('crew-1', 'Crew', '2026-04-22T00:00:00Z',
+                     '2026-04-22T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO missions (id, crew_id, title, status, started_at)
+             VALUES ('mission-1', 'crew-1', 'Mission', 'running',
+                     '2026-04-22T00:00:00Z')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, slot_id, status, started_at)
+             VALUES ('mission-session', 'mission-1', ?1, 'slot-1',
+                     'running', '2026-04-22T00:00:00Z')",
+            params![r.id],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, slot_id, status, started_at, archived_at)
+             VALUES ('archived-direct', NULL, ?1, NULL, 'stopped',
+                     '2026-04-22T00:00:00Z', '2026-04-22T01:00:00Z')",
+            params![r.id],
+        )
+        .unwrap();
+
+        delete(&mut conn, &r.id).unwrap();
+        let session_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions
+                  WHERE id IN ('mission-session', 'archived-direct')",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        let mission_count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM missions WHERE id = 'mission-1'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(session_count, 0, "runner sessions are hard-deleted");
+        assert_eq!(mission_count, 1, "runner delete does not delete missions");
+    }
+
+    #[test]
+    fn activity_direct_session_id_ignores_slot_bound_orphans() {
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let r = make(&conn, "alpha");
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, slot_id, status, started_at)
+             VALUES ('slot-orphan', NULL, ?1, 'slot-old', 'running',
+                     '2026-04-22T00:00:00Z')",
+            params![r.id],
+        )
+        .unwrap();
+
+        let got = activity(&conn, &r.id).unwrap();
+        assert_eq!(
+            got.direct_session_id, None,
+            "slot-bound orphan must not be treated as direct chat activity"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -325,9 +325,10 @@ pub async fn session_list_recent_direct(
 /// read-only (no PTY attach, no Resume, no live composer) instead of
 /// silently failing to find the session.
 ///
-/// Returns `None` if the id doesn't exist. Mission sessions are not
-/// returned here — this command is for direct chats only, matching
-/// the surface that `listRecentDirect` covers.
+/// Returns `None` if the id doesn't exist. Mission sessions and
+/// slot-bound legacy orphans are not returned here — this command is
+/// for direct chats only, matching the surface that `listRecentDirect`
+/// covers.
 ///
 /// The SQL lives in `get_direct(...)` below so the test module can
 /// exercise the real query against an in-memory DB without spinning
@@ -635,6 +636,7 @@ mod tests {
                    FROM sessions s
                    LEFT JOIN runners r ON r.id = s.runner_id
                   WHERE s.mission_id IS NULL
+                    AND s.slot_id IS NULL
                     AND s.archived_at IS NULL
                   ORDER BY CASE WHEN s.pinned_at IS NOT NULL THEN 0 ELSE 1 END,
                            CASE WHEN s.status = 'running'    THEN 0 ELSE 1 END,

--- a/src-tauri/src/mcp/tools/crew.rs
+++ b/src-tauri/src/mcp/tools/crew.rs
@@ -1,12 +1,12 @@
 use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{CallToolResult, Content};
 use rmcp::{tool, tool_router, ErrorData};
-use rusqlite::{params, Connection};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use tauri::Emitter;
 
 use crate::commands::crew;
+use crate::error::Error;
 use crate::mcp::server::RunnerMcpHandler;
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -23,22 +23,11 @@ pub struct UpdateCrewArgs {
     pub input: crew::UpdateCrewInput,
 }
 
-fn unarchived_mission_session_ids_for_crew(
-    conn: &Connection,
-    crew_id: &str,
-) -> rusqlite::Result<Vec<String>> {
-    let mut stmt = conn.prepare(
-        "SELECT DISTINCT m.id
-           FROM missions m
-           JOIN sessions s ON s.mission_id = m.id
-          WHERE m.crew_id = ?1
-            AND s.archived_at IS NULL
-          ORDER BY m.started_at ASC",
-    )?;
-    let ids = stmt
-        .query_map(params![crew_id], |row| row.get::<_, String>(0))?
-        .collect::<rusqlite::Result<Vec<_>>>()?;
-    Ok(ids)
+fn command_error(e: Error) -> ErrorData {
+    match e {
+        Error::Msg(message) => ErrorData::invalid_request(message, None),
+        other => ErrorData::internal_error(other.to_string(), None),
+    }
 }
 
 #[tool_router(router = crew_router, vis = "pub(crate)")]
@@ -107,101 +96,16 @@ impl RunnerMcpHandler {
         &self,
         Parameters(CrewIdArgs { id }): Parameters<CrewIdArgs>,
     ) -> Result<CallToolResult, ErrorData> {
-        let conn = self
+        let mut conn = self
             .state
             .db
             .get()
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
-        let affected_missions = unarchived_mission_session_ids_for_crew(&conn, &id)
-            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
-        if !affected_missions.is_empty() {
-            return Err(ErrorData::invalid_request(
-                format!(
-                    "crew {id} has unarchived mission sessions; archive those sessions first: {}",
-                    affected_missions.join(", ")
-                ),
-                None,
-            ));
-        }
-        crew::delete(&conn, &id).map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        crew::delete(&mut conn, &id).map_err(command_error)?;
         self.state.app_handle.emit("crew/changed", ()).ok();
         self.state.app_handle.emit("slot/changed", ()).ok();
         Ok(CallToolResult::success(vec![Content::json(
             serde_json::json!({ "deleted": true, "id": id }),
         )?]))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::db;
-
-    #[test]
-    fn unarchived_mission_session_ids_for_crew_blocks_stopped_and_running_sessions() {
-        let pool = db::open_in_memory().unwrap();
-        let conn = pool.get().unwrap();
-        let now = "2026-06-19T00:00:00Z";
-        conn.execute(
-            "INSERT INTO crews (id, name, created_at, updated_at)
-             VALUES ('crew-live', 'Live', ?1, ?1)",
-            params![now],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO crews (id, name, created_at, updated_at)
-             VALUES ('crew-other', 'Other', ?1, ?1)",
-            params![now],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO runners (id, handle, display_name, runtime, command, created_at, updated_at)
-             VALUES ('runner-1', 'runner1', 'Runner 1', 'shell', 'sh', ?1, ?1)",
-            params![now],
-        )
-        .unwrap();
-        for (mission_id, crew_id) in [
-            ("mission-live", "crew-live"),
-            ("mission-stopped", "crew-live"),
-            ("mission-archived-session", "crew-live"),
-            ("mission-other", "crew-other"),
-        ] {
-            conn.execute(
-                "INSERT INTO missions (id, crew_id, title, status, started_at)
-                 VALUES (?1, ?2, ?1, 'running', ?3)",
-                params![mission_id, crew_id, now],
-            )
-            .unwrap();
-        }
-        conn.execute(
-            "INSERT INTO sessions (id, mission_id, runner_id, status, started_at)
-             VALUES ('session-live', 'mission-live', 'runner-1', 'running', ?1)",
-            params![now],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO sessions (id, mission_id, runner_id, status, started_at)
-             VALUES ('session-stopped', 'mission-stopped', 'runner-1', 'stopped', ?1)",
-            params![now],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO sessions (id, mission_id, runner_id, status, started_at, archived_at)
-             VALUES ('session-archived', 'mission-archived-session', 'runner-1', 'stopped', ?1, ?1)",
-            params![now],
-        )
-        .unwrap();
-        conn.execute(
-            "INSERT INTO sessions (id, mission_id, runner_id, status, started_at)
-             VALUES ('session-other', 'mission-other', 'runner-1', 'running', ?1)",
-            params![now],
-        )
-        .unwrap();
-
-        let ids = unarchived_mission_session_ids_for_crew(&conn, "crew-live").unwrap();
-        assert_eq!(
-            ids,
-            vec!["mission-live".to_string(), "mission-stopped".to_string()]
-        );
     }
 }

--- a/src-tauri/src/mcp/tools/runner.rs
+++ b/src-tauri/src/mcp/tools/runner.rs
@@ -6,6 +6,7 @@ use serde::Deserialize;
 use tauri::Emitter;
 
 use crate::commands::runner;
+use crate::error::Error;
 use crate::mcp::server::RunnerMcpHandler;
 
 #[derive(Debug, Deserialize, JsonSchema)]
@@ -26,6 +27,13 @@ pub struct UpdateRunnerArgs {
     pub id: String,
     /// Fields to update. Omitted fields are preserved.
     pub input: runner::UpdateRunnerInput,
+}
+
+fn command_error(e: Error) -> ErrorData {
+    match e {
+        Error::Msg(message) => ErrorData::invalid_request(message, None),
+        other => ErrorData::internal_error(other.to_string(), None),
+    }
 }
 
 #[tool_router(router = runner_router, vis = "pub(crate)")]
@@ -111,6 +119,14 @@ impl RunnerMcpHandler {
         &self,
         Parameters(RunnerIdArgs { id }): Parameters<RunnerIdArgs>,
     ) -> Result<CallToolResult, ErrorData> {
+        {
+            let conn = self
+                .state
+                .db
+                .get()
+                .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+            runner::ensure_delete_allowed(&conn, &id).map_err(command_error)?;
+        }
         self.state
             .sessions
             .kill_all_for_runner(&id)
@@ -120,8 +136,7 @@ impl RunnerMcpHandler {
             .db
             .get()
             .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
-        runner::delete(&mut conn, &id)
-            .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
+        runner::delete(&mut conn, &id).map_err(command_error)?;
         self.state.app_handle.emit("runner/changed", ()).ok();
         self.state.app_handle.emit("slot/changed", ()).ok();
         Ok(CallToolResult::success(vec![Content::json(

--- a/src-tauri/src/repo/session.rs
+++ b/src-tauri/src/repo/session.rs
@@ -358,6 +358,9 @@ pub fn list_for_mission(
 
 /// A direct-chat session row plus the runner-template labels the sidebar
 /// needs. `runner_*` fields are None for runtime-only chats (#195).
+/// Direct chats are exactly rows with no mission and no slot; legacy
+/// orphaned mission-slot rows can have `mission_id NULL` after the old
+/// FK behavior, but their `slot_id` must keep them off this surface.
 #[derive(Debug, Clone)]
 pub struct DirectSessionRow {
     pub row: SessionRowDb,
@@ -392,6 +395,7 @@ pub fn list_recent_direct(conn: &Connection) -> rusqlite::Result<Vec<DirectSessi
            FROM sessions s
            LEFT JOIN runners r ON r.id = s.runner_id
           WHERE s.mission_id IS NULL
+            AND s.slot_id IS NULL
             AND s.archived_at IS NULL
           ORDER BY CASE WHEN s.pinned_at IS NOT NULL THEN 0 ELSE 1 END,
                    CASE WHEN s.status = 'running'    THEN 0 ELSE 1 END,
@@ -413,7 +417,8 @@ pub fn get_direct(conn: &Connection, id: &str) -> rusqlite::Result<Option<Direct
            FROM sessions s
            LEFT JOIN runners r ON r.id = s.runner_id
           WHERE s.id = ?1
-            AND s.mission_id IS NULL",
+            AND s.mission_id IS NULL
+            AND s.slot_id IS NULL",
         qualified_select_list("s", COLUMNS)
     );
     conn.query_row(&sql, rusqlite::params![id], direct_row)
@@ -647,6 +652,14 @@ mod tests {
             rusqlite::params![now],
         )
         .unwrap();
+        // Legacy orphan from the old mission FK: no mission, but still
+        // slot-bound, so it must never masquerade as a direct chat.
+        conn.execute(
+            "INSERT INTO sessions (id, mission_id, runner_id, slot_id, status, started_at)
+             VALUES ('orphan-slot', NULL, 'r1', 'slot-old', 'stopped', ?1)",
+            rusqlite::params![now],
+        )
+        .unwrap();
 
         let listed = list_recent_direct(&conn).unwrap();
         let ids: Vec<&str> = listed.iter().map(|d| d.row.id.as_str()).collect();
@@ -660,5 +673,9 @@ mod tests {
 
         let archived = get_direct(&conn, "d3").unwrap().unwrap();
         assert!(archived.row.archived_at.is_some());
+        assert!(
+            get_direct(&conn, "orphan-slot").unwrap().is_none(),
+            "slot-bound orphaned mission sessions must stay off direct-chat surfaces"
+        );
     }
 }

--- a/src-tauri/src/session/manager/mod.rs
+++ b/src-tauri/src/session/manager/mod.rs
@@ -833,7 +833,11 @@ fn emit_runner_activity(pool: &DbPool, runner: &Runner, events: &dyn SessionEven
     let direct_session_id: Option<String> = conn
         .query_row(
             "SELECT id FROM sessions
-              WHERE runner_id = ?1 AND status = 'running' AND mission_id IS NULL
+              WHERE runner_id = ?1
+                AND status = 'running'
+                AND mission_id IS NULL
+                AND slot_id IS NULL
+                AND archived_at IS NULL
               ORDER BY started_at DESC
               LIMIT 1",
             params![runner.id],

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -1454,6 +1454,57 @@ fn spawn_direct_writes_session_with_null_mission_id_and_emits_activity() {
 }
 
 #[test]
+fn runner_activity_event_direct_session_id_ignores_slot_bound_orphans() {
+    let pool = pool_with_schema();
+    let now = Utc::now();
+    let runner_id = ulid::Ulid::new().to_string();
+    {
+        let conn = pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'directevent', 'Direct Event', 'shell', '/bin/cat',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+            params![runner_id, now.to_rfc3339()],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions
+                    (id, mission_id, runner_id, slot_id, status, started_at)
+                 VALUES ('slot-orphan-newer', NULL, ?1, 'slot-old', 'running', ?2)",
+            params![
+                runner_id,
+                (now + chrono::Duration::seconds(10)).to_rfc3339()
+            ],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions
+                    (id, mission_id, runner_id, slot_id, status, started_at)
+                 VALUES ('direct-valid-older', NULL, ?1, NULL, 'running', ?2)",
+            params![runner_id, now.to_rfc3339()],
+        )
+        .unwrap();
+    }
+
+    let mut r = runner("/bin/cat", &[]);
+    r.id = runner_id;
+    r.handle = "directevent".into();
+    let cap = capture();
+    emit_runner_activity(&pool, &r, cap.as_ref());
+
+    let activity = cap.activity.lock().unwrap();
+    let ev = activity.last().expect("runner/activity event emitted");
+    assert_eq!(
+        ev.direct_session_id.as_deref(),
+        Some("direct-valid-older"),
+        "slot-bound orphan must not be emitted as a direct chat"
+    );
+}
+
+#[test]
 fn direct_chat_status_transition_emits_session_status_busy() {
     let pool = pool_with_schema();
     let now = Utc::now().to_rfc3339();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { AppShell } from "./components/AppShell";
+import { ToastProvider } from "./contexts/ToastContext";
 import { UpdateProvider } from "./contexts/UpdateContext";
 import { nudgeAppZoom } from "./lib/appZoom";
 import { readAppZoom } from "./lib/settings";
@@ -78,21 +79,23 @@ export default function App() {
 
   return (
     <UpdateProvider>
-      <BrowserRouter>
-        <InitialRouteBootstrap />
-        <Routes>
-          <Route element={<AppShell />}>
-            <Route path="/" element={<Navigate to="/runners" replace />} />
-            <Route path="/crews" element={<Crews />} />
-            <Route path="/crews/:crewId" element={<CrewEditor />} />
-            <Route path="/runners" element={<Runners />} />
-            <Route path="/runners/:handle" element={<RunnerDetail />} />
-            <Route path="/chats/:sessionId" element={<RunnerChat />} />
-            <Route path="/missions/:id" element={<MissionWorkspace />} />
-            <Route path="*" element={<Navigate to="/runners" replace />} />
-          </Route>
-        </Routes>
-      </BrowserRouter>
+      <ToastProvider>
+        <BrowserRouter>
+          <InitialRouteBootstrap />
+          <Routes>
+            <Route element={<AppShell />}>
+              <Route path="/" element={<Navigate to="/runners" replace />} />
+              <Route path="/crews" element={<Crews />} />
+              <Route path="/crews/:crewId" element={<CrewEditor />} />
+              <Route path="/runners" element={<Runners />} />
+              <Route path="/runners/:handle" element={<RunnerDetail />} />
+              <Route path="/chats/:sessionId" element={<RunnerChat />} />
+              <Route path="/missions/:id" element={<MissionWorkspace />} />
+              <Route path="*" element={<Navigate to="/runners" replace />} />
+            </Route>
+          </Routes>
+        </BrowserRouter>
+      </ToastProvider>
     </UpdateProvider>
   );
 }

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,0 +1,99 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+import { X } from "lucide-react";
+
+type ToastTone = "info" | "success" | "error";
+
+interface ToastState {
+  message: string;
+  tone: ToastTone;
+}
+
+interface ToastOptions {
+  tone?: ToastTone;
+  durationMs?: number | null;
+}
+
+interface ToastContextValue {
+  showToast: (message: string, options?: ToastOptions) => void;
+  hideToast: () => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+const toneClass: Record<ToastTone, string> = {
+  info: "border-line-strong bg-panel text-fg",
+  success: "border-accent/40 bg-panel text-accent",
+  error: "border-danger/40 bg-panel text-danger",
+};
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toast, setToast] = useState<ToastState | null>(null);
+  const timerRef = useRef<number | null>(null);
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current != null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const hideToast = useCallback(() => {
+    clearTimer();
+    setToast(null);
+  }, [clearTimer]);
+
+  const showToast = useCallback(
+    (message: string, options: ToastOptions = {}) => {
+      clearTimer();
+      setToast({ message, tone: options.tone ?? "info" });
+      const durationMs = options.durationMs === undefined ? 6000 : options.durationMs;
+      if (durationMs == null) return;
+      timerRef.current = window.setTimeout(() => {
+        setToast(null);
+        timerRef.current = null;
+      }, durationMs);
+    },
+    [clearTimer],
+  );
+
+  useEffect(() => clearTimer, [clearTimer]);
+
+  return (
+    <ToastContext.Provider value={{ showToast, hideToast }}>
+      {children}
+      {toast ? (
+        <div
+          role={toast.tone === "error" ? "alert" : "status"}
+          className={`fixed left-1/2 top-5 z-[60] flex w-[min(420px,calc(100vw-32px))] -translate-x-1/2 items-start gap-3 rounded-lg border px-4 py-3 text-sm shadow-[0_8px_24px_rgba(0,0,0,0.5)] ${toneClass[toast.tone]}`}
+        >
+          <span className="min-w-0 flex-1 break-words leading-5">{toast.message}</span>
+          <button
+            type="button"
+            onClick={hideToast}
+            aria-label="Dismiss notification"
+            className="mt-0.5 flex size-5 shrink-0 cursor-pointer items-center justify-center rounded text-current opacity-70 transition-opacity hover:opacity-100"
+          >
+            <X aria-hidden className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      ) : null}
+    </ToastContext.Provider>
+  );
+}
+
+// Co-located with the provider to match UpdateContext's local pattern.
+// eslint-disable-next-line react-refresh/only-export-components
+export function useToast() {
+  const ctx = useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within ToastProvider");
+  return ctx;
+}

--- a/src/pages/Crews.tsx
+++ b/src/pages/Crews.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from "react-router-dom";
 
 import { listen } from "@tauri-apps/api/event";
 
+import { useToast } from "../contexts/ToastContext";
 import { api } from "../lib/api";
 import type { CrewListItem } from "../lib/types";
 import { Button } from "../components/ui/Button";
@@ -21,6 +22,8 @@ export default function Crews() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
+  const [deletingCrewId, setDeletingCrewId] = useState<string | null>(null);
+  const { showToast } = useToast();
   const navigate = useNavigate();
 
   const refresh = useCallback(async () => {
@@ -75,12 +78,24 @@ export default function Crews() {
   }, [refresh]);
 
   const onDelete = async (id: string, name: string) => {
+    if (deletingCrewId) return;
     if (!confirm(`Delete crew "${name}"? This removes all its slots.`)) return;
+    if (
+      !confirm(
+        `Delete crew "${name}" permanently?\n\nThis also deletes archived missions and session history for this crew. Crews with non-archived missions cannot be deleted until those missions are archived.`,
+      )
+    )
+      return;
+    setDeletingCrewId(id);
+    showToast(`Deleting crew "${name}"...`, { durationMs: null });
     try {
       await api.crew.delete(id);
       await refresh();
+      showToast(`Deleted crew "${name}".`, { tone: "success" });
     } catch (e) {
-      setError(String(e));
+      showToast(String(e), { tone: "error" });
+    } finally {
+      setDeletingCrewId(null);
     }
   };
 
@@ -131,6 +146,7 @@ export default function Crews() {
                 <CrewCard
                   key={c.id}
                   item={c}
+                  deleting={deletingCrewId === c.id}
                   onOpen={() => navigate(`/crews/${c.id}`)}
                   onDelete={() => onDelete(c.id, c.name)}
                 />
@@ -181,10 +197,12 @@ function UsersIcon() {
 // list each slot with `@slot_handle` + `runtime-runner_handle`.
 function CrewCard({
   item,
+  deleting,
   onOpen,
   onDelete,
 }: {
   item: CrewListItem;
+  deleting: boolean;
   onOpen: () => void;
   onDelete: () => void;
 }) {
@@ -263,14 +281,15 @@ function CrewCard({
                 </button>
                 <button
                   type="button"
+                  disabled={deleting}
                   onClick={(e) => {
                     e.stopPropagation();
                     setMenuOpen(false);
                     onDelete();
                   }}
-                  className="cursor-pointer rounded px-2 py-1.5 text-left text-[13px] text-danger hover:bg-danger/10"
+                  className="cursor-pointer rounded px-2 py-1.5 text-left text-[13px] text-danger hover:bg-danger/10 disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent"
                 >
-                  Delete
+                  {deleting ? "Deleting…" : "Delete"}
                 </button>
               </div>
             ) : null}

--- a/src/pages/Runners.tsx
+++ b/src/pages/Runners.tsx
@@ -12,6 +12,7 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { listen } from "@tauri-apps/api/event";
 import { MessageSquare } from "lucide-react";
 
+import { useToast } from "../contexts/ToastContext";
 import { api } from "../lib/api";
 import { readDefaultWorkingDir } from "../lib/settings";
 import type { RunnerActivityEvent, RunnerWithActivity } from "../lib/types";
@@ -27,6 +28,7 @@ export default function Runners() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [creating, setCreating] = useState(false);
+  const { showToast } = useToast();
   const location = useLocation();
   const navigate = useNavigate();
 
@@ -136,7 +138,7 @@ export default function Runners() {
         state: { sessionStatus: "running" },
       });
     } catch (e) {
-      setError(String(e));
+      showToast(String(e), { tone: "error" });
     } finally {
       setChatPending(null);
     }
@@ -145,15 +147,16 @@ export default function Runners() {
   const onDelete = async (id: string, handle: string) => {
     if (
       !confirm(
-        `Delete runner @${handle}? This removes it from every crew it's in, kills any live chats, and erases its session history. Crews and missions are kept.`,
+        `Delete runner @${handle}? This removes it from every crew it's in and deletes archived session history for that runner. Unarchived chats must be archived first. Crews and missions are kept.`,
       )
     )
       return;
     try {
       await api.runner.delete(id);
       await refresh();
+      showToast(`Deleted runner @${handle}.`, { tone: "success" });
     } catch (e) {
-      setError(String(e));
+      showToast(String(e), { tone: "error" });
     }
   };
 


### PR DESCRIPTION
Fixes #263.

Summary:
- Block runner deletion when unarchived direct chats exist, then hard-delete all runner sessions before deleting the runner row.
- Block crew deletion when non-archived missions exist, then hard-delete archived mission sessions before deleting the crew row.
- Treat direct chats as mission_id IS NULL and slot_id IS NULL across direct-chat listing and runner activity, including live runner/activity events.
- Add shared top-center toast handling for delete progress, success, and action errors.

Validation:
- cargo fmt
- cargo test -p runner session::manager --lib
- cargo test -p runner commands::crew --lib
- cargo test -p runner commands::runner --lib
- cargo test -p runner repo::session --lib
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check