### PR TITLE
fix(ui): keep chat and mission surfaces mounted across route changes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,10 +17,8 @@ import { eventMatchesShortcut } from "./lib/keymap";
 import { readAppZoom } from "./lib/settings";
 import Crews from "./pages/Crews";
 import CrewEditor from "./pages/CrewEditor";
-import MissionWorkspace from "./pages/MissionWorkspace";
 import Runners from "./pages/Runners";
 import RunnerDetail from "./pages/RunnerDetail";
-import RunnerChat from "./pages/RunnerChat";
 import SettingsPage from "./pages/SettingsPage";
 
 export default function App() {
@@ -84,8 +82,13 @@ export default function App() {
               <Route path="/crews/:crewId" element={<CrewEditor />} />
               <Route path="/runners" element={<Runners />} />
               <Route path="/runners/:handle" element={<RunnerDetail />} />
-              <Route path="/chats/:sessionId" element={<RunnerChat />} />
-              <Route path="/missions/:id" element={<MissionWorkspace />} />
+              {/* Null elements on purpose: the chat surface and mission
+                  workspace render through AppShell's PersistentSurfaces
+                  layer, which keeps them mounted across route changes so
+                  terminals survive visits to the list pages. The routes
+                  still exist so matching works and `*` doesn't redirect. */}
+              <Route path="/chats/:sessionId" element={null} />
+              <Route path="/missions/:id" element={null} />
               <Route path="*" element={<Navigate to="/runners" replace />} />
             </Route>
             {/* Settings takes over the whole window — its own two-column

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -6,10 +6,15 @@
 // listener — and any event emitted during the brief reattach window
 // (e.g., the activity event from `session_start_direct` triggered on
 // the chat page's mount) gets lost, leaving the SESSION list stale.
+//
+// The chat surface and mission workspace don't render through the Outlet
+// at all: PersistentSurfaces keeps them mounted across route changes so
+// their terminals survive visits to the list pages (see that file).
 
 import { useEffect, useState, type ReactNode } from "react";
 import { Outlet } from "react-router-dom";
 
+import { PersistentSurfaces } from "./PersistentSurfaces";
 import { Sidebar } from "./Sidebar";
 import {
   STORAGE_SIDEBAR_COLLAPSED,
@@ -87,6 +92,7 @@ export function AppShell({ children }: { children?: ReactNode }) {
           className="pointer-events-auto absolute left-0 right-0 top-0 z-10 h-7"
         />
         {children ?? <Outlet />}
+        <PersistentSurfaces />
       </main>
     </div>
   );

--- a/src/components/ChatPaneGroup.tsx
+++ b/src/components/ChatPaneGroup.tsx
@@ -56,6 +56,11 @@ export interface PaneChat {
 }
 
 export interface ChatPaneGroupProps {
+  /** False while the whole chat surface is hidden by the keep-alive host
+   *  (PersistentSurfaces): every pane must go inactive so terminals
+   *  release their WebGL context and stop pushing geometry from a
+   *  display:none rect. The buffers stay; re-show is an active flip. */
+  surfaceVisible: boolean;
   /** The layout to render: the store group when the open chat is a member,
    *  else an ephemeral single-leaf layout for it. */
   layout: PaneLayout;
@@ -92,6 +97,7 @@ export interface ChatPaneGroupProps {
 }
 
 export function ChatPaneGroup({
+  surfaceVisible,
   layout,
   grouped,
   chats,
@@ -348,7 +354,7 @@ export function ChatPaneGroup({
             // While the resume/start loader is up the canvas is hidden, so
             // xterm behaves as inactive (no resize pushes, no focus); when
             // the flag clears, the activation effect fits + repaints.
-            active={visible && !transitional}
+            active={surfaceVisible && visible && !transitional}
             autoFocus={visible && paneLeaf.id === layout.focusedPaneId}
             disabled={dead || transitional}
             onExit={onTerminalExit}

--- a/src/components/PersistentSurfaces.tsx
+++ b/src/components/PersistentSurfaces.tsx
@@ -1,0 +1,73 @@
+// Keep-alive host for the two terminal-bearing surfaces (impl 0018 shell,
+// chat surface + mission workspace).
+//
+// React Router unmounts route elements on navigation, which for these
+// surfaces means disposing every xterm instance and replaying PTY
+// snapshots on return. That cold-remount path has to re-fit geometry
+// mid-layout, and a fit against a not-yet-settled rect pushes wrong cols
+// to the PTY — the agent repaints at ~half width and the ring purge makes
+// that narrow frame the only snapshot content. Rather than hardening the
+// remount path further, the surfaces stay mounted: this host renders the
+// last-visited chat surface and mission workspace as display:none layers
+// while list pages are shown — the same mechanism ChatPaneGroup already
+// uses for hidden panes inside the surface. Returning to a chat or
+// mission is then an `active` flip on a live terminal (the tab-return
+// path) instead of a cold remount.
+//
+// The `visible` prop gates what a hidden surface must not do: report
+// window subjects (impl 0018 ownership), hold global shortcut listeners
+// (both surfaces listen for RUNNER_TERMINAL_CYCLE_EVENT — an ungated
+// hidden listener would double-handle it), and keep terminals `active`
+// (hidden panes release their WebGL context and skip geometry pushes).
+//
+// Retention is bounded: at most one chat surface and one mission
+// workspace, keyed to the last-visited id. Settings is a full-window
+// takeover route outside the AppShell, so a Settings round-trip still
+// remounts — that path keeps the cold-mount hardening from #308.
+
+import { useEffect, useState } from "react";
+import { matchPath, useLocation } from "react-router-dom";
+
+import MissionWorkspace from "../pages/MissionWorkspace";
+import RunnerChat from "../pages/RunnerChat";
+
+export function PersistentSurfaces() {
+  const location = useLocation();
+  const chatId =
+    matchPath("/chats/:sessionId", location.pathname)?.params.sessionId ??
+    null;
+  const missionId =
+    matchPath("/missions/:id", location.pathname)?.params.id ?? null;
+
+  const [lastChatId, setLastChatId] = useState<string | null>(null);
+  const [lastMissionId, setLastMissionId] = useState<string | null>(null);
+  useEffect(() => {
+    if (chatId) setLastChatId(chatId);
+  }, [chatId]);
+  useEffect(() => {
+    if (missionId) setLastMissionId(missionId);
+  }, [missionId]);
+
+  const mountedChatId = chatId ?? lastChatId;
+  const mountedMissionId = missionId ?? lastMissionId;
+
+  // `contents` keeps each page root a direct flex item of AppShell's
+  // <main>, identical to rendering through <Outlet />.
+  return (
+    <>
+      {mountedChatId !== null ? (
+        <div className={chatId !== null ? "contents" : "hidden"}>
+          <RunnerChat sessionId={mountedChatId} visible={chatId !== null} />
+        </div>
+      ) : null}
+      {mountedMissionId !== null ? (
+        <div className={missionId !== null ? "contents" : "hidden"}>
+          <MissionWorkspace
+            missionId={mountedMissionId}
+            visible={missionId !== null}
+          />
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/lib/windowFocus.ts
+++ b/src/lib/windowFocus.ts
@@ -105,29 +105,40 @@ export function reportSubjectsNow(subjects: Subject[]): void {
 }
 
 /**
- * Report `subjects` on mount and clear them (report []) on unmount. Subject
- * pages (MissionWorkspace, RunnerChat) call this; the unmount-clear is what
- * lets the focus map go empty when the user navigates to a non-subject page
- * that doesn't report anything itself. RunnerChat passes one subject per
- * visible pane so a split window owns every session it shows (impl 0020).
+ * Report `subjects` while `enabled` and clear them (report []) when the
+ * reporter is disabled or unmounts. Subject pages (MissionWorkspace,
+ * RunnerChat) call this; the disable/unmount-clear is what lets the focus
+ * map go empty when the user navigates to a non-subject page that doesn't
+ * report anything itself. RunnerChat passes one subject per visible pane so
+ * a split window owns every session it shows (impl 0020).
+ *
+ * `enabled: false` makes the reporter fully inert rather than an active
+ * reporter of []. Both keep-alive surfaces (PersistentSurfaces) stay
+ * mounted and share the module-global last-write-wins debounce above, so a
+ * hidden surface that kept reporting [] would race the newly visible
+ * surface's report and could erase this window's claim (its create-effect
+ * runs after the visible surface's in mount order). Inert means the only
+ * [] report is the cleanup on the visible → hidden flip, which React runs
+ * before the other surface's create-effect in the same commit.
  */
-export function useReportSubjects(subjects: Subject[]): void {
+export function useReportSubjects(subjects: Subject[], enabled = true): void {
   // Key by content, not array identity, so the effect re-fires only on a
   // real subject-set change rather than every render.
   const key = subjects.map((s) => `${s.type}:${s.value}`).join(",");
   useEffect(() => {
+    if (!enabled) return;
     reportSubjects(subjects);
     return () => {
       reportSubjects([]);
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [key]);
+  }, [key, enabled]);
 }
 
 /** Single-subject convenience over `useReportSubjects` for surfaces that
  *  only ever show one subject (MissionWorkspace). */
-export function useReportSubject(subject: Subject | null): void {
-  useReportSubjects(subject ? [subject] : []);
+export function useReportSubject(subject: Subject | null, enabled = true): void {
+  useReportSubjects(subject ? [subject] : [], enabled);
 }
 
 function sameSubject(a: Subject | null, b: Subject | null): boolean {

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -11,7 +11,7 @@
 // snapshot covers bytes emitted before a pane first mounts.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 import { listen } from "@tauri-apps/api/event";
 import {
@@ -116,8 +116,18 @@ function workspaceDimsFromContainer(
   return terminalGridFromElement(container);
 }
 
-export default function MissionWorkspace() {
-  const { id } = useParams<{ id: string }>();
+// Rendered by PersistentSurfaces (not a route element), which passes the
+// route param in and keeps this surface mounted — `visible: false` —
+// while a non-mission route is shown. Hidden, the workspace must not
+// report its window subject, hold global shortcut listeners, or keep the
+// active slot's terminal active; the gates below key off `visible`.
+export default function MissionWorkspace({
+  missionId: id,
+  visible,
+}: {
+  missionId: string;
+  visible: boolean;
+}) {
   const navigate = useNavigate();
   const [mission, setMission] = useState<Mission | null>(null);
   const [crew, setCrew] = useState<Crew | null>(null);
@@ -161,7 +171,10 @@ export default function MissionWorkspace() {
     () => (id ? { type: "Mission", value: id } : null),
     [id],
   );
-  useReportSubject(subject);
+  // Hidden (keep-alive) workspaces report no subject: navigating away
+  // must release this window's claim exactly as unmounting did before
+  // PersistentSurfaces (impl 0018).
+  useReportSubject(visible ? subject : null);
   const { secondary: isSecondary, primaryLabel } = isSecondaryFor(
     focusMap,
     myWindowLabel,
@@ -770,8 +783,12 @@ export default function MissionWorkspace() {
   );
 
   // RunnerTerminal re-dispatches the same event when WKWebView delivers
-  // a mission-tab shortcut straight to xterm.
+  // a mission-tab shortcut straight to xterm. Gated on `visible`: a
+  // hidden keep-alive workspace must not cycle its tabs off keystrokes
+  // meant for the visible surface (the chat surface listens for the
+  // same RUNNER_TERMINAL_CYCLE_EVENT).
   useEffect(() => {
+    if (!visible) return;
     const onKeyDown = (e: KeyboardEvent) => {
       const direction =
         eventMatchesShortcut(e, "mission-tab-previous")
@@ -798,7 +815,7 @@ export default function MissionWorkspace() {
       window.removeEventListener("keydown", onKeyDown, { capture: true });
       window.removeEventListener(RUNNER_TERMINAL_CYCLE_EVENT, onCycle);
     };
-  }, [cycleMissionTab]);
+  }, [visible, cycleMissionTab]);
 
   // Project ask_human → human_question pairings + human_response
   // resolutions out of the feed. Mirrors the router's reconstruct_from_log
@@ -1215,7 +1232,10 @@ export default function MissionWorkspace() {
                     <Pane key={s.id} active={activeTab === s.id}>
                       <SlotPtyPane
                         session={s}
-                        active={activeTab === s.id}
+                        // `visible` gate: a hidden keep-alive workspace
+                        // deactivates even its front tab's terminal so it
+                        // releases WebGL and skips geometry pushes.
+                        active={visible && activeTab === s.id}
                         forcedResuming={resumingAll && !archivingMission}
                         anySessionLive={anySessionLive}
                         onError={setError}

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -171,10 +171,12 @@ export default function MissionWorkspace({
     () => (id ? { type: "Mission", value: id } : null),
     [id],
   );
-  // Hidden (keep-alive) workspaces report no subject: navigating away
-  // must release this window's claim exactly as unmounting did before
-  // PersistentSurfaces (impl 0018).
-  useReportSubject(visible ? subject : null);
+  // Hidden (keep-alive) workspaces are inert reporters — not active
+  // reporters of []. The hide-flip cleanup releases this window's claim
+  // exactly as unmounting did before PersistentSurfaces (impl 0018),
+  // while staying out of the shared debounce that the newly visible
+  // surface is writing its subjects into.
+  useReportSubject(subject, visible);
   const { secondary: isSecondary, primaryLabel } = isSecondaryFor(
     focusMap,
     myWindowLabel,
@@ -1178,7 +1180,10 @@ export default function MissionWorkspace({
                 events={events}
                 resolvedAsks={resolvedAsks}
                 askersByQuestion={askersByQuestion}
-                active={feedActive}
+                // `visible` gate: a hidden keep-alive workspace keeps
+                // feedActive, but the feed must see itself inactive so
+                // the tab-return re-anchor fires on surface return too.
+                active={visible && feedActive}
                 onError={setError}
               />
               {/* Secondary windows can't send input: human_said is

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -10,7 +10,7 @@
 // can't interpret the control sequences these agents emit.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 
 import { listen } from "@tauri-apps/api/event";
 import {
@@ -170,10 +170,18 @@ async function inheritGroupPin(
   }
 }
 
-export default function RunnerChat() {
-  const { sessionId: sessionIdParam } = useParams<{
-    sessionId: string;
-  }>();
+// Rendered by PersistentSurfaces (not a route element), which passes the
+// route param in and keeps this surface mounted — `visible: false` —
+// while a non-chat route is shown. Hidden, the surface must not report
+// window subjects, hold global shortcut listeners, or keep terminals
+// active; every gate below keys off `visible`.
+export default function RunnerChat({
+  sessionId: sessionIdParam,
+  visible,
+}: {
+  sessionId: string;
+  visible: boolean;
+}) {
   const location = useLocation();
   const navigate = useNavigate();
   const activeProject = useActiveProjectScope();
@@ -324,8 +332,14 @@ export default function RunnerChat() {
     sessionId && !paneSessionIds.includes(sessionId)
       ? [sessionId, ...paneSessionIds]
       : paneSessionIds;
+  // Hidden (keep-alive) surfaces report no subjects: navigating to a
+  // list page must release this window's claim exactly as unmounting
+  // did before PersistentSurfaces, or another window could never become
+  // primary for these chats (impl 0018).
   useReportSubjects(
-    subjectIds.map((value) => ({ type: "DirectChat", value }) as Subject),
+    visible
+      ? subjectIds.map((value) => ({ type: "DirectChat", value }) as Subject)
+      : [],
   );
   const secondaryBySession = new Map<string, SecondaryState>(
     subjectIds.map((value) => [
@@ -1034,7 +1048,7 @@ export default function RunnerChat() {
   }, [closePaneById, sessionId]);
 
   useEffect(() => {
-    if (!splitActive) return;
+    if (!visible || !splitActive) return;
     const onKey = (e: KeyboardEvent) => {
       if (!eventMatchesShortcut(e, "close-pane")) return;
       e.preventDefault();
@@ -1044,7 +1058,7 @@ export default function RunnerChat() {
     window.addEventListener("keydown", onKey, { capture: true });
     return () =>
       window.removeEventListener("keydown", onKey, { capture: true });
-  }, [splitActive, closeFocusedPane]);
+  }, [visible, splitActive, closeFocusedPane]);
 
   // Two entry points mirror the sidebar's pattern: a window capture
   // listener for ordinary keystrokes, plus RunnerTerminal's
@@ -1063,7 +1077,7 @@ export default function RunnerChat() {
   );
 
   useEffect(() => {
-    if (!splitActive) return;
+    if (!visible || !splitActive) return;
     const onKey = (e: KeyboardEvent) => {
       const direction =
         eventMatchesShortcut(e, "pane-previous")
@@ -1089,7 +1103,7 @@ export default function RunnerChat() {
       window.removeEventListener("keydown", onKey, { capture: true });
       window.removeEventListener(RUNNER_TERMINAL_CYCLE_EVENT, onCycle);
     };
-  }, [splitActive, cyclePaneFocus]);
+  }, [visible, splitActive, cyclePaneFocus]);
 
   // Stop/resume take a session id: split pane headers control their own
   // session, the topbar controls the URL chat (single) or every visible
@@ -1689,6 +1703,7 @@ export default function RunnerChat() {
           // renders an empty group until the branch above takes over.
           <>
             <ChatPaneGroup
+              surfaceVisible={visible}
               layout={viewLayout}
               grouped={splitActive}
               chats={directSessions}

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -332,14 +332,14 @@ export default function RunnerChat({
     sessionId && !paneSessionIds.includes(sessionId)
       ? [sessionId, ...paneSessionIds]
       : paneSessionIds;
-  // Hidden (keep-alive) surfaces report no subjects: navigating to a
-  // list page must release this window's claim exactly as unmounting
-  // did before PersistentSurfaces, or another window could never become
-  // primary for these chats (impl 0018).
+  // Hidden (keep-alive) surfaces are inert reporters — not active
+  // reporters of []. The hide-flip cleanup releases this window's claim
+  // exactly as unmounting did before PersistentSurfaces (impl 0018),
+  // while staying out of the shared debounce that the newly visible
+  // surface is writing its subjects into.
   useReportSubjects(
-    visible
-      ? subjectIds.map((value) => ({ type: "DirectChat", value }) as Subject)
-      : [],
+    subjectIds.map((value) => ({ type: "DirectChat", value }) as Subject),
+    visible,
   );
   const secondaryBySession = new Map<string, SecondaryState>(
     subjectIds.map((value) => [
@@ -794,15 +794,27 @@ export default function RunnerChat({
   }, [starting, sessionId]);
 
   // Surface non-fatal session warnings (today: agent-resume fallback).
-  // Mounted once per page — only one direct chat is in view at a time,
-  // so we don't need to filter by session id here. Re-subscribing on
-  // every directSessions change would tear down and recreate the
-  // listener constantly during spawn handshakes.
+  // Mounted once for the surface's lifetime — re-subscribing on every
+  // directSessions change would tear down and recreate the listener
+  // constantly during spawn handshakes. This surface stays mounted while
+  // hidden (PersistentSurfaces), so it can no longer assume it is the
+  // only page alive: filter to direct-chat warnings for sessions this
+  // surface shows, or a mission resume fallback captured while hidden
+  // would render later as an unrelated chat banner. The ref keeps the
+  // filter current without re-subscribing.
+  const warningSessionIdsRef = useRef<string[]>([]);
+  useEffect(() => {
+    warningSessionIdsRef.current = subjectIds;
+  });
   useEffect(() => {
     let unlisten: (() => void) | null = null;
     let cancelled = false;
     void (async () => {
       const fn = await listen<WarningEvent>("session/warning", (event) => {
+        if (event.payload.mission_id !== null) return;
+        if (!warningSessionIdsRef.current.includes(event.payload.session_id)) {
+          return;
+        }
         setWarning(event.payload.message);
       });
       if (cancelled) {


### PR DESCRIPTION
## Problem

Returning to a chat after visiting the runner/crew list pages (or a mission showing its feed) left claude-code painted at roughly half the pane width until a manual window resize.

Root cause chain:

1. `/runners`, `/crews`, and `/missions/:id` are separate route elements, so navigating away fully unmounted the chat surface and every xterm in it.
2. On return, the cold remount re-fit the fresh xterm against a not-yet-settled rect and pushed wrong (≈half) cols to the PTY.
3. That cols change tripped #308's cols-gated ring purge, so the agent's SIGWINCH repaint at the narrow width became the only snapshot content — a clean-looking half-width frame, with older wide bytes wrapped into garble above it.
4. The corrective full-width push was swallowed by the resize dedupe/delay interplay, so nothing healed it until a manual OS-window resize.

## Fix

Stop remounting instead of hardening the remount path further. A new `PersistentSurfaces` layer in `AppShell` keeps the last-visited chat surface and mission workspace mounted as `display:none` layers while other routes show — the same mechanism `ChatPaneGroup` already uses for hidden panes inside the surface. Returning to a chat or mission is now an `active` flip on a live terminal (the tab-return path fixed by #308) instead of a cold remount.

The `/chats/:sessionId` and `/missions/:id` routes keep matching but render null; the surfaces take their params as props from the host.

Hidden surfaces are gated off everything a background layer must not do:

- **Window-subject reports (impl 0018):** a hidden surface reports no subjects, so navigating away releases this window's ownership claim exactly as unmounting did.
- **Global shortcut/cycle listeners:** both surfaces listen for `RUNNER_TERMINAL_CYCLE_EVENT`; ungated, a hidden workspace would double-handle keystrokes meant for the visible surface.
- **Terminal `active`:** hidden panes release their WebGL context (WKWebView context budget unchanged) and skip geometry pushes from a `display:none` rect.

Retention is bounded: at most one chat surface + one mission workspace. Settings remains a full-window takeover route outside AppShell, so a Settings round-trip still cold-remounts — that path keeps #308's hardening.

## Verification

- `pnpm exec tsc --noEmit` clean
- `pnpm run lint` clean
- `pnpm run test` — 133/133 pass
- Manual smoke (Jason): chat → Runners/Crews → back keeps full-width TUI; chat → mission feed → back likewise; mission slot tabs still repaint correctly; split panes + ⌘W / pane-cycle shortcuts unaffected on list pages; second window over the same chat/mission still resolves primary/secondary correctly after navigating away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)