### PR TITLE
fix(session): terminal history loss on tab return — ring purge cols-gate + measurable WebGL attach

### DIFF
--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -50,7 +50,6 @@ links to its tracking issue.
 - [38 — Sidebar folders for tabs](./38-sidebar-folders-for-tabs.md) — invert the sidebar hierarchy to Folder → Tab: collapsible user folders group chat tabs, every tab (single- or multi-pane) is one row, panes leave the sidebar; folders + tabs persist in SQLite, replacing the localStorage layout store.
 - [39 — Chat working and unread-completion indicators](./39-chat-working-unread-indicators.md) — replace the removed sidebar lifecycle dot with a trailing tab spinner while any pane is working and a durable unread dot when the tab settles outside the focused visible chat; collapsed folders and CHAT roll hidden state upward.
 - [40 — Projects](./40-projects.md) — cwd-bound project containers grouping chats and missions in a Codex-style PROJECT sidebar section; a `projects` table plus `project_id` on sessions and missions, direct folder-picker creation, and cwd inheritance for work started inside a project.
-- [42 — Headless terminal model](./42-headless-terminal-model.md) — in-process vt model per session fed by the PTY forwarder; `output_snapshot` serializes screen + scrollback + modes instead of replaying a purged raw-byte ring, making claude-code history survive replay and deleting the resize purge / 2J clear / resize-dance compensation web.
 
 ## Archive
 

--- a/docs/features/archive/42-headless-terminal-model.md
+++ b/docs/features/archive/42-headless-terminal-model.md
@@ -1,5 +1,7 @@
 # 42 — Headless terminal model for durable session scrollback
 
+> **Status: closed unshipped** (2026-07-18). Issue #306 closed as not planned — the interim symptom fix shipped as PR #308 (rows-only resize ring gate + measurable WebGL attach), and the recorded long-term direction is the Rust-native UI rewrite (#307), which dissolves the parity problem this spec's Phase 0 existed to de-risk. Archived for the failure analysis (Motivation) and the fixture-corpus / round-trip-harness design, which #307 inherits as its regression suite.
+
 Tracking issue: https://github.com/yicheng47/runner/issues/306
 
 ## Motivation
@@ -26,6 +28,8 @@ Each mechanism guards against a real prior regression (frame stacking, box-drawi
 The calculus has changed since 0011: the "pure UX patch" ring has itself grown a compensation web (purge-on-resize with a per-runtime DB probe, frontend 2J clears, the activation resize dance, synthetic alt-screen/bracketed-paste prefixes derived from regex chunk scans, overflow snapshot refetch), and the remaining user-facing cost — claude-code history loss — is the top dogfooding friction and has resisted multiple patch rounds. That is the same fragility signal that justified the 0011 pivot, now pointing back the other way.
 
 This is also the industry-standard shape: VS Code's pty host feeds every persistent terminal's bytes into `@xterm/headless` and reattaches by replaying a `SerializeAddon` stream; tmux, mosh, WezTerm mux, and shpool all keep the terminal state machine with the PTY and treat the client as a repaintable view.
+
+**Field validation — Orca** (`~/repos/orca`, Electron, same product category: parallel claude-code/codex orchestration) ships exactly this design in production: a daemon-side `TerminalHost` with a per-session write-only `HeadlessEmulator` (`@xterm/headless` + `SerializeAddon` + Unicode11), snapshot restore via serialized ANSI + explicit mode-rehydrate sequences, PTY lifetime decoupled from view lifetime, and an on-disk framed history log for restart-survivable replay. Their fidelity bug inventory (`src/main/daemon/headless-emulator.ts` comments) is the field-tested checklist for our Phase 0 fixtures: partial escape sequences split across chunk boundaries, Unicode/emoji width parity between mirror and renderer, SerializeAddon's relative-cursor restore bug, SGR reset before alt-screen re-enter, and query-reply double-answer races. Notably they hit all of these *with the same xterm engine on both sides*; a Rust-crate mirror has a strictly harder parity problem and must budget for it.
 
 ## Design
 
@@ -55,7 +59,17 @@ Out of scope: process-survival sidecar (0011's decision stands — agents die wi
 
 ### Phase 0 — Fixture corpus + crate spike
 
-Capture real byte logs (temporary forwarder tap): a long claude-code conversation including resizes, a codex session with alt-screen + the startup query handshake, a plain shell. Evaluate candidate crates against the corpus: `vt100` (ships `contents_formatted`/`state_formatted` — a built-in SerializeAddon analog), `alacritty_terminal` (battle-tested grid, serializer hand-written), `wezterm-term`. Deliverable: crate decision + fixtures checked into `src-tauri/tests/fixtures/` + a round-trip harness (feed bytes → serialize → feed serialization into a fresh model → grids must match).
+Capture real byte logs (temporary forwarder tap): a long claude-code conversation including resizes, a codex session with alt-screen + the startup query handshake, a plain shell. Evaluate candidate crates against the corpus: `vt100` (ships `contents_formatted`/`state_formatted` — a built-in SerializeAddon analog), `alacritty_terminal` (battle-tested grid, serializer hand-written), `wezterm-term`.
+
+Hard gate for candidates: **resize reflow must match xterm.js semantics** — wrapped lines tracked as wrapped and re-flowed through width changes, so scrollback serialized after a resize matches what a live xterm that watched the same stream would hold. Resize reflow is the exact failure this feature exists to fix (the ring purge existed because old-width bytes replay wrong), so a model that truncates/pads on resize is disqualified regardless of its other merits. This is the known risk for `vt100`; if it fails the gate, fall back to `alacritty_terminal`.
+
+Second hard gate: **Unicode width parity with xterm.js** — the model must advance the cursor over emoji/ZWJ/wide characters exactly as the renderer does (xterm.js uses Unicode 11 tables in modern setups). Claude-code's status line is emoji-dense; a width mismatch accumulates cell-shifted tears in the mirror that a restore then paints back as garbage. Orca hit exactly this even with xterm-on-both-sides and fixed it by forcing matching unicode providers. Fixtures must include emoji-dense claude-code status-line output, and the round-trip harness must compare grids cell-by-cell, not line text.
+
+Serializer detail learned from Orca: a chunk ending mid-escape leaves the partial sequence in the parser, not the grid, so a snapshot taken at that moment drops it and the next live chunk's continuation renders as literal text. The model must carry the partial-escape tail across chunk boundaries and the snapshot must ship it as a separate field the frontend writes *last* (after any reset), so the next live chunk completes it. Fixtures must include escape sequences split across chunk boundaries — the same hazard `update_terminal_mode_state`'s "boundary caveat" comment acknowledges today.
+
+Head start for the `alacritty_terminal` path: PR #157's branch already contains an `alacritty_terminal::Term` mirror + `screen_to_ansi` serializer that compiled and passed tests. It was closed for architectural reasons (sidecar, IPC, seq races, host-side key translation) that do not apply to the passive in-process design — resurrect the serializer from that branch as the spike's starting point rather than rewriting it.
+
+Deliverable: crate decision + fixtures checked into `src-tauri/tests/fixtures/` + a round-trip harness (feed bytes → serialize → feed serialization into a fresh model → grids must match).
 
 ### Phase 1 — Model plumbing, no behavior change
 
@@ -85,5 +99,7 @@ Drop the raw ring (`output_buffer`, `MAX_OUTPUT_BUFFER_CHUNKS`) and dead per-run
 
 - Scrollback restore cap: VS Code defaults to ~100 lines; Runner wants far more. Proposal: model cap 10k lines, serialize up to the frontend's configured xterm scrollback.
 - Whether the resume flow keeps the SIGWINCH dance after the snapshot swap, or resume also becomes serialize-first.
-- Crate choice (phase 0 decides; `vt100` first look for the built-in serializer, `alacritty_terminal` fallback for fidelity).
-- Whether a later phase persists serialized state to disk for restart-survivable scrollback (currently out of scope; `--resume` covers restarts).
+- Crate choice (phase 0 decides against the reflow gate; `vt100` first look for the built-in serializer, `alacritty_terminal` + the PR #157 serializer as fallback).
+- Whether a later phase persists serialized state to disk for restart-survivable scrollback (currently out of scope; `--resume` covers restarts). If revisited, Orca's shape is the proven one: an incremental framed append-log (length-prefixed output/resize/clear frames with a generation header) so a torn final append truncates cleanly instead of replaying half an escape sequence, replayed into the model on startup.
+
+If the parity fallback ladder is exhausted in practice after this ships, the recorded long-term option is the Rust-native UI rewrite (#307) — one parser as both model and renderer. This spec's fixture corpus doubles as that rewrite's regression suite either way.

--- a/src-tauri/src/session/manager/mod.rs
+++ b/src-tauri/src/session/manager/mod.rs
@@ -482,6 +482,12 @@ struct SessionState {
     resume_watermark_seq: u64,
     alt_screen_on: bool,
     bracketed_paste_on: bool,
+    /// Cols of the last PTY winsize applied (seeded at spawn, updated by
+    /// `resize`). Gates the resize ring purge: rows-only changes — the
+    /// frontend's SIGWINCH nudge dance on every tab return — can't garble
+    /// replay reflow (wrap depends on cols alone), so the ring survives
+    /// them; only a real width change still purges.
+    last_pty_cols: Option<u16>,
     resuming: bool,
     killed: bool,
 }
@@ -498,6 +504,7 @@ impl SessionState {
             && self.resume_watermark_seq == 0
             && !self.alt_screen_on
             && !self.bracketed_paste_on
+            && self.last_pty_cols.is_none()
             && !self.resuming
             && !self.killed
     }
@@ -669,12 +676,17 @@ impl SessionManager {
         session_id: &str,
         handle: SessionHandle,
         mission_status_sink: Option<ForwarderEmitCtx>,
+        initial_size: Option<(u16, u16)>,
     ) {
         let state = self.session_state_or_insert(session_id);
         let mut state = state.lock().unwrap();
         state.handle = Some(handle);
         state.mission_status_sink = mission_status_sink;
         state.killed = false;
+        // Seed the resize purge gate with the cols the PTY actually opened
+        // at (the runtime defaults unsized spawns to 80×24), so the first
+        // same-width resize after spawn/resume doesn't purge the ring.
+        state.last_pty_cols = Some(initial_size.map_or(80, |(cols, _)| cols));
     }
 
     fn install_forwarder(&self, session_id: &str, forwarder: thread::JoinHandle<()>) {

--- a/src-tauri/src/session/manager/output.rs
+++ b/src-tauri/src/session/manager/output.rs
@@ -349,16 +349,30 @@ impl SessionManager {
         let rt_session = self.live_runtime_session(session_id)?;
         self.runtime.resize(&rt_session, cols, rows)?;
         // Full-repaint TUI runtimes (claude-code, codex) redraw the whole
-        // frame on SIGWINCH, so bytes buffered before this resize describe
-        // a stale grid width. Replaying them into the new grid on a later
-        // snapshot re-attach wraps their absolute-positioned frames wrong
-        // — box-drawing borders shredded into scrollback garbage (seen
-        // dogfooding split view, impl 0020). Drop them: the incoming
+        // frame on SIGWINCH, so bytes buffered before a *width* change
+        // describe a stale grid width. Replaying them into the new grid on
+        // a later snapshot re-attach wraps their absolute-positioned frames
+        // wrong — box-drawing borders shredded into scrollback garbage
+        // (seen dogfooding split view, impl 0020). Drop them: the incoming
         // repaint rebuilds the buffer at the new width, and the frontend
         // already hard-clears its local viewport for these runtimes on
-        // resize. Shells keep their buffer — no repaint would arrive, and
-        // their history is meaningful.
-        if runtime_clears_on_resize(session_id, pool) {
+        // width changes.
+        //
+        // Rows-only resizes keep the ring: reflow depends on cols alone,
+        // and the frontend's activation dance nudges rows (rows-1 → rows)
+        // with width held constant on every tab return — purging there
+        // threw away claude-code history that snapshot replay could have
+        // restored (the #306 symptom: remount shows only the latest
+        // frame). Shells keep their buffer unconditionally — no repaint
+        // would arrive, and their history is meaningful.
+        let cols_changed = {
+            let state = self.session_state_or_insert(session_id);
+            let mut state = state.lock().unwrap();
+            let changed = state.last_pty_cols != Some(cols);
+            state.last_pty_cols = Some(cols);
+            changed
+        };
+        if cols_changed && runtime_clears_on_resize(session_id, pool) {
             self.purge_output_buffer_keep_modes(session_id);
         }
         Ok(())
@@ -424,6 +438,7 @@ impl SessionManager {
             state.resume_watermark_seq = 0;
             state.alt_screen_on = false;
             state.bracketed_paste_on = false;
+            state.last_pty_cols = None;
         }
         self.prune_empty_session_state(session_id);
     }

--- a/src-tauri/src/session/manager/spawn.rs
+++ b/src-tauri/src/session/manager/spawn.rs
@@ -388,6 +388,7 @@ impl SessionManager {
         }
 
         let spawn_started_at_dt = Utc::now();
+        let initial_size = spec.initial_size;
         let (rt_session, output) = self
             .runtime
             .spawn(spec)
@@ -469,6 +470,7 @@ impl SessionManager {
                 stop,
             },
             spawn_emit_ctx.clone(),
+            initial_size,
         );
         if first_turn_delivered_via_argv {
             self.arm_completion(&session_id);
@@ -843,6 +845,7 @@ impl SessionManager {
                 stop: output.stop_flag(),
             },
             None,
+            initial_size,
         );
         if first_turn_delivered_via_argv {
             self.arm_completion(&session_id);
@@ -1250,6 +1253,7 @@ impl SessionManager {
                 stop: output.stop_flag(),
             },
             resume_emit_ctx.clone(),
+            initial_size,
         );
         if snap.mission_id.is_none() {
             self.publish_direct_activity(

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -3258,6 +3258,80 @@ fn runtime_clears_on_resize_resolves_runner_backed_runtimes() {
     assert!(!super::output::runtime_clears_on_resize("s-missing", &pool));
 }
 
+// The resize ring purge must gate on a *width* change. The frontend's
+// activation dance resizes rows-1 → rows with cols held constant on
+// every tab return; purging there wiped claude-code's replayable
+// history even though rows-only SIGWINCHes can't garble reflow (wrap
+// depends on cols alone) — the #306 "remount shows only the latest
+// frame" symptom. Spawn seeds the gate, so even the first same-width
+// resize keeps the ring.
+#[test]
+fn resize_purges_ring_only_on_cols_change() {
+    let pool = pool_with_schema();
+    let now = Utc::now().to_rfc3339();
+    let runner_id = ulid::Ulid::new().to_string();
+    {
+        let conn = pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     args_json, working_dir, system_prompt, env_json,
+                     created_at, updated_at)
+                 VALUES (?1, 'colsgate', 'ColsGate', 'claude-code', '/bin/cat',
+                         NULL, NULL, NULL, NULL, ?2, ?2)",
+            params![runner_id, now],
+        )
+        .unwrap();
+    }
+
+    let mut runner = runner("/bin/cat", &[]);
+    runner.id = runner_id;
+    runner.handle = "colsgate".into();
+
+    let fake = fake_runtime();
+    let mgr = mgr_with_fake(None, Arc::clone(&fake));
+    let spawned = mgr
+        .spawn_direct(
+            &runner,
+            None,
+            None,
+            Some("/tmp"),
+            Some(120),
+            Some(30),
+            std::path::Path::new("/tmp"),
+            Arc::clone(&pool),
+            capture(),
+            None,
+        )
+        .unwrap();
+
+    fake.push_output(0, b"history to keep");
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while mgr.output_snapshot(&spawned.id).is_empty() {
+        if Instant::now() > deadline {
+            panic!("output never reached the ring");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    // Rows-only nudge (the activation dance): ring must survive both legs.
+    mgr.resize(&spawned.id, 120, 29, &pool).unwrap();
+    mgr.resize(&spawned.id, 120, 30, &pool).unwrap();
+    assert!(
+        !mgr.output_snapshot(&spawned.id).is_empty(),
+        "rows-only resize must keep the replay ring"
+    );
+
+    // Width change: stale-width bytes must still purge.
+    mgr.resize(&spawned.id, 100, 30, &pool).unwrap();
+    assert!(
+        mgr.output_snapshot(&spawned.id).is_empty(),
+        "cols change must purge the replay ring"
+    );
+
+    mgr.kill(&spawned.id).unwrap();
+}
+
 // ---------------------------------------------------------------------
 // Feature 41 — runtime override (per slot / per direct chat)
 // ---------------------------------------------------------------------

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -271,6 +271,33 @@ export const RunnerTerminal = forwardRef<
     autoFocusRef.current = autoFocus ?? true;
   }, [autoFocus]);
 
+  // Attach the WebGL renderer only from refreshActiveTerminal, i.e. only
+  // once the pane is active AND its container has a measurable rect. The
+  // addon reads canvas geometry at load; attaching it on a bare `active`
+  // flip could initialize against a hidden / not-yet-settled layout, and
+  // when the subsequent fit resolves the SAME cols/rows, xterm never
+  // fires the resize that would correct the renderer — the pane paints
+  // stale until a real grid change (the "wrong until I resize the
+  // window" tab-return artifact). Deferring creation to the measurable
+  // path closes that window.
+  const ensureWebglRenderer = useCallback(() => {
+    const term = termRef.current;
+    if (!term || webglRef.current) return;
+    let webgl: WebglAddon | null = null;
+    try {
+      webgl = new WebglAddon();
+      webgl.onContextLoss(() => {
+        webgl?.dispose();
+        if (webglRef.current === webgl) webglRef.current = null;
+      });
+      term.loadAddon(webgl);
+      webglRef.current = webgl;
+    } catch {
+      webgl?.dispose();
+      // No WebGL — xterm keeps its DOM renderer.
+    }
+  }, []);
+
   const refreshActiveTerminal = useCallback(
     ({
       focus = false,
@@ -300,6 +327,7 @@ export const RunnerTerminal = forwardRef<
               `pushBackend=${pushBackendSize}`,
           );
         }
+        ensureWebglRenderer();
         tryDrainReplayRef.current?.();
         if (replayFlushPendingRef.current) {
           if (focus && !disabledRef.current) t.focus();
@@ -393,7 +421,7 @@ export const RunnerTerminal = forwardRef<
         return false;
       }
     },
-    [],
+    [ensureWebglRenderer],
   );
 
   useEffect(() => {
@@ -926,32 +954,17 @@ export const RunnerTerminal = forwardRef<
   // attached session mounted, and WKWebView starts evicting old contexts at
   // roughly 16. Active chat splits and mission tabs need at most three.
   //
-  // A genuine GPU context loss disposes the addon immediately so xterm falls
-  // back to its DOM renderer. The next inactive -> active transition runs
-  // this effect again and restores WebGL instead of degrading permanently.
+  // Creation lives in `ensureWebglRenderer` (invoked by
+  // refreshActiveTerminal once the pane is measurable); this effect only
+  // releases the context when the pane leaves the foreground. A genuine
+  // GPU context loss disposes the addon immediately so xterm falls back
+  // to its DOM renderer; the next activation/wake refresh restores WebGL
+  // instead of degrading permanently.
   useEffect(() => {
     if (!active) return;
-    const term = termRef.current;
-    if (!term) return;
-
-    let webgl: WebglAddon | null = null;
-    try {
-      webgl = new WebglAddon();
-      webgl.onContextLoss(() => {
-        webgl?.dispose();
-        if (webglRef.current === webgl) webglRef.current = null;
-      });
-      term.loadAddon(webgl);
-      webglRef.current = webgl;
-    } catch {
-      webgl?.dispose();
-      // No WebGL — xterm keeps its DOM renderer.
-    }
-
     return () => {
-      if (!webgl || webglRef.current !== webgl) return;
+      webglRef.current?.dispose();
       webglRef.current = null;
-      webgl.dispose();
     };
   }, [active]);
 


### PR DESCRIPTION
## What

Two interim fixes for the claude-code scrollback-loss class tracked by #306 (spec `docs/features/42-headless-terminal-model.md`):

1. **Ring purge gates on width change** (`SessionManager::resize`). The purge previously fired on every resize — including the activation dance's rows-1/rows SIGWINCH nudge on every tab return — so the snapshot ring almost never held more than the latest repaint frame, and any remount replayed a single frame (history gone). Reflow depends on cols alone, so rows-only resizes now keep the ring. `last_pty_cols` is seeded from the spawn spec in `install_handle` and updated per resize; width changes purge exactly as before, shells stay exempt.

2. **WebGL renderer attaches only once the pane is measurable** (`RunnerTerminal`). Loading the addon on the bare `active` flip could initialize it against an unsettled layout; when the subsequent fit resolved the same cols/rows, no resize event ever corrected the renderer — the returned tab painted stale until a manual window resize. Creation now lives behind `refreshActiveTerminal`'s active + measurable-rect guard; the `[active]` effect only releases the context on deactivation.

## Why not more

This is deliberately the interim fix. The architectural fix (host-side headless terminal model, serialize-based snapshots, deletion of the purge/clear/dance compensation web) is #306 and is unchanged by this PR. Width-changing resizes (sidebar toggle, window resize) still purge by design.

## Testing

- New regression test `resize_purges_ring_only_on_cols_change` (rows-only nudge keeps ring incl. first post-spawn resize via seed; cols change purges).
- `make test-rust` green (fmt + clippy -D warnings + workspace tests), `tsc --noEmit` + `eslint` clean.
- Manual smoke pending (Jason): long claude chat → tab switches → route away/back → scroll-up shows history; tab return renders correctly without a manual resize.

Refs #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)