### PR TITLE
Fix split chat group status

### DIFF
--- a/src/components/ChatPaneGroup.tsx
+++ b/src/components/ChatPaneGroup.tsx
@@ -28,7 +28,8 @@ import {
   type PaneLeaf,
   type PaneNode,
 } from "../lib/paneLayout";
-import type { SessionActivityState, SessionStatus } from "../lib/types";
+import type { DirectChatDisplayStatus } from "../lib/directChatStatus";
+import type { SessionStatus } from "../lib/types";
 import type { SecondaryState } from "../lib/windowFocus";
 import { DuplicateSubjectOverlay } from "./DuplicateSubjectOverlay";
 import {
@@ -47,11 +48,6 @@ interface ExitEvent {
   exit_code: number | null;
   success: boolean;
 }
-
-export type DirectChatDisplayStatus =
-  | SessionActivityState
-  | "stopped"
-  | "crashed";
 
 /** One attached session in the flat terminal stack. */
 export interface PaneChat {

--- a/src/lib/directChatStatus.test.ts
+++ b/src/lib/directChatStatus.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  directChatDisplayStatus,
+  summarizeDirectChatGroupStatus,
+} from "./directChatStatus";
+
+describe("directChatDisplayStatus", () => {
+  it("projects running sessions to their live activity state", () => {
+    expect(directChatDisplayStatus("running", "idle")).toBe("idle");
+    expect(directChatDisplayStatus("running", "busy")).toBe("busy");
+  });
+
+  it("keeps terminal lifecycle states as display states", () => {
+    expect(directChatDisplayStatus("stopped", "busy")).toBe("stopped");
+    expect(directChatDisplayStatus("crashed", "idle")).toBe("crashed");
+  });
+});
+
+describe("summarizeDirectChatGroupStatus", () => {
+  it("uses pane display state instead of raw running lifecycle state", () => {
+    expect(summarizeDirectChatGroupStatus(["idle", "idle"], 2)).toMatchObject({
+      status: "idle",
+      count: 2,
+      paneCount: 2,
+      label: "2/2 idle",
+    });
+  });
+
+  it("counts the highest-priority visible display state", () => {
+    expect(
+      summarizeDirectChatGroupStatus(["idle", "busy", "stopped"], 3),
+    ).toMatchObject({
+      status: "busy",
+      count: 1,
+      label: "1/3 busy",
+    });
+  });
+
+  it("surfaces crashed panes before live activity", () => {
+    expect(
+      summarizeDirectChatGroupStatus(["busy", "crashed", "idle"], 3),
+    ).toMatchObject({
+      status: "crashed",
+      count: 1,
+      label: "1/3 crashed",
+    });
+  });
+});

--- a/src/lib/directChatStatus.ts
+++ b/src/lib/directChatStatus.ts
@@ -1,0 +1,52 @@
+import type { SessionActivityState, SessionStatus } from "./types";
+
+export type DirectChatDisplayStatus =
+  | SessionActivityState
+  | "stopped"
+  | "crashed";
+
+export function directChatDisplayStatus(
+  status: SessionStatus,
+  activity: SessionActivityState | undefined,
+): DirectChatDisplayStatus {
+  if (status === "stopped" || status === "crashed") return status;
+  return activity ?? "busy";
+}
+
+export interface DirectChatGroupStatusSummary {
+  status: DirectChatDisplayStatus;
+  count: number;
+  paneCount: number;
+  label: string;
+}
+
+const GROUP_STATUS_PRIORITY: readonly DirectChatDisplayStatus[] = [
+  "crashed",
+  "busy",
+  "idle",
+  "stopped",
+];
+
+export function summarizeDirectChatGroupStatus(
+  statuses: readonly DirectChatDisplayStatus[],
+  paneCount = statuses.length,
+): DirectChatGroupStatusSummary {
+  const counts: Record<DirectChatDisplayStatus, number> = {
+    busy: 0,
+    idle: 0,
+    stopped: 0,
+    crashed: 0,
+  };
+  for (const status of statuses) counts[status] += 1;
+
+  const status =
+    GROUP_STATUS_PRIORITY.find((candidate) => counts[candidate] > 0) ??
+    "stopped";
+  const count = counts[status];
+  return {
+    status,
+    count,
+    paneCount,
+    label: `${count}/${paneCount} ${status}`,
+  };
+}

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -78,6 +78,11 @@ import {
   shouldInheritPinOnAdd,
 } from "../lib/groupPinning";
 import {
+  directChatDisplayStatus,
+  summarizeDirectChatGroupStatus,
+  type DirectChatDisplayStatus,
+} from "../lib/directChatStatus";
+import {
   isSecondaryFor,
   reportSubjectsNow,
   useCurrentWindowLabel,
@@ -157,16 +162,6 @@ async function inheritGroupPin(
   } catch (e) {
     console.error("RunnerChat: group pin inherit failed", e);
   }
-}
-
-type DirectChatDisplayStatus = SessionActivityState | "stopped" | "crashed";
-
-function directChatDisplayStatus(
-  status: SessionStatus,
-  activity: SessionActivityState | undefined,
-): DirectChatDisplayStatus {
-  if (status === "stopped" || status === "crashed") return status;
-  return activity ?? "busy";
 }
 
 export default function RunnerChat() {
@@ -1412,24 +1407,27 @@ export default function RunnerChat() {
         ? visiblePaneSessions.map((s) => paneNameFor(s.id)).join(" + ")
         : "Empty group"))
     : null;
-  const runningPaneCount = visiblePaneSessions.filter(
-    (s) => s.status === "running",
-  ).length;
-  const anyPaneBusy = visiblePaneSessions.some(
-    (s) =>
-      s.status === "running" && (activityBySession[s.id] ?? "busy") === "busy",
+  const groupStatus = summarizeDirectChatGroupStatus(
+    visiblePaneSessions.map((s) => paneStatusFor(s.id)),
+    paneCount,
   );
-  const groupStatusLabel = `${runningPaneCount}/${paneCount} running`;
-  const groupStatusDotClass = anyPaneBusy
-    ? "bg-accent"
-    : runningPaneCount > 0
-      ? "bg-accent/35"
-      : "bg-fg-3";
-  const groupStatusBadgeClass = anyPaneBusy
-    ? "bg-accent/10 text-accent"
-    : runningPaneCount > 0
-      ? "bg-accent/5 text-fg-2"
-      : "bg-line-strong text-fg-2";
+  const groupStatusLabel = groupStatus.label;
+  const groupStatusDotClass =
+    groupStatus.status === "busy"
+      ? "bg-accent"
+      : groupStatus.status === "idle"
+        ? "bg-accent/35"
+        : groupStatus.status === "crashed"
+          ? "bg-danger"
+          : "bg-fg-3";
+  const groupStatusBadgeClass =
+    groupStatus.status === "busy"
+      ? "bg-accent/10 text-accent"
+      : groupStatus.status === "idle"
+        ? "bg-accent/5 text-fg-2"
+        : groupStatus.status === "crashed"
+          ? "bg-danger/10 text-danger"
+          : "bg-line-strong text-fg-2";
   // Meta: pane count, plus the working dir when every member shares one.
   const groupCwds = visiblePaneSessions.map((s) => paneRow(s.id)?.cwd ?? null);
   const sharedGroupCwd =


### PR DESCRIPTION
Fixes #269.\n\nSummary:\n- Aggregate split direct-chat group status from the same display state used by pane headers.\n- Share the direct-chat display status helper with ChatPaneGroup.\n- Add regression coverage for idle group aggregation.\n\nValidation:\n- pnpm exec vitest run src/lib/directChatStatus.test.ts\n- pnpm exec tsc --noEmit\n- pnpm run lint\n- pnpm test\n- git diff --check\n\nReviewer: clean working-tree review from @reviewer; no must-fix issues.