### PR TITLE
feat(session): preserve claude-code scrollback across resume

### DIFF
--- a/docs/arch/arch.md
+++ b/docs/arch/arch.md
@@ -418,6 +418,8 @@ The PTY master writer is shared between the human (via `send_input` command) and
 
 Bounded raw-byte ring per session in SessionManager. It survives tab switches, route changes, and late workspace attachment while the app process is alive. It does not survive app restart, and there is no on-disk scrollback overflow today. The ring sees raw bytes including alt-screen toggles — acceptable because the frontend replays through xterm.js which can absorb them.
 
+Resume preserves the ring for claude-code (impl 0024): it paints inline into the main screen, so kept scrollback + resume banner + tail repaint is what a physical terminal would show, and a later remount replay keeps the pre-resume conversation. The ring stays bounded and process-local as before — old and new bytes share the same cap. Codex still purges on resume: it repaints its whole frame (and its own resume replay restores a deep conversation tail), so retained scrollback under the new frame stacks garbled content. Either way `resume` stamps a seq watermark first; the frontend's starting/resuming pills only honor TUI-ready escapes above it, so retained pre-resume bytes can't clear an overlay that's waiting on the new PTY.
+
 ### 5.9 Death and kill
 
 Reader thread owns the child handle. On EOF, it calls `wait()`, emits `session:{id}:exit`, updates the sessions row. No auto-restart.

--- a/docs/impls/0024-resume-scrollback-preservation.md
+++ b/docs/impls/0024-resume-scrollback-preservation.md
@@ -1,0 +1,98 @@
+# Preserve claude-code scrollback across session resume
+
+## Status
+
+Planned. Grew out of the investigation on issue #267 (Claude Code output history not accessible from Runner). This impl fixes the in-app half of that report — resume discarding scrollback the process still had. The durable half (history across app restart, read from claude-code's JSONL transcript) is a separate feature and stays tracked by #267; this change does not close it.
+
+## Problem
+
+Resuming a claude-code session throws away all pre-resume terminal history, even though nothing required losing it.
+
+`SessionManager::resume` calls `purge_output_buffer` up front (`src-tauri/src/session/manager/spawn.rs:932`), wiping the session's in-memory output ring. The mounted xterm instance still shows the old content (the resume overlay is only `opacity-0` — `src/components/ChatPaneGroup.tsx:323`), so the loss is invisible at first. It materializes on the next remount (route switch, webview reload): `RunnerTerminal`'s replay path does `term.reset()` and re-feeds the ring (`src/components/RunnerTerminal.tsx:1005`), which now contains only post-resume bytes.
+
+What the user gets after that is whatever `claude --resume` repaints on its own — measured empirically at roughly the **last 4 turns** of the conversation, regardless of session length. A real terminal (Ghostty, iTerm) resuming the same session keeps the entire prior scrollback above the resume banner and appends the tail repaint below it. Runner deviates from that baseline for no user-visible benefit: it deletes history a terminal emulator would keep.
+
+Why the purge exists today (contracts documented at the `spawn.rs` call site):
+
+1. **TUI-ready race.** The starting/resuming pill effects call `session_output_snapshot` to catch a `\x1b[?2004h` (bracketed paste = TUI ready) that fired before their live listener attached (`src/pages/RunnerChat.tsx:731`, `src/pages/MissionWorkspace.tsx:1423`). If the ring still held the *old* PTY's chunks — which include the pre-stop `\x1b[?2004h` — the snapshot check would clear the pill before the new PTY exists. Purging at the top of `resume()` closes that window by brute force.
+2. **Seq continuity.** `purge_output_buffer` retains the seq counter so the new PTY's first chunk continues at `last + 1` and the frontend's `seq <= lastWrittenSeq` filter doesn't drop it.
+3. **No stacked frames on remount replay.** For full-frame-repaint TUIs, replaying the old frame under the new one stacks garbled content in scrollback (the artifact class from impls 0009/0011/0020).
+
+Contract 3 is real for codex but wrong for claude-code: codex repaints the whole frame (and re-renders a large conversation tail on resume anyway — measured ~77 turns), while claude-code paints inline into the main screen, where "old content, then resume banner, then tail repaint" is exactly what a physical terminal shows. Contracts 1 and 2 can both be satisfied without deleting anything: 2 already is (the counter survives either way), and 1 needs a *boundary marker*, not an empty buffer.
+
+## Key Decisions
+
+1. **Keep the ring across resume for claude-code only.** Codex keeps today's purge: its full-frame repaint over retained scrollback is the stacking artifact the purge was added for, and its own resume replay already restores a deep tail. Shells and future runtimes (opencode, feature 30) keep today's behavior for scope; extending them later is a one-line gate change. Gate via a `runtime_purges_on_resume(session_id, pool)` helper mirroring `runtime_clears_on_resize` (`src-tauri/src/session/manager/output.rs:419`) — same COALESCE join, returns `true` for `codex`, `false` for `claude-code`, callable right after the row snapshot loads so the purge/skip decision still happens at the top of `resume()`, before any long-running step.
+2. **A seq watermark replaces "clean buffer" as the pill contract.** At the same top-of-`resume()` point, record `resume_watermark_seq = output_seq` in `SessionState` (all runtimes, uniformly — for codex it's equal to the post-purge floor, so filtering is a no-op). The pill effects' snapshot fast-path only honors TUI-ready escapes in events with `seq > watermark`. Old chunks stay replayable for the terminal but can no longer clear the overlay early.
+3. **Expose the watermark via a dedicated read command,** `session_replay_watermark(session_id) -> u64`, rather than changing `session_output_snapshot`'s return shape (which `RunnerTerminal` replay consumes as a bare array) or `session_resume`'s (a resume can be triggered from another window — impl 0018 — so the pill can't rely on the resume RPC's response reaching it). Fresh spawns report 0, so the filter is inert outside resume flows.
+4. **Do not reset the terminal-mode flags on the keep path.** `purge_output_buffer` resets `alt_screen_on` / `bracketed_paste_on` because after a purge no escape bytes remain to justify a synthetic snapshot prefix. When the buffer is kept, the old chunks carry their own mode escapes and `update_terminal_mode_state` keeps deriving state from the live stream; the seq=0 synthetic prefix stays correct for the evicted-escape case it was built for. Worst case is a redundant `\x1b[?2004h` replayed from both the prefix and a surviving chunk — harmless.
+5. **Accept the double-tail and stale-width artifacts.** The last ~4 turns will appear twice after a resume (once in kept scrollback, once in claude's repaint) — identical to resuming in Ghostty; not a bug. Kept bytes were emitted at the old grid width; a later remount replays them into the current grid, so lines wrap at the recorded width. For claude-code's inline text this reads like ordinary terminal reflow; it is bounded anyway because live resizes still purge the ring for claude-code (`resize` → `purge_output_buffer_keep_modes`, unchanged by this impl), so the kept segment never spans a width change that happened while the session was running.
+6. **No frontend rendering changes.** In-place resume already preserves the mounted xterm buffer under the `opacity-0` overlay; this impl makes the backend ring agree with it so remounts stop losing what the screen already showed. `ResumeSettleTracker` (`src/pages/RunnerChat.tsx`) listens to live events only — live events during a resume window can only come from the new PTY (resume is refused while the row is running) — so it needs no watermark. The stale `clearVersion` comment block at `src/pages/RunnerChat.tsx:1120` gets rewritten to describe the real mechanism.
+
+## Goals
+
+- Resuming a claude-code session (direct chat or mission slot) keeps all pre-resume output in the ring: scrolling up after resume shows the prior conversation, and it survives route switches / remounts for the lifetime of the app process, matching what a terminal emulator would keep.
+- The resuming/starting pills still clear only on the *new* PTY's ready signal or idle heuristic — never on stale pre-stop bytes.
+- Seq continuity, codex resume behavior, resize purge behavior, and archive/delete purge behavior are unchanged.
+
+## Non-Goals
+
+- History across app restart. The ring stays process-local and bounded (arch: `docs/arch/arch.md` §scrollback); after a restart the only full record is claude-code's JSONL under `~/.claude/projects/<encoded-cwd>/<uuid>.jsonl`. Surfacing that is #267's transcript-viewer feature, not this impl.
+- Persisting PTY bytes to disk, raising `MAX_OUTPUT_BUFFER_CHUNKS`, or any change to the bounded-ring architecture.
+- Keeping scrollback across resume for codex, shells, or other runtimes.
+- Deduplicating claude's repainted tail against kept scrollback.
+
+## Implementation Phases
+
+### Phase 1 — backend: gated purge + watermark (`src-tauri/src/session/manager/`)
+
+- `mod.rs`: add `resume_watermark_seq: u64` to `SessionState` (alongside `output_seq`).
+- `output.rs`: add `runtime_purges_on_resume(session_id, pool) -> bool` next to `runtime_clears_on_resize` (same query; matches `Some("codex")`; DB miss → `true`, i.e. fail toward today's purge). Add a `set_resume_watermark(session_id)` + `replay_watermark(session_id) -> u64` pair on `SessionManager`.
+- `spawn.rs` `resume()` (~line 929): at the existing purge point, always set the watermark from the current `output_seq`; call `purge_output_buffer` only when `runtime_purges_on_resume` says so. Rewrite the call-site comment: contract 1 is now carried by the watermark, contract 2 by the untouched counter.
+- Tests (`tests.rs`): claude-code resume keeps prior chunks and new output continues seq monotonically through a snapshot; codex resume still purges; watermark equals the pre-resume max seq for both; fresh spawn reports watermark 0; archive purge (`purge_session_buffers`) resets the watermark with the rest of the state.
+
+### Phase 2 — command + api surface
+
+- `src-tauri/src/commands/session.rs`: `session_replay_watermark(session_id) -> u64`; register in the handler list.
+- `src/lib/api.ts`: `api.session.replayWatermark(sessionId)` beside `outputSnapshot` (~line 206).
+
+### Phase 3 — frontend: watermark-aware pill fast-paths
+
+- `src/lib/sessionLifecycle.ts`: add `snapshotIndicatesTuiReady(events: OutputEvent[], watermark: number)` — `events.some((ev) => ev.seq > watermark && chunkIndicatesTuiReady(ev.data))` — so the filter lives in one tested helper.
+- `src/pages/RunnerChat.tsx` (~731) and `src/pages/MissionWorkspace.tsx` (~1423): fetch `Promise.all([outputSnapshot, replayWatermark])` in the snapshot fast-path and use the helper. The mission path is the one that actually needs it (a resumed slot re-enters the pill via `isFreshSpawn(started_at)` with old bytes now retained); the RunnerChat `starting` path gets it for uniformity (fresh rows report 0).
+- `src/pages/RunnerChat.tsx:1120`: fix the stale resume-sequence comment (`clearVersion` no longer exists; the backend no longer drops the buffer for claude-code).
+- Unit tests (vitest) for the helper: below-watermark ready escape ignored; above-watermark honored; watermark 0 degenerates to today's behavior.
+
+### Phase 4 — docs
+
+- `docs/arch/arch.md` scrollback section (~407): note that resume preserves the ring for claude-code (bounded, process-local as before) and why codex still purges.
+- Doc comments on `purge_output_buffer` (`output.rs:333`) — no longer "used by resume" unconditionally.
+
+### Phase 5 — verify
+
+- `cargo fmt && cargo clippy && cargo test --workspace`; `pnpm exec tsc --noEmit && pnpm run lint`.
+- Manual smoke (user-run): claude-code chat with a dozen turns → Stop → Resume → scroll up: pre-resume history present above the resume repaint; switch route away/back → still present; quit + relaunch → gone as before (expected; see Non-Goals); codex slot Resume → unchanged (fresh repaint, no stacked frames); mission Resume all with mixed claude/codex slots → pills clear on new-PTY readiness, not instantly.
+
+## Relevant Code
+
+- `src-tauri/src/session/manager/spawn.rs:929` — the purge call in `resume()` and its two-contract comment.
+- `src-tauri/src/session/manager/output.rs:263-357` — `output_snapshot`, `purge_session_buffers`, `purge_output_buffer`, `purge_output_buffer_keep_modes`; `runtime_clears_on_resize` at 419 (pattern for the new gate).
+- `src-tauri/src/session/manager/mod.rs:50` — `MAX_OUTPUT_BUFFER_CHUNKS`; `SessionState` fields (~447).
+- `src-tauri/src/commands/session.rs:462` — `session_resume`; new command lands beside it.
+- `src/pages/RunnerChat.tsx:697-770, 1120-1170, ResumeSettleTracker` — starting pill, resume sequence, settle tracker.
+- `src/pages/MissionWorkspace.tsx:600-667, 1385-1463` — mission resume-all dims fallback, slot starting pill.
+- `src/components/ChatPaneGroup.tsx:314-361` — transitional `opacity-0` pane (unchanged, but the mechanism this impl aligns with).
+- `src/components/RunnerTerminal.tsx:953-1105` — replay drain (`reset()` + snapshot re-feed) that turns the ring purge into visible loss.
+- `src/lib/sessionLifecycle.ts:60` — `chunkIndicatesTuiReady`.
+
+## Open Questions
+
+- **Extend the keep path to shells?** A resumed shell has no repaint at all, so keeping its scrollback is strictly closer to real-terminal behavior. Left out only for scope; flipping the gate later is trivial.
+- **Ring budget sharing.** Old and new bytes now share the 4096-chunk ring, so a long post-resume session evicts the kept history first. That is the intended bounded behavior, but if it feels too tight in practice, bumping the cap (or capping kept-history chunks at resume time) is a follow-up knob, not part of this impl.
+
+## References
+
+- Issue #267 — Claude Code output history not accessible from Runner (parent problem; durable JSONL surface remains open there).
+- Measurements (2026-07-09, claude-code 2.1.205 / codex-cli 0.143.0): `claude --resume` repaints only the last ~4 turns of a 20-turn session; `codex resume` repaints the full history of a short session and a ~77-turn tail of a 169-turn session. Neither enters the alternate screen.
+- impl [0009](archive/0009-terminal-alt-screen-reattach.md), [0011](archive/0011-pty-host-terminal-runtime.md), [0020](0020-direct-chat-split-view.md) — the repaint/stacking artifact history behind the purge-on-resume and clear-on-resize policies.
+- `docs/features/21-resume-cwd-sessions.md:25` — the original (claude-optimistic) assumption that the resumed agent repaints its own history.

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -107,6 +107,21 @@ pub async fn session_output_snapshot(
     Ok(state.sessions.output_snapshot(&session_id))
 }
 
+/// The seq the output ring had reached when the session's most
+/// recent resume started (0 for sessions that never resumed). A
+/// dedicated read command rather than a field on the snapshot or the
+/// resume RPC: the snapshot's return shape is consumed as a bare
+/// array by terminal replay, and a resume can be triggered from
+/// another window (impl 0018), so the pill effects can't rely on the
+/// resume response reaching them.
+#[tauri::command]
+pub async fn session_replay_watermark(
+    state: State<'_, AppState>,
+    session_id: String,
+) -> Result<u64> {
+    Ok(state.sessions.replay_watermark(&session_id))
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct PasteImageFormat {
     extension: &'static str,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -310,6 +310,7 @@ pub fn run() {
             commands::session::session_kill,
             commands::session::session_resize,
             commands::session::session_output_snapshot,
+            commands::session::session_replay_watermark,
             commands::session::session_paste_image,
             commands::session::session_start_direct,
             commands::session::session_start_runtime,

--- a/src-tauri/src/session/manager/mod.rs
+++ b/src-tauri/src/session/manager/mod.rs
@@ -444,6 +444,12 @@ struct SessionState {
     handle: Option<SessionHandle>,
     output_buffer: VecDeque<OutputEvent>,
     output_seq: u64,
+    /// `output_seq` at the moment the most recent resume started.
+    /// The pill fast-paths only honor TUI-ready escapes in chunks
+    /// with `seq > resume_watermark_seq`, so pre-resume bytes kept
+    /// in the ring (claude-code) can never clear a resuming overlay
+    /// that's waiting on the *new* PTY. 0 outside resume flows.
+    resume_watermark_seq: u64,
     alt_screen_on: bool,
     bracketed_paste_on: bool,
     resuming: bool,
@@ -455,6 +461,7 @@ impl SessionState {
         self.handle.is_none()
             && self.output_buffer.is_empty()
             && self.output_seq == 0
+            && self.resume_watermark_seq == 0
             && !self.alt_screen_on
             && !self.bracketed_paste_on
             && !self.resuming

--- a/src-tauri/src/session/manager/output.rs
+++ b/src-tauri/src/session/manager/output.rs
@@ -317,19 +317,43 @@ impl SessionManager {
             let mut state = state.lock().unwrap();
             state.output_buffer.clear();
             state.output_seq = 0;
+            state.resume_watermark_seq = 0;
             state.alt_screen_on = false;
             state.bracketed_paste_on = false;
         }
         self.prune_empty_session_state(session_id);
     }
 
+    /// Record the resume watermark: the seq the ring had reached when
+    /// the current resume started. Called at the top of `resume()`
+    /// for every runtime — on the purge path (codex) it equals the
+    /// post-purge floor, so the frontend's `seq > watermark` filter
+    /// is a no-op there.
+    pub fn set_resume_watermark(&self, session_id: &str) {
+        if let Some(state) = self.session_state(session_id) {
+            let mut state = state.lock().unwrap();
+            state.resume_watermark_seq = state.output_seq;
+        }
+    }
+
+    /// Read back the resume watermark for the pill fast-paths.
+    /// Sessions that never resumed (or whose state was purged)
+    /// report 0, which degenerates the frontend filter to
+    /// "any chunk counts".
+    pub fn replay_watermark(&self, session_id: &str) -> u64 {
+        self.session_state(session_id)
+            .map(|state| state.lock().unwrap().resume_watermark_seq)
+            .unwrap_or(0)
+    }
+
     /// Drop only the output buffer for a session, keeping the seq
-    /// counter. Used by `resume`: clearing the buffer means the
-    /// post-resume snapshot is fresh (no double banner / stacked
-    /// agent output on remount), while preserving the monotonic seq
-    /// means the new PTY's first chunk is `last + 1` rather than
-    /// `1` — which the frontend's `seq <= lastWrittenSeq` filter
-    /// would otherwise drop.
+    /// counter. Used by `resume` for runtimes that repaint their
+    /// whole frame on resume (codex — see `runtime_purges_on_resume`):
+    /// clearing the buffer means the post-resume snapshot is fresh
+    /// (no double banner / stacked agent output on remount), while
+    /// preserving the monotonic seq means the new PTY's first chunk
+    /// is `last + 1` rather than `1` — which the frontend's
+    /// `seq <= lastWrittenSeq` filter would otherwise drop.
     pub fn purge_output_buffer(&self, session_id: &str) {
         if let Some(state) = self.session_state(session_id) {
             let mut state = state.lock().unwrap();
@@ -432,4 +456,33 @@ pub(super) fn runtime_clears_on_resize(session_id: &str, pool: &DbPool) -> bool 
         .ok()
         .flatten();
     matches!(runtime.as_deref(), Some("claude-code") | Some("codex"))
+}
+
+/// Whether `resume` should drop the session's output ring before
+/// spawning the new PTY. Codex repaints its whole frame on resume
+/// (and its own resume replay restores a deep conversation tail), so
+/// replaying retained scrollback under the new frame stacks garbled
+/// content — the artifact class from impls 0009/0011/0020. Claude-code
+/// paints inline into the main screen: kept scrollback, then the
+/// resume banner, then the tail repaint is exactly what a physical
+/// terminal shows, so its ring is kept. Shells and future runtimes
+/// keep today's purge purely
+/// for scope (extending them is a one-line change here). Best-effort:
+/// a DB miss fails toward the purge, i.e. today's behavior.
+pub(super) fn runtime_purges_on_resume(session_id: &str, pool: &DbPool) -> bool {
+    let Ok(conn) = pool.get() else {
+        return true;
+    };
+    let runtime = conn
+        .query_row(
+            "SELECT COALESCE(s.agent_runtime, r.runtime)
+               FROM sessions s
+               LEFT JOIN runners r ON r.id = s.runner_id
+              WHERE s.id = ?1",
+            params![session_id],
+            |r| r.get::<_, Option<String>>(0),
+        )
+        .ok()
+        .flatten();
+    !matches!(runtime.as_deref(), Some("claude-code"))
 }

--- a/src-tauri/src/session/manager/spawn.rs
+++ b/src-tauri/src/session/manager/spawn.rs
@@ -911,25 +911,33 @@ impl SessionManager {
             row
         };
 
-        // Purge the prior session's output buffer up front. Two
+        // Stamp the resume watermark (and, for full-frame-repaint
+        // runtimes, purge the prior output buffer) up front. Two
         // properties depend on this happening *before* any
         // long-running step (gate, runtime.spawn, mission/runner
         // re-lookup):
         //
         // 1. The frontend's resuming-pill effect calls
         //    `session_output_snapshot` to catch a TUI-ready escape
-        //    that fired before its live listener attached. If the
-        //    purge happens after `runtime.spawn` (the original
-        //    placement), the snapshot races the resume and can
-        //    return the *old* PTY's chunks — which include the
-        //    pre-stop `\x1b[?2004h` — clearing the resuming overlay
-        //    before the new PTY exists. Purging at the top closes
-        //    that window.
-        // 2. The seq counter is intentionally retained (see
+        //    that fired before its live listener attached. The old
+        //    PTY's chunks include the pre-stop `\x1b[?2004h`, so the
+        //    pill only honors ready escapes in chunks with
+        //    `seq > session_replay_watermark`. Stamping the watermark
+        //    at the top closes the window where the snapshot could
+        //    clear the resuming overlay before the new PTY exists.
+        // 2. The seq counter is never touched (see
         //    `purge_output_buffer`'s contract) so the new PTY's first
         //    chunk continues at `last + 1` and the frontend's
         //    `seq <= lastWrittenSeq` filter doesn't drop it.
-        self.purge_output_buffer(session_id);
+        //
+        // Whether the ring itself survives is per-runtime: claude-code
+        // keeps it (a terminal emulator would; scrolling up after
+        // resume shows the prior conversation), codex/shells purge —
+        // see `runtime_purges_on_resume`.
+        self.set_resume_watermark(session_id);
+        if output::runtime_purges_on_resume(session_id, &pool) {
+            self.purge_output_buffer(session_id);
+        }
 
         // Mission resume: pull the slot + mission so we can stamp the
         // in-mission env (RUNNER_HANDLE = slot_handle, RUNNER_CREW_ID,

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -1960,6 +1960,231 @@ fn resume_reuses_row_and_preserves_agent_session_key() {
     mgr.kill(&session_id).unwrap();
 }
 
+/// Poll `output_snapshot` until it holds at least `min_len` chunks.
+/// The forwarder thread records chunks asynchronously, so tests that
+/// push through FakeRuntime must wait for the ring to catch up.
+fn wait_for_snapshot(mgr: &SessionManager, session_id: &str, min_len: usize) -> Vec<OutputEvent> {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let snapshot = mgr.output_snapshot(session_id);
+        if snapshot.len() >= min_len {
+            return snapshot;
+        }
+        if Instant::now() > deadline {
+            panic!("snapshot for {session_id} never reached {min_len} chunks");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+/// Poll the sessions row until the forwarder demotes it from
+/// `running` — `resume()` refuses rows that still look live.
+fn wait_for_db_stop(pool: &DbPool, session_id: &str) {
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let conn = pool.get().unwrap();
+        let status: String = conn
+            .query_row(
+                "SELECT status FROM sessions WHERE id = ?1",
+                params![session_id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        if status != "running" {
+            return;
+        }
+        if Instant::now() > deadline {
+            panic!("session {session_id} never left running");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+}
+
+#[test]
+fn resume_keeps_scrollback_for_claude_code() {
+    // Impl 0024: resuming a claude-code session must NOT drop the
+    // output ring — a terminal emulator keeps pre-resume scrollback
+    // above the resume repaint, and the ring has to agree with the
+    // mounted xterm so a later remount replay doesn't lose what the
+    // screen already showed. The pill race the old unconditional
+    // purge closed is carried by the resume watermark instead.
+    let pool = pool_with_schema();
+    let now = Utc::now().to_rfc3339();
+    let runner_id = ulid::Ulid::new().to_string();
+    {
+        let conn = pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'keeper', 'K', 'claude-code', '/bin/sh',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+            params![runner_id, now],
+        )
+        .unwrap();
+    }
+    let mut runner = runner("/bin/sh", &[]);
+    runner.id = runner_id;
+    runner.handle = "keeper".into();
+    runner.runtime = "claude-code".into();
+
+    let fake = fake_runtime();
+    let mgr = mgr_with_fake(None, Arc::clone(&fake));
+    let spawned = mgr
+        .spawn_direct(
+            &runner,
+            Some("/tmp"),
+            None,
+            None,
+            std::path::Path::new("/tmp"),
+            Arc::clone(&pool),
+            capture(),
+            None,
+        )
+        .unwrap();
+    let session_id = spawned.id.clone();
+
+    assert_eq!(
+        mgr.replay_watermark(&session_id),
+        0,
+        "fresh spawn must report watermark 0"
+    );
+
+    fake.push_output(0, b"pre-resume scrollback");
+    let pre_max_seq = wait_for_snapshot(&mgr, &session_id, 1).last().unwrap().seq;
+
+    fake.close_spawn(0);
+    wait_for_db_stop(&pool, &session_id);
+
+    let resumed = mgr
+        .resume(
+            &session_id,
+            None,
+            None,
+            std::path::Path::new("/tmp"),
+            Arc::clone(&pool),
+            capture(),
+        )
+        .unwrap();
+    assert_eq!(resumed.id, session_id);
+
+    assert_eq!(
+        mgr.replay_watermark(&session_id),
+        pre_max_seq,
+        "watermark must equal the pre-resume max seq"
+    );
+    let kept = BASE64.encode(b"pre-resume scrollback");
+    assert!(
+        mgr.output_snapshot(&session_id)
+            .iter()
+            .any(|ev| ev.data == kept),
+        "claude-code resume must keep pre-resume chunks in the ring"
+    );
+
+    // The new PTY (spawn index 1) continues the seq counter: its
+    // chunk lands after the kept scrollback, strictly above the
+    // watermark, with no reset back to 1.
+    fake.push_output(1, b"post-resume repaint");
+    let snapshot = wait_for_snapshot(&mgr, &session_id, 2);
+    assert!(
+        snapshot.windows(2).all(|w| w[0].seq < w[1].seq),
+        "snapshot seqs must stay strictly monotonic across resume"
+    );
+    let new_chunk = snapshot.last().unwrap();
+    assert_eq!(new_chunk.data, BASE64.encode(b"post-resume repaint"));
+    assert!(
+        new_chunk.seq > pre_max_seq,
+        "post-resume chunk must continue above the watermark"
+    );
+
+    mgr.kill(&session_id).unwrap();
+    mgr.purge_session_buffers(&session_id);
+    assert_eq!(
+        mgr.replay_watermark(&session_id),
+        0,
+        "purge_session_buffers must reset the watermark with the rest of the state"
+    );
+}
+
+#[test]
+fn resume_purges_scrollback_for_codex() {
+    // Codex keeps the pre-0024 behavior: its full-frame repaint over
+    // retained scrollback is the stacking artifact the purge was
+    // added for, so resume still drops the ring — while the watermark
+    // is stamped uniformly (equal to the post-purge floor here).
+    let pool = pool_with_schema();
+    let now = Utc::now().to_rfc3339();
+    let runner_id = ulid::Ulid::new().to_string();
+    {
+        let conn = pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'purger', 'P', 'codex', '/bin/sh',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+            params![runner_id, now],
+        )
+        .unwrap();
+    }
+    let mut runner = runner("/bin/sh", &[]);
+    runner.id = runner_id;
+    runner.handle = "purger".into();
+    runner.runtime = "codex".into();
+
+    let fake = fake_runtime();
+    let mgr = mgr_with_fake(None, Arc::clone(&fake));
+    let spawned = mgr
+        .spawn_direct(
+            &runner,
+            Some("/tmp"),
+            None,
+            None,
+            std::path::Path::new("/tmp"),
+            Arc::clone(&pool),
+            capture(),
+            None,
+        )
+        .unwrap();
+    let session_id = spawned.id.clone();
+
+    fake.push_output(0, b"pre-resume frame");
+    let pre_max_seq = wait_for_snapshot(&mgr, &session_id, 1).last().unwrap().seq;
+
+    fake.close_spawn(0);
+    wait_for_db_stop(&pool, &session_id);
+
+    mgr.resume(
+        &session_id,
+        None,
+        None,
+        std::path::Path::new("/tmp"),
+        Arc::clone(&pool),
+        capture(),
+    )
+    .unwrap();
+
+    assert!(
+        mgr.output_snapshot(&session_id).is_empty(),
+        "codex resume must still purge the output ring"
+    );
+    assert_eq!(
+        mgr.replay_watermark(&session_id),
+        pre_max_seq,
+        "watermark must equal the pre-resume max seq on the purge path too"
+    );
+
+    // Seq continuity across the purge: the new PTY's first chunk is
+    // `last + 1`, i.e. strictly above the watermark.
+    fake.push_output(1, b"fresh repaint");
+    let snapshot = wait_for_snapshot(&mgr, &session_id, 1);
+    assert_eq!(snapshot[0].seq, pre_max_seq + 1);
+
+    mgr.kill(&session_id).unwrap();
+}
+
 #[test]
 fn resume_refuses_running_and_archived_rows() {
     // Mission rows are no longer rejected — see

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -205,6 +205,13 @@ export const api = {
       invoke<void>("session_resize", { sessionId, cols, rows }),
     outputSnapshot: (sessionId: string) =>
       invoke<SessionOutputEvent[]>("session_output_snapshot", { sessionId }),
+    /** Seq the output ring had reached when the most recent resume
+     *  started; 0 for sessions that never resumed. The pill effects
+     *  only honor TUI-ready escapes in snapshot chunks above this,
+     *  so retained pre-resume scrollback (claude-code, impl 0024)
+     *  can't clear a resuming overlay early. */
+    replayWatermark: (sessionId: string) =>
+      invoke<number>("session_replay_watermark", { sessionId }),
     pasteImage: (bytes: Uint8Array, mimeType: PasteImageMimeType) =>
       invoke<void>("session_paste_image", {
         bytes: Array.from(bytes),

--- a/src/lib/sessionLifecycle.test.ts
+++ b/src/lib/sessionLifecycle.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+
+import { snapshotIndicatesTuiReady } from "./sessionLifecycle";
+import type { SessionOutputEvent } from "./types";
+
+const READY = btoa("\x1b[?2004h");
+const PLAIN = btoa("plain output, no ready escape");
+
+function ev(seq: number, data: string): SessionOutputEvent {
+  return { session_id: "s1", mission_id: null, seq, data };
+}
+
+describe("snapshotIndicatesTuiReady", () => {
+  it("ignores a ready escape at or below the watermark", () => {
+    // Retained pre-resume chunks (impl 0024) carry the old PTY's
+    // bracketed-paste escape; they must not clear the resuming pill.
+    expect(snapshotIndicatesTuiReady([ev(5, READY)], 5)).toBe(false);
+    expect(snapshotIndicatesTuiReady([ev(3, READY), ev(6, PLAIN)], 5)).toBe(
+      false,
+    );
+  });
+
+  it("honors a ready escape above the watermark", () => {
+    expect(snapshotIndicatesTuiReady([ev(3, PLAIN), ev(6, READY)], 5)).toBe(
+      true,
+    );
+  });
+
+  it("degenerates to any-chunk-counts at watermark 0", () => {
+    expect(snapshotIndicatesTuiReady([ev(1, READY)], 0)).toBe(true);
+    expect(snapshotIndicatesTuiReady([ev(1, PLAIN)], 0)).toBe(false);
+    expect(snapshotIndicatesTuiReady([], 0)).toBe(false);
+  });
+});

--- a/src/lib/sessionLifecycle.ts
+++ b/src/lib/sessionLifecycle.ts
@@ -7,6 +7,8 @@
 // edit. Splitting them out gives both clean HMR behavior and a more
 // honest home for these as logic primitives, not UI.
 
+import type { SessionOutputEvent } from "./types";
+
 /// True iff `startedAt` is within the last few seconds — the only
 /// case where the StartingOverlay pill should fire. Switching tabs
 /// to a chat that's been running for an hour, or reopening a mission
@@ -68,5 +70,22 @@ export function chunkIndicatesTuiReady(base64: string): boolean {
     bytes.includes("\x1b[?2004h") ||
     bytes.includes("\x1b[?1049h") ||
     bytes.includes("\x1b[?47h")
+  );
+}
+
+/// Watermark-aware variant of the snapshot fast-path check. Since
+/// impl 0024 a claude-code resume keeps the output ring, so a
+/// `session_output_snapshot` taken during the resume window still
+/// contains the *old* PTY's chunks — including its pre-stop
+/// `\x1b[?2004h`. Only chunks with `seq` above the resume watermark
+/// (`api.session.replayWatermark`) can come from the new PTY, so
+/// only those may clear a starting/resuming pill. Watermark 0 (fresh
+/// spawn, never-resumed session) degenerates to "any chunk counts".
+export function snapshotIndicatesTuiReady(
+  events: SessionOutputEvent[],
+  watermark: number,
+): boolean {
+  return events.some(
+    (ev) => ev.seq > watermark && chunkIndicatesTuiReady(ev.data),
   );
 }

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -66,7 +66,11 @@ import {
   ResumeButton,
   StopButton,
 } from "../components/ui/SessionControl";
-import { chunkIndicatesTuiReady, isFreshSpawn } from "../lib/sessionLifecycle";
+import {
+  chunkIndicatesTuiReady,
+  isFreshSpawn,
+  snapshotIndicatesTuiReady,
+} from "../lib/sessionLifecycle";
 import { terminalGridFromElement } from "../lib/terminalSizing";
 import { useDelayedFlag } from "../lib/useDelayedFlag";
 import { useResizableWidth } from "../hooks/useResizableWidth";
@@ -1419,12 +1423,18 @@ function SlotPtyPane({
     // serially) so by the time this slot pane mounts, the lead's
     // TUI has often already emitted the bracketed-paste / alt-screen
     // ready signal. The live listener missed those bytes; the
-    // snapshot still carries them via output_buffers.
-    void api.session
-      .outputSnapshot(targetId)
-      .then((snapshot) => {
+    // snapshot still carries them via output_buffers. A resumed
+    // claude-code slot re-enters this pill with its pre-resume
+    // chunks retained in the ring (impl 0024) — the watermark keeps
+    // the old PTY's ready escape from clearing the pill before the
+    // new PTY exists.
+    void Promise.all([
+      api.session.outputSnapshot(targetId),
+      api.session.replayWatermark(targetId),
+    ])
+      .then(([snapshot, watermark]) => {
         if (cancelled) return;
-        if (snapshot.some((ev) => chunkIndicatesTuiReady(ev.data))) {
+        if (snapshotIndicatesTuiReady(snapshot, watermark)) {
           finish();
         }
       })

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -37,7 +37,11 @@ import {
   StartingOverlay,
 } from "../components/SessionEndedOverlay";
 import { api, type DirectSessionEntry } from "../lib/api";
-import { chunkIndicatesTuiReady, isFreshSpawn } from "../lib/sessionLifecycle";
+import {
+  chunkIndicatesTuiReady,
+  isFreshSpawn,
+  snapshotIndicatesTuiReady,
+} from "../lib/sessionLifecycle";
 import { useDelayedFlag } from "../lib/useDelayedFlag";
 import { useResizableWidth } from "../hooks/useResizableWidth";
 import { useTerminalBg } from "../lib/useTerminalBg";
@@ -727,12 +731,17 @@ export default function RunnerChat() {
     const hardTimeout = window.setTimeout(finish, STARTING_HARD_TIMEOUT_MS);
 
     // Snapshot check covers the race where the PTY emitted its
-    // TUI-ready escape before this effect's listener attached.
-    void api.session
-      .outputSnapshot(targetId)
-      .then((snapshot) => {
+    // TUI-ready escape before this effect's listener attached. The
+    // watermark keeps retained pre-resume chunks (impl 0024) from
+    // counting as ready; fresh rows report 0, so the filter is inert
+    // here outside resume flows.
+    void Promise.all([
+      api.session.outputSnapshot(targetId),
+      api.session.replayWatermark(targetId),
+    ])
+      .then(([snapshot, watermark]) => {
         if (cancelled) return;
-        if (snapshot.some((ev) => chunkIndicatesTuiReady(ev.data))) {
+        if (snapshotIndicatesTuiReady(snapshot, watermark)) {
           finish();
         }
       })
@@ -1118,12 +1127,15 @@ export default function RunnerChat() {
   // state. Calls `session_resume`, which respawns a PTY for the same
   // row id and hands the agent CLI its prior `agent_session_key`.
   // Sequence:
-  //   1. Flip into resuming mode and bump clearVersion so the active
-  //      RunnerTerminal wipes its xterm canvas. The backend also
-  //      drops the prior buffer in `purge_output_buffer`, so any
-  //      remount during the resume window starts blank too.
+  //   1. Flip into resuming mode. The mounted RunnerTerminal keeps
+  //      its xterm canvas — the transitional overlay is opacity-0 on
+  //      top of it. The backend stamps a resume watermark at the
+  //      current seq; claude-code keeps its output ring (impl 0024 —
+  //      a remount replays pre-resume scrollback like a terminal
+  //      emulator would), codex still purges (its full-frame repaint
+  //      would stack over retained frames).
   //   2. Await the resume RPC. The new PTY's first chunk continues
-  //      the seq counter (we keep it across forget) so the live
+  //      the seq counter (never reset across resume) so the live
   //      listener doesn't drop the agent's repaint.
   //   3. Flip the local pane status back to running. Clearing the
   //      resuming id waits for the agent's repaint (ResumeSettleTracker).


### PR DESCRIPTION
## Summary

Implements [impl 0024](docs/impls/0024-resume-scrollback-preservation.md) — the in-app half of #267. Resuming a claude-code session no longer discards pre-resume terminal history: the output ring survives the resume, so scrolling up (and any later remount replay) shows the prior conversation above the resume repaint, matching what a real terminal keeps.

- `resume()` stamps a `resume_watermark_seq` (the ring's current seq) for every runtime, then purges the ring only when `runtime_purges_on_resume()` says so — kept for claude-code, purged for codex (full-frame repaint would stack over retained scrollback), shells, and DB misses.
- New `session_replay_watermark` command / `api.session.replayWatermark`; the RunnerChat and MissionWorkspace pill snapshot fast-paths filter TUI-ready escapes through it via the new `snapshotIndicatesTuiReady` helper, so retained pre-resume bytes can't clear a starting/resuming pill before the new PTY exists.
- Seq continuity, resize purge, and archive purge behavior unchanged; `purge_session_buffers` also resets the watermark.
- Docs: arch.md §5.8 scrollback section, `purge_output_buffer` doc comment, stale `clearVersion` comment in RunnerChat.

## Test plan

- New Rust tests: `resume_keeps_scrollback_for_claude_code`, `resume_purges_scrollback_for_codex` (keep path, purge path, watermark = pre-resume max seq, fresh spawn = 0, archive reset, seq monotonicity).
- New vitest coverage for `snapshotIndicatesTuiReady` (below/above watermark, watermark-0 degeneration).
- `cargo fmt --check`, `cargo clippy --workspace`, `cargo test --workspace` (340 lib tests), `tsc --noEmit`, `eslint`, `vitest` (82) all green.
- Manual smoke (passed): claude-code stop→resume keeps history across scroll-up and route switches; codex resume unchanged; pills clear on new-PTY readiness only; history gone after app relaunch as before (non-goal, tracked by #267).

🤖 Generated with [Claude Code](https://claude.com/claude-code)