### PR TITLE
feat(ui): morph update prompt into hover-expanding pill

### DIFF
--- a/src/components/UpdatePromptCard.tsx
+++ b/src/components/UpdatePromptCard.tsx
@@ -1,12 +1,15 @@
-// Arc-style in-app update prompt — impl 0025 (spec `e1jYEa` in
-// `design/runner-setting.pen`). Floats in the app sidebar directly
-// above the Settings row once an update has downloaded and is ready
-// to restart-install. Replaces the old top-center UpdateToast.
+// Arc-style in-app update prompt, current-Arc form: at rest it's a
+// slim centered pill ("New Runner version available") directly above
+// the sidebar Settings row; hovering (or keyboard-focusing) it morphs
+// the pill into the full card — the card is bottom-anchored OVER the
+// pill and grows upward, so its header band reads as the pill risen
+// to the top and the two are never visible at once. Supersedes the
+// always-expanded card from spec `e1jYEa` per user direction.
 //
-// Dismissal is per launch (sessionStorage), so the card reappears on
-// the next launch until the update is installed. The "Automatic
-// updates" checkbox writes the same persisted setting as About's
-// toggle — one storage key, two surfaces.
+// Dismissal is per launch (sessionStorage), so the pill reappears on
+// the next launch until the update is installed. The checkbox writes
+// the same persisted setting as About's toggle — one storage key,
+// two surfaces.
 
 import { useCallback, useState } from "react";
 import { Check, X } from "lucide-react";
@@ -45,52 +48,82 @@ export function UpdatePromptCard() {
   if (status !== "ready" || dismissed) return null;
 
   return (
-    <div className="mx-3 mb-2 overflow-hidden rounded-lg border border-line-strong bg-[radial-gradient(140%_120%_at_50%_0%,var(--color-sidebar-selected)_0%,var(--color-panel)_100%)] shadow-[0_8px_24px_rgba(0,0,0,0.35)]">
-      {/* Full-bleed header band with the dismiss affordance. */}
-      <div className="flex items-center justify-between gap-2 border-b border-line-strong bg-sidebar-selected px-3 py-2">
-        <span className="min-w-0 truncate text-[12px] font-medium text-fg">
+    <div className="group relative mx-3 mb-2">
+      {/* Resting pill — the only thing visible until hover. A real
+          button so it's natively focusable; the explicit focus() on
+          click covers WebKit, which doesn't focus buttons on click,
+          so a click also pins the card open via focus-within. It
+          renders BEFORE the card so Tab walks trigger → revealed
+          controls in order. */}
+      <button
+        type="button"
+        aria-haspopup="true"
+        onClick={(e) => e.currentTarget.focus()}
+        className="flex h-6 w-full cursor-pointer items-center justify-center rounded-full border border-sidebar-selected-border bg-sidebar-selected/60 px-3 focus:outline-none"
+      >
+        <span className="truncate whitespace-nowrap text-[11px] font-medium text-fg-2">
           New Runner version available
         </span>
-        <button
-          type="button"
-          onClick={dismiss}
-          aria-label="Dismiss update prompt"
-          className="flex h-5 w-5 shrink-0 cursor-pointer items-center justify-center rounded text-fg-3 transition-colors hover:bg-raised hover:text-fg"
-        >
-          <X aria-hidden className="h-3 w-3" />
-        </button>
-      </div>
-      <div className="flex flex-col gap-2.5 px-3 py-2.5">
-        <button
-          type="button"
-          role="checkbox"
-          aria-checked={autoInstall}
-          onClick={() => setAutoInstall(!autoInstall)}
-          className="flex cursor-pointer items-center gap-2 text-left text-[11px] text-fg-2 transition-colors hover:text-fg"
-        >
-          <span
-            className={`flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded border transition-colors ${
-              autoInstall
-                ? "border-accent bg-accent text-accent-ink"
-                : "border-line-strong bg-raised"
-            }`}
-          >
-            {autoInstall ? <Check aria-hidden className="h-2.5 w-2.5" /> : null}
-          </span>
-          Automatic updates
-        </button>
-        <button
-          type="button"
-          onClick={() => void restart()}
-          className="relative h-[26px] w-full cursor-pointer overflow-hidden rounded-md bg-accent text-[12px] font-semibold text-accent-ink transition-opacity hover:opacity-90"
-        >
-          {/* Center-glow highlight over the accent fill. */}
-          <span
-            aria-hidden
-            className="pointer-events-none absolute inset-0 bg-[radial-gradient(60%_140%_at_50%_50%,rgba(255,255,255,0.28),rgba(255,255,255,0)_70%)]"
-          />
-          <span className="relative">Restart and Update</span>
-        </button>
+      </button>
+      {/* Pop-up card — bottom edge pinned to the pill's bottom
+          (`bottom-0`), so it covers the pill and grows upward over
+          the list above. No gap to hover across, and the pill is
+          never visible alongside the card. */}
+      <div className="invisible absolute bottom-0 left-0 right-0 z-40 translate-y-1 opacity-0 transition-all duration-150 group-focus-within:visible group-focus-within:translate-y-0 group-focus-within:opacity-100 group-hover:visible group-hover:translate-y-0 group-hover:opacity-100">
+        <div className="overflow-hidden rounded-lg border border-line-strong bg-[radial-gradient(140%_120%_at_50%_0%,var(--color-sidebar-selected)_0%,var(--color-panel)_100%)] shadow-[0_8px_24px_rgba(0,0,0,0.35)]">
+          {/* Header band — title centered per spec; the × dismiss
+              (now specced) stays pinned to the band's right, with px-6
+              reserving symmetric space so the title centers truly. */}
+          <div className="relative flex items-center justify-center border-b border-line-strong bg-sidebar-selected px-6 py-1.5">
+            <span className="min-w-0 truncate text-[11px] font-medium text-fg">
+              New Runner version available
+            </span>
+            <button
+              type="button"
+              onClick={dismiss}
+              aria-label="Dismiss update prompt"
+              className="absolute right-2 top-1/2 flex h-4 w-4 -translate-y-1/2 cursor-pointer items-center justify-center rounded text-fg-3 transition-colors hover:bg-raised hover:text-fg"
+            >
+              <X aria-hidden className="h-2.5 w-2.5" />
+            </button>
+          </div>
+          <div className="flex flex-col gap-2 px-3 py-2">
+            {/* Checked state is deliberately NEUTRAL (spec hexes) —
+                per the settings design rule, accent green marks only
+                the meaning moment: the Restart button below. */}
+            <button
+              type="button"
+              role="checkbox"
+              aria-checked={autoInstall}
+              onClick={() => setAutoInstall(!autoInstall)}
+              className="flex cursor-pointer items-center gap-2 self-center text-left text-[11px] text-fg-2 transition-colors hover:text-fg"
+            >
+              <span
+                className={`flex h-3.5 w-3.5 shrink-0 items-center justify-center rounded border transition-colors ${
+                  autoInstall
+                    ? "border-[#4A4C56] bg-[#3A3C46] text-fg"
+                    : "border-line-strong bg-raised"
+                }`}
+              >
+                {autoInstall ? (
+                  <Check aria-hidden className="h-2.5 w-2.5" />
+                ) : null}
+              </span>
+              Automatic updates
+            </button>
+            <button
+              type="button"
+              onClick={() => void restart()}
+              className="relative h-[26px] w-full cursor-pointer overflow-hidden rounded-md bg-accent text-[12px] font-semibold text-accent-ink transition-opacity hover:opacity-90"
+            >
+              <span
+                aria-hidden
+                className="pointer-events-none absolute inset-0 bg-[radial-gradient(60%_140%_at_50%_50%,rgba(255,255,255,0.28),rgba(255,255,255,0)_70%)]"
+              />
+              <span className="relative">Restart and Update</span>
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/hooks/useUpdateChecker.ts
+++ b/src/hooks/useUpdateChecker.ts
@@ -16,6 +16,36 @@ export type UpdateStatus =
   | "ready"
   | "error";
 
+const UPDATE_STATUSES: readonly UpdateStatus[] = [
+  "idle",
+  "checking",
+  "available",
+  "downloading",
+  "ready",
+  "error",
+];
+
+// Dev-only escape hatch: seed the state machine from localStorage so
+// the update surfaces (About button ladder, sidebar prompt pill/card)
+// can be smoke-tested without staging a real release — outside a
+// signed build, `check()` never yields an update, so "ready" is
+// otherwise unreachable in dev. In the devtools console:
+//   localStorage.setItem("runner.dev.updateStatus", "ready"); location.reload()
+// and remove the key to restore normal behavior. The resting-state
+// guard in checkForUpdate keeps the launch auto-check from clobbering
+// a seeded non-resting status. DEV-gated: release builds never read it.
+function readDevStatusOverride(): UpdateStatus | null {
+  if (!import.meta.env.DEV) return null;
+  try {
+    const raw = localStorage.getItem("runner.dev.updateStatus");
+    return raw && (UPDATE_STATUSES as readonly string[]).includes(raw)
+      ? (raw as UpdateStatus)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 export interface UpdateState {
   status: UpdateStatus;
   update: Update | null;
@@ -27,16 +57,22 @@ export interface UpdateState {
 }
 
 export function useUpdateChecker(): UpdateState {
-  const [status, setStatus] = useState<UpdateStatus>("idle");
+  const [status, setStatus] = useState<UpdateStatus>(
+    () => readDevStatusOverride() ?? "idle",
+  );
   const [update, setUpdate] = useState<Update | null>(null);
-  const [progress, setProgress] = useState(0);
+  // A seeded "downloading" gets a mid-flight progress value so the
+  // About pane's bar reads as a real download, not a frozen 0%.
+  const [progress, setProgress] = useState(() =>
+    readDevStatusOverride() === "downloading" ? 37 : 0,
+  );
   const [error, setError] = useState<string | null>(null);
   // Guard against concurrent checks — auto-check + manual click can race.
   const checking = useRef(false);
   // Mirror of `status` readable from the stable `checkForUpdate`
   // closure (its useCallback deps stay empty so consumers can treat it
   // as stable).
-  const statusRef = useRef<UpdateStatus>("idle");
+  const statusRef = useRef<UpdateStatus>(status);
   useEffect(() => {
     statusRef.current = status;
   }, [status]);


### PR DESCRIPTION
Follow-up to #274 (impl 0025). Reworks the in-app update prompt from an always-expanded card into current-Arc form:

- **Resting state**: a slim centered pill ("New Runner version available") above the sidebar Settings row — quiet until you engage.
- **Hover / keyboard focus**: the pill morphs into the full card (header band, centered Automatic updates checkbox — neutral, no accent — and the glowing Restart and Update button). The card bottom-anchors over the pill and grows upward, so the two are never visible at once; a click pins it open via focus-within (explicit `focus()` covers WebKit's no-focus-on-click behavior).
- **Dev escape hatch** (`useUpdateChecker`): DEV-gated `runner.dev.updateStatus` localStorage override to seed the update state machine, since "ready" is unreachable in unsigned builds — makes the pill/card and About's button ladder smoke-testable. A seeded "downloading" gets a mid-flight progress value so the About bar reads as live.

Checks: `tsc --noEmit`, `eslint`, `vitest` (85 passed) — all clean.

Note: this supersedes the always-expanded card in `design/runner-setting.pen` spec `e1jYEa`; the design file will be updated to the pill-morph pattern separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)