### PR TITLE
fix(ui): make sidebar tab dragging reliable

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "tauri:before:build": "node scripts/stage-runner-cli.mjs && npm run build"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/inter": "^5.2.8",
     "@fontsource-variable/roboto": "^5.2.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
       '@fontsource-variable/geist':
         specifier: ^5.2.9
         version: 5.2.9
@@ -205,6 +211,28 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -1800,6 +1828,9 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2076,6 +2107,31 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
 
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
@@ -3743,6 +3799,8 @@ snapshots:
   ts-api-utils@2.5.0(typescript@5.8.3):
     dependencies:
       typescript: 5.8.3
+
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:

--- a/src/components/ChatTabGroup.test.ts
+++ b/src/components/ChatTabGroup.test.ts
@@ -35,7 +35,7 @@ describe("ChatTabGroup", () => {
 
     expect(html).toContain("lucide-columns-3");
     expect(html).not.toContain(">3</span>");
-    expect(html).toContain('draggable="true"');
+    expect(html).not.toContain("draggable=");
     expect(html).toContain('fill="none"');
   });
 

--- a/src/components/ChatTabGroup.tsx
+++ b/src/components/ChatTabGroup.tsx
@@ -10,16 +10,12 @@ import { chatTabIsLive, derivedChatTabTitle } from "../lib/chatTabs";
 import { findLeaf, leaves, type PaneLayout } from "../lib/paneLayout";
 import { SidebarTabRow } from "./SidebarTabRow";
 
-export const CHAT_TAB_DRAG_TYPE = "application/x-runner-chat-tab";
-
 export function ChatTabGroup({
   layout,
   members,
   active,
   onActivate,
   onContextMenu,
-  onDragStart,
-  onDragEnd,
   dragging,
   attention,
 }: {
@@ -28,8 +24,6 @@ export function ChatTabGroup({
   active: boolean;
   onActivate: (session: DirectSessionEntry) => void;
   onContextMenu: (anchor: { x: number; y: number }) => void;
-  onDragStart?: (tabId: string) => void;
-  onDragEnd?: () => void;
   dragging?: boolean;
   attention: ChatAttentionState;
 }) {
@@ -45,13 +39,6 @@ export function ChatTabGroup({
 
   return (
     <SidebarTabRow
-      draggable={layout.id.length > 0}
-      onDragStart={(event) => {
-        event.dataTransfer.effectAllowed = "move";
-        event.dataTransfer.setData(CHAT_TAB_DRAG_TYPE, layout.id);
-        onDragStart?.(layout.id);
-      }}
-      onDragEnd={onDragEnd}
       dragging={dragging}
       selected={active}
       label={name}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -22,7 +22,6 @@ import {
   useRef,
   useState,
   type ComponentType,
-  type CSSProperties,
   type ReactNode,
 } from "react";
 import {
@@ -2130,27 +2129,15 @@ function SortableChatTab({
   children: ReactNode;
 }) {
   const {
-    isDragging,
     listeners,
     setNodeRef,
-    transform,
-    transition,
   } = useSortable({
     id: tabDndId(tabId),
     data: { kind: "tab", tabId, folderId } satisfies ChatTabDndData,
   });
-  const style: CSSProperties = {
-    position: isDragging ? "relative" : undefined,
-    zIndex: isDragging ? 30 : undefined,
-    transform: transform
-      ? `translate3d(${transform.x}px, ${transform.y}px, 0) scaleX(${transform.scaleX}) scaleY(${transform.scaleY})`
-      : undefined,
-    transition,
-    touchAction: "none",
-  };
 
   return (
-    <div ref={setNodeRef} style={style} {...listeners}>
+    <div ref={setNodeRef} style={{ touchAction: "none" }} {...listeners}>
       {children}
     </div>
   );

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -22,9 +22,26 @@ import {
   useRef,
   useState,
   type ComponentType,
-  type DragEvent,
+  type CSSProperties,
   type ReactNode,
 } from "react";
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  pointerWithin,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragOverEvent,
+  type DragStartEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import {
   NavLink,
   useLocation,
@@ -97,10 +114,7 @@ import {
   visibleSessionIds,
   type PaneLayout,
 } from "../lib/paneLayout";
-import {
-  CHAT_TAB_DRAG_TYPE,
-  ChatTabGroup,
-} from "./ChatTabGroup";
+import { ChatTabGroup } from "./ChatTabGroup";
 import {
   ChatAttentionIndicator,
   SidebarTabIcon,
@@ -134,6 +148,30 @@ const STORAGE_MISSION_OPEN = "runner.sidebar.mission.open";
 const STORAGE_SESSION_OPEN = "runner.sidebar.session.open";
 const SIDEBAR_NAVIGATE_EVENT = "runner:navigate-sidebar-page";
 const SIDEBAR_NAVIGATION_HISTORY_LIMIT = 64;
+
+type TabDropTarget = {
+  folderId: string | null;
+  index: number;
+  markerKey: string;
+};
+
+type ChatTabDndData =
+  | {
+      kind: "tab";
+      tabId: string;
+      folderId: string | null;
+    }
+  | ({ kind: "position" } & TabDropTarget)
+  | {
+      kind: "collapsed-folder";
+      folderId: string;
+    };
+
+const tabDndId = (tabId: string) => `chat-tab:${tabId}`;
+const tabDropDndId = (folderId: string | null, markerKey: string) =>
+  `chat-tab-drop:${folderId ?? "ungrouped"}:${markerKey}`;
+const collapsedFolderDndId = (folderId: string) =>
+  `chat-folder-drop:${folderId}`;
 
 type SidebarNavigationDirection = "previous" | "next";
 
@@ -215,6 +253,11 @@ export function Sidebar({
 }: SidebarProps) {
   const navigate = useNavigate();
   const location = useLocation();
+  const tabDragSensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 },
+    }),
+  );
 
   // Width + resize state. The right-edge handle below grows the
   // sidebar when dragged rightward. The aside ref lets the hook
@@ -304,13 +347,14 @@ export function Sidebar({
     x: number;
     y: number;
   } | null>(null);
-  const [dragOverFolderId, setDragOverFolderId] = useState<string | null>(null);
+  const [collapsedFolderDropId, setCollapsedFolderDropId] = useState<
+    string | null
+  >(null);
   const [draggedTabId, setDraggedTabId] = useState<string | null>(null);
-  const [tabDropTarget, setTabDropTarget] = useState<{
-    folderId: string | null;
-    index: number;
-    markerKey: string;
-  } | null>(null);
+  const [tabDropTarget, setTabDropTarget] = useState<TabDropTarget | null>(
+    null,
+  );
+  const tabDropTargetRef = useRef<TabDropTarget | null>(null);
 
   // Identify the currently-open runtime so we can highlight the matching
   // sidebar row. `useMatch` returns null when the URL doesn't match.
@@ -372,6 +416,9 @@ export function Sidebar({
         ),
       ),
     [missions],
+  );
+  const draggedTabItem = tabItems.find(
+    (item) => item.layout.id === draggedTabId,
   );
   const orderedChatRows = useMemo(
     () => tabItems.map((item) => item.members[0]),
@@ -1001,8 +1048,9 @@ export function Sidebar({
 
   const clearTabDrag = useCallback(() => {
     setDraggedTabId(null);
-    setDragOverFolderId(null);
+    setCollapsedFolderDropId(null);
     setTabDropTarget(null);
+    tabDropTargetRef.current = null;
   }, []);
 
   const commitTabDrop = useCallback(
@@ -1036,12 +1084,198 @@ export function Sidebar({
     [clearTabDrag, tabItems],
   );
 
-  const dropTabIntoFolder = useCallback(
-    (tabId: string, folderId: string) => {
-      setDragOverFolderId(null);
-      void commitTabDrop(tabId, folderId, Number.MAX_SAFE_INTEGER);
+  const resolveTabDropTarget = useCallback(
+    (event: DragOverEvent | DragEndEvent): TabDropTarget | null => {
+      const activeData = event.active.data.current as
+        | ChatTabDndData
+        | undefined;
+      const overData = event.over?.data.current as
+        | ChatTabDndData
+        | undefined;
+      if (activeData?.kind !== "tab" || !overData) return null;
+
+      const dragged = tabItems.find(
+        (item) => item.layout.id === activeData.tabId,
+      );
+      if (!dragged) return null;
+
+      if (overData.kind === "position") {
+        const targetItems = tabItems.filter(
+          (item) => item.layout.folderId === overData.folderId,
+        );
+        const allowed = isChatTabDropIndexAllowed(
+          targetItems.map((item) => ({
+            id: item.layout.id,
+            pinned: item.members.every((member) => member.pinned),
+          })),
+          dragged.layout.id,
+          dragged.members.every((member) => member.pinned),
+          overData.index,
+        );
+        return allowed
+          ? {
+              folderId: overData.folderId,
+              index: overData.index,
+              markerKey: overData.markerKey,
+            }
+          : null;
+      }
+
+      if (overData.kind !== "tab") return null;
+      const targetItems = tabItems.filter(
+        (item) => item.layout.folderId === overData.folderId,
+      );
+      const overIndex = targetItems.findIndex(
+        (item) => item.layout.id === overData.tabId,
+      );
+      if (overIndex < 0 || !event.over) return null;
+
+      const activeRect =
+        event.active.rect.current.translated ??
+        event.active.rect.current.initial;
+      const after = activeRect
+        ? activeRect.top + activeRect.height / 2 >=
+          event.over.rect.top + event.over.rect.height / 2
+        : false;
+      const originalIndex = overIndex + (after ? 1 : 0);
+      const index = targetItems
+        .slice(0, originalIndex)
+        .filter((item) => item.layout.id !== dragged.layout.id).length;
+      if (
+        !isChatTabDropIndexAllowed(
+          targetItems.map((item) => ({
+            id: item.layout.id,
+            pinned: item.members.every((member) => member.pinned),
+          })),
+          dragged.layout.id,
+          dragged.members.every((member) => member.pinned),
+          index,
+        )
+      ) {
+        return null;
+      }
+
+      return {
+        folderId: overData.folderId,
+        index,
+        markerKey:
+          originalIndex < targetItems.length
+            ? `before-${targetItems[originalIndex].layout.id}`
+            : `after-${overData.folderId ?? "ungrouped"}`,
+      };
     },
-    [commitTabDrop],
+    [tabItems],
+  );
+
+  const resolveCollapsedFolderDropTarget = useCallback(
+    (tabId: string, folderId: string): TabDropTarget | null => {
+      const dragged = tabItems.find((item) => item.layout.id === tabId);
+      if (!dragged) return null;
+      const targetItems = tabItems.filter(
+        (item) => item.layout.folderId === folderId,
+      );
+      const orderedIds = orderedChatTabIdsAfterDrop(
+        targetItems.map((item) => ({
+          id: item.layout.id,
+          pinned: item.members.every((member) => member.pinned),
+        })),
+        tabId,
+        dragged.members.every((member) => member.pinned),
+        Number.MAX_SAFE_INTEGER,
+      );
+      const index = orderedIds.indexOf(tabId);
+      const remaining = targetItems.filter(
+        (item) => item.layout.id !== tabId,
+      );
+      if (index < 0) return null;
+      return {
+        folderId,
+        index,
+        markerKey:
+          index < remaining.length
+            ? `before-${remaining[index].layout.id}`
+            : `after-${folderId}`,
+      };
+    },
+    [tabItems],
+  );
+
+  const handleTabDragStart = useCallback((event: DragStartEvent) => {
+    const data = event.active.data.current as ChatTabDndData | undefined;
+    if (data?.kind !== "tab") return;
+    setDraggedTabId(data.tabId);
+    setCollapsedFolderDropId(null);
+    setTabDropTarget(null);
+    tabDropTargetRef.current = null;
+  }, []);
+
+  const handleTabDragOver = useCallback(
+    (event: DragOverEvent) => {
+      const activeData = event.active.data.current as
+        | ChatTabDndData
+        | undefined;
+      const overData = event.over?.data.current as
+        | ChatTabDndData
+        | undefined;
+      if (
+        activeData?.kind === "tab" &&
+        overData?.kind === "collapsed-folder"
+      ) {
+        const target = resolveCollapsedFolderDropTarget(
+          activeData.tabId,
+          overData.folderId,
+        );
+        setCollapsedFolderDropId(overData.folderId);
+        setTabDropTarget(target);
+        tabDropTargetRef.current = target;
+        return;
+      }
+
+      setCollapsedFolderDropId((folderId) => {
+        if (
+          folderId &&
+          (overData?.kind === "position" || overData?.kind === "tab") &&
+          overData.folderId === folderId
+        ) {
+          return folderId;
+        }
+        return null;
+      });
+      const target = resolveTabDropTarget(event);
+      setTabDropTarget(target);
+      tabDropTargetRef.current = target;
+    },
+    [resolveCollapsedFolderDropTarget, resolveTabDropTarget],
+  );
+
+  const handleTabDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const activeData = event.active.data.current as
+        | ChatTabDndData
+        | undefined;
+      const overData = event.over?.data.current as
+        | ChatTabDndData
+        | undefined;
+      if (activeData?.kind !== "tab") {
+        clearTabDrag();
+        return;
+      }
+      if (overData?.kind === "collapsed-folder") {
+        void commitTabDrop(
+          activeData.tabId,
+          overData.folderId,
+          Number.MAX_SAFE_INTEGER,
+        );
+        return;
+      }
+      const target = resolveTabDropTarget(event) ?? tabDropTargetRef.current;
+      if (target) {
+        void commitTabDrop(activeData.tabId, target.folderId, target.index);
+      } else {
+        clearTabDrag();
+      }
+    },
+    [clearTabDrag, commitTabDrop, resolveTabDropTarget],
   );
 
   const toggleMissions = useCallback(() => {
@@ -1063,26 +1297,25 @@ export function Sidebar({
       (member) => member.session_id === currentChatSessionId,
     );
     return (
-      <ChatTabGroup
+      <SortableChatTab
         key={item.layout.id}
-        layout={item.layout}
-        members={item.members}
-        active={active}
-        attention={item.attention}
-        onActivate={(entry) =>
-          activateTabChat(item.layout.id, item.members, entry)
-        }
-        onContextMenu={(anchor) =>
-          openChatTabMenu(item.layout, item.members, anchor)
-        }
-        onDragStart={(tabId) => {
-          setDraggedTabId(tabId);
-          setDragOverFolderId(null);
-          setTabDropTarget(null);
-        }}
-        onDragEnd={clearTabDrag}
-        dragging={draggedTabId === item.layout.id}
-      />
+        tabId={item.layout.id}
+        folderId={item.layout.folderId}
+      >
+        <ChatTabGroup
+          layout={item.layout}
+          members={item.members}
+          active={active}
+          attention={item.attention}
+          onActivate={(entry) =>
+            activateTabChat(item.layout.id, item.members, entry)
+          }
+          onContextMenu={(anchor) =>
+            openChatTabMenu(item.layout, item.members, anchor)
+          }
+          dragging={draggedTabId === item.layout.id}
+        />
+      </SortableChatTab>
     );
   };
 
@@ -1092,47 +1325,35 @@ export function Sidebar({
     originalIndex: number,
     key: string,
   ) => {
-    if (!draggedTabId) return null;
     const dragged = tabItems.find((item) => item.layout.id === draggedTabId);
-    if (!dragged) return null;
     const index = items
       .slice(0, originalIndex)
       .filter((item) => item.layout.id !== draggedTabId).length;
-    if (
-      !isChatTabDropIndexAllowed(
-        items.map((item) => ({
-          id: item.layout.id,
-          pinned: item.members.every((member) => member.pinned),
-        })),
-        dragged.layout.id,
-        dragged.members.every((member) => member.pinned),
-        index,
-      )
-    ) {
-      return null;
-    }
+    const enabled = Boolean(
+      dragged &&
+        isChatTabDropIndexAllowed(
+          items.map((item) => ({
+            id: item.layout.id,
+            pinned: item.members.every((member) => member.pinned),
+          })),
+          dragged.layout.id,
+          dragged.members.every((member) => member.pinned),
+          index,
+        ),
+    );
     return (
       <TabDropDivider
         key={key}
+        id={tabDropDndId(folderId, key)}
+        enabled={enabled}
+        folderId={folderId}
+        index={index}
+        markerKey={key}
         active={
           tabDropTarget?.folderId === folderId &&
           tabDropTarget.index === index &&
           tabDropTarget.markerKey === key
         }
-        onDragOver={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          event.dataTransfer.dropEffect = "move";
-          setDragOverFolderId(null);
-          setTabDropTarget({ folderId, index, markerKey: key });
-        }}
-        onDrop={(event) => {
-          event.preventDefault();
-          event.stopPropagation();
-          const tabId = event.dataTransfer.getData(CHAT_TAB_DRAG_TYPE);
-          if (tabId) void commitTabDrop(tabId, folderId, index);
-          else clearTabDrag();
-        }}
       />
     );
   };
@@ -1140,34 +1361,33 @@ export function Sidebar({
   const renderTabItems = (
     items: typeof tabItems,
     folderId: string | null,
-  ) => (
-    <>
-      {items.map((item, originalIndex) => {
-        const dropIndex = (after: boolean) =>
-          items
-            .slice(0, originalIndex + (after ? 1 : 0))
-            .filter((candidate) => candidate.layout.id !== draggedTabId)
-            .length;
-        const canDropAt = (index: number) => {
-          const dragged = tabItems.find(
-            (candidate) => candidate.layout.id === draggedTabId,
-          );
-          if (!dragged) return false;
-          return isChatTabDropIndexAllowed(
-            items.map((candidate) => ({
-              id: candidate.layout.id,
-              pinned: candidate.members.every((member) => member.pinned),
-            })),
-            dragged.layout.id,
-            dragged.members.every((member) => member.pinned),
-            index,
-          );
-        };
-        const pointerIndex = (event: DragEvent<HTMLDivElement>) => {
-          const rect = event.currentTarget.getBoundingClientRect();
-          return dropIndex(event.clientY >= rect.top + rect.height / 2);
-        };
-        return (
+  ) => {
+    if (items.length === 0) {
+      const markerKey = `after-${folderId ?? "ungrouped"}`;
+      return (
+        <SortableContext items={[]} strategy={verticalListSortingStrategy}>
+          <EmptyTabDropArea
+            id={tabDropDndId(folderId, markerKey)}
+            enabled={draggedTabId !== null}
+            folderId={folderId}
+            markerKey={markerKey}
+            active={
+              tabDropTarget?.folderId === folderId &&
+              tabDropTarget.index === 0 &&
+              tabDropTarget.markerKey === markerKey
+            }
+            label={folderId === null ? null : "Empty folder"}
+          />
+        </SortableContext>
+      );
+    }
+
+    return (
+      <SortableContext
+        items={items.map((item) => tabDndId(item.layout.id))}
+        strategy={verticalListSortingStrategy}
+      >
+        {items.map((item, originalIndex) => (
           <Fragment key={item.layout.id}>
             {renderTabDropDivider(
               folderId,
@@ -1175,66 +1395,18 @@ export function Sidebar({
               originalIndex,
               `before-${item.layout.id}`,
             )}
-            <div
-              onDragOver={(event) => {
-                if (
-                  !Array.from(event.dataTransfer.types).includes(
-                    CHAT_TAB_DRAG_TYPE,
-                  )
-                ) {
-                  return;
-                }
-                const index = pointerIndex(event);
-                if (!canDropAt(index)) {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  event.dataTransfer.dropEffect = "none";
-                  setTabDropTarget(null);
-                  return;
-                }
-                event.preventDefault();
-                event.stopPropagation();
-                event.dataTransfer.dropEffect = "move";
-                setDragOverFolderId(null);
-                const after =
-                  event.clientY >=
-                  event.currentTarget.getBoundingClientRect().top +
-                    event.currentTarget.getBoundingClientRect().height / 2;
-                const markerKey = after
-                  ? originalIndex + 1 < items.length
-                    ? `before-${items[originalIndex + 1].layout.id}`
-                    : `after-${folderId ?? "ungrouped"}`
-                  : `before-${item.layout.id}`;
-                setTabDropTarget({ folderId, index, markerKey });
-              }}
-              onDrop={(event) => {
-                const index = pointerIndex(event);
-                if (!canDropAt(index)) {
-                  event.preventDefault();
-                  event.stopPropagation();
-                  clearTabDrag();
-                  return;
-                }
-                event.preventDefault();
-                event.stopPropagation();
-                const tabId = event.dataTransfer.getData(CHAT_TAB_DRAG_TYPE);
-                if (tabId) void commitTabDrop(tabId, folderId, index);
-                else clearTabDrag();
-              }}
-            >
-              {renderTabItem(item)}
-            </div>
+            {renderTabItem(item)}
           </Fragment>
-        );
-      })}
-      {renderTabDropDivider(
-        folderId,
-        items,
-        items.length,
-        `after-${folderId ?? "ungrouped"}`,
-      )}
-    </>
-  );
+        ))}
+        {renderTabDropDivider(
+          folderId,
+          items,
+          items.length,
+          `after-${folderId ?? "ungrouped"}`,
+        )}
+      </SortableContext>
+    );
+  };
 
   const sidebarVisible = !collapsed || previewOpen;
   const sidebarPreview = collapsed && previewOpen;
@@ -1423,6 +1595,14 @@ export function Sidebar({
                     }}
                     className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-3 pt-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
                   >
+                    <DndContext
+                      sensors={tabDragSensors}
+                      collisionDetection={pointerWithin}
+                      onDragStart={handleTabDragStart}
+                      onDragOver={handleTabDragOver}
+                      onDragEnd={handleTabDragEnd}
+                      onDragCancel={clearTabDrag}
+                    >
                     {creatingFolder ? (
                       <NewFolderRow
                         onSubmit={submitFolderCreate}
@@ -1447,42 +1627,12 @@ export function Sidebar({
                           const folderLive = items.some((item) =>
                             chatTabIsLive(item.members),
                           );
+                          const visuallyCollapsed =
+                            folder.collapsed &&
+                            collapsedFolderDropId !== folder.id;
                           return (
                             <div
                               key={folder.id}
-                              onDragOver={(event) => {
-                                if (
-                                  !Array.from(event.dataTransfer.types).includes(
-                                    CHAT_TAB_DRAG_TYPE,
-                                  )
-                                ) {
-                                  return;
-                                }
-                                event.preventDefault();
-                                event.dataTransfer.dropEffect = "move";
-                                setDragOverFolderId(folder.id);
-                                setTabDropTarget(null);
-                              }}
-                              onDragLeave={(event) => {
-                                const next = event.relatedTarget;
-                                if (
-                                  !(next instanceof Node) ||
-                                  !event.currentTarget.contains(next)
-                                ) {
-                                  setDragOverFolderId(null);
-                                }
-                              }}
-                              onDrop={(event) => {
-                                event.preventDefault();
-                                const tabId = event.dataTransfer.getData(
-                                  CHAT_TAB_DRAG_TYPE,
-                                );
-                                if (tabId) {
-                                  void dropTabIntoFolder(tabId, folder.id);
-                                } else {
-                                  setDragOverFolderId(null);
-                                }
-                              }}
                               className="flex flex-col gap-0.5"
                             >
                               {renamingFolderId === folder.id ? (
@@ -1501,19 +1651,17 @@ export function Sidebar({
                                   onCancel={() => setRenamingFolderId(null)}
                                 />
                               ) : (
-                                <div
-                                  onContextMenu={(event) => {
-                                    event.preventDefault();
-                                    openFolderMenu(folder, {
-                                      x: event.clientX,
-                                      y: event.clientY,
-                                    });
-                                  }}
-                                  className={`group flex items-center gap-1.5 rounded border px-2.5 py-1.5 text-xs transition-colors ${
-                                    dragOverFolderId === folder.id
-                                      ? "border-accent bg-accent/10 text-fg"
-                                      : "border-transparent text-fg-2 hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg"
-                                  }`}
+                                <CollapsedFolderDropRow
+                                  folderId={folder.id}
+                                  enabled={
+                                    folder.collapsed && draggedTabId !== null
+                                  }
+                                  active={
+                                    collapsedFolderDropId === folder.id
+                                  }
+                                  onContextMenu={(anchor) =>
+                                    openFolderMenu(folder, anchor)
+                                  }
                                 >
                                   <button
                                     type="button"
@@ -1525,7 +1673,7 @@ export function Sidebar({
                                     }
                                     className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
                                   >
-                                    {folder.collapsed ? (
+                                    {visuallyCollapsed ? (
                                       <ChevronRight aria-hidden className="h-3 w-3 shrink-0" />
                                     ) : (
                                       <ChevronDown aria-hidden className="h-3 w-3 shrink-0" />
@@ -1539,7 +1687,9 @@ export function Sidebar({
                                     </span>
                                     <ChatAttentionIndicator
                                       state={
-                                        folder.collapsed ? folderAttention : null
+                                        visuallyCollapsed
+                                          ? folderAttention
+                                          : null
                                       }
                                     />
                                   </button>
@@ -1557,16 +1707,11 @@ export function Sidebar({
                                   >
                                     <MoreHorizontal aria-hidden className="h-3 w-3" />
                                   </button>
-                                </div>
+                                </CollapsedFolderDropRow>
                               )}
-                              {folder.collapsed ? null : (
+                              {visuallyCollapsed ? null : (
                                 <div className="ml-3 flex flex-col gap-0.5 border-l border-line pl-2">
                                   {renderTabItems(items, folder.id)}
-                                  {items.length === 0 ? (
-                                    <p className="px-2.5 py-1.5 text-xs text-fg-3">
-                                      Empty folder
-                                    </p>
-                                  ) : null}
                                 </div>
                               )}
                             </div>
@@ -1580,6 +1725,24 @@ export function Sidebar({
                         )}
                       </>
                     )}
+                    <DragOverlay dropAnimation={null}>
+                      {draggedTabItem ? (
+                        <div className="shadow-[0_8px_24px_rgba(0,0,0,0.45)]">
+                          <ChatTabGroup
+                            layout={draggedTabItem.layout}
+                            members={draggedTabItem.members}
+                            active={draggedTabItem.members.some(
+                              (member) =>
+                                member.session_id === currentChatSessionId,
+                            )}
+                            attention={draggedTabItem.attention}
+                            onActivate={() => undefined}
+                            onContextMenu={() => undefined}
+                          />
+                        </div>
+                      ) : null}
+                    </DragOverlay>
+                    </DndContext>
                   </div>
                 ) : null}
               </section>
@@ -1957,21 +2120,151 @@ function CollapsibleSectionHeader({
 
 // ---- sidebar list rows ------------------------------------------------
 
-function TabDropDivider({
-  active,
-  onDragOver,
-  onDrop,
+function SortableChatTab({
+  tabId,
+  folderId,
+  children,
 }: {
-  active: boolean;
-  onDragOver: (event: DragEvent<HTMLDivElement>) => void;
-  onDrop: (event: DragEvent<HTMLDivElement>) => void;
+  tabId: string;
+  folderId: string | null;
+  children: ReactNode;
 }) {
+  const {
+    isDragging,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+  } = useSortable({
+    id: tabDndId(tabId),
+    data: { kind: "tab", tabId, folderId } satisfies ChatTabDndData,
+  });
+  const style: CSSProperties = {
+    position: isDragging ? "relative" : undefined,
+    zIndex: isDragging ? 30 : undefined,
+    transform: transform
+      ? `translate3d(${transform.x}px, ${transform.y}px, 0) scaleX(${transform.scaleX}) scaleY(${transform.scaleY})`
+      : undefined,
+    transition,
+    touchAction: "none",
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...listeners}>
+      {children}
+    </div>
+  );
+}
+
+function CollapsedFolderDropRow({
+  folderId,
+  enabled,
+  active,
+  onContextMenu,
+  children,
+}: {
+  folderId: string;
+  enabled: boolean;
+  active: boolean;
+  onContextMenu: (anchor: { x: number; y: number }) => void;
+  children: ReactNode;
+}) {
+  const { setNodeRef } = useDroppable({
+    id: collapsedFolderDndId(folderId),
+    disabled: !enabled,
+    data: {
+      kind: "collapsed-folder",
+      folderId,
+    } satisfies ChatTabDndData,
+  });
+
   return (
     <div
-      onDragOver={onDragOver}
-      onDrop={onDrop}
-      className="relative z-20 -my-1 h-2 shrink-0"
+      ref={setNodeRef}
+      onContextMenu={(event) => {
+        event.preventDefault();
+        onContextMenu({ x: event.clientX, y: event.clientY });
+      }}
+      className={`group flex items-center gap-1.5 rounded border px-2.5 py-1.5 text-xs transition-colors ${
+        active
+          ? "border-accent bg-accent/10 text-fg"
+          : "border-transparent text-fg-2 hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg"
+      }`}
     >
+      {children}
+    </div>
+  );
+}
+
+function EmptyTabDropArea({
+  id,
+  enabled,
+  folderId,
+  markerKey,
+  active,
+  label,
+}: {
+  id: string;
+  enabled: boolean;
+  folderId: string | null;
+  markerKey: string;
+  active: boolean;
+  label: string | null;
+}) {
+  const { setNodeRef } = useDroppable({
+    id,
+    disabled: !enabled,
+    data: {
+      kind: "position",
+      folderId,
+      index: 0,
+      markerKey,
+    } satisfies ChatTabDndData,
+  });
+
+  return (
+    <div ref={setNodeRef} className="relative min-h-7 shrink-0">
+      {active ? (
+        <>
+          <span className="absolute left-0 top-1 h-1.5 w-1.5 -translate-y-1/2 rounded-full bg-accent" />
+          <span className="absolute inset-x-0 top-1 h-0.5 -translate-y-1/2 rounded-full bg-accent" />
+        </>
+      ) : null}
+      {label ? (
+        <p className="px-2.5 py-1.5 text-xs text-fg-3">{label}</p>
+      ) : null}
+    </div>
+  );
+}
+
+function TabDropDivider({
+  id,
+  enabled,
+  folderId,
+  index,
+  markerKey,
+  active,
+}: {
+  id: string;
+  enabled: boolean;
+  folderId: string | null;
+  index: number;
+  markerKey: string;
+  active: boolean;
+}) {
+  const { setNodeRef } = useDroppable({
+    id,
+    disabled: !enabled,
+    data: {
+      kind: "position",
+      folderId,
+      index,
+      markerKey,
+    } satisfies ChatTabDndData,
+  });
+
+  return (
+    <div ref={setNodeRef} className="relative z-20 -my-1 h-2 shrink-0">
       {active ? (
         <>
           <span className="absolute left-0 top-1/2 h-1.5 w-1.5 -translate-y-1/2 rounded-full bg-accent" />

--- a/src/lib/chatTabs.test.ts
+++ b/src/lib/chatTabs.test.ts
@@ -181,4 +181,37 @@ describe("chat tab drop ordering", () => {
     ]);
     expect(isChatTabDropIndexAllowed(tabs, "b", false, 1)).toBe(false);
   });
+
+  it("clamps cross-list appends to the dragged tab's pin tier", () => {
+    const target = [
+      { id: "p1", pinned: true },
+      { id: "a", pinned: false },
+    ];
+
+    expect(
+      orderedChatTabIdsAfterDrop(
+        target,
+        "incoming-pinned",
+        true,
+        Number.MAX_SAFE_INTEGER,
+      ),
+    ).toEqual(["p1", "incoming-pinned", "a"]);
+    expect(
+      orderedChatTabIdsAfterDrop(
+        target,
+        "incoming",
+        false,
+        Number.MAX_SAFE_INTEGER,
+      ),
+    ).toEqual(["p1", "a", "incoming"]);
+    expect(
+      orderedChatTabIdsAfterDrop(target, "incoming", false, 0),
+    ).toEqual(["p1", "incoming", "a"]);
+    expect(
+      isChatTabDropIndexAllowed(target, "incoming-pinned", true, 2),
+    ).toBe(false);
+    expect(isChatTabDropIndexAllowed(target, "incoming", false, 0)).toBe(
+      false,
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- replace native HTML5 chat-tab dragging with dnd-kit pointer dragging
- show tier-aware insertion dividers for reordering and folder moves, including transient reveal for collapsed folders
- preserve pinned-first ordering and persist drops through reorderTab

## Checks

- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm test (102 passed)
- pnpm build
- git diff --check

## Manual WKWebView smoke

- reorder within a list
- drag into an expanded folder and verify the destination line
- drag out to the ungrouped list
- verify pinned-tier boundaries reject invalid positions
- drop onto a collapsed folder and verify the tier-clamped line and append result
- move into and out of empty lists

Manual smoke is intentionally left to the human per the mission brief.

Fixes #288