### PR TITLE
fix(ui): align sidebar runtime indicators

### DIFF
--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -102,15 +102,15 @@ pub struct MissionSummary {
     pub crew_name: String,
     pub pending_ask_count: usize,
     /// True iff at least one of the mission's session rows is `status =
-    /// 'running'`. Drives the sidebar mission-row status dot: live
-    /// missions paint with the accent, "paused" missions (status =
-    /// running but every slot is stopped/crashed) mute the dot so the
-    /// human can tell which workspaces will accept input at a glance,
-    /// without entering each one.
+    /// 'running'`. A mission without live sessions never shows the sidebar
+    /// working indicator.
     pub any_session_live: bool,
+    /// True iff every current, unarchived session row is `running`.
+    /// Partial crash/resume states keep the sidebar mission icon muted.
+    pub all_sessions_live: bool,
     /// Optional live activity projection derived from per-slot
     /// `runner_status` events. `None` means the mission has no live
-    /// sessions, preserving the existing paused/no-live sidebar behavior.
+    /// sessions and keeps the sidebar attention slot clear.
     pub activity: Option<MissionActivityState>,
 }
 
@@ -1704,6 +1704,19 @@ fn live_session_handles(conn: &Connection, mission_id: &str) -> rusqlite::Result
     rows.collect()
 }
 
+fn all_mission_sessions_live(conn: &Connection, mission_id: &str) -> rusqlite::Result<bool> {
+    let (total, running): (usize, usize) = conn.query_row(
+        "SELECT COUNT(*),
+                COALESCE(SUM(CASE WHEN status = 'running' THEN 1 ELSE 0 END), 0)
+           FROM sessions
+          WHERE mission_id = ?1
+            AND archived_at IS NULL",
+        params![mission_id],
+        |row| Ok((row.get(0)?, row.get(1)?)),
+    )?;
+    Ok(total > 0 && running == total)
+}
+
 pub(crate) async fn mission_list_summary_impl(
     state: &AppState,
     crew_id: Option<String>,
@@ -1740,6 +1753,7 @@ pub(crate) async fn mission_list_summary_impl(
         // `activity` overlays busy/idle only for live mission slots.
         let live_handles = live_session_handles(&conn, &m.id).unwrap_or_default();
         let any_session_live = !live_handles.is_empty();
+        let all_sessions_live = all_mission_sessions_live(&conn, &m.id).unwrap_or(false);
         let activity = if any_session_live {
             let mission_dir = event_log::mission_dir(&state.app_data_dir, &m.crew_id, &m.id);
             mission_activity_from_log(&mission_dir, &live_handles)
@@ -1751,6 +1765,7 @@ pub(crate) async fn mission_list_summary_impl(
             crew_name,
             pending_ask_count,
             any_session_live,
+            all_sessions_live,
             activity,
         });
     }
@@ -2547,6 +2562,10 @@ mod tests {
             vec!["lead".to_string()],
             "projection must key live sessions by slot_handle"
         );
+        assert!(
+            !all_mission_sessions_live(&conn, &out.mission.id).unwrap(),
+            "one stopped slot keeps the mission-level live state false"
+        );
 
         let mission_dir = event_log::mission_dir(tmp.path(), &crew_id, &out.mission.id);
         let log = EventLog::open(&mission_dir).unwrap();
@@ -2556,6 +2575,16 @@ mod tests {
             mission_activity_from_log(&mission_dir, &handles),
             Some(MissionActivityState::Idle),
             "stopped slot statuses must not keep the mission busy"
+        );
+
+        conn.execute(
+            "UPDATE sessions SET status = 'running' WHERE mission_id = ?1",
+            params![out.mission.id],
+        )
+        .unwrap();
+        assert!(
+            all_mission_sessions_live(&conn, &out.mission.id).unwrap(),
+            "all running slots make the mission-level live state true"
         );
     }
 

--- a/src/components/ChatTabGroup.test.ts
+++ b/src/components/ChatTabGroup.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from "vitest";
 import type { DirectSessionEntry } from "../lib/api";
 import { applyPresetPure } from "../lib/paneLayout";
 import { ChatTabGroup } from "./ChatTabGroup";
+import { ChatAttentionIndicator } from "./SidebarTabRow";
 
 const session = {
   session_id: "A",
@@ -12,6 +13,7 @@ const session = {
   display_name: "Coder",
   title: null,
   pinned: false,
+  status: "running",
 } as DirectSessionEntry;
 
 describe("ChatTabGroup", () => {
@@ -34,6 +36,69 @@ describe("ChatTabGroup", () => {
     expect(html).toContain("lucide-columns-3");
     expect(html).not.toContain(">3</span>");
     expect(html).toContain('draggable="true"');
+    expect(html).toContain('fill="none"');
+  });
+
+  it("colors a live tab icon without filling it", () => {
+    const layout = {
+      ...applyPresetPure("single", "A", ["A"]),
+      id: "tab-1",
+    };
+    const html = renderToStaticMarkup(
+      createElement(ChatTabGroup, {
+        layout,
+        members: [session],
+        active: true,
+        attention: null,
+        onActivate: () => {},
+        onContextMenu: () => {},
+      }),
+    );
+
+    expect(html).toContain('fill="none"');
+    expect(html).toContain("text-accent");
+  });
+
+  it("keeps a live multi-pane icon outlined", () => {
+    const layout = {
+      ...applyPresetPure("cols-2", "A", ["A"]),
+      id: "tab-1",
+    };
+    const html = renderToStaticMarkup(
+      createElement(ChatTabGroup, {
+        layout,
+        members: [session],
+        active: true,
+        attention: null,
+        onActivate: () => {},
+        onContextMenu: () => {},
+      }),
+    );
+
+    expect(html).toContain("lucide-columns-2");
+    expect(html).toContain('fill="none"');
+    expect(html).toContain("text-accent");
+    expect(html).not.toContain('fill="var(--color-accent)"');
+  });
+
+  it("mutes a fully stopped tab icon", () => {
+    const layout = {
+      ...applyPresetPure("single", "A", ["A"]),
+      id: "tab-1",
+    };
+    const html = renderToStaticMarkup(
+      createElement(ChatTabGroup, {
+        layout,
+        members: [{ ...session, status: "stopped" }],
+        active: true,
+        attention: null,
+        onActivate: () => {},
+        onContextMenu: () => {},
+      }),
+    );
+
+    expect(html).toContain('fill="none"');
+    expect(html).toContain("text-fg-2");
   });
 
   it("renders working and unread states in the fixed trailing slot", () => {
@@ -55,7 +120,6 @@ describe("ChatTabGroup", () => {
     expect(working).toContain("animate-spin");
     expect(working).toContain("origin-center");
     expect(working).toContain("text-fg-3");
-    expect(working).not.toContain("text-accent");
 
     const unread = renderToStaticMarkup(
       createElement(ChatTabGroup, {
@@ -68,5 +132,17 @@ describe("ChatTabGroup", () => {
       }),
     );
     expect(unread).toContain('aria-label="Completed — not viewed"');
+  });
+
+  it("supports a mission-specific working label", () => {
+    const html = renderToStaticMarkup(
+      createElement(ChatAttentionIndicator, {
+        state: "working",
+        workingLabel: "Mission working",
+      }),
+    );
+
+    expect(html).toContain('aria-label="Mission working"');
+    expect(html).toContain('title="Mission working"');
   });
 });

--- a/src/components/ChatTabGroup.tsx
+++ b/src/components/ChatTabGroup.tsx
@@ -1,16 +1,14 @@
 import {
   Columns2,
   Columns3,
-  LoaderCircle,
   MessageSquare,
-  MoreHorizontal,
-  Pin,
 } from "lucide-react";
 
 import type { DirectSessionEntry } from "../lib/api";
 import type { ChatAttentionState } from "../lib/chatAttention";
-import { derivedChatTabTitle } from "../lib/chatTabs";
+import { chatTabIsLive, derivedChatTabTitle } from "../lib/chatTabs";
 import { findLeaf, leaves, type PaneLayout } from "../lib/paneLayout";
+import { SidebarTabRow } from "./SidebarTabRow";
 
 export const CHAT_TAB_DRAG_TYPE = "application/x-runner-chat-tab";
 
@@ -41,11 +39,12 @@ export function ChatTabGroup({
 
   const name = layout.name ?? derivedChatTabTitle(members);
   const pinned = members.length > 0 && members.every((member) => member.pinned);
+  const live = chatTabIsLive(members);
   const paneCount = leaves(layout.root).length;
   const SplitIcon = paneCount >= 3 ? Columns3 : Columns2;
 
   return (
-    <div
+    <SidebarTabRow
       draggable={layout.id.length > 0}
       onDragStart={(event) => {
         event.dataTransfer.effectAllowed = "move";
@@ -53,81 +52,16 @@ export function ChatTabGroup({
         onDragStart?.(layout.id);
       }}
       onDragEnd={onDragEnd}
-      onContextMenu={(event) => {
-        event.preventDefault();
-        onContextMenu({ x: event.clientX, y: event.clientY });
-      }}
-      className={`group relative flex items-center gap-1.5 rounded border px-2.5 py-1.5 text-xs transition-colors transition-opacity ${
-        dragging ? "opacity-40" : ""
-      } ${
-        active
-          ? "border-sidebar-selected-border bg-sidebar-selected text-fg"
-          : "border-transparent text-fg-2 hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg"
-      }`}
-    >
-      <button
-        type="button"
-        onClick={() => onActivate(target)}
-        title={name}
-        className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
-      >
-        {pinned ? (
-          <Pin aria-hidden className="h-2.5 w-2.5 shrink-0 -rotate-45 text-fg-3" />
-        ) : null}
-        {paneCount > 1 ? (
-          <SplitIcon aria-hidden className={`h-3 w-3 shrink-0 ${active ? "text-accent" : "text-fg-2"}`} />
-        ) : (
-          <MessageSquare aria-hidden className={`h-3 w-3 shrink-0 ${active ? "text-accent" : "text-fg-2"}`} />
-        )}
-        <span className={`min-w-0 flex-1 truncate ${active ? "font-semibold" : ""}`}>
-          {name}
-        </span>
-        <ChatAttentionIndicator state={attention} />
-      </button>
-      <button
-        type="button"
-        onClick={(event) => onContextMenu({ x: event.clientX, y: event.clientY })}
-        title="More actions"
-        aria-label="More actions"
-        className="cursor-pointer rounded p-0.5 text-fg-3 opacity-0 transition-opacity hover:bg-raised hover:text-fg group-hover:opacity-100 focus:opacity-100"
-      >
-        <MoreHorizontal aria-hidden className="h-3 w-3" />
-      </button>
-    </div>
+      dragging={dragging}
+      selected={active}
+      label={name}
+      icon={paneCount > 1 ? SplitIcon : MessageSquare}
+      iconActive={live}
+      pinned={pinned}
+      attention={attention}
+      onClick={() => onActivate(target)}
+      onContextMenu={onContextMenu}
+      title={name}
+    />
   );
-}
-
-export function ChatAttentionIndicator({
-  state,
-}: {
-  state: ChatAttentionState;
-}) {
-  if (state === "working") {
-    return (
-      <span
-        className="flex h-3 w-3 shrink-0 items-center justify-center"
-        aria-label="Agent working"
-        title="Agent working"
-      >
-        <span
-          aria-hidden
-          className="flex h-3 w-3 origin-center animate-spin items-center justify-center text-fg-3 motion-reduce:animate-none"
-        >
-          <LoaderCircle className="block h-3 w-3" />
-        </span>
-      </span>
-    );
-  }
-  if (state === "unread") {
-    return (
-      <span
-        className="flex h-3 w-3 shrink-0 items-center justify-center"
-        aria-label="Completed — not viewed"
-        title="Completed — not viewed"
-      >
-        <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-accent" />
-      </span>
-    );
-  }
-  return <span aria-hidden className="h-3 w-3 shrink-0" />;
 }

--- a/src/components/Sidebar.test.ts
+++ b/src/components/Sidebar.test.ts
@@ -1,0 +1,107 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Folder } from "lucide-react";
+import { describe, expect, it } from "vitest";
+
+import type { MissionSummary } from "../lib/types";
+import { MissionRow, NewFolderRow } from "./Sidebar";
+import { SidebarTabIcon } from "./SidebarTabRow";
+
+const mission = {
+  title: "Ship release",
+  crew_name: "Build squad",
+  any_session_live: true,
+  all_sessions_live: true,
+  activity: "busy",
+  pinned_at: null,
+} as MissionSummary;
+
+const renderMissionRow = (
+  renaming: boolean,
+  selected = false,
+  overrides: Partial<MissionSummary> = {},
+) =>
+  renderToStaticMarkup(
+    createElement(MissionRow, {
+      mission: { ...mission, ...overrides },
+      selected,
+      renaming,
+      onClick: () => {},
+      onContextMenu: () => {},
+      onRenameSubmit: () => {},
+      onRenameCancel: () => {},
+    }),
+  );
+
+describe("MissionRow", () => {
+  it("renders a leading flag before the title and trailing status", () => {
+    const html = renderMissionRow(false);
+
+    const flagIndex = html.indexOf("lucide-flag");
+    const titleIndex = html.indexOf("Ship release");
+    const statusIndex = html.indexOf('aria-label="Mission working"');
+    expect(flagIndex).toBeGreaterThanOrEqual(0);
+    expect(flagIndex).toBeLessThan(titleIndex);
+    expect(titleIndex).toBeLessThan(statusIndex);
+    expect(html).toContain('fill="none"');
+    expect(html).not.toContain('fill="var(--color-accent)"');
+  });
+
+  it("keeps the flag while renaming", () => {
+    const html = renderMissionRow(true);
+
+    expect(html).toContain("lucide-flag");
+    expect(html).toContain('value="Ship release"');
+  });
+
+  it("colors a live mission flag without filling it", () => {
+    const html = renderMissionRow(false, true);
+
+    expect(html).toContain('fill="none"');
+    expect(html).toContain("text-accent");
+  });
+
+  it("mutes a partially resumed mission flag", () => {
+    const html = renderMissionRow(false, true, {
+      any_session_live: true,
+      all_sessions_live: false,
+    });
+
+    expect(html).toContain("lucide-flag h-3 w-3 shrink-0 text-fg-2");
+  });
+});
+
+describe("SidebarTabIcon", () => {
+  it("colors a live-status icon without filling it", () => {
+    const live = renderToStaticMarkup(
+      createElement(SidebarTabIcon, {
+        icon: Folder,
+        active: true,
+      }),
+    );
+    const stopped = renderToStaticMarkup(
+      createElement(SidebarTabIcon, {
+        icon: Folder,
+        active: false,
+      }),
+    );
+
+    expect(live).toContain('fill="none"');
+    expect(live).toContain("text-accent");
+    expect(stopped).toContain('fill="none"');
+    expect(stopped).toContain("text-fg-2");
+  });
+
+  it("uses a muted outline while creating an empty folder", () => {
+    const html = renderToStaticMarkup(
+      createElement(NewFolderRow, {
+        onSubmit: async () => {},
+        onCancel: () => {},
+      }),
+    );
+
+    expect(html).toContain("lucide-folder");
+    expect(html).toContain('fill="none"');
+    expect(html).toContain("text-fg-2");
+  });
+});

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -37,6 +37,7 @@ import {
   Archive,
   ChevronDown,
   ChevronRight,
+  Flag,
   Folder,
   FolderPlus,
   MessageSquarePlus,
@@ -66,10 +67,12 @@ import {
 } from "../lib/groupPinning";
 import {
   chatTabArchiveLabel,
+  chatTabIsLive,
   isChatTabDropIndexAllowed,
   orderedChatTabIdsAfterDrop,
 } from "../lib/chatTabs";
 import {
+  missionAttentionState,
   rollupAttentionState,
   tabAttentionState,
   useDirectSessionActivity,
@@ -96,9 +99,13 @@ import {
 } from "../lib/paneLayout";
 import {
   CHAT_TAB_DRAG_TYPE,
-  ChatAttentionIndicator,
   ChatTabGroup,
 } from "./ChatTabGroup";
+import {
+  ChatAttentionIndicator,
+  SidebarTabIcon,
+  SidebarTabRow,
+} from "./SidebarTabRow";
 import { PanelToggleGlyph } from "./PanelToggleGlyph";
 import { PopoverMenu } from "./ui/PopoverMenu";
 import { useResizableWidth } from "../hooks/useResizableWidth";
@@ -110,7 +117,6 @@ import {
 import { reportSubjectsNow } from "../lib/windowFocus";
 import type {
   AppendedEvent,
-  MissionActivityState,
   MissionSummary,
   SessionActivityState,
 } from "../lib/types";
@@ -354,6 +360,18 @@ export function Sidebar({
   const chatAttention = useMemo(
     () => rollupAttentionState(tabItems.map((item) => item.attention)),
     [tabItems],
+  );
+  const missionAttention = useMemo(
+    () =>
+      rollupAttentionState(
+        missions.map((mission) =>
+          missionAttentionState(
+            mission.any_session_live,
+            mission.activity,
+          ),
+        ),
+      ),
+    [missions],
   );
   const orderedChatRows = useMemo(
     () => tabItems.map((item) => item.members[0]),
@@ -1323,6 +1341,8 @@ export function Sidebar({
                 <CollapsibleSectionHeader
                   label="MISSION"
                   open={missionsOpen}
+                  attention={missionsOpen ? null : missionAttention}
+                  attentionWorkingLabel="Mission working"
                   onToggle={toggleMissions}
                   onPlus={() => setCreatingMission(true)}
                   plusTitle="Start mission"
@@ -1424,6 +1444,9 @@ export function Sidebar({
                           const folderAttention = rollupAttentionState(
                             items.map((item) => item.attention),
                           );
+                          const folderLive = items.some((item) =>
+                            chatTabIsLive(item.members),
+                          );
                           return (
                             <div
                               key={folder.id}
@@ -1466,6 +1489,7 @@ export function Sidebar({
                                 <FolderRenameRow
                                   initial={folder.name}
                                   collapsed={folder.collapsed}
+                                  live={folderLive}
                                   attention={folderAttention}
                                   onSubmit={(nextName) =>
                                     void submitFolderRename(
@@ -1506,7 +1530,10 @@ export function Sidebar({
                                     ) : (
                                       <ChevronDown aria-hidden className="h-3 w-3 shrink-0" />
                                     )}
-                                    <Folder aria-hidden className="h-3 w-3 shrink-0" />
+                                    <SidebarTabIcon
+                                      icon={Folder}
+                                      active={folderLive}
+                                    />
                                     <span className="min-w-0 flex-1 truncate font-medium">
                                       {folder.name}
                                     </span>
@@ -1860,6 +1887,7 @@ function CollapsibleSectionHeader({
   plusMenu,
   onPlusMenuClose,
   attention,
+  attentionWorkingLabel,
 }: {
   label: string;
   open: boolean;
@@ -1873,6 +1901,7 @@ function CollapsibleSectionHeader({
   plusMenu?: ReactNode;
   onPlusMenuClose?: () => void;
   attention?: ChatAttentionState;
+  attentionWorkingLabel?: string;
 }) {
   const plusRef = useRef<HTMLButtonElement>(null);
   return (
@@ -1892,7 +1921,10 @@ function CollapsibleSectionHeader({
       </button>
       <div className="flex items-center gap-1.5">
         {attention !== undefined ? (
-          <ChatAttentionIndicator state={attention} />
+          <ChatAttentionIndicator
+            state={attention}
+            workingLabel={attentionWorkingLabel}
+          />
         ) : null}
         <button
           ref={plusRef}
@@ -1950,7 +1982,7 @@ function TabDropDivider({
   );
 }
 
-function NewFolderRow({
+export function NewFolderRow({
   onSubmit,
   onCancel,
 }: {
@@ -1987,7 +2019,7 @@ function NewFolderRow({
       className="flex items-center gap-1.5 rounded border border-sidebar-selected-border bg-sidebar-selected px-2.5 py-1.5 text-xs shadow-sm"
     >
       <ChevronDown aria-hidden className="h-3 w-3 shrink-0 text-fg-2" />
-      <Folder aria-hidden className="h-3 w-3 shrink-0 text-fg-2" />
+      <SidebarTabIcon icon={Folder} active={false} />
       <input
         ref={inputRef}
         value={draft}
@@ -2013,12 +2045,14 @@ function NewFolderRow({
 function FolderRenameRow({
   initial,
   collapsed,
+  live,
   attention,
   onSubmit,
   onCancel,
 }: {
   initial: string;
   collapsed: boolean;
+  live: boolean;
   attention: ChatAttentionState;
   onSubmit: (name: string) => void;
   onCancel: () => void;
@@ -2041,7 +2075,10 @@ function FolderRenameRow({
       ) : (
         <ChevronDown aria-hidden className="h-3 w-3 shrink-0" />
       )}
-      <Folder aria-hidden className="h-3 w-3 shrink-0" />
+      <SidebarTabIcon
+        icon={Folder}
+        active={live}
+      />
       <input
         ref={inputRef}
         value={draft}
@@ -2063,188 +2100,6 @@ function FolderRenameRow({
         className="min-w-0 flex-1 bg-transparent text-xs font-medium text-fg outline-none"
       />
       <ChatAttentionIndicator state={collapsed ? attention : null} />
-    </div>
-  );
-}
-
-function SidebarListRow({
-  selected,
-  accentBar,
-  label,
-  onClick,
-  onContextMenu,
-  title,
-  mono,
-  dim,
-  dotClassName,
-  pinned,
-  renaming,
-  renameValue,
-  renamePlaceholder,
-  onRenameSubmit,
-  onRenameCancel,
-}: {
-  selected: boolean;
-  /** 2px accent bar on the row's left edge — marks the chat in the
-   *  focused split pane (impl 0020), mirroring the pane focus ring. */
-  accentBar?: boolean;
-  label: string;
-  onClick: () => void;
-  /** Right-click handler. Anchor the menu at clientX/clientY. */
-  onContextMenu?: (anchor: { x: number; y: number }) => void;
-  title?: string;
-  mono?: boolean;
-  /** True when the row represents a non-running runtime (e.g. a stopped
-   *  direct chat that can be resumed). Mutes the status dot so the user
-   *  can tell which sessions are live at a glance. */
-  dim?: boolean;
-  /** Optional explicit status-dot color for rows with richer live state. */
-  dotClassName?: string;
-  /** Pinned rows show a Pin icon next to the label. */
-  pinned?: boolean;
-  /** When true, replaces the label with an inline rename input. */
-  renaming?: boolean;
-  /** Current editable value. Defaults to `label`. */
-  renameValue?: string;
-  /** Placeholder shown while the editable value is empty. */
-  renamePlaceholder?: string;
-  onRenameSubmit?: (next: string) => void;
-  onRenameCancel?: () => void;
-}) {
-  if (renaming && onRenameSubmit && onRenameCancel) {
-    return (
-      <SidebarRowRenameInput
-        initial={renameValue ?? label}
-        placeholder={renamePlaceholder ?? label}
-        title={title}
-        mono={mono}
-        dim={dim}
-        dotClassName={dotClassName}
-        onSubmit={onRenameSubmit}
-        onCancel={onRenameCancel}
-      />
-    );
-  }
-  return (
-    <div
-      onContextMenu={
-        onContextMenu
-          ? (e) => {
-              e.preventDefault();
-              onContextMenu({ x: e.clientX, y: e.clientY });
-            }
-          : undefined
-      }
-      className={`group relative flex w-full items-center gap-2 rounded border px-2.5 py-1.5 text-left text-xs transition-colors ${
-        selected
-          ? "border-sidebar-selected-border bg-sidebar-selected font-semibold text-fg shadow-sm"
-          : "border-transparent text-fg-2 hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg"
-      }`}
-    >
-      {accentBar ? (
-        <span
-          aria-hidden
-          className="absolute inset-y-0.5 left-0 w-0.5 rounded-full bg-accent"
-        />
-      ) : null}
-      <button
-        type="button"
-        onClick={onClick}
-        title={title}
-        className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-left"
-      >
-        <span
-          className={`inline-flex h-1.5 w-1.5 shrink-0 rounded-full ${
-            dotClassName ?? (dim ? "bg-fg-3" : "bg-accent")
-          }`}
-        />
-        {pinned ? (
-          <Pin
-            aria-hidden
-            className="h-2.5 w-2.5 shrink-0 -rotate-45 text-fg-3"
-          />
-        ) : null}
-        <span className={`truncate ${mono ? "font-mono" : ""}`}>{label}</span>
-      </button>
-      {/* Kebab anchor for the same context menu the row's
-          right-click triggers. Mirrors SessionRow's affordance so
-          mission rows get a discoverable "..." button on hover —
-          right-click alone isn't an obvious entry point. */}
-      {onContextMenu ? (
-        <button
-          type="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            onContextMenu({ x: e.clientX, y: e.clientY });
-          }}
-          title="More actions"
-          aria-label="More actions"
-          className="cursor-pointer rounded p-0.5 text-fg-3 opacity-0 transition-opacity hover:bg-raised hover:text-fg group-hover:opacity-100 focus:opacity-100"
-        >
-          <MoreHorizontal aria-hidden className="h-3 w-3" />
-        </button>
-      ) : null}
-    </div>
-  );
-}
-
-function SidebarRowRenameInput({
-  initial,
-  placeholder,
-  title,
-  mono,
-  dim,
-  dotClassName,
-  onSubmit,
-  onCancel,
-}: {
-  initial: string;
-  placeholder: string;
-  title?: string;
-  mono?: boolean;
-  dim?: boolean;
-  dotClassName?: string;
-  onSubmit: (next: string) => void;
-  onCancel: () => void;
-}) {
-  const [draft, setDraft] = useState(initial);
-  const inputRef = useRef<HTMLInputElement>(null);
-  useEffect(() => {
-    inputRef.current?.focus();
-    inputRef.current?.select();
-  }, []);
-  return (
-    <div
-      className="flex w-full items-center gap-2 rounded border border-sidebar-selected-border bg-sidebar-selected px-2.5 py-1.5 text-xs shadow-sm"
-      title={title}
-    >
-      <span
-        className={`inline-flex h-1.5 w-1.5 shrink-0 rounded-full ${
-          dotClassName ?? (dim ? "bg-fg-3" : "bg-accent")
-        }`}
-      />
-      <input
-        ref={inputRef}
-        value={draft}
-        placeholder={placeholder}
-        onChange={(e) => setDraft(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") {
-            e.preventDefault();
-            onSubmit(draft.trim());
-          } else if (e.key === "Escape") {
-            e.preventDefault();
-            onCancel();
-          }
-        }}
-        onBlur={() => {
-          if (draft.trim() === initial.trim()) onCancel();
-          else onSubmit(draft.trim());
-        }}
-        className={`min-w-0 flex-1 bg-transparent text-xs text-fg outline-none placeholder:text-fg-3 ${
-          mono ? "font-mono" : ""
-        }`}
-      />
     </div>
   );
 }
@@ -2277,20 +2132,7 @@ function directChatDotClassName(status: DirectChatDisplayStatus): string {
   }
 }
 
-function missionActivityDotClassName(
-  activity: MissionActivityState | null,
-): string {
-  switch (activity) {
-    case "busy":
-      return "bg-accent";
-    case "idle":
-      return "bg-accent/30";
-    case null:
-      return "bg-fg-3";
-  }
-}
-
-function MissionRow({
+export function MissionRow({
   mission,
   selected,
   renaming,
@@ -2314,14 +2156,19 @@ function MissionRow({
   }`;
 
   return (
-    <SidebarListRow
+    <SidebarTabRow
       selected={selected}
       label={mission.title}
+      icon={Flag}
+      iconActive={mission.all_sessions_live}
       onClick={onClick}
       onContextMenu={onContextMenu}
       title={tooltip}
-      dim={!mission.any_session_live}
-      dotClassName={missionActivityDotClassName(activity)}
+      attention={missionAttentionState(
+        mission.any_session_live,
+        mission.activity,
+      )}
+      attentionWorkingLabel="Mission working"
       pinned={!!mission.pinned_at}
       renaming={renaming}
       onRenameSubmit={onRenameSubmit}
@@ -2363,7 +2210,7 @@ export function SessionRow({
   }${session.pinned ? " · pinned" : ""}`;
 
   return (
-    <SidebarListRow
+    <SidebarTabRow
       selected={selected}
       accentBar={paneFocused}
       label={label}

--- a/src/components/SidebarTabRow.tsx
+++ b/src/components/SidebarTabRow.tsx
@@ -1,0 +1,305 @@
+import {
+  useEffect,
+  useRef,
+  useState,
+  type ComponentType,
+  type DragEventHandler,
+} from "react";
+import { LoaderCircle, MoreHorizontal, Pin } from "lucide-react";
+
+import type { ChatAttentionState } from "../lib/chatAttention";
+
+type SidebarTabIconComponent = ComponentType<{
+  className?: string;
+  fill?: string;
+  "aria-hidden"?: boolean;
+}>;
+
+export function SidebarTabIcon({
+  icon: Icon,
+  active,
+}: {
+  icon: SidebarTabIconComponent;
+  active: boolean;
+}) {
+  return (
+    <Icon
+      aria-hidden
+      fill="none"
+      className={`h-3 w-3 shrink-0 ${
+        active ? "text-accent" : "text-fg-2"
+      }`}
+    />
+  );
+}
+
+export function SidebarTabRow({
+  selected,
+  accentBar,
+  label,
+  icon: Icon,
+  iconActive,
+  onClick,
+  onContextMenu,
+  title,
+  mono,
+  dim,
+  dotClassName,
+  attention,
+  attentionWorkingLabel,
+  pinned,
+  renaming,
+  renameValue,
+  renamePlaceholder,
+  onRenameSubmit,
+  onRenameCancel,
+  draggable,
+  dragging,
+  onDragStart,
+  onDragEnd,
+}: {
+  selected: boolean;
+  accentBar?: boolean;
+  label: string;
+  icon?: SidebarTabIconComponent;
+  iconActive?: boolean;
+  onClick: () => void;
+  onContextMenu?: (anchor: { x: number; y: number }) => void;
+  title?: string;
+  mono?: boolean;
+  dim?: boolean;
+  dotClassName?: string;
+  attention?: ChatAttentionState;
+  attentionWorkingLabel?: string;
+  pinned?: boolean;
+  renaming?: boolean;
+  renameValue?: string;
+  renamePlaceholder?: string;
+  onRenameSubmit?: (next: string) => void;
+  onRenameCancel?: () => void;
+  draggable?: boolean;
+  dragging?: boolean;
+  onDragStart?: DragEventHandler<HTMLDivElement>;
+  onDragEnd?: DragEventHandler<HTMLDivElement>;
+}) {
+  if (renaming && onRenameSubmit && onRenameCancel) {
+    return (
+      <SidebarTabRenameInput
+        initial={renameValue ?? label}
+        placeholder={renamePlaceholder ?? label}
+        icon={Icon}
+        iconActive={iconActive ?? selected}
+        title={title}
+        mono={mono}
+        dim={dim}
+        dotClassName={dotClassName}
+        attention={attention}
+        attentionWorkingLabel={attentionWorkingLabel}
+        onSubmit={onRenameSubmit}
+        onCancel={onRenameCancel}
+      />
+    );
+  }
+
+  return (
+    <div
+      draggable={draggable}
+      onDragStart={onDragStart}
+      onDragEnd={onDragEnd}
+      onContextMenu={
+        onContextMenu
+          ? (event) => {
+              event.preventDefault();
+              onContextMenu({ x: event.clientX, y: event.clientY });
+            }
+          : undefined
+      }
+      className={`group relative flex w-full items-center gap-1.5 rounded border px-2.5 py-1.5 text-left text-xs transition-colors transition-opacity ${
+        dragging ? "opacity-40" : ""
+      } ${
+        selected
+          ? "border-sidebar-selected-border bg-sidebar-selected text-fg"
+          : "border-transparent text-fg-2 hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg"
+      }`}
+    >
+      {accentBar ? (
+        <span
+          aria-hidden
+          className="absolute inset-y-0.5 left-0 w-0.5 rounded-full bg-accent"
+        />
+      ) : null}
+      <button
+        type="button"
+        onClick={onClick}
+        title={title}
+        className="flex min-w-0 flex-1 cursor-pointer items-center gap-1.5 text-left"
+      >
+        {attention === undefined ? (
+          <span
+            className={`inline-flex h-1.5 w-1.5 shrink-0 rounded-full ${
+              dotClassName ?? (dim ? "bg-fg-3" : "bg-accent")
+            }`}
+          />
+        ) : null}
+        {pinned ? (
+          <Pin
+            aria-hidden
+            className="h-2.5 w-2.5 shrink-0 -rotate-45 text-fg-3"
+          />
+        ) : null}
+        {Icon ? (
+          <SidebarTabIcon
+            icon={Icon}
+            active={iconActive ?? selected}
+          />
+        ) : null}
+        <span
+          className={`min-w-0 flex-1 truncate ${
+            selected ? "font-semibold" : ""
+          } ${mono ? "font-mono" : ""}`}
+        >
+          {label}
+        </span>
+        {attention !== undefined ? (
+          <ChatAttentionIndicator
+            state={attention}
+            workingLabel={attentionWorkingLabel}
+          />
+        ) : null}
+      </button>
+      {onContextMenu ? (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            onContextMenu({ x: event.clientX, y: event.clientY });
+          }}
+          title="More actions"
+          aria-label="More actions"
+          className="cursor-pointer rounded p-0.5 text-fg-3 opacity-0 transition-opacity hover:bg-raised hover:text-fg group-hover:opacity-100 focus:opacity-100"
+        >
+          <MoreHorizontal aria-hidden className="h-3 w-3" />
+        </button>
+      ) : null}
+    </div>
+  );
+}
+
+function SidebarTabRenameInput({
+  initial,
+  placeholder,
+  icon: Icon,
+  iconActive,
+  title,
+  mono,
+  dim,
+  dotClassName,
+  attention,
+  attentionWorkingLabel,
+  onSubmit,
+  onCancel,
+}: {
+  initial: string;
+  placeholder: string;
+  icon?: SidebarTabIconComponent;
+  iconActive: boolean;
+  title?: string;
+  mono?: boolean;
+  dim?: boolean;
+  dotClassName?: string;
+  attention?: ChatAttentionState;
+  attentionWorkingLabel?: string;
+  onSubmit: (next: string) => void;
+  onCancel: () => void;
+}) {
+  const [draft, setDraft] = useState(initial);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+    inputRef.current?.select();
+  }, []);
+
+  return (
+    <div
+      className="flex w-full items-center gap-1.5 rounded border border-sidebar-selected-border bg-sidebar-selected px-2.5 py-1.5 text-xs"
+      title={title}
+    >
+      {attention === undefined ? (
+        <span
+          className={`inline-flex h-1.5 w-1.5 shrink-0 rounded-full ${
+            dotClassName ?? (dim ? "bg-fg-3" : "bg-accent")
+          }`}
+        />
+      ) : null}
+      {Icon ? (
+        <SidebarTabIcon icon={Icon} active={iconActive} />
+      ) : null}
+      <input
+        ref={inputRef}
+        value={draft}
+        placeholder={placeholder}
+        onChange={(event) => setDraft(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            event.preventDefault();
+            onSubmit(draft.trim());
+          } else if (event.key === "Escape") {
+            event.preventDefault();
+            onCancel();
+          }
+        }}
+        onBlur={() => {
+          if (draft.trim() === initial.trim()) onCancel();
+          else onSubmit(draft.trim());
+        }}
+        className={`min-w-0 flex-1 bg-transparent text-xs text-fg outline-none placeholder:text-fg-3 ${
+          mono ? "font-mono" : ""
+        }`}
+      />
+      {attention !== undefined ? (
+        <ChatAttentionIndicator
+          state={attention}
+          workingLabel={attentionWorkingLabel}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+export function ChatAttentionIndicator({
+  state,
+  workingLabel = "Agent working",
+}: {
+  state: ChatAttentionState;
+  workingLabel?: string;
+}) {
+  if (state === "working") {
+    return (
+      <span
+        className="flex h-3 w-3 shrink-0 items-center justify-center"
+        aria-label={workingLabel}
+        title={workingLabel}
+      >
+        <span
+          aria-hidden
+          className="flex h-3 w-3 origin-center animate-spin items-center justify-center text-fg-3 motion-reduce:animate-none"
+        >
+          <LoaderCircle className="block h-3 w-3" />
+        </span>
+      </span>
+    );
+  }
+  if (state === "unread") {
+    return (
+      <span
+        className="flex h-3 w-3 shrink-0 items-center justify-center"
+        aria-label="Completed — not viewed"
+        title="Completed — not viewed"
+      >
+        <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-accent" />
+      </span>
+    );
+  }
+  return <span aria-hidden className="h-3 w-3 shrink-0" />;
+}

--- a/src/lib/chatAttention.test.ts
+++ b/src/lib/chatAttention.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { DirectSessionEntry } from "./api";
 import {
   applySessionActivityEvents,
+  missionAttentionState,
   rollupAttentionState,
   tabAttentionState,
 } from "./chatAttention";
@@ -65,5 +66,12 @@ describe("chat attention", () => {
     expect(rollupAttentionState([null, "unread"])).toBe("unread");
     expect(rollupAttentionState(["unread", "working"])).toBe("working");
     expect(rollupAttentionState([null, null])).toBeNull();
+  });
+
+  it("maps mission activity to the chat working indicator", () => {
+    expect(missionAttentionState(true, "busy")).toBe("working");
+    expect(missionAttentionState(true, null)).toBe("working");
+    expect(missionAttentionState(true, "idle")).toBeNull();
+    expect(missionAttentionState(false, "busy")).toBeNull();
   });
 });

--- a/src/lib/chatAttention.ts
+++ b/src/lib/chatAttention.ts
@@ -3,7 +3,11 @@ import { useEffect, useState } from "react";
 import { listen } from "@tauri-apps/api/event";
 
 import { api, type DirectSessionEntry } from "./api";
-import type { SessionActivityEvent, SessionActivityState } from "./types";
+import type {
+  MissionActivityState,
+  SessionActivityEvent,
+  SessionActivityState,
+} from "./types";
 
 export type ChatAttentionState = "working" | "unread" | null;
 export type SessionActivityMap = Record<
@@ -55,6 +59,14 @@ export function rollupAttentionState(
   if (states.includes("working")) return "working";
   if (states.includes("unread")) return "unread";
   return null;
+}
+
+export function missionAttentionState(
+  anySessionLive: boolean,
+  activity: MissionActivityState | null,
+): ChatAttentionState {
+  if (!anySessionLive || activity === "idle") return null;
+  return "working";
 }
 
 export function useDirectSessionActivity(): SessionActivityMap {

--- a/src/lib/chatTabs.test.ts
+++ b/src/lib/chatTabs.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildChatListItems,
   chatTabArchiveLabel,
+  chatTabIsLive,
   derivedChatTabTitle,
   isChatTabDropIndexAllowed,
   orderedChatTabIdsAfterDrop,
@@ -138,6 +139,17 @@ describe("chatTabArchiveLabel", () => {
     );
     expect(chatTabArchiveLabel(applyPresetPure("cols-2", "A", ["A"]))).toBe(
       "Archive all",
+    );
+  });
+});
+
+describe("chatTabIsLive", () => {
+  it("stays live while any pane session is running", () => {
+    expect(chatTabIsLive([{ status: "running" }, { status: "stopped" }])).toBe(
+      true,
+    );
+    expect(chatTabIsLive([{ status: "stopped" }, { status: "crashed" }])).toBe(
+      false,
     );
   });
 });

--- a/src/lib/chatTabs.ts
+++ b/src/lib/chatTabs.ts
@@ -42,6 +42,12 @@ export interface OrderedChatTab {
   pinned: boolean;
 }
 
+export function chatTabIsLive(
+  members: readonly { status: string }[],
+): boolean {
+  return members.some((member) => member.status === "running");
+}
+
 export function chatTabArchiveLabel(layout: PaneLayout): string {
   return leaves(layout.root).length > 1 ? "Archive all" : "Archive";
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -322,14 +322,13 @@ export interface MissionSummary extends Mission {
   crew_name: string;
   pending_ask_count: number;
   /** True iff at least one of the mission's sessions is `status =
-   *  'running'`. Drives the sidebar mission-row status dot — live
-   *  missions get the accent, paused missions (mission.status =
-   *  running but every slot is stopped/crashed) get a muted dot so
-   *  the operator can tell which workspaces accept input without
-   *  entering each one. */
+   *  'running'`. A mission without live sessions never shows the sidebar
+   *  working indicator. */
   any_session_live: boolean;
+  /** True iff every current mission session is running. */
+  all_sessions_live: boolean;
   /** Optional busy/idle projection for live mission slots. Null means
-   *  the mission has no live sessions and should keep the paused styling. */
+   *  the mission has no live sessions and keeps the attention slot clear. */
   activity: MissionActivityState | null;
 }
 


### PR DESCRIPTION
## Summary
- align mission working indicators with the chat tab attention model, including collapsed-section rollup
- share sidebar tab-row icon, attention, rename, pin, context-menu, and drag styling across chat and mission rows
- show outline icon color from runtime state: live chats/folders are accent, fully resumed missions are accent, stopped or partial states are muted

## Verification
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm test (113 tests)
- pnpm build
- cargo fmt --all --check
- cargo test --workspace
- git diff --check