### PR TITLE
Fix split chat sidebar tab UI

### DIFF
--- a/src/components/ChatTabGroup.tsx
+++ b/src/components/ChatTabGroup.tsx
@@ -1,5 +1,5 @@
 // Sidebar accordion for a multi-pane tab (impl 0023). A tab with ≥2 member
-// chats renders as a disclosure header (split icon · name · pin marker · a
+// chats renders as a disclosure header (pin marker · split icon · name · a
 // trailing collapse chevron) over a left rail wrapping the member rows.
 // Single-member and un-tabbed chats never reach here — they stay flat
 // `SessionRow` leaves.
@@ -14,6 +14,7 @@
 import { ChevronDown, Columns2, Columns3, Pin } from "lucide-react";
 
 import type { DirectSessionEntry } from "../lib/api";
+import { derivedChatTabTitle } from "../lib/chatTabs";
 import {
   findLeaf,
   setTabCollapsed,
@@ -21,13 +22,6 @@ import {
 } from "../lib/paneLayout";
 import type { SessionActivityState } from "../lib/types";
 import { SessionRow } from "./Sidebar";
-
-function memberLabel(session: DirectSessionEntry): string {
-  return (
-    session.title ??
-    (session.handle ? `@${session.handle}` : session.display_name)
-  );
-}
 
 export function ChatTabGroup({
   layout,
@@ -38,6 +32,7 @@ export function ChatTabGroup({
   renamingId,
   onOpenChat,
   onActivateTab,
+  onTabContextMenu,
   onMemberContextMenu,
   onMemberRenameSubmit,
   onMemberRenameCancel,
@@ -55,6 +50,10 @@ export function ChatTabGroup({
   onOpenChat: (session: DirectSessionEntry) => void;
   /** Header click: activate this tab, never fill another tab's empty pane. */
   onActivateTab: (session: DirectSessionEntry) => void;
+  onTabContextMenu: (
+    members: DirectSessionEntry[],
+    anchor: { x: number; y: number },
+  ) => void;
   onMemberContextMenu: (
     session: DirectSessionEntry,
     anchor: { x: number; y: number },
@@ -68,7 +67,7 @@ export function ChatTabGroup({
     findLeaf(layout.root, layout.focusedPaneId)?.sessionId ?? null;
   const nameSource =
     members.find((m) => m.session_id === paneFocusedSessionId) ?? members[0];
-  const name = layout.name ?? memberLabel(nameSource);
+  const name = layout.name ?? derivedChatTabTitle(members);
   const pinned = members.every((m) => m.pinned);
 
   const SplitIcon = members.length >= 3 ? Columns3 : Columns2;
@@ -79,7 +78,13 @@ export function ChatTabGroup({
 
   return (
     <div className="flex flex-col gap-0.5">
-      <div className="group relative flex items-center gap-1.5 rounded-md border border-transparent px-2.5 py-1.5 text-xs transition-colors hover:border-sidebar-selected-border hover:bg-sidebar-selected/40">
+      <div
+        onContextMenu={(e) => {
+          e.preventDefault();
+          onTabContextMenu(members, { x: e.clientX, y: e.clientY });
+        }}
+        className="group relative flex items-center gap-1.5 rounded-md border border-transparent px-2.5 py-1.5 text-xs transition-colors hover:border-sidebar-selected-border hover:bg-sidebar-selected/40"
+      >
         <button
           type="button"
           onClick={() => {
@@ -93,16 +98,16 @@ export function ChatTabGroup({
           title={name}
           className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
         >
-          <SplitIcon
-            aria-hidden
-            className={`h-3 w-3 shrink-0 ${active ? "text-accent" : "text-fg-2"}`}
-          />
           {pinned ? (
             <Pin
               aria-hidden
               className="h-2.5 w-2.5 shrink-0 -rotate-45 text-fg-3"
             />
           ) : null}
+          <SplitIcon
+            aria-hidden
+            className={`h-3 w-3 shrink-0 ${active ? "text-accent" : "text-fg-2"}`}
+          />
           <span className={`truncate text-fg ${active ? "font-semibold" : ""}`}>
             {name}
           </span>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -69,6 +69,7 @@ import {
   leafForSession,
   newChatTargetPane,
   removeSessionFromLayout,
+  setGroupNameForSession,
   usePaneLayout,
   usePaneLayouts,
   visibleSessionIds,
@@ -238,6 +239,11 @@ export function Sidebar({
   // both work without per-row refs. `null` = closed.
   const [sessionMenu, setSessionMenu] = useState<{
     session: DirectSessionEntry;
+    x: number;
+    y: number;
+  } | null>(null);
+  const [chatTabMenu, setChatTabMenu] = useState<{
+    members: DirectSessionEntry[];
     x: number;
     y: number;
   } | null>(null);
@@ -616,14 +622,27 @@ export function Sidebar({
   // render path so the menu stays visible near the right edge.
   const openSessionMenu = useCallback(
     (session: DirectSessionEntry, anchor: { x: number; y: number }) => {
+      setChatTabMenu(null);
+      setMissionMenu(null);
       setSessionMenu({ session, x: anchor.x, y: anchor.y });
     },
     [],
   );
   const closeSessionMenu = useCallback(() => setSessionMenu(null), []);
+  const openChatTabMenu = useCallback(
+    (members: DirectSessionEntry[], anchor: { x: number; y: number }) => {
+      setSessionMenu(null);
+      setMissionMenu(null);
+      setChatTabMenu({ members, x: anchor.x, y: anchor.y });
+    },
+    [],
+  );
+  const closeChatTabMenu = useCallback(() => setChatTabMenu(null), []);
 
   const openMissionMenu = useCallback(
     (mission: MissionSummary, anchor: { x: number; y: number }) => {
+      setChatTabMenu(null);
+      setSessionMenu(null);
       setMissionMenu({ mission, x: anchor.x, y: anchor.y });
     },
     [],
@@ -779,6 +798,66 @@ export function Sidebar({
       }
     },
     [currentChatSessionId, navigate, refreshDirectSessions],
+  );
+
+  const setChatTabPin = useCallback(
+    async (members: DirectSessionEntry[], nextPinned: boolean) => {
+      const memberIds = members.map((member) => member.session_id);
+      const firstId = memberIds[0];
+      if (!firstId) return;
+      const targets = groupPinTargets(
+        firstId,
+        memberIds,
+        pinnedSessionIds(directSessions),
+        nextPinned,
+      );
+      try {
+        await Promise.all(targets.map((id) => api.session.pin(id, nextPinned)));
+        await refreshDirectSessions();
+      } catch (e) {
+        console.error("sidebar: chat tab session_pin failed", e);
+      }
+    },
+    [directSessions, refreshDirectSessions],
+  );
+
+  const renameChatTab = useCallback((members: DirectSessionEntry[]) => {
+    const first = members[0];
+    if (!first) return;
+    const layout = getPaneLayout(first.session_id);
+    const proposed = window.prompt(
+      "Rename group (blank = derive from chats)",
+      layout.name ?? "",
+    );
+    if (proposed === null) return;
+    setGroupNameForSession(first.session_id, proposed);
+  }, []);
+
+  const openChatTabInNewWindow = useCallback((members: DirectSessionEntry[]) => {
+    const first = members[0];
+    if (!first) return;
+    const layout = getPaneLayout(first.session_id);
+    const focusedSessionId =
+      findLeaf(layout.root, layout.focusedPaneId)?.sessionId ?? null;
+    const target =
+      members.find((member) => member.session_id === focusedSessionId) ?? first;
+    void api.window.open(`/chats/${target.session_id}`).catch((e) =>
+      console.error("sidebar: open chat tab in new window failed", e),
+    );
+  }, []);
+
+  const archiveChatTab = useCallback(
+    async (members: DirectSessionEntry[]) => {
+      const ordered = [...members].sort((a, b) => {
+        if (a.session_id === currentChatSessionId) return 1;
+        if (b.session_id === currentChatSessionId) return -1;
+        return 0;
+      });
+      for (const member of ordered) {
+        await archiveSession(member);
+      }
+    },
+    [archiveSession, currentChatSessionId],
   );
 
   const submitRename = useCallback(
@@ -946,6 +1025,7 @@ export function Sidebar({
           renamingId={renamingId}
           onOpenChat={openDirectChat}
           onActivateTab={activateTabChat}
+          onTabContextMenu={openChatTabMenu}
           onMemberContextMenu={openSessionMenu}
           onMemberRenameSubmit={(sessionId, title) =>
             void submitRename(sessionId, title)
@@ -1260,6 +1340,36 @@ export function Sidebar({
           onArchive={() => {
             void archiveSession(sessionMenu.session);
             closeSessionMenu();
+          }}
+        />
+      ) : null}
+
+      {chatTabMenu ? (
+        <RowContextMenu
+          pinned={chatTabMenu.members.every((member) => member.pinned)}
+          anchorX={chatTabMenu.x}
+          anchorY={chatTabMenu.y}
+          renameLabel="Rename group"
+          archiveLabel="Archive all"
+          onClose={closeChatTabMenu}
+          onPin={() => {
+            void setChatTabPin(
+              chatTabMenu.members,
+              !chatTabMenu.members.every((member) => member.pinned),
+            );
+            closeChatTabMenu();
+          }}
+          onRename={() => {
+            renameChatTab(chatTabMenu.members);
+            closeChatTabMenu();
+          }}
+          onOpenInNewWindow={() => {
+            openChatTabInNewWindow(chatTabMenu.members);
+            closeChatTabMenu();
+          }}
+          onArchive={() => {
+            void archiveChatTab(chatTabMenu.members);
+            closeChatTabMenu();
           }}
         />
       ) : null}
@@ -1783,6 +1893,8 @@ function RowContextMenu({
   onRename,
   onOpenInNewWindow,
   onArchive,
+  renameLabel = "Rename",
+  archiveLabel = "Archive",
 }: {
   pinned: boolean;
   anchorX: number;
@@ -1792,6 +1904,8 @@ function RowContextMenu({
   onRename: () => void;
   onOpenInNewWindow: () => void;
   onArchive: () => void;
+  renameLabel?: string;
+  archiveLabel?: string;
 }) {
   const ref = useRef<HTMLDivElement>(null);
   const [pos, setPos] = useState({ x: anchorX, y: anchorY });
@@ -1833,7 +1947,7 @@ function RowContextMenu({
         label={pinned ? "Unpin" : "Pin"}
         onClick={onPin}
       />
-      <ContextMenuItem icon={SquarePen} label="Rename" onClick={onRename} />
+      <ContextMenuItem icon={SquarePen} label={renameLabel} onClick={onRename} />
       <ContextMenuItem
         icon={AppWindow}
         label="Open in New Window"
@@ -1841,7 +1955,7 @@ function RowContextMenu({
       />
       <ContextMenuItem
         icon={Archive}
-        label="Archive"
+        label={archiveLabel}
         onClick={onArchive}
         danger
       />

--- a/src/lib/chatTabs.test.ts
+++ b/src/lib/chatTabs.test.ts
@@ -1,10 +1,28 @@
 import { describe, expect, it } from "vitest";
 
-import { buildChatListItems, type ChatListItem } from "./chatTabs";
+import {
+  buildChatListItems,
+  derivedChatTabTitle,
+  type ChatListItem,
+} from "./chatTabs";
 import { applyPresetPure } from "./paneLayout";
 
 function rows(...ids: string[]): { session_id: string }[] {
   return ids.map((session_id) => ({ session_id }));
+}
+
+function titleMembers(
+  ...members: {
+    title?: string | null;
+    handle?: string | null;
+    display_name?: string;
+  }[]
+) {
+  return members.map((member, index) => ({
+    title: member.title ?? null,
+    handle: member.handle ?? null,
+    display_name: member.display_name ?? `Runner ${index + 1}`,
+  }));
 }
 
 // Group → "[A,B]" (members in slot order); loose → "A".
@@ -83,5 +101,29 @@ describe("buildChatListItems", () => {
     const input = rows("A", "X");
     const tab = applyPresetPure("cols-2", "A", ["A", "GONE"]);
     expect(shape(buildChatListItems(input, [tab]))).toEqual(["A", "X"]);
+  });
+});
+
+describe("derivedChatTabTitle", () => {
+  it("combines default-created chat titles for multi-chat tabs", () => {
+    expect(
+      derivedChatTabTitle(
+        titleMembers(
+          { title: "Chat with Codex", handle: "codex" },
+          { title: "Chat with Claude", handle: "claude" },
+        ),
+      ),
+    ).toBe("Chat with Codex + Chat with Claude");
+  });
+
+  it("falls back to handle then display name for unnamed chats", () => {
+    expect(
+      derivedChatTabTitle(
+        titleMembers(
+          { handle: "coder", display_name: "Codex" },
+          { display_name: "Runtime chat" },
+        ),
+      ),
+    ).toBe("@coder + Runtime chat");
   });
 });

--- a/src/lib/chatTabs.ts
+++ b/src/lib/chatTabs.ts
@@ -24,6 +24,26 @@ export interface LooseChatItem<T> {
 
 export type ChatListItem<T> = TabGroupItem<T> | LooseChatItem<T>;
 
+export function chatTabMemberLabel(member: {
+  title?: string | null;
+  handle?: string | null;
+  display_name: string;
+}): string {
+  return (
+    member.title ?? (member.handle ? `@${member.handle}` : member.display_name)
+  );
+}
+
+export function derivedChatTabTitle<
+  T extends {
+    title?: string | null;
+    handle?: string | null;
+    display_name: string;
+  },
+>(members: readonly T[]): string {
+  return members.map(chatTabMemberLabel).join(" + ");
+}
+
 /**
  * Order the CHAT list into groups and loose rows. Backend sort order is
  * preserved: each group is anchored where its best-sorted member already

--- a/src/lib/paneLayout.test.ts
+++ b/src/lib/paneLayout.test.ts
@@ -21,6 +21,7 @@ import {
   resetPaneLayoutsForTest,
   serializeLayout,
   serializeLayoutSet,
+  setGroupNameForSession,
   setRouteAnchorSession,
   setSizesPure,
   setTabCollapsed,
@@ -303,6 +304,31 @@ describe("setTabCollapsed", () => {
     setTabCollapsed(7, true);
 
     expect(getPaneLayouts()).toBe(before);
+  });
+});
+
+describe("setGroupNameForSession", () => {
+  afterEach(() => {
+    resetPaneLayoutsForTest();
+  });
+
+  it("renames a background group without activating it", () => {
+    applyPreset("cols-2", "A", ["A", "B"]);
+    applyPreset("cols-2", "C", ["C", "D"]);
+    activatePaneLayoutForSession("A");
+
+    setGroupNameForSession("C", "review pair");
+
+    expect(getPaneLayout()).toBe(getPaneLayouts()[0]);
+    expect(getPaneLayouts()[1].name).toBe("review pair");
+  });
+
+  it("clears a group name with blank input", () => {
+    applyPreset("cols-2", "A", ["A", "B"], "review pair");
+
+    setGroupNameForSession("A", "   ");
+
+    expect(getPaneLayout("A").name).toBeNull();
   });
 });
 

--- a/src/lib/paneLayout.ts
+++ b/src/lib/paneLayout.ts
@@ -779,12 +779,31 @@ export function applyPreset(
   return currentLayout();
 }
 
-/** Name (or un-name, with null/blank) the split group. */
+function normalizedGroupName(name: string | null): string | null {
+  return name?.trim() || null;
+}
+
+function setGroupNameAtIndex(index: number, name: string | null): void {
+  if (index < 0 || index >= layouts.length) return;
+  const trimmed = normalizedGroupName(name);
+  const layout = layouts[index];
+  if (layout.name === trimmed) return;
+  const nextLayouts = [...layouts];
+  nextLayouts[index] = { ...layout, name: trimmed };
+  setLayoutSet(nextLayouts, activeIndex);
+}
+
+/** Name (or un-name, with null/blank) the active split group. */
 export function setGroupName(name: string | null): void {
-  const trimmed = name?.trim() || null;
-  const active = currentLayout();
-  if (active.name === trimmed) return;
-  setCurrent({ ...active, name: trimmed });
+  setGroupNameAtIndex(activeIndex, name);
+}
+
+/** Name (or un-name, with null/blank) a split group by any member session. */
+export function setGroupNameForSession(
+  sessionId: string,
+  name: string | null,
+): void {
+  setGroupNameAtIndex(findLayoutIndexForSession(sessionId), name);
 }
 
 /** Collapse or expand a tab's sidebar accordion (impl 0023), persisted with


### PR DESCRIPTION
Summary:
- Render pinned split chat tab headers as pin, split icon, then title.
- Derive unnamed multi-chat tab headers from all contained chat labels.
- Add right-click actions on multi-pane chat tab headers for pin/unpin, rename group, open in new window, and archive all.
- Add focused regression coverage for derived tab titles and background group renaming.

Validation:
- pnpm exec tsc --noEmit
- pnpm vitest run src/lib/chatTabs.test.ts src/lib/paneLayout.test.ts
- pnpm run lint
- make test (outside sandbox due MCP Unix socket bind permission)
- git diff --check

Review:
- Working-tree review clean from reviewer before PR.