### PR TITLE
fix(session): suppress mission local-input busy

### DIFF
--- a/docs/impls/0030-mission-status-local-input-suppression.md
+++ b/docs/impls/0030-mission-status-local-input-suppression.md
@@ -1,0 +1,77 @@
+# Mission status local-input suppression
+
+## Status
+
+Planned. Tracks issue [#302](https://github.com/yicheng47/runner/issues/302). No design gate: no UI change — the sidebar mission row and rail badge just stop lying.
+
+## Problem
+
+Chats and missions share the PTY `IdleDetector`, but its transitions exit through two doors in the forwarder consumer (`session/manager/output.rs:71-104`). Direct chats go through `publish_direct_activity` (`mod.rs:664-698`), which tracks `session.activity`, drops forwarder-sourced busy while `suppress_local_input_busy` is set, and dedupes unchanged states. Mission sessions go through `ForwarderEmitCtx::try_append_runner_status` (`mod.rs:200-217`), which appends the raw transition to the mission event log.
+
+Mission sessions are also outside the activity bookkeeping entirely: spawn/resume busy seeding is gated on `mission_id.is_none()` (`spawn.rs:1199`), and `publish_direct_activity` never runs for them, so `session.activity` stays `None`. That makes `inject_direct_stdin`'s suppression arming (`output.rs:216-218`, requires `activity == Some(Idle)`) and its synthetic `input-submit` busy transition dead code for mission sessions — the whole mechanism silently no-ops.
+
+Net effect: typing into an idle mission runner's terminal echoes bytes, the detector flips busy, the raw row lands in the log, and the sidebar shows "Mission working" (`Sidebar.tsx:2982` via `mission_activity_from_log`, `commands/mission.rs:1705`) plus the rail badge (`MissionWorkspace.tsx:832`) for at least the 750ms threshold. The identical interaction in a chat tab shows nothing. Only the SIGWINCH resize grace (`9c18453`) reached missions, because it lives at the detector level in `pty_runtime.rs`.
+
+## Key Decisions
+
+1. **One transition gate for both surfaces.** Extract the surface/suppress decision out of `publish_direct_activity` into a manager-level helper — `note_forwarder_transition(session_id, state, source) -> bool` — that updates `session.activity`, applies the `suppress_local_input_busy` rules (swallow forwarder-sourced busy while set; clear on idle), and returns whether the transition should be surfaced. The forwarder consumer calls it on every `StatusTransition` regardless of path; only the sink differs (Tauri `session/status` event vs mission-log append). Semantics can't drift again because there is only one place they live.
+2. **Suppressed busy must be repaired at submit, or real work goes invisible.** Once an echo-busy is swallowed, the detector is already in Busy and will not re-emit when the agent starts genuinely working — the log would read idle through an entire real turn. Chats already solve this: `inject_direct_stdin` computes a synthetic busy transition on submit from `Idle` (`output.rs:203-214`, source `input-submit`). With decision 3 tracking activity for missions, that same computed transition applies; it just needs to reach the mission log instead of the Tauri event. This is the load-bearing pair: suppression without submit-repair is a worse bug than the one being fixed.
+3. **Track `session.activity` for mission sessions.** The gate in decision 1 writes it on every forwarder transition, which also makes `inject_direct_stdin`'s existing idle-check arming work for missions verbatim. No seeding changes: mission "busy until proven idle" stays a projection-side default (`mission_activity_from_latest` already treats a live handle with no status row as not-idle).
+4. **Sessions carry a status sink.** Store the mission `ForwarderEmitCtx` (already `Clone`, holds the cached `Arc<EventLog>`) on `SessionState` at spawn/resume, beside `suppress_local_input_busy`. `inject_direct_stdin` routes its computed transition to the sink: `events.status(...)` for direct chats, blocking `append_runner_status(state, "input-submit")` for missions. Forwarder appends remain best-effort and non-blocking because their consumer shares the terminal-output channel; submit repair is load-bearing, runs on the command thread after the keystroke reaches the PTY, and waits through transient log-lock contention instead of dropping the busy row. Permanent append failures are logged.
+5. **The router change is accepted, and it is small.** The router projects busy/idle from the same `runner_status` rows (`router/handlers.rs:212`). After this fix it no longer sees echo-busy — "user is typing in a runner's terminal" stops deferring anything that keys off idle. That is the correct reading: typing was never evidence the runner is working. The submit-repair in decision 2 means genuinely-started turns are still visible immediately. Any future "hold delivery while the human is typing" behavior should be its own explicit signal, not a side effect of echo bytes.
+6. **Dedupe falls out of activity tracking.** The gate only surfaces a transition when `session.activity` actually changes, so the suppress-then-idle sequence (idle → suppressed echo-busy → idle again) appends nothing instead of a duplicate idle row. Consumers already take latest-per-handle, so this is hygiene, not a behavior fix.
+
+## Non-Goals
+
+- Changing `IdleDetector` thresholds, the resize grace, or anything in `pty_runtime.rs`.
+- An unread/attention model for mission rows (spec 39 explicitly scoped mission-row status out; still out).
+- Backfilling or rewriting historical `runner_status` rows in existing mission logs.
+- Any change to the CLI's own `runner status` signal path (`cli/src/signal.rs`) — agent-reported statuses stay untouched.
+- Deferring router signal delivery while the human types (see decision 5 — separate feature if ever wanted).
+
+## Implementation Phases
+
+### Phase 1 — shared transition gate
+
+- Add `note_forwarder_transition(&self, session_id, state: SessionActivityState, source: &str) -> bool` to `SessionManager`: lock the session state, apply the suppression + dedupe rules currently inlined in `publish_direct_activity`, update `session.activity`, return surface/skip.
+- Rewrite `publish_direct_activity` on top of it (behavior identical; existing tests hold).
+- In the forwarder consumer (`output.rs:71-104`), call the gate before both sinks; skip `try_append_runner_status` when it returns false.
+- Tests (`session/manager/tests.rs`): mission echo-busy (suppression set, forwarder busy) appends nothing; idle transition clears suppression and appends; unchanged-state transitions append nothing; direct-chat paths unchanged.
+
+### Phase 2 — status sink on the session
+
+- Add the optional emit ctx to `SessionState`; populate it in mission `spawn` / `resume` where the `ForwarderEmitCtx` is already constructed.
+- In `inject_direct_stdin`, route the computed submit transition to the sink instead of assuming `events.status`; source stays `input-submit`.
+- Clear the sink with the rest of the handle state on exit (`lifecycle.rs` already resets `activity` / `suppress_local_input_busy` — same sweep).
+- Tests: type-then-submit on an idle mission session appends exactly one busy row with source `input-submit`; suppressed episode without submit appends nothing; direct-chat submit still emits the Tauri event and no log row.
+
+### Phase 3 — validation
+
+- `cargo fmt` + `cargo clippy` + `cargo test --workspace` (CI enforces the lint gates), `pnpm exec tsc --noEmit`, `pnpm run lint`.
+- Manual pass over the verification list in a dev build.
+
+## Verification
+
+- [ ] Idle mission, click a runner terminal, type without submitting: no "Mission working" spinner, no rail-badge flip, no new `runner_status` rows in the mission log.
+- [ ] Submit the prompt: busy row (source `input-submit`) lands immediately; spinner lights; settles idle after the turn.
+- [ ] Type, wait for the echo to settle, then submit: same as above — the suppressed episode leaves no idle/busy row pair behind.
+- [ ] Direct-chat behavior byte-for-byte unchanged: typing no spinner, submit spinner, unread dots still armed-gated (#296 tests green).
+- [ ] Router: signal delivery to an idle runner is not deferred by typing in its terminal; a mid-turn runner still reads busy.
+- [ ] Resize while idle still doesn't flip busy (detector-level grace untouched).
+- [ ] `cargo test --workspace`, `cargo clippy`, `pnpm exec tsc --noEmit`, `pnpm run lint` clean.
+
+## Relevant Code
+
+- `src-tauri/src/session/manager/output.rs:71-104` — forwarder consumer fork (gate call site), `:190-241` — `inject_direct_stdin` (suppression arming, submit transition, new sink routing).
+- `src-tauri/src/session/manager/mod.rs:200-217` — `try_append_runner_status`, `:453-460` — `SessionState` (new sink field), `:664-698` — `publish_direct_activity` (rebase onto the gate).
+- `src-tauri/src/session/manager/spawn.rs:1199` — the `mission_id.is_none()` seeding gate (unchanged, cited for context); emit-ctx construction sites for the sink.
+- `src-tauri/src/session/manager/lifecycle.rs:67,217` — state resets to extend.
+- `src-tauri/src/commands/mission.rs:1652-1714` — log→activity projection (unchanged consumer).
+- `src-tauri/src/router/handlers.rs:212` — router status projection (behavioral note, decision 5).
+
+## References
+
+- Issue #302 — bug: mission status ignores local-input suppression.
+- Issue #296 / impl `0029-armed-tab-completions-and-pill-removal.md` — the chat-side attention tightening this brings missions in line with.
+- Archived spec `docs/features/archive/13-pty-silence-idle-detection.md` — origin of the byte-silence heuristic and the mission/direct fork.
+- Issue #124 — origin of the forwarder-emitted `runner_status` rows.

--- a/src-tauri/src/session/manager/lifecycle.rs
+++ b/src-tauri/src/session/manager/lifecycle.rs
@@ -66,6 +66,7 @@ impl SessionManager {
                 Some(mut h) => {
                     state.activity = None;
                     state.suppress_local_input_busy = false;
+                    state.mission_status_sink = None;
                     state.completion_armed = false;
                     (h.stop.clone(), h.forwarder.take())
                 }
@@ -216,6 +217,7 @@ impl SessionManager {
                 state.handle = None;
                 state.activity = None;
                 state.suppress_local_input_busy = false;
+                state.mission_status_sink = None;
                 state.completion_armed = false;
             }
         }

--- a/src-tauri/src/session/manager/mod.rs
+++ b/src-tauri/src/session/manager/mod.rs
@@ -190,6 +190,20 @@ enum AppendOutcome {
 }
 
 impl ForwarderEmitCtx {
+    fn runner_status_draft(&self, state: RunnerStatus, source: &'static str) -> EventDraft {
+        let state_str = match state {
+            RunnerStatus::Busy => "busy",
+            RunnerStatus::Idle => "idle",
+        };
+        EventDraft::signal(
+            self.crew_id.clone(),
+            self.mission_id.clone(),
+            self.handle.clone(),
+            SignalType::new("runner_status"),
+            serde_json::json!({ "state": state_str, "source": source }),
+        )
+    }
+
     /// Non-blocking append of a forwarder-emitted `runner_status`
     /// row. The consumer thread runs this on every status
     /// transition; it must not block (it shares the mpsc receiver
@@ -198,22 +212,24 @@ impl ForwarderEmitCtx {
     /// `cli/src/signal.rs::run_status` so router / UI projections
     /// can't tell the two apart except by `payload.source`.
     fn try_append_runner_status(&self, state: RunnerStatus, source: &'static str) -> AppendOutcome {
-        let state_str = match state {
-            RunnerStatus::Busy => "busy",
-            RunnerStatus::Idle => "idle",
-        };
-        let draft = EventDraft::signal(
-            self.crew_id.clone(),
-            self.mission_id.clone(),
-            self.handle.clone(),
-            SignalType::new("runner_status"),
-            serde_json::json!({ "state": state_str, "source": source }),
-        );
-        match self.event_log.try_append(draft) {
+        match self
+            .event_log
+            .try_append(self.runner_status_draft(state, source))
+        {
             Ok(_) => AppendOutcome::Ok,
             Err(TryAppendError::Contended) => AppendOutcome::Contended,
             Err(TryAppendError::Failed(_)) => AppendOutcome::Failed,
         }
+    }
+
+    fn append_runner_status(
+        &self,
+        state: RunnerStatus,
+        source: &'static str,
+    ) -> runner_core::Result<()> {
+        self.event_log
+            .append(self.runner_status_draft(state, source))
+            .map(|_| ())
     }
 }
 
@@ -454,6 +470,7 @@ struct SessionState {
     handle: Option<SessionHandle>,
     activity: Option<SessionActivityState>,
     suppress_local_input_busy: bool,
+    mission_status_sink: Option<ForwarderEmitCtx>,
     completion_armed: bool,
     output_buffer: VecDeque<OutputEvent>,
     output_seq: u64,
@@ -474,6 +491,7 @@ impl SessionState {
         self.handle.is_none()
             && self.activity.is_none()
             && !self.suppress_local_input_busy
+            && self.mission_status_sink.is_none()
             && !self.completion_armed
             && self.output_buffer.is_empty()
             && self.output_seq == 0
@@ -646,10 +664,16 @@ impl SessionManager {
         }
     }
 
-    fn install_handle(&self, session_id: &str, handle: SessionHandle) {
+    fn install_handle(
+        &self,
+        session_id: &str,
+        handle: SessionHandle,
+        mission_status_sink: Option<ForwarderEmitCtx>,
+    ) {
         let state = self.session_state_or_insert(session_id);
         let mut state = state.lock().unwrap();
         state.handle = Some(handle);
+        state.mission_status_sink = mission_status_sink;
         state.killed = false;
     }
 
@@ -661,6 +685,30 @@ impl SessionManager {
         }
     }
 
+    pub(crate) fn note_forwarder_transition(
+        &self,
+        session_id: &str,
+        state: SessionActivityState,
+        source: &str,
+    ) -> bool {
+        let session = self.session_state_or_insert(session_id);
+        let mut session = session.lock().unwrap();
+        if source == "forwarder"
+            && state == SessionActivityState::Busy
+            && session.suppress_local_input_busy
+        {
+            return false;
+        }
+        if state == SessionActivityState::Idle {
+            session.suppress_local_input_busy = false;
+        }
+        if session.activity == Some(state) {
+            return false;
+        }
+        session.activity = Some(state);
+        true
+    }
+
     pub(crate) fn publish_direct_activity(
         &self,
         session_id: &str,
@@ -668,27 +716,7 @@ impl SessionManager {
         source: &str,
         events: &dyn SessionEvents,
     ) {
-        let session = self.session_state_or_insert(session_id);
-        let should_emit = {
-            let mut session = session.lock().unwrap();
-            if source == "forwarder"
-                && state == SessionActivityState::Busy
-                && session.suppress_local_input_busy
-            {
-                false
-            } else {
-                if state == SessionActivityState::Idle {
-                    session.suppress_local_input_busy = false;
-                }
-                if session.activity == Some(state) {
-                    false
-                } else {
-                    session.activity = Some(state);
-                    true
-                }
-            }
-        };
-        if !should_emit {
+        if !self.note_forwarder_transition(session_id, state, source) {
             return;
         }
         events.status(&SessionActivityEvent {

--- a/src-tauri/src/session/manager/output.rs
+++ b/src-tauri/src/session/manager/output.rs
@@ -70,6 +70,13 @@ impl SessionManager {
                     }
                     Ok(RuntimeOutput::StatusTransition { state, source }) => {
                         if let Some(ctx) = emit_ctx.as_ref() {
+                            if !manager_t.note_forwarder_transition(
+                                &session_id,
+                                state.into(),
+                                source,
+                            ) {
+                                continue;
+                            }
                             let outcome = ctx.try_append_runner_status(state, source);
                             match outcome {
                                 AppendOutcome::Ok => {
@@ -196,46 +203,60 @@ impl SessionManager {
         let rt_session = self.live_runtime_session(session_id)?;
         let submitted = bytes == b"\r";
         let session = self.session_state(session_id);
-        let transition = if let Some(session) = session.as_ref() {
-            let mut session = session.lock().unwrap();
-            let previous_activity = session.activity;
-            let previous_suppression = session.suppress_local_input_busy;
-            let transition = if previous_activity.is_some() && submitted {
-                session.suppress_local_input_busy = false;
-                if previous_activity == Some(SessionActivityState::Idle) {
-                    session.activity = Some(SessionActivityState::Busy);
-                    Some(SessionActivityEvent {
-                        session_id: session_id.to_string(),
-                        state: SessionActivityState::Busy,
-                        source: "input-submit".to_string(),
-                    })
+        let (transition, mission_status_sink, mission_scoped) =
+            if let Some(session) = session.as_ref() {
+                let mut session = session.lock().unwrap();
+                let previous_activity = session.activity;
+                let previous_suppression = session.suppress_local_input_busy;
+                let mission_status_sink = session.mission_status_sink.clone();
+                let mission_scoped = session
+                    .handle
+                    .as_ref()
+                    .is_some_and(|handle| handle.mission_id.is_some());
+                let transition = if previous_activity.is_some() && submitted {
+                    session.suppress_local_input_busy = false;
+                    if previous_activity == Some(SessionActivityState::Idle) {
+                        session.activity = Some(SessionActivityState::Busy);
+                        Some(SessionActivityEvent {
+                            session_id: session_id.to_string(),
+                            state: SessionActivityState::Busy,
+                            source: "input-submit".to_string(),
+                        })
+                    } else {
+                        None
+                    }
                 } else {
+                    if previous_activity == Some(SessionActivityState::Idle) {
+                        session.suppress_local_input_busy = true;
+                    }
                     None
+                };
+                if let Err(error) = self.write_stdin_bytes(&rt_session, bytes) {
+                    session.activity = previous_activity;
+                    session.suppress_local_input_busy = previous_suppression;
+                    return Err(error);
                 }
+                if submitted {
+                    session.completion_armed = true;
+                }
+                (transition, mission_status_sink, mission_scoped)
             } else {
-                if previous_activity == Some(SessionActivityState::Idle) {
-                    session.suppress_local_input_busy = true;
-                }
-                None
+                self.write_stdin_bytes(&rt_session, bytes)?;
+                (None, None, false)
             };
-            if let Err(error) = self.write_stdin_bytes(&rt_session, bytes) {
-                session.activity = previous_activity;
-                session.suppress_local_input_busy = previous_suppression;
-                return Err(error);
-            }
-            if submitted {
-                session.completion_armed = true;
-            }
-            transition
-        } else {
-            self.write_stdin_bytes(&rt_session, bytes)?;
-            None
-        };
         if submitted {
             self.capture_codex_session_key(session_id);
         }
         if let Some(transition) = transition.as_ref() {
-            events.status(transition);
+            if let Some(sink) = mission_status_sink.as_ref() {
+                if let Err(error) = sink.append_runner_status(RunnerStatus::Busy, "input-submit") {
+                    log::error!(
+                        "append input-submit runner_status failed for {session_id}: {error}"
+                    );
+                }
+            } else if !mission_scoped {
+                events.status(transition);
+            }
         }
         Ok(())
     }

--- a/src-tauri/src/session/manager/spawn.rs
+++ b/src-tauri/src/session/manager/spawn.rs
@@ -431,6 +431,13 @@ impl SessionManager {
             None
         };
 
+        let spawn_emit_ctx = open_mission_event_log(&app_data_dir, &mission.crew_id, &mission.id)
+            .map(|event_log| ForwarderEmitCtx {
+                crew_id: mission.crew_id.clone(),
+                mission_id: mission.id.clone(),
+                handle: slot_handle.clone(),
+                event_log,
+            });
         let stop = output.stop_flag();
         let runtime_session_for_log = rt_session.session_id.clone();
         self.install_handle(
@@ -444,18 +451,12 @@ impl SessionManager {
                 forwarder: None,
                 stop,
             },
+            spawn_emit_ctx.clone(),
         );
         if first_turn_delivered_via_argv {
             self.arm_completion(&session_id);
         }
 
-        let spawn_emit_ctx = open_mission_event_log(&app_data_dir, &mission.crew_id, &mission.id)
-            .map(|event_log| ForwarderEmitCtx {
-                crew_id: mission.crew_id.clone(),
-                mission_id: mission.id.clone(),
-                handle: slot_handle.clone(),
-                event_log,
-            });
         let forwarder = self.start_forwarder_thread(
             session_id.clone(),
             Some(mission.id.clone()),
@@ -807,6 +808,7 @@ impl SessionManager {
                 forwarder: None,
                 stop: output.stop_flag(),
             },
+            None,
         );
         if first_turn_delivered_via_argv {
             self.arm_completion(&session_id);
@@ -1184,6 +1186,16 @@ impl SessionManager {
             None
         };
 
+        let resume_emit_ctx = mission_ctx.as_ref().and_then(|ctx| {
+            open_mission_event_log(app_data_dir, &ctx.crew_id, &ctx.mission_id).map(|event_log| {
+                ForwarderEmitCtx {
+                    crew_id: ctx.crew_id.clone(),
+                    mission_id: ctx.mission_id.clone(),
+                    handle: ctx.slot_handle.clone(),
+                    event_log,
+                }
+            })
+        });
         self.install_handle(
             session_id,
             SessionHandle {
@@ -1195,6 +1207,7 @@ impl SessionManager {
                 forwarder: None,
                 stop: output.stop_flag(),
             },
+            resume_emit_ctx.clone(),
         );
         if snap.mission_id.is_none() {
             self.publish_direct_activity(
@@ -1211,16 +1224,6 @@ impl SessionManager {
         // window. See the call site above this function's mission
         // lookup.)
 
-        let resume_emit_ctx = mission_ctx.as_ref().and_then(|ctx| {
-            open_mission_event_log(app_data_dir, &ctx.crew_id, &ctx.mission_id).map(|event_log| {
-                ForwarderEmitCtx {
-                    crew_id: ctx.crew_id.clone(),
-                    mission_id: ctx.mission_id.clone(),
-                    handle: ctx.slot_handle.clone(),
-                    event_log,
-                }
-            })
-        });
         let forwarder = self.start_forwarder_thread(
             session_id.to_string(),
             snap.mission_id.clone(),

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -1666,6 +1666,15 @@ fn direct_chat_status_transition_emits_session_status_idle() {
             None,
         )
         .unwrap();
+    assert!(
+        mgr.session_state(&spawned.id)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .mission_status_sink
+            .is_none(),
+        "direct chats must not carry a mission status sink",
+    );
 
     fake.push_status(0, RunnerStatus::Idle);
     let ev = wait_for_session_status_event(&cap, &spawned.id, SessionActivityState::Idle);
@@ -1765,7 +1774,7 @@ fn direct_chat_typing_stays_idle_until_submit() {
 }
 
 #[test]
-fn mission_status_transition_appends_runner_status_without_session_status_event() {
+fn mission_status_transition_appends_once_without_session_status_event() {
     let pool = pool_with_schema();
     let mission_base = Mission {
         crew_id: "c".into(),
@@ -1809,22 +1818,29 @@ fn mission_status_transition_appends_runner_status_without_session_status_event(
         .unwrap();
 
     fake.push_status(0, RunnerStatus::Busy);
+    fake.push_status(0, RunnerStatus::Busy);
     fake.close_spawn(0);
     join_forwarder_for_test(&mgr, &spawned.id);
 
     let log = EventLog::open(&mission_dir).unwrap();
-    let event = log
+    let events: Vec<_> = log
         .read_from(0)
         .unwrap()
         .into_iter()
         .map(|entry| entry.event)
-        .find(|event| {
+        .filter(|event| {
             event
                 .signal_type
                 .as_ref()
                 .is_some_and(|ty| ty.as_str() == "runner_status")
         })
-        .expect("runner_status event should be appended before the forwarder exits");
+        .collect();
+    assert_eq!(
+        events.len(),
+        1,
+        "unchanged mission states must not append duplicate rows",
+    );
+    let event = &events[0];
 
     assert_eq!(event.from, runner.handle);
     assert_eq!(event.payload["state"], "busy");
@@ -1833,6 +1849,168 @@ fn mission_status_transition_appends_runner_status_without_session_status_event(
         cap.status.lock().unwrap().is_empty(),
         "mission sessions must not emit live session/status events",
     );
+}
+
+#[test]
+fn mission_typing_stays_idle_until_submit() {
+    let pool = pool_with_schema();
+    let mission_base = Mission {
+        crew_id: "c".into(),
+        ..mission()
+    };
+    let runner = runner("/bin/cat", &[]);
+    let slot_id = insert_crew_runner(&pool, &mission_base.id, &runner.id);
+    let fresh_mission_id: String = {
+        let conn = pool.get().unwrap();
+        conn.query_row("SELECT id FROM missions LIMIT 1", [], |r| r.get(0))
+            .unwrap()
+    };
+    let mission = Mission {
+        id: fresh_mission_id,
+        ..mission_base
+    };
+    let mut slot = slot_for(&runner);
+    slot.id = slot_id;
+    slot.crew_id = mission.crew_id.clone();
+
+    let app_data = tempfile::tempdir().unwrap();
+    let events_log_path =
+        runner_core::event_log::path::events_path(app_data.path(), &mission.crew_id, &mission.id);
+    let mission_dir =
+        runner_core::event_log::path::mission_dir(app_data.path(), &mission.crew_id, &mission.id);
+
+    let fake = fake_runtime();
+    let mgr = mgr_with_fake(None, Arc::clone(&fake));
+    let cap = capture();
+    let spawned = mgr
+        .spawn(
+            &mission,
+            &runner,
+            &slot,
+            app_data.path(),
+            events_log_path,
+            Arc::clone(&pool),
+            Arc::clone(&cap) as Arc<dyn SessionEvents>,
+            None,
+        )
+        .unwrap();
+
+    fake.push_status(0, RunnerStatus::Idle);
+    fake.push_output(0, b"initial-idle-synced");
+    wait_for_output_event(&cap, &spawned.id);
+    cap.output.lock().unwrap().clear();
+
+    let log = EventLog::open(&mission_dir).unwrap();
+    let read_statuses = || {
+        log.read_from(0)
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.event)
+            .filter(|event| {
+                event
+                    .signal_type
+                    .as_ref()
+                    .is_some_and(|ty| ty.as_str() == "runner_status")
+            })
+            .collect::<Vec<_>>()
+    };
+    let initial_statuses = read_statuses();
+    assert_eq!(initial_statuses.len(), 1);
+    assert_eq!(initial_statuses[0].payload["state"], "idle");
+    assert_eq!(initial_statuses[0].payload["source"], "forwarder");
+
+    mgr.inject_direct_stdin(&spawned.id, b"x", cap.as_ref())
+        .unwrap();
+    fake.push_status(0, RunnerStatus::Busy);
+    fake.push_status(0, RunnerStatus::Idle);
+    fake.push_status(0, RunnerStatus::Idle);
+    fake.push_output(0, b"typing-echo-drained");
+    wait_for_output_event(&cap, &spawned.id);
+
+    assert_eq!(
+        read_statuses().len(),
+        1,
+        "suppressed echo-busy and the unchanged idle transition must append nothing",
+    );
+    assert_eq!(
+        mgr.activity_snapshot().get(&spawned.id),
+        Some(&SessionActivityState::Idle),
+    );
+    assert!(
+        !mgr.session_state(&spawned.id)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .suppress_local_input_busy,
+        "the idle transition must clear local-input suppression",
+    );
+
+    use fs2::FileExt;
+    use std::fs::OpenOptions;
+    let blocker = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .append(true)
+        .open(log.path())
+        .unwrap();
+    blocker.lock_exclusive().unwrap();
+
+    let submit_mgr = Arc::clone(&mgr);
+    let submit_cap = Arc::clone(&cap);
+    let submit_session_id = spawned.id.clone();
+    let (submit_done_tx, submit_done_rx) = std::sync::mpsc::channel();
+    let submit = std::thread::spawn(move || {
+        let result = submit_mgr
+            .inject_direct_stdin(&submit_session_id, b"\r", submit_cap.as_ref())
+            .map_err(|error| error.to_string());
+        submit_done_tx.send(result).unwrap();
+    });
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !fake
+        .keys()
+        .iter()
+        .any(|(session_id, key)| session_id == &spawned.id && key == "Enter")
+    {
+        assert!(
+            Instant::now() <= deadline,
+            "submit never reached the PTY while the event log was contended",
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    assert!(matches!(
+        submit_done_rx.recv_timeout(Duration::from_millis(50)),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+    ));
+
+    blocker.unlock().unwrap();
+    submit_done_rx
+        .recv_timeout(Duration::from_secs(2))
+        .unwrap()
+        .unwrap();
+    submit.join().unwrap();
+
+    let statuses = read_statuses();
+    assert_eq!(statuses.len(), 2);
+    assert_eq!(statuses[1].payload["state"], "busy");
+    assert_eq!(statuses[1].payload["source"], "input-submit");
+    assert_eq!(
+        statuses
+            .iter()
+            .filter(|event| event.payload["source"] == "input-submit")
+            .count(),
+        1,
+    );
+    assert_eq!(
+        mgr.activity_snapshot().get(&spawned.id),
+        Some(&SessionActivityState::Busy),
+    );
+    assert!(
+        cap.status.lock().unwrap().is_empty(),
+        "mission typing and submit must not emit live session/status events",
+    );
+
+    mgr.kill(&spawned.id).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- route direct-chat and mission forwarder transitions through one suppression and dedupe gate
- persist the mission status sink on session state and append load-bearing input-submit busy rows through blocking log writes
- cover mission echo suppression, dedupe, submit repair, and event-log contention
- add implementation plan 0030

## Validation

- cargo fmt
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- pnpm exec tsc --noEmit
- pnpm run lint
- git diff --check

Closes #302