### PR TITLE
fix(ui): restore inline chat tab rename

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "jsdom": "26.1.0",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.56.1",
     "vite": "^7.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,6 +114,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
         version: 0.5.2(eslint@9.39.4(jiti@2.6.1))
+      jsdom:
+        specifier: 26.1.0
+        version: 26.1.0
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -125,9 +128,12 @@ importers:
         version: 7.3.2(jiti@2.6.1)(lightningcss@1.32.0)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.9(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0))
+        version: 4.1.9(jsdom@26.1.0)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0))
 
 packages:
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -211,6 +217,34 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -989,6 +1023,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -1084,8 +1122,16 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1095,6 +1141,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -1119,6 +1168,10 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   es-module-lexer@2.3.0:
     resolution: {integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==}
@@ -1279,8 +1332,24 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-url-attributes@3.0.1:
     resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1325,6 +1394,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -1338,6 +1410,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@26.1.0:
+    resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^3.0.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1448,6 +1529,9 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -1616,6 +1700,9 @@ packages:
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
 
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
     engines: {node: '>=12.20.0'}
@@ -1638,6 +1725,9 @@ packages:
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1738,6 +1828,16 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
@@ -1794,6 +1894,9 @@ packages:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@4.2.4:
     resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
 
@@ -1815,6 +1918,21 @@ packages:
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
@@ -1961,6 +2079,27 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1974,6 +2113,25 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1995,6 +2153,14 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -2107,6 +2273,26 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.5)':
     dependencies:
@@ -2750,6 +2936,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv@6.14.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -2831,11 +3019,23 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -2857,6 +3057,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
+
+  entities@6.0.1: {}
 
   es-module-lexer@2.3.0: {}
 
@@ -3061,7 +3263,29 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-url-attributes@3.0.1: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -3095,6 +3319,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   isexe@2.0.0: {}
 
   jiti@2.6.1: {}
@@ -3104,6 +3330,33 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@26.1.0:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.8.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.21.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -3180,6 +3433,8 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   longest-streak@3.1.0: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -3560,6 +3815,8 @@ snapshots:
 
   node-releases@2.0.37: {}
 
+  nwsapi@2.2.24: {}
+
   obug@2.1.3: {}
 
   optionator@0.9.4:
@@ -3592,6 +3849,10 @@ snapshots:
       is-alphanumerical: 2.0.1
       is-decimal: 2.0.1
       is-hexadecimal: 2.0.1
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   path-exists@4.0.0: {}
 
@@ -3734,6 +3995,14 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  rrweb-cssom@0.8.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -3777,6 +4046,8 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@4.2.4: {}
 
   tapable@2.3.3: {}
@@ -3791,6 +4062,20 @@ snapshots:
       picomatch: 4.0.4
 
   tinyrainbow@3.1.0: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   trim-lines@3.0.1: {}
 
@@ -3885,7 +4170,7 @@ snapshots:
       jiti: 2.6.1
       lightningcss: 1.32.0
 
-  vitest@4.1.9(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)):
+  vitest@4.1.9(jsdom@26.1.0)(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)):
     dependencies:
       '@vitest/expect': 4.1.9
       '@vitest/mocker': 4.1.9(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0))
@@ -3907,8 +4192,27 @@ snapshots:
       tinyrainbow: 3.1.0
       vite: 7.3.2(jiti@2.6.1)(lightningcss@1.32.0)
       why-is-node-running: 2.3.0
+    optionalDependencies:
+      jsdom: 26.1.0
     transitivePeerDependencies:
       - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which@2.0.2:
     dependencies:
@@ -3920,6 +4224,12 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  ws@8.21.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 

--- a/src/components/ChatTabGroup.test.ts
+++ b/src/components/ChatTabGroup.test.ts
@@ -16,6 +16,13 @@ const session = {
   status: "running",
 } as DirectSessionEntry;
 
+const reviewerSession = {
+  ...session,
+  session_id: "B",
+  handle: "reviewer",
+  display_name: "Reviewer",
+} as DirectSessionEntry;
+
 describe("ChatTabGroup", () => {
   it("marks a multi-pane tab with a split icon and no count badge", () => {
     const layout = {
@@ -79,6 +86,49 @@ describe("ChatTabGroup", () => {
     expect(html).toContain('fill="none"');
     expect(html).toContain("text-accent");
     expect(html).not.toContain('fill="var(--color-accent)"');
+  });
+
+  it("renders the durable tab name as a controlled inline rename", () => {
+    const layout = {
+      ...applyPresetPure("cols-2", "A", ["A", "B"], "Review pair"),
+      id: "tab-1",
+    };
+    const html = renderToStaticMarkup(
+      createElement(ChatTabGroup, {
+        layout,
+        members: [session, reviewerSession],
+        active: false,
+        attention: null,
+        renaming: true,
+        onActivate: () => {},
+        onContextMenu: () => {},
+        onRenameSubmit: () => {},
+        onRenameCancel: () => {},
+      }),
+    );
+
+    expect(html).toContain('value="Review pair"');
+    expect(html).toContain('placeholder="@coder + @reviewer"');
+    expect(html).toContain("lucide-columns-2");
+  });
+
+  it("shows the derived member label when the durable name is clear", () => {
+    const layout = {
+      ...applyPresetPure("cols-2", "A", ["A", "B"]),
+      id: "tab-1",
+    };
+    const html = renderToStaticMarkup(
+      createElement(ChatTabGroup, {
+        layout,
+        members: [session, reviewerSession],
+        active: false,
+        attention: null,
+        onActivate: () => {},
+        onContextMenu: () => {},
+      }),
+    );
+
+    expect(html).toContain("@coder + @reviewer");
   });
 
   it("mutes a fully stopped tab icon", () => {

--- a/src/components/ChatTabGroup.tsx
+++ b/src/components/ChatTabGroup.tsx
@@ -18,6 +18,9 @@ export function ChatTabGroup({
   onContextMenu,
   dragging,
   attention,
+  renaming,
+  onRenameSubmit,
+  onRenameCancel,
 }: {
   layout: PaneLayout;
   members: DirectSessionEntry[];
@@ -26,12 +29,16 @@ export function ChatTabGroup({
   onContextMenu: (anchor: { x: number; y: number }) => void;
   dragging?: boolean;
   attention: ChatAttentionState;
+  renaming?: boolean;
+  onRenameSubmit?: (name: string) => void;
+  onRenameCancel?: () => void;
 }) {
   const focused = findLeaf(layout.root, layout.focusedPaneId)?.sessionId;
   const target = members.find((member) => member.session_id === focused) ?? members[0];
   if (!target) return null;
 
-  const name = layout.name ?? derivedChatTabTitle(members);
+  const derivedName = derivedChatTabTitle(members);
+  const name = layout.name ?? derivedName;
   const pinned = members.length > 0 && members.every((member) => member.pinned);
   const live = chatTabIsLive(members);
   const paneCount = leaves(layout.root).length;
@@ -49,6 +56,11 @@ export function ChatTabGroup({
       onClick={() => onActivate(target)}
       onContextMenu={onContextMenu}
       title={name}
+      renaming={renaming}
+      renameValue={layout.name ?? ""}
+      renamePlaceholder={derivedName}
+      onRenameSubmit={onRenameSubmit}
+      onRenameCancel={onRenameCancel}
     />
   );
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -332,15 +332,15 @@ export function Sidebar({
     x: number;
     y: number;
   } | null>(null);
-  // Inline rename: when set, the row whose id matches renders an input
-  // instead of its label. Submit (Enter) → session_rename + refresh.
-  // Cancel (Escape / blur with no change) → close without write.
   // CHAT creation state. The `+` and empty-space context menus can start a
   // chat or insert a focused inline folder-name row.
   const [creatingChat, setCreatingChat] = useState(false);
   const [newChatFolderId, setNewChatFolderId] = useState<string | null>(null);
   const [chatAddMenuOpen, setChatAddMenuOpen] = useState(false);
   const [creatingFolder, setCreatingFolder] = useState(false);
+  const [renamingChatTabId, setRenamingChatTabId] = useState<string | null>(
+    null,
+  );
   const [renamingFolderId, setRenamingFolderId] = useState<string | null>(null);
   const [chatCreateMenu, setChatCreateMenu] = useState<{
     x: number;
@@ -886,17 +886,13 @@ export function Sidebar({
     [directSessions, refreshDirectSessions],
   );
 
-  const renameChatTab = useCallback((members: DirectSessionEntry[]) => {
-    const first = members[0];
-    if (!first) return;
-    const layout = getPaneLayout(first.session_id);
-    const proposed = window.prompt(
-      "Rename tab (blank = derive from chats)",
-      layout.name ?? "",
-    );
-    if (proposed === null) return;
-    setGroupNameForSession(first.session_id, proposed);
-  }, []);
+  const submitChatTabRename = useCallback(
+    (sessionId: string, nextName: string) => {
+      setRenamingChatTabId(null);
+      setGroupNameForSession(sessionId, nextName);
+    },
+    [],
+  );
 
   const beginFolderCreate = useCallback(() => {
     setChatAddMenuOpen(false);
@@ -1300,6 +1296,7 @@ export function Sidebar({
         key={item.layout.id}
         tabId={item.layout.id}
         folderId={item.layout.folderId}
+        disabled={renamingChatTabId === item.layout.id}
       >
         <ChatTabGroup
           layout={item.layout}
@@ -1313,6 +1310,11 @@ export function Sidebar({
             openChatTabMenu(item.layout, item.members, anchor)
           }
           dragging={draggedTabId === item.layout.id}
+          renaming={renamingChatTabId === item.layout.id}
+          onRenameSubmit={(nextName) =>
+            submitChatTabRename(item.members[0].session_id, nextName)
+          }
+          onRenameCancel={() => setRenamingChatTabId(null)}
         />
       </SortableChatTab>
     );
@@ -1911,7 +1913,7 @@ export function Sidebar({
             closeChatTabMenu();
           }}
           onRename={() => {
-            renameChatTab(chatTabMenu.members);
+            setRenamingChatTabId(chatTabMenu.layout.id);
             closeChatTabMenu();
           }}
           onArchive={() => {
@@ -2122,10 +2124,12 @@ function CollapsibleSectionHeader({
 function SortableChatTab({
   tabId,
   folderId,
+  disabled,
   children,
 }: {
   tabId: string;
   folderId: string | null;
+  disabled: boolean;
   children: ReactNode;
 }) {
   const {
@@ -2133,6 +2137,7 @@ function SortableChatTab({
     setNodeRef,
   } = useSortable({
     id: tabDndId(tabId),
+    disabled,
     data: { kind: "tab", tabId, folderId } satisfies ChatTabDndData,
   });
 

--- a/src/components/SidebarRename.test.ts
+++ b/src/components/SidebarRename.test.ts
@@ -1,0 +1,290 @@
+/** @vitest-environment jsdom */
+
+import { act, createElement, type ReactNode } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  tabRows: [
+    {
+      id: "tab-a",
+      folder_id: null,
+      name: "",
+      position: 0,
+      layout:
+        '{"preset":"cols-2","slots":["A","B"],"sizes":{"cols-2:outer":[50,50]}}',
+      created_at: "2026-07-14T00:00:00Z",
+    },
+    {
+      id: "tab-b",
+      folder_id: "folder-1",
+      name: "",
+      position: 1,
+      layout:
+        '{"preset":"cols-2","slots":["C","D"],"sizes":{"cols-2:outer":[50,50]}}',
+      created_at: "2026-07-14T00:00:01Z",
+    },
+  ],
+  tabUpsert: vi.fn(),
+  sessionPin: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ label: "test-window" }),
+}));
+
+vi.mock("@dnd-kit/core", () => ({
+  DndContext: ({ children }: { children: ReactNode }) => children,
+  DragOverlay: ({ children }: { children: ReactNode }) => children,
+  PointerSensor: function PointerSensor() {},
+  pointerWithin: () => [],
+  useDroppable: () => ({ setNodeRef: () => {} }),
+  useSensor: () => ({}),
+  useSensors: () => [],
+}));
+
+vi.mock("@dnd-kit/sortable", () => ({
+  SortableContext: ({ children }: { children: ReactNode }) => children,
+  useSortable: () => ({ listeners: {}, setNodeRef: () => {} }),
+  verticalListSortingStrategy: {},
+}));
+
+vi.mock("../lib/api", () => ({
+  api: {
+    mission: {
+      listSummary: vi.fn(async () => []),
+    },
+    session: {
+      listRecentDirect: vi.fn(async () => [
+        {
+          session_id: "A",
+          handle: "alpha",
+          display_name: "Alpha",
+          title: null,
+          pinned: false,
+          status: "running",
+        },
+        {
+          session_id: "B",
+          handle: "beta",
+          display_name: "Beta",
+          title: null,
+          pinned: false,
+          status: "running",
+        },
+        {
+          session_id: "C",
+          handle: "coder",
+          display_name: "Coder",
+          title: null,
+          pinned: true,
+          status: "running",
+        },
+        {
+          session_id: "D",
+          handle: "reviewer",
+          display_name: "Reviewer",
+          title: null,
+          pinned: true,
+          status: "running",
+        },
+      ]),
+      activitySnapshot: vi.fn(async () => ({})),
+      pin: mocks.sessionPin,
+    },
+    tab: {
+      importOnce: vi.fn(async () => mocks.tabRows),
+      list: vi.fn(async () => mocks.tabRows),
+      upsert: vi.fn(async (input) => {
+        mocks.tabUpsert(input);
+        mocks.tabRows = mocks.tabRows.map((row) =>
+          row.id === input.id ? { ...row, name: input.name } : row,
+        );
+      }),
+      delete: vi.fn(async () => undefined),
+    },
+    folder: {
+      list: vi.fn(async () => [
+        {
+          id: "folder-1",
+          name: "Review",
+          position: 0,
+          collapsed: false,
+          created_at: "2026-07-14T00:00:00Z",
+        },
+      ]),
+    },
+  },
+}));
+
+vi.mock("./StartMissionModal", () => ({ StartMissionModal: () => null }));
+vi.mock("./StartChatModal", () => ({ StartChatModal: () => null }));
+vi.mock("./CommandPalette", () => ({ CommandPalette: () => null }));
+vi.mock("./UpdatePromptCard", () => ({ UpdatePromptCard: () => null }));
+
+import {
+  getPaneLayout,
+  getPaneLayouts,
+  hydratePaneLayoutsFromDb,
+} from "../lib/paneLayout";
+import { Sidebar } from "./Sidebar";
+
+function buttonWithTitle(container: HTMLElement, title: string) {
+  const button = Array.from(
+    container.querySelectorAll<HTMLButtonElement>("button"),
+  ).find((candidate) => candidate.title === title);
+  if (!button) throw new Error(`missing button: ${title}`);
+  return button;
+}
+
+function menuItem(container: HTMLElement, label: string) {
+  const button = Array.from(
+    container.querySelectorAll<HTMLButtonElement>('[role="menuitem"]'),
+  ).find((candidate) => candidate.textContent?.trim() === label);
+  if (!button) throw new Error(`missing menu item: ${label}`);
+  return button;
+}
+
+function renameInput(container: HTMLElement) {
+  const input = container.querySelector<HTMLInputElement>("input");
+  if (!input) throw new Error("missing rename input");
+  return input;
+}
+
+async function click(element: HTMLElement) {
+  await act(async () => {
+    element.dispatchEvent(
+      new MouseEvent("click", {
+        bubbles: true,
+        clientX: 100,
+        clientY: 100,
+      }),
+    );
+  });
+}
+
+async function startRename(container: HTMLElement, title: string) {
+  const row = buttonWithTitle(container, title).parentElement!;
+  await click(buttonWithTitle(row, "More actions"));
+  await click(menuItem(container, "Rename tab"));
+}
+
+async function changeInput(input: HTMLInputElement, value: string) {
+  await act(async () => {
+    const setter = Object.getOwnPropertyDescriptor(
+      HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function press(input: HTMLInputElement, key: string) {
+  await act(async () => {
+    input.dispatchEvent(new KeyboardEvent("keydown", { bubbles: true, key }));
+  });
+}
+
+describe("Sidebar chat tab rename", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    localStorage.clear();
+    mocks.tabRows[0].name = "";
+    mocks.tabRows[1].name = "";
+    mocks.tabUpsert.mockClear();
+    mocks.sessionPin.mockClear();
+    await hydratePaneLayoutsFromDb();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("renames and clears a background durable tab without activating or moving it", async () => {
+    await act(async () => {
+      root.render(
+        createElement(
+          MemoryRouter,
+          { initialEntries: ["/chats/A"] },
+          createElement(Sidebar, {
+            collapsed: false,
+            onCollapsedChange: () => {},
+            previewOpen: false,
+            onPreviewOpenChange: () => {},
+          }),
+        ),
+      );
+    });
+    const originalPlacement = getPaneLayouts().map((layout) => ({
+      id: layout.id,
+      folderId: layout.folderId,
+    }));
+
+    await startRename(container, "@coder + @reviewer");
+    let input = renameInput(container);
+    expect(input.value).toBe("");
+    expect(input.placeholder).toBe("@coder + @reviewer");
+
+    await changeInput(input, "Review pair");
+    input = renameInput(container);
+    await press(input, "Enter");
+
+    expect(buttonWithTitle(container, "Review pair")).toBeTruthy();
+    expect(getPaneLayout().id).toBe("tab-a");
+    expect(getPaneLayout("A").name).toBeNull();
+    expect(getPaneLayout("C").name).toBe("Review pair");
+    expect(mocks.tabUpsert).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: "tab-b", name: "Review pair" }),
+    );
+    expect(
+      getPaneLayouts().map((layout) => ({
+        id: layout.id,
+        folderId: layout.folderId,
+      })),
+    ).toEqual(originalPlacement);
+    expect(mocks.sessionPin).not.toHaveBeenCalled();
+
+    const writesAfterRename = mocks.tabUpsert.mock.calls.length;
+    await startRename(container, "Review pair");
+    input = renameInput(container);
+    await changeInput(input, "Discarded");
+    input = renameInput(container);
+    await press(input, "Escape");
+    expect(getPaneLayout("C").name).toBe("Review pair");
+    expect(mocks.tabUpsert).toHaveBeenCalledTimes(writesAfterRename);
+
+    await startRename(container, "Review pair");
+    input = renameInput(container);
+    await changeInput(input, "");
+    input = renameInput(container);
+    await press(input, "Enter");
+
+    expect(buttonWithTitle(container, "@coder + @reviewer")).toBeTruthy();
+    expect(getPaneLayout().id).toBe("tab-a");
+    expect(getPaneLayout("C").name).toBeNull();
+    expect(mocks.tabUpsert).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: "tab-b", name: "" }),
+    );
+    expect(
+      getPaneLayouts().map((layout) => ({
+        id: layout.id,
+        folderId: layout.folderId,
+      })),
+    ).toEqual(originalPlacement);
+    expect(mocks.sessionPin).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/paneLayout.test.ts
+++ b/src/lib/paneLayout.test.ts
@@ -714,6 +714,23 @@ describe("cold-start hydration", () => {
     ]);
     expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
 
+    mod.setGroupNameForSession("A", "Review pair");
+    await vi.waitFor(() =>
+      expect(tabUpsert).toHaveBeenLastCalledWith(
+        expect.objectContaining({ id: tabs[0].id, name: "Review pair" }),
+      ),
+    );
+    expect(mod.getPaneLayout("A").name).toBe("Review pair");
+
+    mod.setGroupNameForSession("A", "   ");
+    await vi.waitFor(() =>
+      expect(tabUpsert).toHaveBeenLastCalledWith(
+        expect.objectContaining({ id: tabs[0].id, name: "" }),
+      ),
+    );
+    expect(mod.getPaneLayout("A").name).toBeNull();
+    tabUpsert.mockClear();
+
     let releaseStale: (rows: typeof folderRows) => void = () => {};
     nextFolderList = new Promise((resolve) => {
       releaseStale = resolve;


### PR DESCRIPTION
## Summary

- replace the Rename tab browser prompt with the existing controlled inline sidebar row editor
- key rename state by durable tab ID and persist custom or cleared names through tab_upsert
- preserve background-tab activation, ordering, folders, pinning, attention, multi-pane rows, and drag/drop
- add real Sidebar DOM interaction coverage for rename, cancel, and blank clear

## Validation

- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm exec vitest run src/components/SidebarRename.test.ts src/components/Sidebar.test.ts src/components/ChatTabGroup.test.ts
- pnpm exec vitest run src/lib/paneLayout.test.ts -t "imports the local v2 payload once and hydrates the DB rows"
- git diff --check

Local pnpm test reached 113 passing tests; four unrelated fake-timer afterEach hooks in paneLayout/windowFocus fail under the current Node 18.20.8 shell. The project requires Node >=22.12.0.