### PR TITLE
feat(ui): restore main-window geometry across restarts (#271)

### DIFF
--- a/design/runner-setting.pen
+++ b/design/runner-setting.pen
@@ -11190,6 +11190,206 @@
           ]
         }
       ]
+    },
+    {
+      "type": "frame",
+      "id": "cETDE",
+      "x": 16000,
+      "y": 0,
+      "name": "component/confirm-dialog",
+      "reusable": true,
+      "width": 420,
+      "fill": "$panel",
+      "cornerRadius": 14,
+      "stroke": "$line",
+      "strokeWidth": 1,
+      "strokeAlignment": "inner",
+      "effect": {
+        "type": "shadow",
+        "shadowType": "outer",
+        "color": "#00000066",
+        "offset": {
+          "x": 0,
+          "y": 16
+        },
+        "blur": 48
+      },
+      "layout": "vertical",
+      "gap": 14,
+      "padding": [
+        20,
+        22
+      ],
+      "children": [
+        {
+          "type": "frame",
+          "id": "Pq1er",
+          "name": "header",
+          "width": "fill_container",
+          "gap": 10,
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon",
+              "id": "xcOFK",
+              "name": "hdr_icon",
+              "width": 15,
+              "height": 15,
+              "icon": "trash-2",
+              "library": "lucide",
+              "fill": "#F87171"
+            },
+            {
+              "type": "text",
+              "id": "k6lgz",
+              "name": "dlg_title",
+              "fill": "$text-1",
+              "content": "Delete all archived items?",
+              "fontFamily": "$font-ui",
+              "fontSize": 15,
+              "fontWeight": "600"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "N8EtC",
+          "name": "dlg_body",
+          "fill": "$text-2",
+          "textGrowth": "fixed-width",
+          "width": "fill_container",
+          "content": "This permanently deletes all 12 archived chats and missions, including mission event logs. This can't be undone.",
+          "lineHeight": 1.5,
+          "fontFamily": "$font-ui",
+          "fontSize": 13,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "yVvw2",
+          "name": "footer",
+          "width": "fill_container",
+          "gap": 8,
+          "justifyContent": "end",
+          "children": [
+            {
+              "type": "frame",
+              "id": "DKQEe",
+              "name": "btn_cancel",
+              "fill": "$raised",
+              "cornerRadius": 8,
+              "padding": [
+                7,
+                14
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "G9V2L3",
+                  "name": "btn_cancel_label",
+                  "fill": "$text-1",
+                  "content": "Cancel",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "wtasO",
+              "name": "btn_danger",
+              "fill": "#2A1416",
+              "cornerRadius": 8,
+              "stroke": "#4A2226",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "padding": [
+                7,
+                14
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "InIQA",
+                  "name": "btn_danger_label",
+                  "fill": "#F87171",
+                  "content": "Delete all",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "IHKhy",
+      "x": 16000,
+      "y": 235,
+      "name": "Spec — Archived Delete all double confirm",
+      "width": 520,
+      "fill": "$bg",
+      "cornerRadius": 14,
+      "stroke": "$line",
+      "strokeWidth": 1,
+      "strokeAlignment": "inner",
+      "layout": "vertical",
+      "gap": 18,
+      "padding": [
+        20,
+        24
+      ],
+      "children": [
+        {
+          "type": "text",
+          "id": "NgYBe",
+          "name": "spec_title",
+          "fill": "$text-1",
+          "content": "Archived — Delete all confirm",
+          "fontFamily": "$font-ui",
+          "fontSize": 14,
+          "fontWeight": "600"
+        },
+        {
+          "type": "frame",
+          "id": "U8wzW",
+          "name": "steps_row",
+          "width": "fill_container",
+          "gap": 48,
+          "children": [
+            {
+              "type": "frame",
+              "id": "Nppi6",
+              "name": "step1_col",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "id": "Jw7fo",
+                  "type": "ref",
+                  "ref": "cETDE",
+                  "name": "step1_dialog"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "note",
+      "id": "q42I1",
+      "x": 17080,
+      "y": 235,
+      "name": "note_delete_all_confirm",
+      "width": 300,
+      "height": 230,
+      "content": "Delete all — confirm dialog (replaces native confirm()):\n\nSingle step. Instances component/confirm-dialog — the per-row trash (also on this screen) reuses the same component later, so styling stays synced.\n\nCopy names the exact archived count and that mission event logs go too; danger button stays quiet-tinted, same family as the Delete all trigger in the title row.\n\nBehavior: centered over the settings surface with a dim scrim; Esc or Cancel aborts; on confirm the danger button disables and reads 'Deleting…' while the loop runs."
     }
   ],
   "variables": {

--- a/docs/impls/0027-window-position-restore.md
+++ b/docs/impls/0027-window-position-restore.md
@@ -2,7 +2,23 @@
 
 ## Status
 
-Planned. Tracks issue [#271](https://github.com/yicheng47/runner/issues/271) (feature, issue-only by request — no spec file).
+Implemented, hand-rolled (see Pivot below — the plugin approach this doc originally planned shipped, failed multi-monitor smoke, and was replaced in the same branch). Tracks issue [#271](https://github.com/yicheng47/runner/issues/271) (feature, issue-only by request — no spec file).
+
+## Pivot (2026-07-11): hand-rolled logical-coordinate persistence
+
+Phase 1 shipped exactly as planned below, and failed manual smoke on a three-display Mac Studio: a main window on a secondary screen restored to the corner of the primary instead. The save was correct (the state file held the secondary-screen position); the plugin's restore was the failure.
+
+Root cause is upstream, not configuration: on multi-monitor macOS, Tauri reports "physical" coordinates from a fractured space — monitor sizes unscaled, monitor offsets scaled, secondary-screen window positions inconsistent with the primary ([tauri#7890](https://github.com/tauri-apps/tauri/issues/7890), open since 2023-09, untriaged). The plugin stores physical coordinates and gates restore on a physical-space monitor-intersection check, so the check fails for any window on a secondary display and restore silently degrades to OS-default placement. Also reported against the plugin directly as [plugins-workspace#1097](https://github.com/tauri-apps/plugins-workspace/issues/1097) (2024-03, open, no fix).
+
+Replacement: `src-tauri/src/window_state.rs` (~180 lines incl. tests), plugin dependency dropped. Same semantics this doc chose for the plugin — size + position + maximized, main window only, restore in `setup` while the window is hidden so `app_ready` reveals at the restored frame — with these differences:
+
+- **Logical coordinates everywhere.** macOS's native global space is logical points and is consistent across mixed-scale monitors; logical `set_position` round-trips cleanly through tao. This is the actual fix.
+- **State file in `app_data_dir`** (`window-state.json`), so the dev/prod split comes free from the existing `-dev` data-dir suffix — no filename split. The plugin couldn't do this (it hardcodes `app_config_dir`).
+- **Maximized quits keep the last normal frame.** A Moved/Resized hook in the existing `run()` event handler caches the last un-maximized geometry (the plugin kept an equivalent cache), so un-maximize after relaunch lands on a real frame.
+- **Checkpoint on hide-on-close** — closes this doc's crash-resilience open question: a crash after the window was closed still restores the frame it was hidden at. Final write stays on `RunEvent::Exit`, falling back to the cache if the window is already gone.
+- **Off-screen recovery in logical space**: position applies only when the saved frame overlaps some monitor's logical rect (unit-tested, including negative-x secondary screens); otherwise the OS places the window and only the size restores.
+
+The investigation and plugin plan below are kept as history of the evaluated-and-rejected approach.
 
 ## Problem
 

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -1505,6 +1505,58 @@ pub async fn mission_unarchive(
     Ok(mission)
 }
 
+/// Permanent delete of an archived mission: session rows first
+/// (`sessions.mission_id` is `ON DELETE SET NULL` — deleting the
+/// mission row alone would orphan them into the direct-chat lists),
+/// then the mission row, one transaction — then its on-disk footprint:
+/// the mission dir (NDJSON log + roster sidecar) and the
+/// `missions/<id>` scratch dir (per-slot runner shims,
+/// cli_install::install_session_runner_shim). Refused for non-archived
+/// missions: archive is the reversible step, delete is not. Dir
+/// removal happens after commit and only logs on failure — the DB is
+/// the source of truth, and a leaked dir is better than a
+/// deleted-but-still-listed mission.
+pub(crate) fn delete_archived(
+    conn: &mut Connection,
+    app_data_dir: &Path,
+    id: &str,
+) -> Result<Mission> {
+    let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    let mission = repo::mission::get(&tx, id)?
+        .ok_or_else(|| Error::msg(format!("mission not found: {id}")))?;
+    if mission.archived_at.is_none() {
+        return Err(Error::msg(format!(
+            "mission {id} is not archived; archive it before deleting"
+        )));
+    }
+    repo::session::delete_all_for_mission(&tx, id)?;
+    repo::mission::delete_archived(&tx, id)?;
+    tx.commit()?;
+    let mission_dir = event_log::mission_dir(app_data_dir, &mission.crew_id, id);
+    let scratch_dir = app_data_dir.join("missions").join(id);
+    for dir in [mission_dir, scratch_dir] {
+        if let Err(e) = std::fs::remove_dir_all(&dir) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                log::warn!(
+                    "mission {id} deleted but removing {} failed: {e}",
+                    dir.display()
+                );
+            }
+        }
+    }
+    Ok(mission)
+}
+
+/// Settings → Archived permanent delete (feature 01 Phase 4). Archived
+/// missions have no live PTYs, bus, or router — `mission_archive`
+/// dropped them — so `delete_archived` covers everything.
+#[tauri::command]
+pub async fn mission_delete(state: State<'_, AppState>, id: String) -> Result<()> {
+    let mut conn = state.db.get()?;
+    delete_archived(&mut conn, &state.app_data_dir, &id)?;
+    Ok(())
+}
+
 #[tauri::command]
 pub async fn mission_list(
     state: State<'_, AppState>,
@@ -1996,6 +2048,99 @@ mod tests {
             "mission_stopped"
         );
         assert_eq!(last.from, "system");
+    }
+
+    #[test]
+    fn delete_refuses_non_archived_mission() {
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "A", None);
+        add_runner(&mut conn, &crew_id, "lead");
+        let tmp = tempfile::tempdir().unwrap();
+
+        let out = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                crew_id,
+                title: "m".into(),
+                goal_override: None,
+                cwd: None,
+            },
+        )
+        .unwrap();
+
+        let err = delete_archived(&mut conn, tmp.path(), &out.mission.id).unwrap_err();
+        assert!(
+            err.to_string().contains("not archived"),
+            "expected archive-first refusal, got: {err}"
+        );
+
+        let unknown = delete_archived(&mut conn, tmp.path(), "no-such-mission").unwrap_err();
+        assert!(unknown.to_string().contains("not found"));
+    }
+
+    #[test]
+    fn delete_archived_removes_mission_and_session_rows() {
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "A", None);
+        add_runner(&mut conn, &crew_id, "lead");
+        let tmp = tempfile::tempdir().unwrap();
+
+        let out = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                crew_id: crew_id.clone(),
+                title: "m".into(),
+                goal_override: None,
+                cwd: None,
+            },
+        )
+        .unwrap();
+        let id = out.mission.id.clone();
+        // A stopped slot session — the cascade must take it with the
+        // mission instead of leaving an orphan (`mission_id` is
+        // ON DELETE SET NULL, which would leak it into direct lists).
+        conn.execute(
+            "INSERT INTO sessions (id, mission_id, slot_id, status, started_at)
+             VALUES ('s-del', ?1, 's1', 'stopped', '2026-07-11T00:00:00Z')",
+            params![id],
+        )
+        .unwrap();
+        stop(&mut conn, tmp.path(), &id).unwrap();
+
+        // On-disk footprint: the event-log dir (created by start) and
+        // the per-slot shim scratch dir (created at spawn — faked here,
+        // the bookkeeping-layer start doesn't spawn PTYs).
+        let mission_dir = event_log::mission_dir(tmp.path(), &crew_id, &id);
+        assert!(mission_dir.exists());
+        let scratch_dir = tmp.path().join("missions").join(&id);
+        std::fs::create_dir_all(scratch_dir.join("shims").join("lead").join("bin")).unwrap();
+
+        let deleted = delete_archived(&mut conn, tmp.path(), &id).unwrap();
+        assert_eq!(deleted.id, id);
+        assert_eq!(deleted.crew_id, crew_id);
+
+        let missions: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM missions WHERE id = ?1",
+                params![id],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(missions, 0);
+        let orphans: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE id = 's-del'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(orphans, 0, "session rows must die with the mission");
+        assert!(!mission_dir.exists(), "event-log dir must be removed");
+        assert!(!scratch_dir.exists(), "shim scratch dir must be removed");
     }
 
     #[test]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -440,6 +440,33 @@ pub async fn session_unarchive(
     Ok(())
 }
 
+/// Permanently delete an archived direct chat (Settings → Archived
+/// delete, feature 01 Phase 4). Refused for non-archived and
+/// mission-scoped rows — archive is the reversible step, delete is
+/// not. Runner keeps nothing else on disk for a direct chat (the
+/// agent's own JSONL belongs to the agent runtime), so the row delete
+/// is the whole cleanup; the scrollback buffer was already purged at
+/// archive time.
+#[tauri::command]
+pub async fn session_delete(state: State<'_, AppState>, session_id: String) -> Result<()> {
+    let conn = state.db.get()?;
+    let deleted = repo::session::delete_archived_direct(&conn, &session_id)?;
+    if deleted == 0 {
+        // Split not-found from the two refusals the scoped DELETE
+        // can't distinguish, mirroring `session_unarchive`.
+        return match repo::session::get_row(&conn, &session_id)? {
+            None => Err(Error::msg(format!("session not found: {session_id}"))),
+            Some(row) if row.mission_id.is_some() || row.slot_id.is_some() => Err(Error::msg(
+                format!("session {session_id} is mission-scoped; only direct chats can be deleted"),
+            )),
+            Some(_) => Err(Error::msg(format!(
+                "session {session_id} is not archived; archive it before deleting"
+            ))),
+        };
+    }
+    Ok(())
+}
+
 /// Archived direct sessions, newest-archived first — the Settings →
 /// Archived pane's chat list. Same DTO as `session_list_recent_direct`
 /// (keys withheld); archived mission-slot rows stay off this surface.
@@ -822,6 +849,45 @@ mod tests {
         )
         .unwrap();
         id
+    }
+
+    #[test]
+    fn delete_archived_direct_only_deletes_archived_direct_rows() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let runner_id = seed_runner(&conn);
+        let active = insert_direct_session(&conn, &runner_id, false);
+        let archived = insert_direct_session(&conn, &runner_id, true);
+        // Archived slot leftover (mission reset): must survive this
+        // path — it dies with its mission, not through chat delete.
+        let slot_bound = ulid::Ulid::new().to_string();
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, slot_id, runner_id, status, started_at, archived_at)
+             VALUES (?1, NULL, 'slot-1', ?2, 'stopped', ?3, ?3)",
+            params![slot_bound, runner_id, Utc::now().to_rfc3339()],
+        )
+        .unwrap();
+
+        assert_eq!(
+            repo::session::delete_archived_direct(&conn, &active).unwrap(),
+            0,
+            "active chats must be archived before deletion"
+        );
+        assert_eq!(
+            repo::session::delete_archived_direct(&conn, &slot_bound).unwrap(),
+            0,
+            "slot-bound rows must not be deletable as chats"
+        );
+        assert_eq!(
+            repo::session::delete_archived_direct(&conn, &archived).unwrap(),
+            1
+        );
+
+        let remaining: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(remaining, 2, "only the archived direct row is gone");
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ mod repo;
 mod router;
 mod session;
 mod shell_path;
+mod window_state;
 mod windows;
 
 use std::path::{Path, PathBuf};
@@ -129,6 +130,14 @@ pub fn run() {
                 }
             };
             std::fs::create_dir_all(&app_data_dir)?;
+
+            // Restore main-window geometry (impl 0027, hand-rolled —
+            // see window_state.rs for why not the plugin) while the
+            // window is still hidden, so `app_ready` reveals it
+            // directly at the restored frame.
+            if let Some(main) = app.get_webview_window("main") {
+                window_state::restore(&main, &app_data_dir);
+            }
 
             // First line of every app start. Triage-from-log starts here.
             log_startup_banner(app.handle(), &app_data_dir);
@@ -292,6 +301,7 @@ pub fn run() {
             commands::mission::mission_stop,
             commands::mission::mission_archive,
             commands::mission::mission_unarchive,
+            commands::mission::mission_delete,
             commands::mission::mission_reset,
             commands::mission::mission_pin,
             commands::mission::mission_rename,
@@ -307,6 +317,7 @@ pub fn run() {
             commands::session::session_get,
             commands::session::session_archive,
             commands::session::session_unarchive,
+            commands::session::session_delete,
             commands::session::session_rename,
             commands::session::session_pin,
             commands::session::session_resume,
@@ -352,8 +363,19 @@ pub fn run() {
                     // reclaims ownership via the `Focused(true)` hook.
                     if let Some(state) = app_handle.try_state::<AppState>() {
                         state.windows.mark_hidden(&label);
+                        // Geometry checkpoint: a crash after this point
+                        // still restores the frame the window was hidden
+                        // at (impl 0027's crash-resilience open question).
+                        window_state::save(app_handle, &state.app_data_dir);
                     }
                     broadcast_focus_map(app_handle);
+                }
+                tauri::RunEvent::WindowEvent {
+                    label,
+                    event: tauri::WindowEvent::Moved(_) | tauri::WindowEvent::Resized(_),
+                    ..
+                } if label == "main" => {
+                    window_state::note(app_handle);
                 }
                 // Any window gaining focus becomes primary for whatever
                 // subject it's on (spec decision 2). Secondary windows close
@@ -383,6 +405,13 @@ pub fn run() {
                     stop_running_sessions_on_quit(app_handle);
                     if let Some(state) = app_handle.try_state::<AppState>() {
                         state.mcp.stop();
+                    }
+                }
+                // Final geometry write. The window may already be gone
+                // here; `save` falls back to the Moved/Resized cache.
+                tauri::RunEvent::Exit => {
+                    if let Some(state) = app_handle.try_state::<AppState>() {
+                        window_state::save(app_handle, &state.app_data_dir);
                     }
                 }
                 #[cfg(target_os = "macos")]

--- a/src-tauri/src/repo/mission.rs
+++ b/src-tauri/src/repo/mission.rs
@@ -201,6 +201,20 @@ pub fn unarchive(conn: &Connection, id: &str) -> rusqlite::Result<usize> {
     )
 }
 
+/// Hard-delete an archived mission row (Settings → Archived delete).
+/// The `IS NOT NULL` guard turns a non-archived target into a 0-row
+/// no-op the command layer refuses; callers must delete the mission's
+/// session rows first — `sessions.mission_id` is `ON DELETE SET NULL`,
+/// so an unguarded row delete would orphan them into the direct-chat
+/// lists.
+pub fn delete_archived(conn: &Connection, id: &str) -> rusqlite::Result<usize> {
+    conn.execute(
+        "DELETE FROM missions
+          WHERE id = ?1 AND archived_at IS NOT NULL",
+        rusqlite::params![id],
+    )
+}
+
 pub fn set_pinned_at(
     conn: &Connection,
     id: &str,

--- a/src-tauri/src/repo/session.rs
+++ b/src-tauri/src/repo/session.rs
@@ -269,6 +269,20 @@ pub fn unarchive_direct(conn: &Connection, id: &str) -> rusqlite::Result<usize> 
     )
 }
 
+/// Hard-delete an archived direct chat (Settings → Archived delete).
+/// Scoped like `unarchive_direct`: mission/slot-bound rows are deleted
+/// through `mission_delete`'s cascade, never through this path.
+pub fn delete_archived_direct(conn: &Connection, id: &str) -> rusqlite::Result<usize> {
+    conn.execute(
+        "DELETE FROM sessions
+          WHERE id = ?1
+            AND mission_id IS NULL
+            AND slot_id IS NULL
+            AND archived_at IS NOT NULL",
+        rusqlite::params![id],
+    )
+}
+
 /// Archive every non-archived session of a mission (mission reset).
 pub fn archive_all_for_mission(
     conn: &Connection,

--- a/src-tauri/src/window_state.rs
+++ b/src-tauri/src/window_state.rs
@@ -1,0 +1,277 @@
+// Main-window geometry persistence (impl 0027), hand-rolled after
+// pivoting off `tauri-plugin-window-state`.
+//
+// Why not the plugin: it stores PHYSICAL coordinates and gates restore
+// on a physical-space monitor-intersection check. On multi-monitor
+// macOS the physical space is fractured (tauri#7890 — monitor sizes
+// unscaled, monitor offsets scaled, secondary-screen window positions
+// inconsistent with the primary), so the check fails for any window on
+// a secondary display and restore silently degrades to OS-default
+// placement. macOS's native global space is LOGICAL points, which is
+// consistent across mixed-scale monitors and round-trips cleanly
+// through tao's set_position — so everything here is stored and
+// applied logical.
+//
+// Semantics match what the plugin was configured for: size + position
+// + maximized, main window only, restored while the window is still
+// hidden (before `app_ready` reveals it, so no flash and no jump).
+// The state file lives in `app_data_dir`, which already carries the
+// dev/prod `-dev` split — no filename games needed.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, LogicalPosition, LogicalSize, Manager, Runtime, WebviewWindow};
+
+const STATE_FILENAME: &str = "window-state.json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct WindowState {
+    /// Outer frame origin and inner size, in logical points. Always the
+    /// NORMAL (un-maximized) frame — a maximized quit keeps the last
+    /// normal geometry here so un-maximize after relaunch lands on a
+    /// real frame instead of a monitor-sized one.
+    pub x: f64,
+    pub y: f64,
+    pub width: f64,
+    pub height: f64,
+    pub maximized: bool,
+}
+
+/// Live snapshot, refreshed on every main-window Moved/Resized and read
+/// back at save time. Needed because `RunEvent::Exit` can fire after
+/// the window is gone, and because a maximized window's live frame is
+/// the monitor's — the last normal geometry only exists here. Main
+/// window only, so a module singleton is enough.
+static LAST: Mutex<Option<WindowState>> = Mutex::new(None);
+
+fn state_path(app_data_dir: &Path) -> PathBuf {
+    app_data_dir.join(STATE_FILENAME)
+}
+
+fn read(app_data_dir: &Path) -> Option<WindowState> {
+    let raw = std::fs::read_to_string(state_path(app_data_dir)).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn write_atomic(app_data_dir: &Path, state: &WindowState) -> std::io::Result<()> {
+    let mut tmp = tempfile::NamedTempFile::new_in(app_data_dir)?;
+    serde_json::to_writer_pretty(&mut tmp, state)?;
+    tmp.flush()?;
+    tmp.persist(state_path(app_data_dir))?;
+    Ok(())
+}
+
+/// Current snapshot from the live window: normal geometry when the
+/// window is normal; the cached normal geometry with the flag flipped
+/// when maximized (the live frame would be the monitor's).
+fn snapshot<R: Runtime>(window: &WebviewWindow<R>) -> Option<WindowState> {
+    let maximized = window.is_maximized().ok()?;
+    if maximized {
+        let last = *LAST.lock().unwrap();
+        return last.map(|s| WindowState {
+            maximized: true,
+            ..s
+        });
+    }
+    let scale = window.scale_factor().ok()?;
+    let position = window.outer_position().ok()?.to_logical::<f64>(scale);
+    let size = window.inner_size().ok()?.to_logical::<f64>(scale);
+    Some(WindowState {
+        x: position.x,
+        y: position.y,
+        width: size.width,
+        height: size.height,
+        maximized: false,
+    })
+}
+
+/// Moved/Resized hook. Cheap enough to run per drag tick; the plugin
+/// maintained the same event-driven cache.
+pub fn note<R: Runtime>(app: &AppHandle<R>) {
+    let Some(window) = app.get_webview_window("main") else {
+        return;
+    };
+    if let Some(s) = snapshot(&window) {
+        *LAST.lock().unwrap() = Some(s);
+    }
+}
+
+/// Persist the current state. Called from the main window's
+/// hide-on-close (checkpoint — also covers crash resilience, the open
+/// question impl 0027 deferred) and from `RunEvent::Exit` (final).
+/// Falls back to the cache when the window is already gone, and to the
+/// existing file when there was never anything to observe.
+pub fn save<R: Runtime>(app: &AppHandle<R>, app_data_dir: &Path) {
+    note(app);
+    let state = (*LAST.lock().unwrap()).or_else(|| read(app_data_dir));
+    let Some(state) = state else {
+        return;
+    };
+    if let Err(e) = write_atomic(app_data_dir, &state) {
+        log::warn!("window-state: save failed: {e}");
+    }
+}
+
+/// Apply persisted geometry during `setup`, while the main window is
+/// still hidden — the `app_ready` reveal then happens directly at the
+/// restored frame. Off-screen recovery: position is applied only when
+/// the saved frame overlaps some monitor's logical rect; otherwise the
+/// OS keeps placement and only the size restores (monitor unplugged
+/// since last quit).
+pub fn restore<R: Runtime>(window: &WebviewWindow<R>, app_data_dir: &Path) {
+    let Some(state) = read(app_data_dir) else {
+        // Fresh install: seed the cache from the config-default frame
+        // anyway. `snapshot`'s maximized branch needs a cached normal
+        // frame, so without this a maximize-before-any-move quit on
+        // first launch would have nothing to persist.
+        *LAST.lock().unwrap() = snapshot(window);
+        return;
+    };
+    let _ = window.set_size(LogicalSize::new(state.width, state.height));
+    let monitors: Vec<Rect> = window
+        .available_monitors()
+        .map(|monitors| {
+            monitors
+                .iter()
+                .map(|m| {
+                    // work_area is computed from NSScreen.visibleFrame
+                    // (AppKit's consistent logical space) scaled by
+                    // this monitor's own factor, so dividing by that
+                    // factor recovers true logical points.
+                    // Monitor::size() does NOT round-trip like this —
+                    // it derives from CGDisplay pixel APIs, the
+                    // fractured space of tauri#7890 this module exists
+                    // to avoid.
+                    let sf = m.scale_factor();
+                    let pos = m.work_area().position.to_logical::<f64>(sf);
+                    let size = m.work_area().size.to_logical::<f64>(sf);
+                    Rect {
+                        x: pos.x,
+                        y: pos.y,
+                        width: size.width,
+                        height: size.height,
+                    }
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+    if overlaps_any(
+        &Rect {
+            x: state.x,
+            y: state.y,
+            width: state.width,
+            height: state.height,
+        },
+        &monitors,
+    ) {
+        let _ = window.set_position(LogicalPosition::new(state.x, state.y));
+    }
+    if state.maximized {
+        let _ = window.maximize();
+    }
+    // Seed the cache so a launch-then-quit without any move/resize
+    // still writes back the same normal geometry.
+    *LAST.lock().unwrap() = Some(state);
+}
+
+#[derive(Debug, Clone, Copy)]
+struct Rect {
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+}
+
+fn overlaps_any(frame: &Rect, monitors: &[Rect]) -> bool {
+    monitors.iter().any(|m| {
+        frame.x < m.x + m.width
+            && frame.x + frame.width > m.x
+            && frame.y < m.y + m.height
+            && frame.y + frame.height > m.y
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rect(x: f64, y: f64, width: f64, height: f64) -> Rect {
+        Rect {
+            x,
+            y,
+            width,
+            height,
+        }
+    }
+
+    #[test]
+    fn state_file_round_trips() {
+        let tmp = tempfile::tempdir().unwrap();
+        let state = WindowState {
+            x: -1080.0,
+            y: 374.0,
+            width: 1080.0,
+            height: 1117.0,
+            maximized: true,
+        };
+        write_atomic(tmp.path(), &state).unwrap();
+        assert_eq!(read(tmp.path()), Some(state));
+    }
+
+    #[test]
+    fn read_tolerates_missing_and_garbage_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(read(tmp.path()), None);
+        std::fs::write(state_path(tmp.path()), "not json").unwrap();
+        assert_eq!(read(tmp.path()), None);
+    }
+
+    #[test]
+    fn overlap_accepts_secondary_monitor_negative_coords() {
+        // Three-screen layout: portrait left at x=-1080, primary at 0,
+        // right at 2560 — logical points. A frame on the left screen
+        // (the exact case the plugin's physical-space check failed)
+        // must count as on-screen.
+        let monitors = [
+            rect(-1080.0, 0.0, 1080.0, 1920.0),
+            rect(0.0, 0.0, 2560.0, 1440.0),
+            rect(2560.0, 0.0, 2560.0, 1440.0),
+        ];
+        assert!(overlaps_any(
+            &rect(-1080.0, 374.0, 1080.0, 1117.0),
+            &monitors
+        ));
+    }
+
+    #[test]
+    fn overlap_rejects_frame_just_beyond_scaled_monitor_edge() {
+        // Guards the doubled-size mistake the review caught: monitor
+        // rects must be true logical (2560 wide for a 2x display, not
+        // 5120 backing pixels). A frame parked just past the right
+        // edge sits inside the doubled rect but outside the real one —
+        // it must be rejected or an unplugged-display frame would
+        // restore off-screen.
+        let monitors = [rect(0.0, 0.0, 2560.0, 1440.0)];
+        assert!(!overlaps_any(
+            &rect(2600.0, 100.0, 1080.0, 800.0),
+            &monitors
+        ));
+        assert!(overlaps_any(&rect(2500.0, 100.0, 1080.0, 800.0), &monitors));
+    }
+
+    #[test]
+    fn overlap_rejects_frame_on_unplugged_monitor() {
+        // Same saved frame, but the left monitor is gone: no overlap,
+        // so restore keeps size and lets the OS place the window.
+        let monitors = [rect(0.0, 0.0, 2560.0, 1440.0)];
+        assert!(!overlaps_any(
+            &rect(-1080.0, 374.0, 1080.0, 1117.0),
+            &monitors
+        ));
+        // Partial overlap (frame straddling a live edge) still counts.
+        assert!(overlaps_any(&rect(-200.0, 100.0, 1080.0, 800.0), &monitors));
+    }
+}

--- a/src/components/settings/ArchivedPane.tsx
+++ b/src/components/settings/ArchivedPane.tsx
@@ -2,16 +2,18 @@
 // direct chats merged by archive recency, with search (title + cwd)
 // and an All | Missions | Chats segmented filter. Unarchive clears
 // `archived_at` only; the backend events (`mission/changed` /
-// `session/updated`) reinstate the row in the app sidebar live. The
-// design's delete affordances (per-row trash, Delete all) ship dark
-// in v1 — feature-spec Phase 4.
+// `session/updated`) reinstate the row in the app sidebar live.
+// Delete all (title row, feature 01 Phase 4) permanently deletes every
+// archived item behind the ConfirmDialog styled per the design's
+// `component/confirm-dialog`; the per-row trash is still deferred.
 
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Archive, MessageSquare, Rocket, Search } from "lucide-react";
+import { Archive, MessageSquare, Rocket, Search, Trash2 } from "lucide-react";
 
 import { api, type DirectSessionEntry } from "../../lib/api";
 import type { Mission } from "../../lib/types";
+import { ConfirmDialog } from "./ConfirmDialog";
 import { PaneHeader, SettingsCard } from "./shared";
 
 type TypeFilter = "all" | "missions" | "chats";
@@ -107,6 +109,8 @@ export function ArchivedPane() {
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState("");
   const [filter, setFilter] = useState<TypeFilter>("all");
+  const [deleting, setDeleting] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -159,11 +163,51 @@ export function ArchivedPane() {
     navigate(item.kind === "mission" ? `/missions/${item.id}` : `/chats/${item.id}`);
   };
 
+  // Deletes everything archived, not just the filtered view — the
+  // dialog body names the full count so the scope is unmissable.
+  // Failed rows stay listed with the first error surfaced. The
+  // `deleting` guard covers the confirm-to-done window: a second
+  // submit would replay the same stale `items` and resurrect
+  // already-deleted rows as not-found failures.
+  const runDeleteAll = async () => {
+    if (deleting || !items || items.length === 0) return;
+    setDeleting(true);
+    try {
+      const failed: ArchivedItem[] = [];
+      let firstError: string | null = null;
+      for (const item of items) {
+        try {
+          if (item.kind === "mission") await api.mission.delete(item.id);
+          else await api.session.delete(item.id);
+        } catch (e) {
+          failed.push(item);
+          firstError ??= e instanceof Error ? e.message : String(e);
+        }
+      }
+      setItems(failed);
+      setError(firstError);
+    } finally {
+      setDeleting(false);
+      setConfirmOpen(false);
+    }
+  };
+
   return (
     <>
       <PaneHeader
         title="Archived chats & missions"
-        subtitle="Everything you've archived — restore anytime; nothing here is deleted."
+        subtitle="Everything you've archived — restore anytime, or delete permanently."
+        action={
+          <button
+            type="button"
+            onClick={() => setConfirmOpen(true)}
+            disabled={deleting || !items || items.length === 0}
+            className="flex h-8 shrink-0 cursor-pointer items-center gap-1.5 rounded-lg border border-danger/40 bg-danger/10 px-3 text-[12px] font-medium text-danger transition-colors hover:bg-danger/20 disabled:cursor-default disabled:opacity-40 disabled:hover:bg-danger/10"
+          >
+            <Trash2 aria-hidden className="h-3.5 w-3.5" />
+            Delete all
+          </button>
+        }
       />
       <div className="flex items-center gap-3">
         <div className="flex h-8 min-w-0 flex-1 items-center gap-2 rounded-md border border-line bg-bg px-2.5">
@@ -210,6 +254,18 @@ export function ArchivedPane() {
           )}
         </SettingsCard>
       )}
+      <ConfirmDialog
+        open={confirmOpen}
+        title="Delete all archived items?"
+        body={`This permanently deletes all ${items?.length ?? 0} archived ${
+          items?.length === 1 ? "item" : "items"
+        }, including mission event logs. This can't be undone.`}
+        confirmLabel="Delete all"
+        busyLabel="Deleting…"
+        busy={deleting}
+        onConfirm={() => void runDeleteAll()}
+        onCancel={() => setConfirmOpen(false)}
+      />
     </>
   );
 }

--- a/src/components/settings/ConfirmDialog.tsx
+++ b/src/components/settings/ConfirmDialog.tsx
@@ -1,0 +1,84 @@
+// Destructive confirm dialog — mirrors Pencil `component/confirm-dialog`
+// in design/runner-setting.pen. One reusable surface for the Archived
+// pane's delete flows (Delete all today, per-row trash later) so the
+// styling stays synced. Esc and outside-click cancel, matching
+// MissionResetConfirm; both are ignored while `busy` so a mid-flight
+// deletion can't be left visually orphaned.
+
+import { useEffect, useRef } from "react";
+import { Trash2 } from "lucide-react";
+
+export function ConfirmDialog({
+  open,
+  title,
+  body,
+  confirmLabel,
+  busyLabel,
+  busy,
+  onConfirm,
+  onCancel,
+}: {
+  open: boolean;
+  title: string;
+  body: string;
+  confirmLabel: string;
+  busyLabel: string;
+  busy: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  const cardRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open || busy) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onCancel();
+    };
+    const onMouseDown = (e: MouseEvent) => {
+      if (cardRef.current && !cardRef.current.contains(e.target as Node)) {
+        onCancel();
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    document.addEventListener("mousedown", onMouseDown);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("mousedown", onMouseDown);
+    };
+  }, [open, busy, onCancel]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/55">
+      <div
+        ref={cardRef}
+        className="flex w-[420px] flex-col gap-3.5 rounded-xl border border-line bg-panel px-[22px] py-5 shadow-[0_16px_48px_rgba(0,0,0,0.4)]"
+      >
+        <header className="flex items-center gap-2.5">
+          <Trash2 aria-hidden className="h-[15px] w-[15px] shrink-0 text-danger" />
+          <h2 className="text-[15px] font-semibold text-fg">{title}</h2>
+        </header>
+        <p className="text-[13px] leading-relaxed text-fg-2">{body}</p>
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={busy}
+            className="cursor-pointer rounded-lg bg-raised px-3.5 py-1.5 text-[12px] font-medium text-fg transition-colors hover:bg-raised/80 disabled:cursor-default disabled:opacity-60"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={busy}
+            className="cursor-pointer rounded-lg border border-danger/40 bg-danger/10 px-3.5 py-1.5 text-[12px] font-medium text-danger transition-colors hover:bg-danger/20 disabled:cursor-default disabled:opacity-60"
+          >
+            {busy ? busyLabel : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/shared.tsx
+++ b/src/components/settings/shared.tsx
@@ -8,13 +8,20 @@ import { Minus, Plus } from "lucide-react";
 export function PaneHeader({
   title,
   subtitle,
+  action,
 }: {
   title: string;
   subtitle: string;
+  /** Right-aligned control on the title row (design: Archived's
+   *  Delete all sits beside the page title, not in the toolbar). */
+  action?: React.ReactNode;
 }) {
   return (
     <div className="flex flex-col gap-1">
-      <h2 className="text-[20px] font-semibold text-fg">{title}</h2>
+      <div className="flex items-center justify-between gap-6">
+        <h2 className="text-[20px] font-semibold text-fg">{title}</h2>
+        {action ? <div className="shrink-0">{action}</div> : null}
+      </div>
       <p className="text-[13px] text-fg-2">{subtitle}</p>
     </div>
   );

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -162,6 +162,10 @@ export const api = {
     /** Archived missions, newest-archived first (Settings → Archived). */
     listArchived: (crewId?: string) =>
       invoke<Mission[]>("mission_list_archived", crewId ? { crewId } : {}),
+    /** Permanently delete an archived mission: session rows, the
+     *  mission row, and its on-disk event log. Refused unless
+     *  archived — archive is the reversible step, this is not. */
+    delete: (id: string) => invoke<void>("mission_delete", { id }),
     /** Wipe the run context and respawn every slot. Mostly for
      *  testing — keeps the mission row, crew, and slots intact;
      *  drops the event log, agent session keys, and router state. */
@@ -200,6 +204,10 @@ export const api = {
      *  Archived). Same DTO as listRecentDirect, keys withheld. */
     listArchived: () =>
       invoke<DirectSessionEntry[]>("session_list_archived"),
+    /** Permanently delete an archived direct chat. Refused unless
+     *  archived — archive is the reversible step, this is not. */
+    delete: (sessionId: string) =>
+      invoke<void>("session_delete", { sessionId }),
     rename: (sessionId: string, title: string | null) =>
       invoke<void>("session_rename", { sessionId, title }),
     pin: (sessionId: string, pinned: boolean) =>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -226,8 +226,8 @@ export default function SettingsPage() {
           className="pointer-events-auto absolute left-0 right-0 top-0 z-10 h-7"
         />
         <div className="flex-1 overflow-y-auto">
-          <div className="pb-16 pl-[120px] pr-10 pt-14">
-            <div className="flex max-w-[760px] flex-col gap-5">
+          <div className="px-10 pb-16 pt-14">
+            <div className="mx-auto flex max-w-[760px] flex-col gap-5">
               {PANES[pane].render()}
             </div>
           </div>


### PR DESCRIPTION
## Summary

Implements impl 0027 (closes #271) plus two riders picked up during the same session.

### Window geometry restore (impl 0027, pivoted)

- Main window position, size, and maximized state persist across restarts.
- **Pivot from the plan**: `tauri-plugin-window-state` shipped first and failed multi-monitor smoke on a three-display setup — it stores physical coordinates, a fractured space on macOS multi-monitor (tauri-apps/tauri#7890), so secondary-display windows restored to the primary's corner. Replaced with a hand-rolled `window_state.rs` storing **logical coordinates** (macOS's consistent points space). Full reasoning recorded in the impl doc's Pivot section.
- Restore happens in `setup` while the window is hidden — the `app_ready` no-flash reveal flow is untouched. Off-screen recovery gates position on `work_area` logical rects; maximized quits keep the last normal frame via a Moved/Resized cache; geometry checkpoints on hide-on-close (closes the doc's crash-resilience open question).
- Secondary `window-<ulid>` windows unaffected (cascade preserved); multi-window session restore deliberately out of scope per the issue.

### Settings → Archived: Delete all (feature 01 Phase 4)

- `mission_delete` / `session_delete` commands, refused for non-archived targets. Mission delete cascades session rows → mission row in one transaction, then removes the event-log dir and `missions/<id>` shim tree.
- Confirm-gated via a new `ConfirmDialog` styled from `component/confirm-dialog` in `design/runner-setting.pen`; trigger in the pane's title row per the design.

### Settings page centering

- Content column was left-anchored at 120px; now centered.

## Review & checks

Peer-reviewed through four rounds on the working-tree diff (crew reviewer); findings fixed: mission shim-tree leak, Delete all double-submit, fresh-install maximize hole, monitor gate using CGDisplay-derived rects.

- `cargo fmt` / `clippy --workspace --all-targets -D warnings` / `cargo test --workspace` (396 tests) green
- `tsc --noEmit` / `eslint` green
- Manual smoke on a three-display Mac Studio: secondary-screen restore, maximize restore, archived Delete all flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)