### PR TITLE
fix: inline folder rename, idle-on-resize, sidebar declutter

### DIFF
--- a/src-tauri/src/session/pty_runtime.rs
+++ b/src-tauri/src/session/pty_runtime.rs
@@ -34,6 +34,14 @@ const RUNTIME_LABEL: &str = "native-pty";
 const READ_BUF: usize = 8 * 1024;
 const DEFAULT_IDLE_THRESHOLD: Duration = Duration::from_millis(750);
 const IDLE_MONITOR_POLL: Duration = Duration::from_millis(50);
+/// Window right after a `resize` (SIGWINCH) during which repaint bytes
+/// from the child's TUI are not treated as fresh activity. Without this,
+/// resizing the window while a session is idle flips it to Busy for a
+/// full idle threshold — the agent redraws its prompt, and silence-based
+/// detection can't tell a repaint from real output. Kept under
+/// `DEFAULT_IDLE_THRESHOLD` so genuine work started right after a resize
+/// still surfaces promptly.
+const RESIZE_GRACE: Duration = Duration::from_millis(500);
 // PTYs can boot before their frontend xterm pane is ready to answer startup
 // probes. Answer them here so Codex does not cache fallback colors first.
 const TERMINAL_QUERY_STARTUP_BUDGET: usize = 8 * 1024;
@@ -80,6 +88,10 @@ struct SessionHandle {
     /// `false` once the reader thread breaks. `status()` reads this
     /// for the trait's `SessionStatus.alive`.
     alive: AtomicBool,
+    /// Timestamp of the last `resize` call. The reader thread consults it
+    /// to ignore SIGWINCH repaint bursts for `RESIZE_GRACE` (see
+    /// `IdleDetector`), so resizing an idle session doesn't read as Busy.
+    last_resize: Mutex<Option<Instant>>,
     pid: Option<i32>,
     command: String,
 }
@@ -175,6 +187,7 @@ impl SessionRuntime for PtyRuntime {
             child: Arc::clone(&child_slot),
             exit_code: AtomicI32::new(EXIT_UNSET),
             alive: AtomicBool::new(true),
+            last_resize: Mutex::new(None),
             pid,
             command: format_command_summary(&spec.command, &spec.args),
         });
@@ -230,15 +243,20 @@ impl SessionRuntime for PtyRuntime {
 
     fn resize(&self, session: &RuntimeSession, cols: u16, rows: u16) -> RuntimeResult<()> {
         let handle = lookup(self, &session.session_id)?;
-        let master = handle.master.lock().expect("master poisoned");
-        master
-            .resize(PtySize {
-                rows,
-                cols,
-                pixel_width: 0,
-                pixel_height: 0,
-            })
-            .map_err(|e| RuntimeError::Msg(format!("MasterPty::resize: {e}")))?;
+        {
+            let master = handle.master.lock().expect("master poisoned");
+            master
+                .resize(PtySize {
+                    rows,
+                    cols,
+                    pixel_width: 0,
+                    pixel_height: 0,
+                })
+                .map_err(|e| RuntimeError::Msg(format!("MasterPty::resize: {e}")))?;
+        }
+        // Open the grace window only after the SIGWINCH is delivered, so the
+        // repaint burst it triggers doesn't read as fresh activity.
+        *handle.last_resize.lock().expect("last_resize poisoned") = Some(Instant::now());
         Ok(())
     }
 
@@ -301,6 +319,17 @@ impl IdleDetector {
         } else {
             None
         }
+    }
+
+    /// Byte arrival during a resize grace window: keep the idle timer
+    /// fresh (a genuinely busy session that was also resized must not
+    /// idle early) but never flip Idle→Busy, so a SIGWINCH repaint on an
+    /// idle session stays idle.
+    fn on_bytes_quiet_at(&mut self, n: usize, now: Instant) {
+        if n == 0 {
+            return;
+        }
+        self.last_byte = now;
     }
 
     fn tick(&mut self) -> Option<RunnerStatus> {
@@ -384,9 +413,19 @@ fn reader_thread(
             Ok(0) => break, // EOF
             Ok(n) => {
                 answer_terminal_queries(&mut query_responder, &buf[..n], &handle, &session_id);
+                let in_resize_grace = handle
+                    .last_resize
+                    .lock()
+                    .expect("last_resize poisoned")
+                    .is_some_and(|t| t.elapsed() < RESIZE_GRACE);
                 let transition = {
                     let mut detector = detector.lock().expect("idle detector poisoned");
-                    detector.on_bytes(n)
+                    if in_resize_grace {
+                        detector.on_bytes_quiet_at(n, Instant::now());
+                        None
+                    } else {
+                        detector.on_bytes(n)
+                    }
                 };
                 if let Some(state) = transition {
                     if tx
@@ -751,6 +790,36 @@ mod tests {
         assert_eq!(
             detector.on_bytes_at(1, start + threshold + Duration::from_millis(2)),
             None
+        );
+    }
+
+    #[test]
+    fn resize_grace_bytes_do_not_wake_idle_detector() {
+        // Models the reader loop's grace branch: an idle session that
+        // emits a SIGWINCH repaint burst stays idle, and its idle timer
+        // is kept fresh so it doesn't immediately re-flip on the next tick.
+        let threshold = Duration::from_millis(750);
+        let start = Instant::now();
+        let mut detector = IdleDetector::new_at(threshold, start);
+
+        assert_eq!(
+            detector.tick_at(start + threshold),
+            Some(RunnerStatus::Idle)
+        );
+
+        // Repaint bytes during the grace window: no Busy transition.
+        let repaint = start + threshold + Duration::from_millis(10);
+        detector.on_bytes_quiet_at(1, repaint);
+
+        // Still idle (a real byte outside grace would have flipped Busy).
+        assert_eq!(detector.tick_at(repaint + Duration::from_millis(1)), None);
+
+        // The quiet burst refreshed last_byte, so a genuinely busy session
+        // that was resized mid-work would not idle early. A later real byte
+        // still wakes it.
+        assert_eq!(
+            detector.on_bytes_at(1, repaint + Duration::from_millis(20)),
+            Some(RunnerStatus::Busy)
         );
     }
 

--- a/src/components/ChatTabGroup.test.ts
+++ b/src/components/ChatTabGroup.test.ts
@@ -15,7 +15,7 @@ const session = {
 } as DirectSessionEntry;
 
 describe("ChatTabGroup", () => {
-  it("shows the layout pane count when some panes are empty", () => {
+  it("marks a multi-pane tab with a split icon and no count badge", () => {
     const layout = {
       ...applyPresetPure("cols-3", "A", ["A"]),
       id: "tab-1",
@@ -32,7 +32,7 @@ describe("ChatTabGroup", () => {
     );
 
     expect(html).toContain("lucide-columns-3");
-    expect(html).toContain(">3</span>");
+    expect(html).not.toContain(">3</span>");
     expect(html).toContain('draggable="true"');
   });
 
@@ -56,9 +56,6 @@ describe("ChatTabGroup", () => {
     expect(working).toContain("origin-center");
     expect(working).toContain("text-fg-3");
     expect(working).not.toContain("text-accent");
-    expect(working.indexOf('aria-label="Agent working"')).toBeLessThan(
-      working.indexOf(">2</span>"),
-    );
 
     const unread = renderToStaticMarkup(
       createElement(ChatTabGroup, {

--- a/src/components/ChatTabGroup.tsx
+++ b/src/components/ChatTabGroup.tsx
@@ -83,11 +83,6 @@ export function ChatTabGroup({
           {name}
         </span>
         <ChatAttentionIndicator state={attention} />
-        {paneCount > 1 ? (
-          <span className="shrink-0 rounded bg-line px-1 py-px text-[9px] text-fg-3">
-            {paneCount}
-          </span>
-        ) : null}
       </button>
       <button
         type="button"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -79,7 +79,6 @@ import {
   activatePaneLayoutForSession,
   assignSessionToPane,
   createChatFolder,
-  findLeaf,
   focusPane,
   getPaneLayout,
   leafForSession,
@@ -263,6 +262,7 @@ export function Sidebar({
   const [folderMenu, setFolderMenu] = useState<{
     id: string;
     name: string;
+    collapsed: boolean;
     x: number;
     y: number;
   } | null>(null);
@@ -662,10 +662,19 @@ export function Sidebar({
   );
   const closeFolderMenu = useCallback(() => setFolderMenu(null), []);
   const openFolderMenu = useCallback(
-    (folder: { id: string; name: string }, anchor: { x: number; y: number }) => {
+    (
+      folder: { id: string; name: string; collapsed: boolean },
+      anchor: { x: number; y: number },
+    ) => {
       setChatTabMenu(null);
       setMissionMenu(null);
-      setFolderMenu({ ...folder, x: anchor.x, y: anchor.y });
+      setFolderMenu({
+        id: folder.id,
+        name: folder.name,
+        collapsed: folder.collapsed,
+        x: anchor.x,
+        y: anchor.y,
+      });
     },
     [],
   );
@@ -911,19 +920,6 @@ export function Sidebar({
     },
     [navigate, refreshDirectSessions],
   );
-
-  const openChatTabInNewWindow = useCallback((members: DirectSessionEntry[]) => {
-    const first = members[0];
-    if (!first) return;
-    const layout = getPaneLayout(first.session_id);
-    const focusedSessionId =
-      findLeaf(layout.root, layout.focusedPaneId)?.sessionId ?? null;
-    const target =
-      members.find((member) => member.session_id === focusedSessionId) ?? first;
-    void api.window.open(`/chats/${target.session_id}`).catch((e) =>
-      console.error("sidebar: open chat tab in new window failed", e),
-    );
-  }, []);
 
   const archiveChatTab = useCallback(
     async (members: DirectSessionEntry[]) => {
@@ -1471,7 +1467,6 @@ export function Sidebar({
                                   initial={folder.name}
                                   collapsed={folder.collapsed}
                                   attention={folderAttention}
-                                  count={items.length}
                                   onSubmit={(nextName) =>
                                     void submitFolderRename(
                                       folder.id,
@@ -1520,23 +1515,6 @@ export function Sidebar({
                                         folder.collapsed ? folderAttention : null
                                       }
                                     />
-                                    <span className="text-[10px] text-fg-3">
-                                      {items.length}
-                                    </span>
-                                  </button>
-                                  <button
-                                    type="button"
-                                    onClick={() => {
-                                      if (folder.collapsed) {
-                                        void toggleFolder(folder.id, true);
-                                      }
-                                      handleNewFolderChat(folder.id);
-                                    }}
-                                    className="cursor-pointer rounded p-0.5 text-fg-3 hover:bg-raised hover:text-fg"
-                                    aria-label={`New chat in ${folder.name}`}
-                                    title="New chat in folder"
-                                  >
-                                    <Plus aria-hidden className="h-3 w-3" />
                                   </button>
                                   <button
                                     type="button"
@@ -1747,10 +1725,6 @@ export function Sidebar({
             renameChatTab(chatTabMenu.members);
             closeChatTabMenu();
           }}
-          onOpenInNewWindow={() => {
-            openChatTabInNewWindow(chatTabMenu.members);
-            closeChatTabMenu();
-          }}
           onArchive={() => {
             void archiveChatTab(chatTabMenu.members);
             closeChatTabMenu();
@@ -1763,6 +1737,11 @@ export function Sidebar({
           anchorX={folderMenu.x}
           anchorY={folderMenu.y}
           onClose={closeFolderMenu}
+          onNewChat={() => {
+            if (folderMenu.collapsed) void toggleFolder(folderMenu.id, true);
+            handleNewFolderChat(folderMenu.id);
+            closeFolderMenu();
+          }}
           onRename={() => {
             setRenamingFolderId(folderMenu.id);
             closeFolderMenu();
@@ -2035,14 +2014,12 @@ function FolderRenameRow({
   initial,
   collapsed,
   attention,
-  count,
   onSubmit,
   onCancel,
 }: {
   initial: string;
   collapsed: boolean;
   attention: ChatAttentionState;
-  count: number;
   onSubmit: (name: string) => void;
   onCancel: () => void;
 }) {
@@ -2086,7 +2063,6 @@ function FolderRenameRow({
         className="min-w-0 flex-1 bg-transparent text-xs font-medium text-fg outline-none"
       />
       <ChatAttentionIndicator state={collapsed ? attention : null} />
-      <span className="text-[10px] text-fg-3">{count}</span>
     </div>
   );
 }
@@ -2466,7 +2442,7 @@ function RowContextMenu({
   onClose: () => void;
   onPin: () => void;
   onRename: () => void;
-  onOpenInNewWindow: () => void;
+  onOpenInNewWindow?: () => void;
   onArchive: () => void;
   renameLabel?: string;
   archiveLabel?: string;
@@ -2515,21 +2491,18 @@ function RowContextMenu({
         onClick={onPin}
       />
       <ContextMenuItem icon={SquarePen} label={renameLabel} onClick={onRename} />
-      <ContextMenuItem
-        icon={AppWindow}
-        label="Open in New Window"
-        onClick={onOpenInNewWindow}
-      />
-      {folders && onMoveToFolder ? (
+      {onOpenInNewWindow ? (
+        <ContextMenuItem
+          icon={AppWindow}
+          label="Open in New Window"
+          onClick={onOpenInNewWindow}
+        />
+      ) : null}
+      {folders &&
+      onMoveToFolder &&
+      folders.some((folder) => folder.id !== currentFolderId) ? (
         <>
           <div className="my-1 h-px bg-line" />
-          {currentFolderId !== null ? (
-            <ContextMenuItem
-              icon={Folder}
-              label="Move out of folder"
-              onClick={() => onMoveToFolder(null)}
-            />
-          ) : null}
           {folders
             .filter((folder) => folder.id !== currentFolderId)
             .map((folder) => (
@@ -2556,12 +2529,14 @@ function FolderContextMenu({
   anchorX,
   anchorY,
   onClose,
+  onNewChat,
   onRename,
   onDelete,
 }: {
   anchorX: number;
   anchorY: number;
   onClose: () => void;
+  onNewChat: () => void;
   onRename: () => void;
   onDelete: () => void;
 }) {
@@ -2596,6 +2571,11 @@ function FolderContextMenu({
       style={{ position: "fixed", left: pos.x, top: pos.y, width: 180 }}
       className="z-50 flex flex-col gap-px rounded-lg border border-line bg-raised p-1.5 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
     >
+      <ContextMenuItem
+        icon={MessageSquarePlus}
+        label="New chat in folder"
+        onClick={onNewChat}
+      />
       <ContextMenuItem icon={SquarePen} label="Rename folder" onClick={onRename} />
       <ContextMenuItem icon={Trash2} label="Delete" onClick={onDelete} danger />
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -293,6 +293,7 @@ export function Sidebar({
   const [newChatFolderId, setNewChatFolderId] = useState<string | null>(null);
   const [chatAddMenuOpen, setChatAddMenuOpen] = useState(false);
   const [creatingFolder, setCreatingFolder] = useState(false);
+  const [renamingFolderId, setRenamingFolderId] = useState<string | null>(null);
   const [chatCreateMenu, setChatCreateMenu] = useState<{
     x: number;
     y: number;
@@ -853,16 +854,20 @@ export function Sidebar({
     [],
   );
 
-  const renameFolder = useCallback(async (id: string, currentName: string) => {
-    const name = window.prompt("Rename folder", currentName);
-    if (!name?.trim() || name.trim() === currentName) return;
-    try {
-      await api.folder.rename(id, name.trim());
-      await hydratePaneLayoutsFromDb();
-    } catch (e) {
-      console.error("sidebar: folder_rename failed", e);
-    }
-  }, []);
+  const submitFolderRename = useCallback(
+    async (id: string, currentName: string, nextName: string) => {
+      const trimmed = nextName.trim();
+      setRenamingFolderId(null);
+      if (!trimmed || trimmed === currentName.trim()) return;
+      try {
+        await api.folder.rename(id, trimmed);
+        await hydratePaneLayoutsFromDb();
+      } catch (e) {
+        console.error("sidebar: folder_rename failed", e);
+      }
+    },
+    [],
+  );
 
   const toggleFolder = useCallback(async (id: string, collapsed: boolean) => {
     try {
@@ -1461,74 +1466,94 @@ export function Sidebar({
                               }}
                               className="flex flex-col gap-0.5"
                             >
-                              <div
-                                onContextMenu={(event) => {
-                                  event.preventDefault();
-                                  openFolderMenu(folder, {
-                                    x: event.clientX,
-                                    y: event.clientY,
-                                  });
-                                }}
-                                className={`group flex items-center gap-1.5 rounded border px-2.5 py-1.5 text-xs transition-colors ${
-                                  dragOverFolderId === folder.id
-                                    ? "border-accent bg-accent/10 text-fg"
-                                    : "border-transparent text-fg-2 hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg"
-                                }`}
-                              >
-                                <button
-                                  type="button"
-                                  onClick={() =>
-                                    void toggleFolder(folder.id, folder.collapsed)
+                              {renamingFolderId === folder.id ? (
+                                <FolderRenameRow
+                                  initial={folder.name}
+                                  collapsed={folder.collapsed}
+                                  attention={folderAttention}
+                                  count={items.length}
+                                  onSubmit={(nextName) =>
+                                    void submitFolderRename(
+                                      folder.id,
+                                      folder.name,
+                                      nextName,
+                                    )
                                   }
-                                  className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
-                                >
-                                  {folder.collapsed ? (
-                                    <ChevronRight aria-hidden className="h-3 w-3 shrink-0" />
-                                  ) : (
-                                    <ChevronDown aria-hidden className="h-3 w-3 shrink-0" />
-                                  )}
-                                  <Folder aria-hidden className="h-3 w-3 shrink-0" />
-                                  <span className="min-w-0 flex-1 truncate font-medium">
-                                    {folder.name}
-                                  </span>
-                                  <ChatAttentionIndicator
-                                    state={
-                                      folder.collapsed ? folderAttention : null
-                                    }
-                                  />
-                                  <span className="text-[10px] text-fg-3">
-                                    {items.length}
-                                  </span>
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={() => {
-                                    if (folder.collapsed) {
-                                      void toggleFolder(folder.id, true);
-                                    }
-                                    handleNewFolderChat(folder.id);
-                                  }}
-                                  className="cursor-pointer rounded p-0.5 text-fg-3 hover:bg-raised hover:text-fg"
-                                  aria-label={`New chat in ${folder.name}`}
-                                  title="New chat in folder"
-                                >
-                                  <Plus aria-hidden className="h-3 w-3" />
-                                </button>
-                                <button
-                                  type="button"
-                                  onClick={(event) =>
+                                  onCancel={() => setRenamingFolderId(null)}
+                                />
+                              ) : (
+                                <div
+                                  onContextMenu={(event) => {
+                                    event.preventDefault();
                                     openFolderMenu(folder, {
                                       x: event.clientX,
                                       y: event.clientY,
-                                    })
-                                  }
-                                  className="cursor-pointer rounded p-0.5 text-fg-3 opacity-0 hover:bg-raised hover:text-fg group-hover:opacity-100 focus:opacity-100"
-                                  aria-label="Folder actions"
-                                  title="Folder actions"
+                                    });
+                                  }}
+                                  className={`group flex items-center gap-1.5 rounded border px-2.5 py-1.5 text-xs transition-colors ${
+                                    dragOverFolderId === folder.id
+                                      ? "border-accent bg-accent/10 text-fg"
+                                      : "border-transparent text-fg-2 hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg"
+                                  }`}
                                 >
-                                  <MoreHorizontal aria-hidden className="h-3 w-3" />
-                                </button>
-                              </div>
+                                  <button
+                                    type="button"
+                                    onClick={() =>
+                                      void toggleFolder(
+                                        folder.id,
+                                        folder.collapsed,
+                                      )
+                                    }
+                                    className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
+                                  >
+                                    {folder.collapsed ? (
+                                      <ChevronRight aria-hidden className="h-3 w-3 shrink-0" />
+                                    ) : (
+                                      <ChevronDown aria-hidden className="h-3 w-3 shrink-0" />
+                                    )}
+                                    <Folder aria-hidden className="h-3 w-3 shrink-0" />
+                                    <span className="min-w-0 flex-1 truncate font-medium">
+                                      {folder.name}
+                                    </span>
+                                    <ChatAttentionIndicator
+                                      state={
+                                        folder.collapsed ? folderAttention : null
+                                      }
+                                    />
+                                    <span className="text-[10px] text-fg-3">
+                                      {items.length}
+                                    </span>
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={() => {
+                                      if (folder.collapsed) {
+                                        void toggleFolder(folder.id, true);
+                                      }
+                                      handleNewFolderChat(folder.id);
+                                    }}
+                                    className="cursor-pointer rounded p-0.5 text-fg-3 hover:bg-raised hover:text-fg"
+                                    aria-label={`New chat in ${folder.name}`}
+                                    title="New chat in folder"
+                                  >
+                                    <Plus aria-hidden className="h-3 w-3" />
+                                  </button>
+                                  <button
+                                    type="button"
+                                    onClick={(event) =>
+                                      openFolderMenu(folder, {
+                                        x: event.clientX,
+                                        y: event.clientY,
+                                      })
+                                    }
+                                    className="cursor-pointer rounded p-0.5 text-fg-3 opacity-0 hover:bg-raised hover:text-fg group-hover:opacity-100 focus:opacity-100"
+                                    aria-label="Folder actions"
+                                    title="Folder actions"
+                                  >
+                                    <MoreHorizontal aria-hidden className="h-3 w-3" />
+                                  </button>
+                                </div>
+                              )}
                               {folder.collapsed ? null : (
                                 <div className="ml-3 flex flex-col gap-0.5 border-l border-line pl-2">
                                   {renderTabItems(items, folder.id)}
@@ -1739,7 +1764,7 @@ export function Sidebar({
           anchorY={folderMenu.y}
           onClose={closeFolderMenu}
           onRename={() => {
-            void renameFolder(folderMenu.id, folderMenu.name);
+            setRenamingFolderId(folderMenu.id);
             closeFolderMenu();
           }}
           onDelete={() => {
@@ -2002,6 +2027,66 @@ function NewFolderRow({
         onBlur={() => void submit()}
         className="min-w-0 flex-1 bg-transparent text-xs text-fg outline-none placeholder:text-fg-3"
       />
+    </div>
+  );
+}
+
+function FolderRenameRow({
+  initial,
+  collapsed,
+  attention,
+  count,
+  onSubmit,
+  onCancel,
+}: {
+  initial: string;
+  collapsed: boolean;
+  attention: ChatAttentionState;
+  count: number;
+  onSubmit: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const [draft, setDraft] = useState(initial);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  return (
+    <div
+      onContextMenu={(event) => event.stopPropagation()}
+      className="flex items-center gap-1.5 rounded border border-sidebar-selected-border bg-sidebar-selected px-2.5 py-1.5 text-xs text-fg shadow-sm"
+    >
+      {collapsed ? (
+        <ChevronRight aria-hidden className="h-3 w-3 shrink-0" />
+      ) : (
+        <ChevronDown aria-hidden className="h-3 w-3 shrink-0" />
+      )}
+      <Folder aria-hidden className="h-3 w-3 shrink-0" />
+      <input
+        ref={inputRef}
+        value={draft}
+        aria-label="Folder name"
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            onSubmit(draft.trim());
+          } else if (event.key === "Escape") {
+            event.preventDefault();
+            onCancel();
+          }
+        }}
+        onBlur={() => {
+          if (draft.trim() === initial.trim()) onCancel();
+          else onSubmit(draft.trim());
+        }}
+        className="min-w-0 flex-1 bg-transparent text-xs font-medium text-fg outline-none"
+      />
+      <ChatAttentionIndicator state={collapsed ? attention : null} />
+      <span className="text-[10px] text-fg-3">{count}</span>
     </div>
   );
 }


### PR DESCRIPTION
Bundles the folder-rename fix with a backend idle-status fix and a round of sidebar decluttering.

## Fixes
- **Inline folder rename** (Closes #284) — replaces the Tauri-incompatible `window.prompt` with the sidebar's inline rename interaction (Enter/blur commit, Escape cancels).
- **Idle status no longer flips on window resize** — the silence-based `IdleDetector` treated SIGWINCH repaint bytes as activity, so resizing an idle session showed it as "running" for a full idle threshold. A short resize grace window now keeps the idle timer fresh without triggering an Idle→Busy transition.

## Sidebar polish
- Drop the pane-count badge from multi-pane tab rows (the split icon already signals 2 vs 3+ panes) and the tab count from folder rows.
- Fold the folder row's always-visible new-chat `+` into the folder actions menu as "New chat in folder".
- Remove "Open in New Window" and "Move out of folder" from the chat tab menu (missions keep open-in-new-window); guard the move-to-folder divider so no stray separator remains.

## Checks
- `pnpm exec tsc --noEmit`, `pnpm run lint`, `pnpm test` (101 tests)
- `cargo fmt --check`, `cargo clippy`, `cargo test session::pty_runtime` (incl. new resize-grace test)

Note: sidebar tab drag-and-drop (reorder + in/out of folder) is a separate, larger change — tracked for its own PR.
