### PR TITLE
feat: add project-aware MCP creation

### DIFF
--- a/docs/product/vision.md
+++ b/docs/product/vision.md
@@ -94,7 +94,7 @@ The user-facing surfaces, described by the value they deliver, not by their impl
 
 ### 4.9 External control
 
-- **MCP** — external Claude Code / Codex sessions can inspect and operate Runner through the bundled `runner-mcp` bridge: crew/runner/slot CRUD plus mission lifecycle, feed, and status tools. Runner.app remains the state owner; MCP is a local control surface, not a remote server.
+- **MCP** — external Claude Code / Codex sessions can inspect and operate Runner through the bundled `runner-mcp` bridge: project discovery, crew/runner/slot CRUD, project-aware mission/direct-chat creation, and mission lifecycle, feed, and status tools. Runner.app remains the state owner; MCP is a local control surface, not a remote server.
 
 ## 5. The demo loop
 

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -23,7 +23,7 @@ use tauri::{Emitter, State};
 use ulid::Ulid as UlidGen;
 
 use crate::{
-    commands::{crew, slot},
+    commands::{crew, project, slot},
     error::{Error, Result},
     model::{Mission, MissionStatus, SessionStatus, Timestamp},
     repo, AppState,
@@ -32,6 +32,7 @@ use crate::{
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct StartMissionInput {
     pub crew_id: String,
+    /// Optional project membership. Its cwd is used when cwd is omitted.
     #[serde(default)]
     pub project_id: Option<String>,
     pub title: String,
@@ -42,6 +43,7 @@ pub struct StartMissionInput {
     #[serde(default)]
     pub goal_override: Option<String>,
     /// Working directory exposed to every session as `$MISSION_CWD`.
+    /// An explicit value overrides the project's bound cwd.
     #[serde(default)]
     pub cwd: Option<String>,
 }
@@ -172,7 +174,7 @@ fn ensure_first_turn_fits(slot_handle: &str, body: &str) -> Result<()> {
 pub fn start(
     conn: &mut Connection,
     app_data_dir: &Path,
-    input: StartMissionInput,
+    mut input: StartMissionInput,
 ) -> Result<StartMissionOutput> {
     let title = input.title.trim().to_string();
     if title.is_empty() {
@@ -181,6 +183,7 @@ pub fn start(
     if let Some(g) = input.goal_override.as_deref() {
         validate_mission_goal(g)?;
     }
+    input.cwd = project::resolve_cwd(conn, input.project_id.as_deref(), input.cwd)?;
 
     // Validate crew exists and is launchable.
     let crew = crew::get(conn, &input.crew_id)?;
@@ -1982,13 +1985,14 @@ mod tests {
                 crew_id: crew_id.clone(),
                 title: "first mission".into(),
                 goal_override: None,
-                cwd: Some("/tmp/work".into()),
+                cwd: None,
             },
         )
         .unwrap();
 
         assert_eq!(out.mission.title, "first mission");
         assert_eq!(out.mission.project_id.as_deref(), Some(project.id.as_str()));
+        assert_eq!(out.mission.cwd.as_deref(), Some("/tmp/work"));
         assert_eq!(out.mission.status, MissionStatus::Running);
         assert_eq!(out.goal, "Ship v0");
 
@@ -2025,6 +2029,63 @@ mod tests {
             !stale_sidecar.exists(),
             "mission_start must not write the legacy signal_types.json sidecar"
         );
+    }
+
+    #[test]
+    fn start_explicit_cwd_overrides_project_default() {
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "Alpha", None);
+        add_runner(&mut conn, &crew_id, "lead");
+        let project = repo::project::create(&conn, "Runner", "/project").unwrap();
+        let tmp = tempfile::tempdir().unwrap();
+
+        let out = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                project_id: Some(project.id),
+                crew_id,
+                title: "override cwd".into(),
+                goal_override: None,
+                cwd: Some("/override".into()),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(out.mission.cwd.as_deref(), Some("/override"));
+    }
+
+    #[test]
+    fn start_unknown_project_creates_no_mission() {
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "Alpha", None);
+        add_runner(&mut conn, &crew_id, "lead");
+        let tmp = tempfile::tempdir().unwrap();
+
+        let error = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                project_id: Some("missing".into()),
+                crew_id,
+                title: "unknown project".into(),
+                goal_override: None,
+                cwd: None,
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(error.to_string(), "project not found: missing");
+        let mission_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM missions", [], |row| row.get(0))
+            .unwrap();
+        let session_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(mission_count, 0);
+        assert_eq!(session_count, 0);
     }
 
     #[test]

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -17,10 +17,30 @@ fn emit_changed(app: &tauri::AppHandle) {
     let _ = app.emit("project/changed", serde_json::json!({}));
 }
 
+pub fn list(conn: &rusqlite::Connection) -> Result<Vec<ProjectRow>> {
+    Ok(repo::project::list(conn)?)
+}
+
+pub fn get(conn: &rusqlite::Connection, id: &str) -> Result<ProjectRow> {
+    repo::project::get(conn, id)?.ok_or_else(|| Error::msg(format!("project not found: {id}")))
+}
+
+pub(crate) fn resolve_cwd(
+    conn: &rusqlite::Connection,
+    project_id: Option<&str>,
+    cwd: Option<String>,
+) -> Result<Option<String>> {
+    let Some(project_id) = project_id else {
+        return Ok(cwd);
+    };
+    let project = get(conn, project_id)?;
+    Ok(cwd.or(Some(project.cwd)))
+}
+
 #[tauri::command]
 pub fn project_list(state: State<'_, AppState>) -> Result<Vec<ProjectRow>> {
     let conn = state.db.get()?;
-    Ok(repo::project::list(&conn)?)
+    list(&conn)
 }
 
 #[tauri::command]
@@ -99,11 +119,38 @@ pub fn project_delete(state: State<'_, AppState>, app: tauri::AppHandle, id: Str
 
 #[cfg(test)]
 mod tests {
-    use super::clean_value;
+    use super::{clean_value, resolve_cwd};
+    use crate::{db, repo};
 
     #[test]
     fn clean_value_trims_and_rejects_blank() {
         assert_eq!(clean_value("  Runner  ".into(), "name").unwrap(), "Runner");
         assert!(clean_value("  ".into(), "cwd").is_err());
+    }
+
+    #[test]
+    fn resolve_cwd_defaults_from_project_and_preserves_override() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let project = repo::project::create(&conn, "Runner", "/project").unwrap();
+
+        assert_eq!(
+            resolve_cwd(&conn, Some(&project.id), None).unwrap(),
+            Some("/project".into())
+        );
+        assert_eq!(
+            resolve_cwd(&conn, Some(&project.id), Some("/override".into())).unwrap(),
+            Some("/override".into())
+        );
+    }
+
+    #[test]
+    fn resolve_cwd_rejects_unknown_project() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+
+        let error = resolve_cwd(&conn, Some("missing"), None).unwrap_err();
+
+        assert_eq!(error.to_string(), "project not found: missing");
     }
 }

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -17,9 +17,9 @@ use serde::{Deserialize, Serialize};
 use tauri::{Emitter, State};
 
 use crate::{
-    commands::runner,
+    commands::{project, runner},
     error::{Error, Result},
-    model::{Session, SessionStatus, Timestamp},
+    model::{Runner, Session, SessionStatus, Timestamp},
     repo,
     session::manager::{
         runtime_direct_runner, OutputEvent, SessionActivityState, SessionEvents, SpawnedSession,
@@ -287,6 +287,14 @@ pub struct DirectSessionEntry {
     /// direct URL. `listRecentDirect` filters these out at SQL, so
     /// rows from that surface always carry `archived_at: None`.
     pub archived_at: Option<Timestamp>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StartDirectSessionOutput {
+    #[serde(flatten)]
+    pub session: SpawnedSession,
+    pub project_id: Option<String>,
+    pub cwd: Option<String>,
 }
 
 /// Assemble the IPC entry from a repo direct-session row. `ship_key`
@@ -621,10 +629,57 @@ pub async fn session_resume(
 /// Detail page's "Chat now" button: the user picks a working directory
 /// and gets a one-on-one terminal with the agent's CLI.
 ///
-/// `cwd` defaults to the runner's own `working_dir` when None — that's
-/// what the spawn path resolves anyway, but exposing it on the row gives
-/// future UI surfaces (session list, recent chats) something to show
-/// without a second lookup against the runner config.
+/// Working-directory precedence is explicit `cwd`, project cwd, then the
+/// runner's own `working_dir`.
+pub(crate) fn resolve_direct_start(
+    conn: &rusqlite::Connection,
+    runner_id: &str,
+    project_id: Option<&str>,
+    cwd: Option<String>,
+) -> Result<(Runner, Option<String>)> {
+    let cwd = project::resolve_cwd(conn, project_id, cwd)?;
+    let runner = runner::get(conn, runner_id)?;
+    let effective_cwd = cwd.or_else(|| runner.working_dir.clone());
+    Ok((runner, effective_cwd))
+}
+
+pub(crate) fn session_start_direct_impl(
+    state: &AppState,
+    app: &tauri::AppHandle,
+    runner_id: String,
+    project_id: Option<String>,
+    cwd: Option<String>,
+    cols: Option<u16>,
+    rows: Option<u16>,
+) -> Result<StartDirectSessionOutput> {
+    let (runner, effective_cwd) = {
+        let conn = state.db.get()?;
+        resolve_direct_start(&conn, &runner_id, project_id.as_deref(), cwd)?
+    };
+    let first_turn =
+        crate::router::prompt::compose_direct_first_turn(runner.system_prompt.as_deref());
+    let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app.clone()));
+    let session = state
+        .sessions
+        .spawn_direct(
+            &runner,
+            project_id.as_deref(),
+            effective_cwd.as_deref(),
+            cols,
+            rows,
+            &state.app_data_dir,
+            state.db.clone(),
+            emitter,
+            first_turn,
+        )
+        .map_err(|e| Error::msg(format!("session_start_direct: {e}")))?;
+    Ok(StartDirectSessionOutput {
+        session,
+        project_id,
+        cwd: effective_cwd,
+    })
+}
+
 #[tauri::command]
 pub async fn session_start_direct(
     state: State<'_, AppState>,
@@ -635,38 +690,7 @@ pub async fn session_start_direct(
     cols: Option<u16>,
     rows: Option<u16>,
 ) -> Result<SpawnedSession> {
-    // Look up the runner under a short-lived connection so we don't hold
-    // a pool slot across the spawn (which itself grabs a connection to
-    // insert the `sessions` row).
-    let runner = {
-        let conn = state.db.get()?;
-        runner::get(&conn, &runner_id)?
-    };
-    // Compose the persona first-user-turn body upstream so the spawn
-    // path can deliver it via the positional `[PROMPT]` argv at
-    // process boot — eliminating the post-spawn paste race the
-    // verify loop was working around. Direct chats are off-bus, so
-    // the body is just the runner's `system_prompt` (no worker
-    // coordination preamble). See
-    // `docs/impls/archive/0007-spawn-time-prompt-delivery.md`.
-    let first_turn =
-        crate::router::prompt::compose_direct_first_turn(runner.system_prompt.as_deref());
-    let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app));
-    let spawned = state
-        .sessions
-        .spawn_direct(
-            &runner,
-            project_id.as_deref(),
-            cwd.as_deref(),
-            cols,
-            rows,
-            &state.app_data_dir,
-            state.db.clone(),
-            emitter,
-            first_turn,
-        )
-        .map_err(|e| Error::msg(format!("session_start_direct: {e}")))?;
-    Ok(spawned)
+    Ok(session_start_direct_impl(&state, &app, runner_id, project_id, cwd, cols, rows)?.session)
 }
 
 #[tauri::command]
@@ -874,6 +898,53 @@ mod tests {
         )
         .unwrap();
         runner_id
+    }
+
+    #[test]
+    fn resolve_direct_start_defaults_cwd_from_project() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let runner_id = seed_runner(&conn);
+        let project = repo::project::create(&conn, "Runner", "/project").unwrap();
+
+        let (runner, cwd) =
+            resolve_direct_start(&conn, &runner_id, Some(&project.id), None).unwrap();
+
+        assert_eq!(runner.id, runner_id);
+        assert_eq!(cwd.as_deref(), Some("/project"));
+    }
+
+    #[test]
+    fn resolve_direct_start_explicit_cwd_overrides_project() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let runner_id = seed_runner(&conn);
+        let project = repo::project::create(&conn, "Runner", "/project").unwrap();
+
+        let (_, cwd) = resolve_direct_start(
+            &conn,
+            &runner_id,
+            Some(&project.id),
+            Some("/override".into()),
+        )
+        .unwrap();
+
+        assert_eq!(cwd.as_deref(), Some("/override"));
+    }
+
+    #[test]
+    fn resolve_direct_start_unknown_project_creates_no_session() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let runner_id = seed_runner(&conn);
+
+        let error = resolve_direct_start(&conn, &runner_id, Some("missing"), None).unwrap_err();
+
+        assert_eq!(error.to_string(), "project not found: missing");
+        let session_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM sessions", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(session_count, 0);
     }
 
     fn insert_direct_session(

--- a/src-tauri/src/mcp/server.rs
+++ b/src-tauri/src/mcp/server.rs
@@ -22,7 +22,9 @@ impl RunnerMcpHandler {
         r.merge(Self::crew_router());
         r.merge(Self::runner_router());
         r.merge(Self::slot_router());
+        r.merge(Self::project_router());
         r.merge(Self::mission_router());
+        r.merge(Self::session_router());
         r
     }
 }
@@ -36,8 +38,8 @@ impl ServerHandler for RunnerMcpHandler {
             .with_protocol_version(ProtocolVersion::LATEST)
             .with_server_info(implementation)
             .with_instructions(
-                "Runner MCP server. Access crews, runners, slots, and mission \
-                 lifecycle/status tools for operating a Runner workspace.",
+                "Runner MCP server. Access projects, crews, runners, slots, direct chats, \
+                 and mission lifecycle/status tools for operating a Runner workspace.",
             )
     }
 }
@@ -88,6 +90,8 @@ mod tests {
             "slot_delete",
             "slot_set_lead",
             "slot_reorder",
+            "project_list",
+            "project_get",
             "mission_list",
             "mission_get",
             "mission_list_summary",
@@ -101,11 +105,12 @@ mod tests {
             "mission_rename",
             "mission_reset",
             "mission_post_human_signal",
+            "session_start_direct",
         ]
         .iter()
         .map(|s| s.to_string())
         .collect();
-        assert_eq!(names, expected, "MCP tool registry diverged from Phase 2");
+        assert_eq!(names, expected, "MCP tool registry diverged");
     }
 
     // Regression for #240. A bare `serde_json::Value` field derives a

--- a/src-tauri/src/mcp/tools/mission.rs
+++ b/src-tauri/src/mcp/tools/mission.rs
@@ -425,7 +425,9 @@ impl RunnerMcpHandler {
         Ok(CallToolResult::success(vec![Content::json(&snapshot)?]))
     }
 
-    #[tool(description = "Start a mission for a crew using the same semantics as the app.")]
+    #[tool(
+        description = "Start a mission for a crew. A project's cwd is used unless cwd is explicitly provided."
+    )]
     pub async fn mission_start(
         &self,
         Parameters(input): Parameters<mission::StartMissionInput>,

--- a/src-tauri/src/mcp/tools/mod.rs
+++ b/src-tauri/src/mcp/tools/mod.rs
@@ -1,4 +1,6 @@
 pub(crate) mod crew;
 pub(crate) mod mission;
+pub(crate) mod project;
 pub(crate) mod runner;
+pub(crate) mod session;
 pub(crate) mod slot;

--- a/src-tauri/src/mcp/tools/project.rs
+++ b/src-tauri/src/mcp/tools/project.rs
@@ -1,0 +1,68 @@
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{tool, tool_router, ErrorData};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::commands::project;
+use crate::error::Error;
+use crate::mcp::server::RunnerMcpHandler;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct ProjectIdArgs {
+    /// Project ID.
+    pub id: String,
+}
+
+fn command_error(error: Error) -> ErrorData {
+    match error {
+        Error::Msg(message) => ErrorData::invalid_request(message, None),
+        other => ErrorData::internal_error(other.to_string(), None),
+    }
+}
+
+#[tool_router(router = project_router, vis = "pub(crate)")]
+impl RunnerMcpHandler {
+    #[tool(description = "List all projects in sidebar order, including their bound cwd.")]
+    pub async fn project_list(&self) -> Result<CallToolResult, ErrorData> {
+        let conn = self
+            .state
+            .db
+            .get()
+            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+        let projects = project::list(&conn).map_err(command_error)?;
+        Ok(CallToolResult::success(vec![Content::json(&projects)?]))
+    }
+
+    #[tool(description = "Get a project by ID, including its bound cwd.")]
+    pub async fn project_get(
+        &self,
+        Parameters(ProjectIdArgs { id }): Parameters<ProjectIdArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let conn = self
+            .state
+            .db
+            .get()
+            .map_err(|error| ErrorData::internal_error(error.to_string(), None))?;
+        let project = project::get(&conn, &id).map_err(command_error)?;
+        Ok(CallToolResult::success(vec![Content::json(&project)?]))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{commands::project, db, repo};
+
+    #[test]
+    fn project_discovery_lists_and_gets_bound_cwd() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let created = repo::project::create(&conn, "Runner", "/runner").unwrap();
+
+        let listed = project::list(&conn).unwrap();
+        let fetched = project::get(&conn, &created.id).unwrap();
+
+        assert_eq!(listed, vec![created.clone()]);
+        assert_eq!(fetched, created);
+    }
+}

--- a/src-tauri/src/mcp/tools/session.rs
+++ b/src-tauri/src/mcp/tools/session.rs
@@ -1,0 +1,52 @@
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::model::{CallToolResult, Content};
+use rmcp::{tool, tool_router, ErrorData};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::commands::session;
+use crate::error::Error;
+use crate::mcp::server::RunnerMcpHandler;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct StartDirectSessionArgs {
+    /// Runner template ID.
+    pub runner_id: String,
+    /// Optional project membership. Its cwd is used when cwd is omitted.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// Optional working-directory override.
+    #[serde(default)]
+    pub cwd: Option<String>,
+}
+
+fn command_error(error: Error) -> ErrorData {
+    match error {
+        Error::Msg(message) => ErrorData::invalid_request(message, None),
+        other => ErrorData::internal_error(other.to_string(), None),
+    }
+}
+
+#[tool_router(router = session_router, vis = "pub(crate)")]
+impl RunnerMcpHandler {
+    #[tool(
+        description = "Start a direct chat for a runner. A project's cwd is used unless cwd is explicitly provided."
+    )]
+    pub async fn session_start_direct(
+        &self,
+        Parameters(args): Parameters<StartDirectSessionArgs>,
+    ) -> Result<CallToolResult, ErrorData> {
+        let app_state = self.state.app_state();
+        let output = session::session_start_direct_impl(
+            &app_state,
+            &self.state.app_handle,
+            args.runner_id,
+            args.project_id,
+            args.cwd,
+            None,
+            None,
+        )
+        .map_err(command_error)?;
+        Ok(CallToolResult::success(vec![Content::json(&output)?]))
+    }
+}

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -1422,6 +1422,10 @@ fn spawn_direct_writes_session_with_null_mission_id_and_emits_activity() {
     let mut runner = runner("/bin/sh", &["-c", "echo direct"]);
     runner.id = runner_id.clone();
     runner.handle = "directrunner".into();
+    let project = {
+        let conn = pool.get().unwrap();
+        crate::repo::project::create(&conn, "Runner", "/project").unwrap()
+    };
 
     let cap = capture();
     let fake = fake_runtime();
@@ -1429,8 +1433,8 @@ fn spawn_direct_writes_session_with_null_mission_id_and_emits_activity() {
     let spawned = mgr
         .spawn_direct(
             &runner,
-            None,
-            Some("/tmp"),
+            Some(&project.id),
+            Some(&project.cwd),
             None,
             None,
             std::path::Path::new("/tmp"),
@@ -1441,6 +1445,17 @@ fn spawn_direct_writes_session_with_null_mission_id_and_emits_activity() {
         .unwrap();
     assert_eq!(spawned.mission_id, None);
     assert_eq!(spawned.runner_id, Some(runner_id.clone()));
+    let (stored_project_id, stored_cwd): (Option<String>, Option<String>) = pool
+        .get()
+        .unwrap()
+        .query_row(
+            "SELECT project_id, cwd FROM sessions WHERE id = ?1",
+            params![&spawned.id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(stored_project_id.as_deref(), Some(project.id.as_str()));
+    assert_eq!(stored_cwd.as_deref(), Some(project.cwd.as_str()));
 
     // Direct chat must NOT have a mission-side shim or
     // bundled-bin in its SpawnSpec — the off-bus invariant.


### PR DESCRIPTION
Closes #294.

## Summary
- add `project_list` and `project_get` MCP discovery tools
- default mission and direct-chat cwd from project membership while preserving explicit overrides
- add `session_start_direct` MCP creation with project/cwd results and strict input schemas
- validate unknown projects before creating mission or session rows

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy`
- `cargo test --workspace`
- clean working-tree review by the peer reviewer