### PR TITLE
feat(settings): support shortcut rebinding

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import { AppShell } from "./components/AppShell";
 import { ToastProvider } from "./contexts/ToastContext";
 import { UpdateProvider } from "./contexts/UpdateContext";
 import { nudgeAppZoom } from "./lib/appZoom";
+import { eventMatchesShortcut } from "./lib/keymap";
 import { readAppZoom } from "./lib/settings";
 import Crews from "./pages/Crews";
 import CrewEditor from "./pages/CrewEditor";
@@ -48,33 +49,23 @@ export default function App() {
     }
   }, []);
 
-  // Global Cmd/Ctrl +/-/0 zoom shortcuts. Capture phase so xterm's
-  // textarea doesn't swallow the key before us; preventDefault only on
-  // matches so other Cmd-key combos (copy, paste, etc.) still work.
-  // Documented in src/lib/keymap.ts (app-zoom).
+  // Zoom shortcuts (keymap: zoom-in / zoom-out / zoom-reset). Capture
+  // phase so xterm's textarea doesn't swallow the key before us;
+  // preventDefault only on matches so other Cmd-key combos (copy,
+  // paste, etc.) still work.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey)) return;
-      if (e.altKey) return;
-      // `+` is reached via Shift+`=` on US layouts, so we must accept
-      // Shift specifically for the zoom-in branch. `-` and `0` are
-      // unshifted keys — Shift there is something else (e.g. Cmd+Shift+0
-      // is Safari's "Show downloads"), so we don't claim it.
-      if (e.key === "+" || e.key === "=") {
-        e.preventDefault();
-        e.stopPropagation();
-        nudgeAppZoom(1);
-      } else if (e.key === "-") {
-        if (e.shiftKey) return;
-        e.preventDefault();
-        e.stopPropagation();
-        nudgeAppZoom(-1);
-      } else if (e.key === "0") {
-        if (e.shiftKey) return;
-        e.preventDefault();
-        e.stopPropagation();
-        nudgeAppZoom("reset");
-      }
+      const action = eventMatchesShortcut(e, "zoom-in")
+        ? (1 as const)
+        : eventMatchesShortcut(e, "zoom-out")
+          ? (-1 as const)
+          : eventMatchesShortcut(e, "zoom-reset")
+            ? ("reset" as const)
+            : null;
+      if (action === null) return;
+      e.preventDefault();
+      e.stopPropagation();
+      nudgeAppZoom(action);
     };
     window.addEventListener("keydown", onKey, true);
     return () => window.removeEventListener("keydown", onKey, true);
@@ -107,14 +98,13 @@ export default function App() {
   );
 }
 
-// ⌘, opens the Settings page — the standard macOS binding, wired
-// app-side (not an OS menu accelerator). Like a native menu item it
-// fires even while a text field is focused; it only navigates, so a
-// stray hit is harmless. Two entry points, mirroring the Cmd+S
-// pattern: the window capture listener for ordinary keystrokes, plus
+// Settings shortcut (keymap: open-settings) — wired app-side, not an
+// OS menu accelerator. Like a native menu item it fires even while a
+// text field is focused; it only navigates, so a stray hit is
+// harmless. Two entry points, mirroring the toggle-sidebar pattern:
+// the window capture listener for ordinary keystrokes, plus
 // RunnerTerminal's re-dispatched custom event for keys WKWebView
 // delivers straight to xterm.
-// Documented in src/lib/keymap.ts (open-settings).
 const OPEN_SETTINGS_EVENT = "runner:open-settings";
 
 function SettingsShortcut() {
@@ -127,8 +117,7 @@ function SettingsShortcut() {
       }
     };
     const onKey = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
-      if (e.key !== ",") return;
+      if (!eventMatchesShortcut(e, "open-settings")) return;
       e.preventDefault();
       e.stopPropagation();
       openSettings();

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -16,6 +16,7 @@ import {
   readStoredBool,
   writeStoredBool,
 } from "../lib/settings";
+import { eventMatchesShortcut } from "../lib/keymap";
 
 const SIDEBAR_TOGGLE_EVENT = "runner:toggle-sidebar";
 
@@ -46,16 +47,11 @@ export function AppShell({ children }: { children?: ReactNode }) {
     return () => window.removeEventListener(SIDEBAR_TOGGLE_EVENT, onToggle);
   }, []);
 
-  // Cmd+S toggles the sidebar. Skip real text fields, but let xterm's
-  // hidden textarea through so terminal focus doesn't swallow the
-  // app-level shortcut. Cmd+\ remains as a legacy alias for anyone who
-  // picked it up during development.
-  // Documented in src/lib/keymap.ts (toggle-sidebar).
+  // Skip real text fields, but let xterm's hidden textarea through so
+  // terminal focus doesn't swallow the app-level shortcut.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (!e.metaKey) return;
-      const key = e.key.toLowerCase();
-      if (key !== "s" && e.key !== "\\") return;
+      if (!eventMatchesShortcut(e, "toggle-sidebar")) return;
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName?.toLowerCase();
       const isTextInput =

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -44,6 +44,7 @@ import {
   shouldDelayTerminalResize,
   type TerminalGridSize,
 } from "../lib/terminalResize";
+import { eventMatchesShortcut } from "../lib/keymap";
 
 interface OutputEvent {
   session_id: string;
@@ -521,51 +522,55 @@ export const RunnerTerminal = forwardRef<
     // false for that event (see #99).
     term.attachCustomKeyEventHandler((e) => {
       if (e.type === "keydown" && e.metaKey) {
-        const key = e.key.toLowerCase();
-        if (key === "s" || e.key === "\\") {
+        if (eventMatchesShortcut(e, "toggle-sidebar")) {
           e.preventDefault();
           window.dispatchEvent(new Event(SIDEBAR_TOGGLE_EVENT));
           return false;
         }
-        // Cmd+, opens Settings (impl 0025). Same bridge reason as
-        // Cmd+S: WKWebView can deliver the key straight to xterm, so
-        // the window listener in App.tsx would never see it.
-        if (e.key === "," && !e.altKey && !e.shiftKey) {
+        if (eventMatchesShortcut(e, "open-settings")) {
           e.preventDefault();
           window.dispatchEvent(new Event(OPEN_SETTINGS_EVENT));
           return false;
         }
-        // Bracket pair, iTerm2-style: plain Cmd+[ / Cmd+] cycles the current
-        // terminal surface (split-chat panes or mission tabs), while
-        // Cmd+Shift+[ / Cmd+Shift+] navigates sidebar pages. Shifted brackets
-        // arrive as "{" / "}" on US layouts, hence the code-first match.
-        if (
-          !e.altKey &&
-          (e.code === "BracketLeft" || e.key === "[" || e.key === "{")
-        ) {
+        if (eventMatchesShortcut(e, "page-previous")) {
           e.preventDefault();
           window.dispatchEvent(
-            new CustomEvent(
-              e.shiftKey
-                ? SIDEBAR_NAVIGATE_EVENT
-                : RUNNER_TERMINAL_CYCLE_EVENT,
-              { detail: { direction: "previous" } },
-            ),
+            new CustomEvent(SIDEBAR_NAVIGATE_EVENT, {
+              detail: { direction: "previous" },
+            }),
+          );
+          return false;
+        }
+        if (eventMatchesShortcut(e, "page-next")) {
+          e.preventDefault();
+          window.dispatchEvent(
+            new CustomEvent(SIDEBAR_NAVIGATE_EVENT, {
+              detail: { direction: "next" },
+            }),
           );
           return false;
         }
         if (
-          !e.altKey &&
-          (e.code === "BracketRight" || e.key === "]" || e.key === "}")
+          eventMatchesShortcut(e, "pane-previous") ||
+          eventMatchesShortcut(e, "mission-tab-previous")
         ) {
           e.preventDefault();
           window.dispatchEvent(
-            new CustomEvent(
-              e.shiftKey
-                ? SIDEBAR_NAVIGATE_EVENT
-                : RUNNER_TERMINAL_CYCLE_EVENT,
-              { detail: { direction: "next" } },
-            ),
+            new CustomEvent(RUNNER_TERMINAL_CYCLE_EVENT, {
+              detail: { direction: "previous" },
+            }),
+          );
+          return false;
+        }
+        if (
+          eventMatchesShortcut(e, "pane-next") ||
+          eventMatchesShortcut(e, "mission-tab-next")
+        ) {
+          e.preventDefault();
+          window.dispatchEvent(
+            new CustomEvent(RUNNER_TERMINAL_CYCLE_EVENT, {
+              detail: { direction: "next" },
+            }),
           );
           return false;
         }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -149,6 +149,7 @@ import { StartChatModal } from "./StartChatModal";
 import { CommandPalette } from "./CommandPalette";
 import { UpdatePromptCard } from "./UpdatePromptCard";
 import { ConfirmDialog } from "./settings/ConfirmDialog";
+import { eventMatchesShortcut } from "../lib/keymap";
 
 const SIDEBAR_MIN = 200;
 const SIDEBAR_MAX = 480;
@@ -196,24 +197,14 @@ interface SidebarNavigationHistory {
   index: number;
 }
 
-// Cmd+Shift+[ / Cmd+Shift+] — page navigation moved to the shifted pair
-// (the tab-switch idiom in iTerm2/Safari/VS Code) so plain Cmd+[ / Cmd+]
-// can cycle split-pane focus in the chat surface (impl 0020), matching
-// iTerm2's pane/tab split. Shifted brackets arrive as "{" / "}" on US
-// layouts, so match on `code` first with the shifted keys as fallback.
-// Documented in src/lib/keymap.ts (page-navigation).
 function sidebarNavigationDirectionFromKey(
   e: KeyboardEvent,
 ): SidebarNavigationDirection | null {
-  if (!(e.metaKey || e.ctrlKey)) return null;
-  if (e.altKey || !e.shiftKey) return null;
-  if (e.code === "BracketLeft" || e.key === "[" || e.key === "{") {
-    return "previous";
-  }
-  if (e.code === "BracketRight" || e.key === "]" || e.key === "}") {
-    return "next";
-  }
-  return null;
+  return eventMatchesShortcut(e, "page-previous")
+    ? "previous"
+    : eventMatchesShortcut(e, "page-next")
+      ? "next"
+      : null;
 }
 
 function sidebarRuntimeKeyForPath(pathname: string): string | null {
@@ -657,18 +648,12 @@ export function Sidebar({
     [location.pathname, navigate, sidebarNavigationEntries],
   );
 
-  // ⌘K / Ctrl+K opens the command palette. ⌘T / Ctrl+T opens the Start
-  // Chat modal (browser/terminal convention: ⌘T = new tab/chat, ⌘N =
-  // new window). ⌘N is owned by the File → New Window menu accelerator
-  // (impl 0018) at the OS level, so it's deliberately absent here to
-  // avoid a double-fire. Skip while editing text controls so shortcuts
-  // don't hijack form input. xterm's hidden textarea is not an editor
-  // field from the app's point of view, so Meta shortcuts still win
-  // there; Ctrl shortcuts stay with the PTY/TUI.
-  // Documented in src/lib/keymap.ts (command-palette, new-chat).
+  // Skip while editing text controls so shortcuts don't hijack form
+  // input. xterm's hidden textarea is not an editor field from the
+  // app's point of view, so Meta shortcuts still win there; Ctrl
+  // shortcuts stay with the PTY/TUI.
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey)) return;
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName?.toLowerCase();
       const isXtermInput = !!target?.closest(".xterm");
@@ -682,11 +667,11 @@ export function Sidebar({
         return;
       }
       if (isXtermInput && !e.metaKey) return;
-      if (e.key === "k" || e.key === "K") {
+      if (eventMatchesShortcut(e, "command-palette")) {
         e.preventDefault();
         e.stopPropagation();
         setPaletteOpen(true);
-      } else if (e.key === "t" || e.key === "T") {
+      } else if (eventMatchesShortcut(e, "new-chat")) {
         e.preventDefault();
         e.stopPropagation();
         setNewChatProjectId(activeProjectId);

--- a/src/components/settings/ShortcutsPane.tsx
+++ b/src/components/settings/ShortcutsPane.tsx
@@ -1,37 +1,158 @@
-// Keyboard shortcuts pane — feature #257 v1. Read-only view over the
-// static registry in `src/lib/keymap.ts`; rebinding is a designed
-// follow-up (see impl 0025 decision 6), so rows render resting-state
-// only: title + description left, mono key chips right.
+import { useEffect, useState } from "react";
+import { Pencil, RotateCcw, Search, Trash2 } from "lucide-react";
 
-import { useMemo, useState } from "react";
-import { Search } from "lucide-react";
-
-import { KEYMAP } from "../../lib/keymap";
+import {
+  KEYMAP,
+  KEYMAP_CHANGED_EVENT,
+  clearKeymapOverride,
+  comboFromEvent,
+  effectiveBinding,
+  findKeymapConflict,
+  formatCombo,
+  readKeymapOverrides,
+  resetKeymapOverrides,
+  setKeymapOverride,
+  suspendShortcutMatching,
+  type KeymapEntry,
+} from "../../lib/keymap";
 import { PaneHeader, SettingsCard } from "./shared";
+
+const STORAGE_KEYMAP_OVERRIDES = "settings.keymapOverrides";
+
+interface ConflictNotice {
+  id: string;
+  message: string;
+}
 
 export function ShortcutsPane() {
   const [query, setQuery] = useState("");
-  const filtered = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return KEYMAP;
-    return KEYMAP.filter(
-      (entry) =>
-        entry.title.toLowerCase().includes(q) ||
-        entry.description.toLowerCase().includes(q) ||
-        entry.keys.some((key) => key.toLowerCase().includes(q)),
-    );
-  }, [query]);
+  const [recordingId, setRecordingId] = useState<string | null>(null);
+  const [conflict, setConflict] = useState<ConflictNotice | null>(null);
+  const [, setKeymapVersion] = useState(0);
+
+  useEffect(() => {
+    const refresh = () => {
+      setKeymapVersion((version) => version + 1);
+      setConflict(null);
+    };
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === null || event.key === STORAGE_KEYMAP_OVERRIDES) {
+        refresh();
+      }
+    };
+    window.addEventListener(KEYMAP_CHANGED_EVENT, refresh);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(KEYMAP_CHANGED_EVENT, refresh);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!recordingId) return;
+    suspendShortcutMatching(true);
+    const onKeyDown = (event: KeyboardEvent) => {
+      event.preventDefault();
+      event.stopPropagation();
+      if (event.key === "Escape") {
+        setRecordingId(null);
+        setConflict(null);
+        return;
+      }
+      const combo = comboFromEvent(event);
+      if (!combo) return;
+      const existing = findKeymapConflict(combo, recordingId);
+      if (existing) {
+        setConflict({
+          id: recordingId,
+          message: `Already used by ${existing.title}`,
+        });
+        return;
+      }
+      setKeymapOverride(recordingId, combo);
+      setRecordingId(null);
+      setConflict(null);
+    };
+    const onPointerDown = (event: PointerEvent) => {
+      if (
+        event.target instanceof Element &&
+        event.target.closest("[data-shortcut-recorder]")
+      ) {
+        return;
+      }
+      setRecordingId(null);
+      setConflict(null);
+    };
+    window.addEventListener("keydown", onKeyDown, { capture: true });
+    window.addEventListener("pointerdown", onPointerDown, { capture: true });
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, { capture: true });
+      window.removeEventListener("pointerdown", onPointerDown, {
+        capture: true,
+      });
+      suspendShortcutMatching(false);
+    };
+  }, [recordingId]);
+
+  const overrides = readKeymapOverrides();
+  const bindings = new Map(
+    KEYMAP.map((entry) => [entry.id, effectiveBinding(entry.id)]),
+  );
+  const q = query.trim().toLowerCase();
+  const filtered = q
+    ? KEYMAP.filter((entry) => {
+        const binding = bindings.get(entry.id);
+        return (
+          entry.title.toLowerCase().includes(q) ||
+          entry.description.toLowerCase().includes(q) ||
+          (binding ? formatCombo(binding) : "unassigned")
+            .toLowerCase()
+            .includes(q)
+        );
+      })
+    : KEYMAP;
+  const hasOverrides = Object.keys(overrides).length > 0;
+
+  const startRecording = (id: string) => {
+    setRecordingId(id);
+    setConflict(null);
+  };
+
+  const resetAll = () => {
+    setRecordingId(null);
+    setConflict(null);
+    resetKeymapOverrides();
+  };
+
+  const restoreDefault = (id: string) => {
+    const existing = clearKeymapOverride(id);
+    if (existing) {
+      setConflict({ id, message: `Already used by ${existing.title}` });
+    }
+  };
+
   return (
     <>
       <PaneHeader
         title="Keyboard shortcuts"
-        subtitle="Bindings are fixed in this version — customization is planned."
+        subtitle="Shortcuts must include ⌘, Control, or Option. Function keys can be used alone."
+        action={
+          <button
+            type="button"
+            onClick={resetAll}
+            disabled={!hasOverrides}
+            className="flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md border border-line bg-raised px-3 py-1.5 text-[12px] font-medium text-fg-2 transition-colors hover:border-line-strong hover:text-fg disabled:cursor-default disabled:opacity-40 disabled:hover:border-line disabled:hover:text-fg-2"
+          >
+            <RotateCcw aria-hidden className="h-3 w-3" />
+            Reset all to defaults
+          </button>
+        }
       />
       <div className="flex h-9 w-[280px] items-center gap-2 rounded-md border border-line bg-panel px-2.5">
         <Search aria-hidden className="h-3.5 w-3.5 shrink-0 text-fg-3" />
         <input
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
+          onChange={(event) => setQuery(event.target.value)}
           placeholder="Search shortcuts"
           className="min-w-0 flex-1 bg-transparent text-[13px] text-fg outline-none placeholder:text-fg-3"
         />
@@ -43,32 +164,119 @@ export function ShortcutsPane() {
       ) : (
         <SettingsCard>
           {filtered.map((entry) => (
-            <div
+            <ShortcutRow
               key={entry.id}
-              className="flex items-center justify-between gap-6 px-4 py-3"
-            >
-              <div className="flex min-w-0 flex-col gap-0.5">
-                <span className="text-[13px] font-medium text-fg">
-                  {entry.title}
-                </span>
-                <span className="text-[11px] text-fg-2">
-                  {entry.description}
-                </span>
-              </div>
-              <div className="flex shrink-0 items-center gap-1.5">
-                {entry.keys.map((key) => (
-                  <kbd
-                    key={key}
-                    className="rounded border border-line bg-raised px-1.5 py-0.5 font-mono text-[11px] leading-tight text-fg-2"
-                  >
-                    {key}
-                  </kbd>
-                ))}
-              </div>
-            </div>
+              entry={entry}
+              binding={bindings.get(entry.id) ?? null}
+              overridden={entry.id in overrides}
+              recording={recordingId === entry.id}
+              conflict={conflict?.id === entry.id ? conflict.message : null}
+              onRecord={() => startRecording(entry.id)}
+              onUnbind={() => setKeymapOverride(entry.id, null)}
+              onRestore={() => restoreDefault(entry.id)}
+            />
           ))}
         </SettingsCard>
       )}
     </>
+  );
+}
+
+function ShortcutRow({
+  entry,
+  binding,
+  overridden,
+  recording,
+  conflict,
+  onRecord,
+  onUnbind,
+  onRestore,
+}: {
+  entry: KeymapEntry;
+  binding: ReturnType<typeof effectiveBinding>;
+  overridden: boolean;
+  recording: boolean;
+  conflict: string | null;
+  onRecord: () => void;
+  onUnbind: () => void;
+  onRestore: () => void;
+}) {
+  const iconButtonClass =
+    "flex h-6 w-6 cursor-pointer items-center justify-center rounded text-fg-3 transition-colors hover:bg-raised hover:text-fg focus-visible:bg-raised focus-visible:text-fg focus-visible:outline-none";
+  return (
+    <div className="grid min-h-[58px] grid-cols-[minmax(0,1fr)_minmax(0,1fr)_24px] items-center gap-4 px-4 py-3">
+      <div className="flex min-w-0 flex-col gap-0.5">
+        <span className="text-[13px] font-medium text-fg">{entry.title}</span>
+        <span className="text-[11px] text-fg-2">{entry.description}</span>
+        {conflict ? (
+          <span className="text-[11px] text-danger">{conflict}</span>
+        ) : null}
+      </div>
+      {recording ? (
+        <>
+          <div
+            data-shortcut-recorder
+            className="flex h-8 w-[184px] max-w-full items-center justify-center rounded-md border border-line-strong bg-bg px-3 shadow-inner"
+          >
+            <span className="text-[12px] text-fg-2">Press keys…</span>
+          </div>
+          <span aria-hidden />
+        </>
+      ) : (
+        <>
+          <div className="flex min-w-0 items-center gap-1.5">
+            {entry.fixed ? (
+              <kbd className="rounded border border-line bg-raised px-2 py-1 font-mono text-[11px] leading-tight text-fg-2">
+                {formatCombo(binding ?? entry.default)}
+              </kbd>
+            ) : (
+              <button
+                type="button"
+                onClick={onRecord}
+                aria-label={`Edit ${entry.title} shortcut`}
+                className="cursor-pointer rounded border border-line bg-raised px-2 py-1 font-mono text-[11px] leading-tight text-fg-2 transition-colors hover:border-line-strong hover:text-fg focus-visible:border-line-strong focus-visible:text-fg focus-visible:outline-none"
+              >
+                {binding ? formatCombo(binding) : "Unassigned"}
+              </button>
+            )}
+            {!entry.fixed ? (
+              <button
+                type="button"
+                onClick={onRecord}
+                aria-label={`Edit ${entry.title} shortcut`}
+                title="Edit shortcut"
+                className={iconButtonClass}
+              >
+                <Pencil aria-hidden className="h-3.5 w-3.5" />
+              </button>
+            ) : null}
+            {overridden ? (
+              <button
+                type="button"
+                onClick={onRestore}
+                aria-label={`Restore default for ${entry.title}`}
+                title="Restore default"
+                className={iconButtonClass}
+              >
+                <RotateCcw aria-hidden className="h-3.5 w-3.5" />
+              </button>
+            ) : null}
+          </div>
+          {!entry.fixed ? (
+            <button
+              type="button"
+              onClick={onUnbind}
+              aria-label={`Unbind ${entry.title}`}
+              title="Unbind shortcut"
+              className={iconButtonClass}
+            >
+              <Trash2 aria-hidden className="h-3.5 w-3.5" />
+            </button>
+          ) : (
+            <span aria-hidden />
+          )}
+        </>
+      )}
+    </div>
   );
 }

--- a/src/lib/keymap.test.ts
+++ b/src/lib/keymap.test.ts
@@ -1,31 +1,291 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { KEYMAP, type KeymapScope } from "./keymap";
+import {
+  KEYMAP,
+  clearKeymapOverride,
+  comboFromEvent,
+  effectiveBinding,
+  eventMatchesShortcut,
+  findKeymapConflict,
+  formatCombo,
+  keymapEntry,
+  readKeymapOverrides,
+  resetKeymapOverrides,
+  setKeymapOverride,
+  suspendShortcutMatching,
+  type KeyCombo,
+  type KeyEventLike,
+  type KeymapScope,
+} from "./keymap";
 
 const SCOPES: readonly KeymapScope[] = ["global", "chat-split", "mission"];
 
+class MemoryStorage implements Storage {
+  private items = new Map<string, string>();
+
+  get length() {
+    return this.items.size;
+  }
+
+  clear() {
+    this.items.clear();
+  }
+
+  getItem(key: string) {
+    return this.items.get(key) ?? null;
+  }
+
+  key(index: number) {
+    return [...this.items.keys()][index] ?? null;
+  }
+
+  removeItem(key: string) {
+    this.items.delete(key);
+  }
+
+  setItem(key: string, value: string) {
+    this.items.set(key, value);
+  }
+}
+
+const keyCombo = (
+  code: string,
+  modifiers: Partial<Omit<KeyCombo, "code">> = {},
+): KeyCombo => ({
+  code,
+  meta: false,
+  ctrl: false,
+  alt: false,
+  shift: false,
+  ...modifiers,
+});
+
+const keyEvent = (
+  code: string,
+  modifiers: Partial<Omit<KeyEventLike, "code">> = {},
+): KeyEventLike => ({
+  code,
+  metaKey: false,
+  ctrlKey: false,
+  altKey: false,
+  shiftKey: false,
+  ...modifiers,
+});
+
+beforeEach(() => {
+  Object.defineProperty(globalThis, "localStorage", {
+    value: new MemoryStorage(),
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  suspendShortcutMatching(false);
+  delete (globalThis as { localStorage?: Storage }).localStorage;
+});
+
 describe("keymap registry", () => {
-  it("has no duplicate ids", () => {
+  it("has one complete entry per action with unique ids", () => {
     const ids = KEYMAP.map((entry) => entry.id);
     expect(new Set(ids).size).toBe(ids.length);
-  });
-
-  it("has no duplicate key chips within a scope", () => {
-    const keys = KEYMAP.flatMap((entry) =>
-      entry.keys.map((key) => `${entry.scope}:${key}`),
-    );
-    expect(new Set(keys).size).toBe(keys.length);
-  });
-
-  it("every entry has a known scope, title, description, and keys", () => {
+    expect(ids).toEqual([
+      "new-window",
+      "new-chat",
+      "command-palette",
+      "toggle-sidebar",
+      "open-settings",
+      "page-previous",
+      "page-next",
+      "zoom-in",
+      "zoom-out",
+      "zoom-reset",
+      "pane-previous",
+      "pane-next",
+      "close-pane",
+      "mission-tab-previous",
+      "mission-tab-next",
+    ]);
     for (const entry of KEYMAP) {
       expect(SCOPES).toContain(entry.scope);
       expect(entry.title.length).toBeGreaterThan(0);
       expect(entry.description.length).toBeGreaterThan(0);
-      expect(entry.keys.length).toBeGreaterThan(0);
-      for (const key of entry.keys) {
-        expect(key.length).toBeGreaterThan(0);
-      }
+      expect(entry.default.code.length).toBeGreaterThan(0);
+      expect(formatCombo(entry.default).length).toBeGreaterThan(0);
     }
+  });
+
+  it("has no conflicting defaults in overlapping scopes", () => {
+    for (const entry of KEYMAP) {
+      expect(findKeymapConflict(entry.default, entry.id)).toBeNull();
+    }
+  });
+
+  it("marks only the native new-window binding as fixed", () => {
+    expect(KEYMAP.filter((entry) => entry.fixed).map((entry) => entry.id)).toEqual([
+      "new-window",
+    ]);
+    expect(() => keymapEntry("missing-action")).toThrow(
+      "unknown keymap entry: missing-action",
+    );
+  });
+});
+
+describe("keymap overrides", () => {
+  it("round-trips rebound, unbound, and cleared entries", () => {
+    const rebound = keyCombo("KeyP", { meta: true, shift: true });
+    setKeymapOverride("command-palette", rebound);
+    expect(readKeymapOverrides()).toEqual({ "command-palette": rebound });
+
+    setKeymapOverride("command-palette", null);
+    expect(readKeymapOverrides()).toEqual({ "command-palette": null });
+
+    clearKeymapOverride("command-palette");
+    expect(readKeymapOverrides()).toEqual({});
+  });
+
+  it("resets all overrides at once", () => {
+    setKeymapOverride("command-palette", keyCombo("KeyP", { meta: true }));
+    setKeymapOverride("new-chat", null);
+    resetKeymapOverrides();
+    expect(readKeymapOverrides()).toEqual({});
+    expect(localStorage.getItem("settings.keymapOverrides")).toBeNull();
+  });
+
+  it("blocks restoring a default claimed by another action", () => {
+    const commandPaletteDefault = keymapEntry("command-palette").default;
+    setKeymapOverride("command-palette", null);
+    setKeymapOverride("new-chat", commandPaletteDefault);
+
+    expect(clearKeymapOverride("command-palette")?.id).toBe("new-chat");
+    expect(effectiveBinding("command-palette")).toBeNull();
+    expect(effectiveBinding("new-chat")).toEqual(commandPaletteDefault);
+  });
+
+  it("resolves defaults, rebound entries, unbound entries, and fixed entries", () => {
+    expect(effectiveBinding("command-palette")).toEqual(
+      keymapEntry("command-palette").default,
+    );
+
+    const rebound = keyCombo("KeyP", { ctrl: true });
+    setKeymapOverride("command-palette", rebound);
+    expect(effectiveBinding("command-palette")).toEqual(rebound);
+
+    setKeymapOverride("command-palette", null);
+    expect(effectiveBinding("command-palette")).toBeNull();
+
+    setKeymapOverride("new-window", null);
+    expect(effectiveBinding("new-window")).toEqual(
+      keymapEntry("new-window").default,
+    );
+  });
+});
+
+describe("keymap conflicts", () => {
+  it("allows the same combo in the chat-split and mission scopes", () => {
+    expect(keymapEntry("pane-previous").default).toEqual(
+      keymapEntry("mission-tab-previous").default,
+    );
+    expect(
+      findKeymapConflict(
+        keymapEntry("mission-tab-previous").default,
+        "pane-previous",
+      ),
+    ).toBeNull();
+  });
+
+  it("detects global bindings against scoped actions", () => {
+    const candidate = keymapEntry("pane-previous").default;
+    setKeymapOverride("command-palette", candidate);
+    expect(findKeymapConflict(candidate, "pane-previous")?.id).toBe(
+      "command-palette",
+    );
+  });
+
+  it("includes fixed global bindings in conflict detection", () => {
+    expect(
+      findKeymapConflict(keymapEntry("new-window").default, "pane-next")?.id,
+    ).toBe("new-window");
+  });
+});
+
+describe("eventMatchesShortcut", () => {
+  it("requires the code and every modifier to match exactly", () => {
+    expect(
+      eventMatchesShortcut(keyEvent("KeyK", { metaKey: true }), "command-palette"),
+    ).toBe(true);
+    expect(
+      eventMatchesShortcut(
+        keyEvent("KeyK", { metaKey: true, shiftKey: true }),
+        "command-palette",
+      ),
+    ).toBe(false);
+    expect(
+      eventMatchesShortcut(
+        keyEvent("KeyK", { metaKey: true, ctrlKey: true }),
+        "command-palette",
+      ),
+    ).toBe(false);
+    expect(eventMatchesShortcut(keyEvent("KeyK"), "command-palette")).toBe(
+      false,
+    );
+    expect(
+      eventMatchesShortcut(keyEvent("KeyP", { metaKey: true }), "command-palette"),
+    ).toBe(false);
+  });
+
+  it("allows either shift state for the zoom-in default only", () => {
+    expect(
+      eventMatchesShortcut(keyEvent("Equal", { metaKey: true }), "zoom-in"),
+    ).toBe(true);
+    expect(
+      eventMatchesShortcut(
+        keyEvent("Equal", { metaKey: true, shiftKey: true }),
+        "zoom-in",
+      ),
+    ).toBe(true);
+    expect(
+      eventMatchesShortcut(
+        keyEvent("Minus", { metaKey: true, shiftKey: true }),
+        "zoom-out",
+      ),
+    ).toBe(false);
+  });
+
+  it("does not match while shortcut handling is suspended", () => {
+    const event = keyEvent("KeyK", { metaKey: true });
+    suspendShortcutMatching(true);
+    expect(eventMatchesShortcut(event, "command-palette")).toBe(false);
+    suspendShortcutMatching(false);
+    expect(eventMatchesShortcut(event, "command-palette")).toBe(true);
+  });
+});
+
+describe("comboFromEvent", () => {
+  it("rejects modifier-only and bare non-function keys", () => {
+    expect(
+      comboFromEvent({
+        ...keyEvent("MetaLeft", { metaKey: true }),
+        key: "Meta",
+      }),
+    ).toBeNull();
+    expect(comboFromEvent({ ...keyEvent("KeyA"), key: "a" })).toBeNull();
+    expect(
+      comboFromEvent({
+        ...keyEvent("KeyA", { shiftKey: true }),
+        key: "A",
+      }),
+    ).toBeNull();
+  });
+
+  it("captures modified keys and bare function keys", () => {
+    expect(
+      comboFromEvent({
+        ...keyEvent("KeyP", { ctrlKey: true, shiftKey: true }),
+        key: "P",
+      }),
+    ).toEqual(keyCombo("KeyP", { ctrl: true, shift: true }));
+    expect(comboFromEvent({ ...keyEvent("F5"), key: "F5" })).toEqual(
+      keyCombo("F5"),
+    );
   });
 });

--- a/src/lib/keymap.ts
+++ b/src/lib/keymap.ts
@@ -1,104 +1,399 @@
-// Static keymap registry — impl 0025 (feature #257 v1). The single
-// documented list of Runner's keyboard shortcuts, rendered read-only
-// by the Settings → Keyboard shortcuts pane.
+// Keymap registry + rebinding layer — feature #273 (v2 of #257).
 //
-// v1 is presentation-only: handlers keep their hardcoded keys and this
-// registry documents them. Each handler carries a one-line comment
-// pointing back here so edits don't drift silently. Rebinding
-// (capture UI, conflict detection, persistence, handler indirection)
-// is a designed follow-up, deliberately out of v1 scope.
+// One entry per action (Codex-style rows: "Previous page" and "Next
+// page" are separate entries, not one row with two chips). Every
+// handler matches events through `eventMatchesShortcut`, so the
+// effective binding — default or user override — is the single source
+// of truth and handlers carry no key literals.
+//
+// Overrides persist in localStorage (`settings.keymapOverrides`) keyed
+// by entry id: a stored combo replaces the default, an explicit `null`
+// unbinds the action, an absent key means "use the default". Reads go
+// straight to localStorage (tiny JSON, keydown-frequency is nothing),
+// which keeps multiple windows coherent without cache invalidation.
 
 export type KeymapScope = "global" | "chat-split" | "mission";
+
+export interface KeyCombo {
+  meta: boolean;
+  ctrl: boolean;
+  alt: boolean;
+  shift: boolean;
+  /** KeyboardEvent.code — layout-independent physical key. */
+  code: string;
+  /** Display glyph for the key part when it beats the code-derived one
+   *  (e.g. "+" for Shift+Equal captured on record). */
+  label?: string;
+  /** Match regardless of Shift. Only the zoom-in default uses this:
+   *  "+" is Shift+"=" on US layouts, so ⌘= and ⌘⇧= must both zoom. */
+  shiftOptional?: boolean;
+}
 
 export interface KeymapEntry {
   id: string;
   title: string;
   description: string;
-  /** Rendered as mono key chips, e.g. "⌘K". */
-  keys: string[];
   scope: KeymapScope;
+  default: KeyCombo;
+  /** Owned by an OS menu accelerator (impl 0018) — shown but not
+   *  rebindable; native menu rebinding is a separate problem. */
+  fixed?: boolean;
 }
+
+const combo = (
+  code: string,
+  mods: { meta?: boolean; ctrl?: boolean; alt?: boolean; shift?: boolean },
+  extra?: Pick<KeyCombo, "label" | "shiftOptional">,
+): KeyCombo => ({
+  meta: mods.meta ?? false,
+  ctrl: mods.ctrl ?? false,
+  alt: mods.alt ?? false,
+  shift: mods.shift ?? false,
+  code,
+  ...extra,
+});
 
 export const KEYMAP: readonly KeymapEntry[] = [
   {
-    // Handler: File → New Window menu accelerator (src-tauri, impl 0018).
     id: "new-window",
     title: "New window",
     description: "Open another Runner window.",
-    keys: ["⌘N"],
     scope: "global",
+    default: combo("KeyN", { meta: true }),
+    fixed: true,
   },
   {
-    // Handler: Sidebar.tsx ⌘T listener.
     id: "new-chat",
     title: "New chat",
     description: "Start a chat in a new tab.",
-    keys: ["⌘T"],
     scope: "global",
+    default: combo("KeyT", { meta: true }),
   },
   {
-    // Handler: Sidebar.tsx ⌘K listener.
     id: "command-palette",
     title: "Command palette",
     description: "Search missions, chats, runners, and crews.",
-    keys: ["⌘K"],
     scope: "global",
+    default: combo("KeyK", { meta: true }),
   },
   {
-    // Handler: AppShell.tsx ⌘S listener. ⌘\ still works as a legacy
-    // alias picked up during development; it is not rendered as a chip.
     id: "toggle-sidebar",
     title: "Toggle sidebar",
     description: "Collapse or expand the app sidebar.",
-    keys: ["⌘S"],
     scope: "global",
+    default: combo("KeyS", { meta: true }),
   },
   {
-    // Handler: App.tsx SettingsShortcut.
     id: "open-settings",
     title: "Open settings",
     description: "Open this settings page.",
-    keys: ["⌘,"],
     scope: "global",
+    default: combo("Comma", { meta: true }),
   },
   {
-    // Handler: Sidebar.tsx sidebarNavigationDirectionFromKey.
-    id: "page-navigation",
-    title: "Previous / next page",
-    description: "Step back and forward through recently viewed missions and chats.",
-    keys: ["⇧⌘[", "⇧⌘]"],
+    id: "page-previous",
+    title: "Previous page",
+    description: "Step back through recently viewed missions and chats.",
     scope: "global",
+    default: combo("BracketLeft", { meta: true, shift: true }),
   },
   {
-    // Handler: App.tsx zoom listener.
-    id: "app-zoom",
-    title: "Zoom",
-    description: "Scale the whole app up, down, or back to 100%.",
-    keys: ["⌘+", "⌘−", "⌘0"],
+    id: "page-next",
+    title: "Next page",
+    description: "Step forward through recently viewed missions and chats.",
     scope: "global",
+    default: combo("BracketRight", { meta: true, shift: true }),
   },
   {
-    // Handler: RunnerChat.tsx cyclePaneFocus listener.
-    id: "pane-focus",
-    title: "Previous / next chat pane",
-    description: "Cycle focus across panes while a chat is split.",
-    keys: ["⌘[", "⌘]"],
+    id: "zoom-in",
+    title: "Zoom in",
+    description: "Scale the whole app up.",
+    scope: "global",
+    default: combo("Equal", { meta: true }, { label: "+", shiftOptional: true }),
+  },
+  {
+    id: "zoom-out",
+    title: "Zoom out",
+    description: "Scale the whole app down.",
+    scope: "global",
+    default: combo("Minus", { meta: true }),
+  },
+  {
+    id: "zoom-reset",
+    title: "Reset zoom",
+    description: "Return the app to 100%.",
+    scope: "global",
+    default: combo("Digit0", { meta: true }),
+  },
+  {
+    id: "pane-previous",
+    title: "Previous chat pane",
+    description: "Focus the previous pane while a chat is split.",
     scope: "chat-split",
+    default: combo("BracketLeft", { meta: true }),
   },
   {
-    // Handler: RunnerChat.tsx closeFocusedPane listener.
+    id: "pane-next",
+    title: "Next chat pane",
+    description: "Focus the next pane while a chat is split.",
+    scope: "chat-split",
+    default: combo("BracketRight", { meta: true }),
+  },
+  {
     id: "close-pane",
     title: "Close pane",
     description: "Collapse the focused pane while a chat is split.",
-    keys: ["⌘W"],
     scope: "chat-split",
+    default: combo("KeyW", { meta: true }),
   },
   {
-    // Handler: MissionWorkspace.tsx mission-tab cycle listener.
-    id: "mission-tabs",
-    title: "Previous / next mission tab",
-    description: "Cycle through the feed and open runner tabs in a mission workspace.",
-    keys: ["⌘[", "⌘]"],
+    id: "mission-tab-previous",
+    title: "Previous mission tab",
+    description: "Cycle back through the feed and open runner tabs.",
     scope: "mission",
+    default: combo("BracketLeft", { meta: true }),
+  },
+  {
+    id: "mission-tab-next",
+    title: "Next mission tab",
+    description: "Cycle forward through the feed and open runner tabs.",
+    scope: "mission",
+    default: combo("BracketRight", { meta: true }),
   },
 ];
+
+const byId = new Map(KEYMAP.map((entry) => [entry.id, entry]));
+
+export function keymapEntry(id: string): KeymapEntry {
+  const entry = byId.get(id);
+  if (!entry) throw new Error(`unknown keymap entry: ${id}`);
+  return entry;
+}
+
+// ---------------------------------------------------------------------------
+// Override store
+
+const STORAGE_KEYMAP_OVERRIDES = "settings.keymapOverrides";
+
+/** Fired on window whenever an override changes, so open panes re-read. */
+export const KEYMAP_CHANGED_EVENT = "runner:keymap-changed";
+
+/** id → replacement combo, or null for "unbound". Absent id = default. */
+export type KeymapOverrides = Record<string, KeyCombo | null>;
+
+function isKeyCombo(value: unknown): value is KeyCombo {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.code === "string" &&
+    typeof v.meta === "boolean" &&
+    typeof v.ctrl === "boolean" &&
+    typeof v.alt === "boolean" &&
+    typeof v.shift === "boolean"
+  );
+}
+
+export function readKeymapOverrides(): KeymapOverrides {
+  if (typeof localStorage === "undefined") return {};
+  const raw = localStorage.getItem(STORAGE_KEYMAP_OVERRIDES);
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return {};
+    const overrides: KeymapOverrides = {};
+    for (const [id, value] of Object.entries(parsed)) {
+      if (!byId.has(id)) continue;
+      if (value === null || isKeyCombo(value)) overrides[id] = value;
+    }
+    return overrides;
+  } catch {
+    return {};
+  }
+}
+
+function writeKeymapOverrides(overrides: KeymapOverrides) {
+  if (typeof localStorage === "undefined") return;
+  if (Object.keys(overrides).length === 0) {
+    localStorage.removeItem(STORAGE_KEYMAP_OVERRIDES);
+  } else {
+    localStorage.setItem(STORAGE_KEYMAP_OVERRIDES, JSON.stringify(overrides));
+  }
+  if (typeof window !== "undefined") {
+    window.dispatchEvent(new Event(KEYMAP_CHANGED_EVENT));
+  }
+}
+
+/** Rebind (combo) or unbind (null) one action. */
+export function setKeymapOverride(id: string, value: KeyCombo | null) {
+  keymapEntry(id);
+  writeKeymapOverrides({ ...readKeymapOverrides(), [id]: value });
+}
+
+/** Restore one action to its default binding, or return the action that
+ *  currently owns that combo when restoring would create a conflict. */
+export function clearKeymapOverride(id: string): KeymapEntry | null {
+  const overrides = readKeymapOverrides();
+  if (!(id in overrides)) return null;
+  const entry = keymapEntry(id);
+  const conflict = findKeymapConflict(entry.default, id);
+  if (conflict) return conflict;
+  delete overrides[id];
+  writeKeymapOverrides(overrides);
+  return null;
+}
+
+export function resetKeymapOverrides() {
+  writeKeymapOverrides({});
+}
+
+/** The binding handlers should honor right now: override ?? default. */
+export function effectiveBinding(id: string): KeyCombo | null {
+  const entry = keymapEntry(id);
+  if (entry.fixed) return entry.default;
+  const overrides = readKeymapOverrides();
+  return id in overrides ? overrides[id] : entry.default;
+}
+
+// ---------------------------------------------------------------------------
+// Event matching
+
+/** Structural subset of KeyboardEvent so pure-logic tests run in node. */
+export interface KeyEventLike {
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+  code: string;
+}
+
+let matchingSuspended = false;
+
+/** While the Settings pane records a new combo, every handler's
+ *  matcher goes dark so half-typed bindings don't trigger actions. */
+export function suspendShortcutMatching(suspended: boolean) {
+  matchingSuspended = suspended;
+}
+
+function comboMatchesEvent(combo: KeyCombo, e: KeyEventLike): boolean {
+  return (
+    e.code === combo.code &&
+    e.metaKey === combo.meta &&
+    e.ctrlKey === combo.ctrl &&
+    e.altKey === combo.alt &&
+    (combo.shiftOptional ? true : e.shiftKey === combo.shift)
+  );
+}
+
+export function eventMatchesShortcut(e: KeyEventLike, id: string): boolean {
+  if (matchingSuspended) return false;
+  const binding = effectiveBinding(id);
+  return binding !== null && comboMatchesEvent(binding, e);
+}
+
+// ---------------------------------------------------------------------------
+// Conflicts
+
+function scopesOverlap(a: KeymapScope, b: KeymapScope): boolean {
+  return a === b || a === "global" || b === "global";
+}
+
+function combosCollide(a: KeyCombo, b: KeyCombo): boolean {
+  return (
+    a.code === b.code &&
+    a.meta === b.meta &&
+    a.ctrl === b.ctrl &&
+    a.alt === b.alt &&
+    (a.shiftOptional || b.shiftOptional || a.shift === b.shift)
+  );
+}
+
+/** First entry whose effective binding would fire on the same combo in
+ *  an overlapping scope, or null. Fixed entries count — binding ⌘N
+ *  elsewhere would double-fire with the OS menu accelerator. */
+export function findKeymapConflict(
+  candidate: KeyCombo,
+  forId: string,
+): KeymapEntry | null {
+  const target = keymapEntry(forId);
+  for (const entry of KEYMAP) {
+    if (entry.id === forId) continue;
+    if (!scopesOverlap(entry.scope, target.scope)) continue;
+    const binding = effectiveBinding(entry.id);
+    if (binding && combosCollide(binding, candidate)) return entry;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Capture + display
+
+const MODIFIER_CODES = /^(Meta|Control|Alt|Shift)(Left|Right)?$/;
+
+/** Capture a KeyboardEvent as a bindable combo, or null when it isn't
+ *  one (modifier-only, or a bare key that would hijack typing — plain
+ *  and shift-only keys are allowed for F-keys only). */
+export function comboFromEvent(e: KeyEventLike & { key: string }): KeyCombo | null {
+  if (MODIFIER_CODES.test(e.code) || e.code === "") return null;
+  const hasRealModifier = e.metaKey || e.ctrlKey || e.altKey;
+  if (!hasRealModifier && !/^F\d{1,2}$/.test(e.code)) return null;
+  const printable =
+    e.key.length === 1 && e.key !== " " ? e.key.toUpperCase() : undefined;
+  return {
+    meta: e.metaKey,
+    ctrl: e.ctrlKey,
+    alt: e.altKey,
+    shift: e.shiftKey,
+    code: e.code,
+    ...(printable && printable !== defaultKeyLabel(e.code)
+      ? { label: printable }
+      : {}),
+  };
+}
+
+const CODE_LABELS: Record<string, string> = {
+  Comma: ",",
+  Period: ".",
+  Slash: "/",
+  Backslash: "\\",
+  Semicolon: ";",
+  Quote: "'",
+  Backquote: "`",
+  Minus: "-",
+  Equal: "=",
+  BracketLeft: "[",
+  BracketRight: "]",
+  Enter: "↩",
+  Tab: "⇥",
+  Space: "Space",
+  Backspace: "⌫",
+  Delete: "⌦",
+  ArrowLeft: "←",
+  ArrowRight: "→",
+  ArrowUp: "↑",
+  ArrowDown: "↓",
+  Home: "↖",
+  End: "↘",
+  PageUp: "⇞",
+  PageDown: "⇟",
+};
+
+function defaultKeyLabel(code: string): string {
+  const fromMap = CODE_LABELS[code];
+  if (fromMap) return fromMap;
+  const letter = /^Key([A-Z])$/.exec(code);
+  if (letter) return letter[1];
+  const digit = /^Digit(\d)$/.exec(code);
+  if (digit) return digit[1];
+  return code;
+}
+
+/** "⌃⌥⇧⌘X" — macOS modifier order, then the key glyph. */
+export function formatCombo(combo: KeyCombo): string {
+  return (
+    (combo.ctrl ? "⌃" : "") +
+    (combo.alt ? "⌥" : "") +
+    (combo.shift && !combo.shiftOptional ? "⇧" : "") +
+    (combo.meta ? "⌘" : "") +
+    (combo.label ?? defaultKeyLabel(combo.code))
+  );
+}

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -89,6 +89,7 @@ import {
   unmarkArchivingMission,
   useArchivingMission,
 } from "../lib/archivingState";
+import { eventMatchesShortcut } from "../lib/keymap";
 
 const RAIL_STORAGE_WIDTH = "runner.mission.rail.width";
 const RAIL_MIN = 200;
@@ -768,16 +769,14 @@ export default function MissionWorkspace() {
     [activeTab, openSessionTabIds, selectFeed, selectPty],
   );
 
-  // ⌘[ / ⌘] cycle the feed and open runner terminal tabs. RunnerTerminal
-  // re-dispatches the same event when WKWebView delivers the keystroke
-  // straight to xterm. Documented in src/lib/keymap.ts (mission-tabs).
+  // RunnerTerminal re-dispatches the same event when WKWebView delivers
+  // a mission-tab shortcut straight to xterm.
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (!e.metaKey || e.ctrlKey || e.altKey || e.shiftKey) return;
       const direction =
-        e.code === "BracketLeft" || e.key === "["
+        eventMatchesShortcut(e, "mission-tab-previous")
           ? "previous"
-          : e.code === "BracketRight" || e.key === "]"
+          : eventMatchesShortcut(e, "mission-tab-next")
             ? "next"
             : null;
       if (!direction) return;

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -104,6 +104,7 @@ import type {
   Subject,
   WarningEvent,
 } from "../lib/types";
+import { eventMatchesShortcut } from "../lib/keymap";
 
 interface ExitEvent {
   session_id: string;
@@ -1026,9 +1027,8 @@ export default function RunnerChat() {
     [sessionId, navigate],
   );
 
-  // Cmd+W while split collapses the focused pane. Single-pane keeps the
-  // OS default (Close Window) — this listener only exists while split.
-  // Documented in src/lib/keymap.ts (close-pane).
+  // Closing a pane only applies while split. Single-pane keeps the OS
+  // default because this listener only exists while split.
   const closeFocusedPane = useCallback(() => {
     closePaneById(getPaneLayout(sessionId).focusedPaneId);
   }, [closePaneById, sessionId]);
@@ -1036,8 +1036,7 @@ export default function RunnerChat() {
   useEffect(() => {
     if (!splitActive) return;
     const onKey = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
-      if (e.key !== "w" && e.key !== "W") return;
+      if (!eventMatchesShortcut(e, "close-pane")) return;
       e.preventDefault();
       e.stopPropagation();
       closeFocusedPane();
@@ -1047,12 +1046,9 @@ export default function RunnerChat() {
       window.removeEventListener("keydown", onKey, { capture: true });
   }, [splitActive, closeFocusedPane]);
 
-  // Cmd+[ / Cmd+] cycle pane focus while split — iTerm2's pane-switch
-  // keys; sidebar page navigation lives on the shifted pair. Two entry
-  // points, mirroring the sidebar's pattern: a window capture listener
-  // for ordinary keystrokes, plus RunnerTerminal's re-dispatched custom
-  // event for keys WKWebView delivers straight to xterm.
-  // Documented in src/lib/keymap.ts (pane-focus).
+  // Two entry points mirror the sidebar's pattern: a window capture
+  // listener for ordinary keystrokes, plus RunnerTerminal's
+  // re-dispatched custom event for keys delivered straight to xterm.
   const cyclePaneFocus = useCallback(
     (direction: "previous" | "next") => {
       const current = getPaneLayout(sessionId);
@@ -1069,11 +1065,10 @@ export default function RunnerChat() {
   useEffect(() => {
     if (!splitActive) return;
     const onKey = (e: KeyboardEvent) => {
-      if (!(e.metaKey || e.ctrlKey) || e.altKey || e.shiftKey) return;
       const direction =
-        e.code === "BracketLeft" || e.key === "["
+        eventMatchesShortcut(e, "pane-previous")
           ? "previous"
-          : e.code === "BracketRight" || e.key === "]"
+          : eventMatchesShortcut(e, "pane-next")
             ? "next"
             : null;
       if (!direction) return;


### PR DESCRIPTION
## Summary
- add persistent, conflict-aware keyboard shortcut overrides
- migrate app and terminal shortcut handlers to the effective keymap
- make Settings shortcuts editable with recording, unbind, restore, reset, and click-outside cancellation
- add node-only coverage for registry, overrides, conflicts, matching, suspension, and capture

## Validation
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm test (15 files, 133 tests)
- git diff --check
- clean working-tree review through Runner

Closes #273