### PR TITLE
fix(ui): blank-grid repaint, Settings keep-alive, and sized mission respawns

### DIFF
--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -1142,6 +1142,7 @@ pub(crate) async fn mission_reset_impl(
     state: &AppState,
     app: &tauri::AppHandle,
     id: String,
+    initial_size: Option<(u16, u16)>,
 ) -> Result<Mission> {
     use crate::event_bus::{BusEmitter, TauriBusEvents};
     use crate::router::{
@@ -1355,6 +1356,12 @@ pub(crate) async fn mission_reset_impl(
     // see the analogous block in `mission_start`. See issue #171.
     for (idx, member) in roster.iter().enumerate() {
         let first_turn = first_turns.get(idx).cloned().flatten();
+        // `initial_size` matters beyond first paint: an unsized respawn
+        // forks at 80×24 and seeds the resize purge gate at 80 cols, so
+        // the agent's launch frames land in the ring at 80 cols and the
+        // first slot-tab activation's real-cols push purges them all
+        // (`SessionManager::resize` cols-gate). Sized respawns make that
+        // push a same-width no-op and the opening history survives.
         let register_res = state.sessions.register_mission_session(
             &mission_for_spawn,
             &member.runner,
@@ -1363,7 +1370,7 @@ pub(crate) async fn mission_reset_impl(
             events_log_path.clone(),
             state.db.clone(),
             first_turn,
-            None,
+            initial_size,
         );
         match register_res {
             Ok(pending) => {
@@ -1478,8 +1485,13 @@ pub async fn mission_reset(
     state: State<'_, AppState>,
     app: tauri::AppHandle,
     id: String,
+    initial_cols: Option<u16>,
+    initial_rows: Option<u16>,
 ) -> Result<Mission> {
-    mission_reset_impl(&state, &app, id).await
+    let initial_size = initial_cols
+        .zip(initial_rows)
+        .filter(|(cols, rows)| *cols > 0 && *rows > 0);
+    mission_reset_impl(&state, &app, id, initial_size).await
 }
 
 /// Terminal end-of-mission. Kills every live PTY, writes the

--- a/src-tauri/src/mcp/tools/mission.rs
+++ b/src-tauri/src/mcp/tools/mission.rs
@@ -515,7 +515,9 @@ impl RunnerMcpHandler {
         Parameters(MissionIdArgs { id }): Parameters<MissionIdArgs>,
     ) -> Result<CallToolResult, ErrorData> {
         let app_state = self.state.app_state();
-        let mission = mission::mission_reset_impl(&app_state, &self.state.app_handle, id)
+        // Headless caller — no workspace to measure, so the respawned
+        // PTYs take the 80×24 default (same as before sizing existed).
+        let mission = mission::mission_reset_impl(&app_state, &self.state.app_handle, id, None)
             .await
             .map_err(mcp_error)?;
         emit_mission_changed(self);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,6 @@ import Crews from "./pages/Crews";
 import CrewEditor from "./pages/CrewEditor";
 import Runners from "./pages/Runners";
 import RunnerDetail from "./pages/RunnerDetail";
-import SettingsPage from "./pages/SettingsPage";
 
 export default function App() {
   // Tell the backend the first frame has painted so it can show + focus the
@@ -89,11 +88,16 @@ export default function App() {
                   still exist so matching works and `*` doesn't redirect. */}
               <Route path="/chats/:sessionId" element={null} />
               <Route path="/missions/:id" element={null} />
+              {/* Settings takes over the whole window (impl 0025) but
+                  renders through AppShell's takeover layer, not the
+                  Outlet: routing it outside AppShell unmounted the
+                  shell — and with it PersistentSurfaces — so every
+                  Settings round-trip cold-remounted the terminals
+                  (the half-width-repaint path #309 closed for list
+                  pages). */}
+              <Route path="/settings/:pane?" element={null} />
               <Route path="*" element={<Navigate to="/runners" replace />} />
             </Route>
-            {/* Settings takes over the whole window — its own two-column
-                surface without the app Sidebar (impl 0025). */}
-            <Route path="/settings/:pane?" element={<SettingsPage />} />
           </Routes>
         </BrowserRouter>
       </ToastProvider>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -10,12 +10,20 @@
 // The chat surface and mission workspace don't render through the Outlet
 // at all: PersistentSurfaces keeps them mounted across route changes so
 // their terminals survive visits to the list pages (see that file).
+//
+// Settings (impl 0025) is a full-window takeover without the app
+// Sidebar, but it must not unmount the shell: PersistentSurfaces lives
+// in <main>, and unmounting it cold-remounts every terminal — the
+// half-width-repaint path #309 removed for list pages. The chrome
+// hides (display:none, subtree retained) under a Settings layer
+// instead, and returning is the same active-flip the list pages use.
 
 import { useEffect, useState, type ReactNode } from "react";
-import { Outlet } from "react-router-dom";
+import { matchPath, Outlet, useLocation } from "react-router-dom";
 
 import { PersistentSurfaces } from "./PersistentSurfaces";
 import { Sidebar } from "./Sidebar";
+import SettingsPage from "../pages/SettingsPage";
 import {
   STORAGE_SIDEBAR_COLLAPSED,
   readStoredBool,
@@ -26,6 +34,9 @@ import { eventMatchesShortcut } from "../lib/keymap";
 const SIDEBAR_TOGGLE_EVENT = "runner:toggle-sidebar";
 
 export function AppShell({ children }: { children?: ReactNode }) {
+  const location = useLocation();
+  const settingsActive =
+    matchPath("/settings/:pane?", location.pathname) != null;
   // Sidebar collapsed/expanded lives at the shell so Cmd+S can toggle
   // it from anywhere in the app, not just when the sidebar is the
   // focused subtree.
@@ -46,15 +57,19 @@ export function AppShell({ children }: { children?: ReactNode }) {
     if (!collapsed) setSidebarPreviewOpen(false);
   }, [collapsed]);
 
+  // Both toggle listeners go inert while Settings covers the window —
+  // the hidden chrome must not flip state the user can't see.
   useEffect(() => {
+    if (settingsActive) return;
     const onToggle = () => setCollapsed((prev) => !prev);
     window.addEventListener(SIDEBAR_TOGGLE_EVENT, onToggle);
     return () => window.removeEventListener(SIDEBAR_TOGGLE_EVENT, onToggle);
-  }, []);
+  }, [settingsActive]);
 
   // Skip real text fields, but let xterm's hidden textarea through so
   // terminal focus doesn't swallow the app-level shortcut.
   useEffect(() => {
+    if (settingsActive) return;
     const onKey = (e: KeyboardEvent) => {
       if (!eventMatchesShortcut(e, "toggle-sidebar")) return;
       const target = e.target as HTMLElement | null;
@@ -69,31 +84,41 @@ export function AppShell({ children }: { children?: ReactNode }) {
     };
     window.addEventListener("keydown", onKey, { capture: true });
     return () => window.removeEventListener("keydown", onKey, { capture: true });
-  }, []);
+  }, [settingsActive]);
 
   return (
     <div className="relative flex h-screen overflow-hidden bg-bg text-fg">
-      {collapsed ? (
-        <div
-          aria-hidden
-          onMouseEnter={() => setSidebarPreviewOpen(true)}
-          className="absolute left-0 top-0 z-30 h-full w-4"
+      {/* `contents` keeps Sidebar and <main> direct flex items; `hidden`
+          swaps to display:none under the Settings takeover without
+          unmounting the subtree (terminals keep their buffers). */}
+      <div className={settingsActive ? "hidden" : "contents"}>
+        {collapsed ? (
+          <div
+            aria-hidden
+            onMouseEnter={() => setSidebarPreviewOpen(true)}
+            className="absolute left-0 top-0 z-30 h-full w-4"
+          />
+        ) : null}
+        <Sidebar
+          collapsed={collapsed}
+          onCollapsedChange={setCollapsed}
+          previewOpen={sidebarPreviewOpen}
+          onPreviewOpenChange={setSidebarPreviewOpen}
         />
+        <main className="relative flex flex-1 flex-col overflow-hidden">
+          <div
+            data-tauri-drag-region
+            className="pointer-events-auto absolute left-0 right-0 top-0 z-10 h-7"
+          />
+          {children ?? <Outlet />}
+          <PersistentSurfaces />
+        </main>
+      </div>
+      {settingsActive ? (
+        <div className="absolute inset-0 z-40">
+          <SettingsPage />
+        </div>
       ) : null}
-      <Sidebar
-        collapsed={collapsed}
-        onCollapsedChange={setCollapsed}
-        previewOpen={sidebarPreviewOpen}
-        onPreviewOpenChange={setSidebarPreviewOpen}
-      />
-      <main className="relative flex flex-1 flex-col overflow-hidden">
-        <div
-          data-tauri-drag-region
-          className="pointer-events-auto absolute left-0 right-0 top-0 z-10 h-7"
-        />
-        {children ?? <Outlet />}
-        <PersistentSurfaces />
-      </main>
     </div>
   );
 }

--- a/src/components/PersistentSurfaces.tsx
+++ b/src/components/PersistentSurfaces.tsx
@@ -22,8 +22,9 @@
 //
 // Retention is bounded: at most one chat surface and one mission
 // workspace, keyed to the last-visited id. Settings is a full-window
-// takeover route outside the AppShell, so a Settings round-trip still
-// remounts — that path keeps the cold-mount hardening from #308.
+// takeover but renders through AppShell's takeover layer (this host
+// stays mounted underneath), so a Settings round-trip is the same
+// hide/show flip as a list-page visit.
 
 import { useEffect, useState } from "react";
 import { matchPath, useLocation } from "react-router-dom";

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -14,6 +14,7 @@ import {
   useEffect,
   useImperativeHandle,
   useRef,
+  useState,
 } from "react";
 
 import { listen } from "@tauri-apps/api/event";
@@ -40,6 +41,10 @@ import {
   STORAGE_TERMINAL_SCROLLBACK,
   STORAGE_TERMINAL_THEME,
 } from "../lib/settings";
+import {
+  blankDanceDecision,
+  createBlankRecheckGate,
+} from "../lib/terminalBlank";
 import {
   shouldDelayTerminalResize,
   type TerminalGridSize,
@@ -238,6 +243,18 @@ export const RunnerTerminal = forwardRef<
   // clear those cells first or Codex can repaint text without the
   // gray input background.
   const replayJustDrainedRef = useRef(false);
+  // Live writes still queued in xterm's async write buffer. The
+  // blank-grid dance check (#312) reads the parsed buffer
+  // synchronously, so bytes in this window are invisible to it — a
+  // pane whose repaint is queued would misread as blank and dance,
+  // defeating the transitional latch. While writes are pending,
+  // blank-driven dances defer; the gate coalesces however many defer
+  // observations into ONE recheck when the queue drains (see
+  // createBlankRecheckGate). The gate tracks the terminal, not the
+  // session: writes from a previous session flush into the same xterm
+  // instance, so the write count deliberately survives session swaps —
+  // only the recheck request is cancelled there.
+  const [blankGate] = useState(createBlankRecheckGate);
 
   // Keep the latest sessionId visible to the data/resize callbacks without
   // re-creating the terminal on prop change. The session listener below
@@ -359,7 +376,38 @@ export const RunnerTerminal = forwardRef<
         if (!sid) return true;
         const cols = t.cols;
         const rows = t.rows;
-        if (!forceResizeDance) {
+        // Blank grid must dance (#312). A running session behind an
+        // empty grid has nothing to lose to a forced repaint and no
+        // other way to gain content: the plain push below dedupes
+        // against lastPushed, and even a sent same-size TIOCSWINSZ is
+        // a kernel no-op — so without the dance nothing ever asks the
+        // agent to paint. The transitional latch exists to protect
+        // retained content from a double repaint; a blank grid has
+        // none, so the latch's guarantee is untouched for non-blank
+        // panes (evaluated fresh on every retry — content that
+        // arrived in between keeps the plain-push path). A blank read
+        // taken while live bytes sit unparsed in xterm's async write
+        // queue is stale — the queued bytes may BE the repaint — so
+        // that case defers: plain push now, re-check after the queue
+        // flushes.
+        let mustDance = forceResizeDance;
+        if (!mustDance) {
+          const decision = blankDanceDecision(t, blankGate.pendingWrites());
+          if (decision === "dance") {
+            mustDance = true;
+            console.info(
+              `[terminal] blank-dance session=${sid} cols=${cols} rows=${rows} ` +
+                `lastPushed=${lastPushedColsRef.current}x${lastPushedRowsRef.current}`,
+            );
+          } else if (decision === "defer") {
+            console.info(
+              `[terminal] blank-dance-defer session=${sid} ` +
+                `pendingWrites=${blankGate.pendingWrites()}`,
+            );
+            blankGate.requestRecheck();
+          }
+        }
+        if (!mustDance) {
           if (
             cols === lastPushedColsRef.current &&
             rows === lastPushedRowsRef.current
@@ -421,7 +469,7 @@ export const RunnerTerminal = forwardRef<
         return false;
       }
     },
-    [ensureWebglRenderer],
+    [ensureWebglRenderer, blankGate],
   );
 
   useEffect(() => {
@@ -984,12 +1032,31 @@ export const RunnerTerminal = forwardRef<
     replayDoneRef.current = false;
     replayFlushPendingRef.current = false;
     replayAfterFlushRef.current = [];
+    // The gate's write count is NOT reset: queued writes from the
+    // previous session still flush into this same xterm instance and
+    // decrement it. Only the deferred recheck request is stale.
+    blankGate.cancelRecheck();
     pendingLiveOverflowRef.current = false;
     snapshotRefreshPendingRef.current = false;
     replayJustDrainedRef.current = false;
 
     const writeOutput = (ev: OutputEvent) => {
-      termRef.current?.write(decodeBase64Chunk(ev.data));
+      const t = termRef.current;
+      if (!t) return;
+      // Counted so the blank-dance check can tell "settled blank grid"
+      // from "repaint still queued in xterm's async parser" — see
+      // blankGate. The write callback fires after the chunk is parsed
+      // into the buffer; when the queue drains, at most one deferred
+      // recheck runs against the settled content. Fixed opts: defer
+      // only ever replaces a plain backend push (a forced dance never
+      // defers), and the original pass already applied its focus.
+      blankGate.beginWrite();
+      t.write(decodeBase64Chunk(ev.data), () => {
+        if (!blankGate.endWrite()) return;
+        window.requestAnimationFrame(() => {
+          refreshActiveTerminal({ pushBackendSize: true });
+        });
+      });
     };
 
     // Replay drains only when (a) the snapshot RPC has returned,
@@ -1147,10 +1214,11 @@ export const RunnerTerminal = forwardRef<
       cancelled = true;
       tryDrainReplayRef.current = null;
       replayAfterFlushRef.current = [];
+      blankGate.cancelRecheck();
       unlistenOutput?.();
       unlistenExit?.();
     };
-  }, [sessionId, refreshActiveTerminal]);
+  }, [sessionId, refreshActiveTerminal, blankGate]);
 
   // Latch WHY this terminal is inactive. `active=false` with
   // `disabled=true` is the transitional resume/start window — the canvas

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -254,6 +254,10 @@ export function Sidebar({
 }: SidebarProps) {
   const navigate = useNavigate();
   const location = useLocation();
+  // Settings takeover (see AppShell): the sidebar stays mounted but
+  // hidden while `/settings` is shown, so its global shortcuts must go
+  // inert — Cmd+T here would spawn a chat under the takeover.
+  const settingsActive = location.pathname.startsWith("/settings");
   const tabDragSensors = useSensors(
     useSensor(PointerSensor, {
       activationConstraint: { distance: 5 },
@@ -652,6 +656,7 @@ export function Sidebar({
   // app's point of view, so Meta shortcuts still win there; Ctrl
   // shortcuts stay with the PTY/TUI.
   useEffect(() => {
+    if (settingsActive) return;
     const onKey = (e: KeyboardEvent) => {
       const target = e.target as HTMLElement | null;
       const tag = target?.tagName?.toLowerCase();
@@ -679,9 +684,10 @@ export function Sidebar({
     };
     window.addEventListener("keydown", onKey, { capture: true });
     return () => window.removeEventListener("keydown", onKey, { capture: true });
-  }, [activeProjectId]);
+  }, [activeProjectId, settingsActive]);
 
   useEffect(() => {
+    if (settingsActive) return;
     const onKey = (e: KeyboardEvent) => {
       const direction = sidebarNavigationDirectionFromKey(e);
       if (!direction) return;
@@ -715,7 +721,7 @@ export function Sidebar({
       window.removeEventListener("keydown", onKey, { capture: true });
       window.removeEventListener(SIDEBAR_NAVIGATE_EVENT, onNavigate);
     };
-  }, [navigateSidebarPage]);
+  }, [navigateSidebarPage, settingsActive]);
 
   useEffect(() => {
     let unlistenEvents: (() => void) | null = null;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -246,7 +246,20 @@ export const api = {
     /** Wipe the run context and respawn every slot. Mostly for
      *  testing — keeps the mission row, crew, and slots intact;
      *  drops the event log, agent session keys, and router state. */
-    reset: (id: string) => invoke<Mission>("mission_reset", { id }),
+    /** Wipe the run and respawn every slot. `initialSize` forks the
+     *  fresh PTYs at the workspace's real grid — unsized respawns
+     *  land at 80×24, and the first slot-tab activation's real-cols
+     *  push purges the ring (cols-gate), dropping the agents' opening
+     *  output. */
+    reset: (
+      id: string,
+      initialSize?: { cols: number; rows: number } | null,
+    ) =>
+      invoke<Mission>("mission_reset", {
+        id,
+        initialCols: initialSize?.cols ?? null,
+        initialRows: initialSize?.rows ?? null,
+      }),
     /** Toggle a mission's pin. Pinned missions float to the top of
      *  the sidebar's MISSION list. */
     pin: (id: string, pinned: boolean) =>

--- a/src/lib/terminalBlank.test.ts
+++ b/src/lib/terminalBlank.test.ts
@@ -1,0 +1,183 @@
+/** @vitest-environment jsdom */
+
+// terminalGridIsBlank + blankDanceDecision (#312): the "blank grid
+// must dance" predicate and its escalation decision. Runs against a
+// real xterm Terminal (unopened — buffer + parser work without a DOM
+// attach) so the tests cover the actual buffer semantics:
+// translateToString trimming, alt-screen buffers, the scrollback
+// shortcut, and the async write queue behind the defer decision.
+
+import type { Terminal as XtermTerminal } from "@xterm/xterm";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+
+import {
+  blankDanceDecision,
+  createBlankRecheckGate,
+  terminalGridIsBlank,
+} from "./terminalBlank";
+
+// jsdom has no canvas: xterm's color helpers probe
+// HTMLCanvasElement.getContext at module load and jsdom logs a noisy
+// (harmless) "Not implemented" error per run. Stub the probe before
+// xterm evaluates — it takes the same fallback as a failed probe,
+// minus the stderr noise. Hence the dynamic import; the type-only
+// import above is erased at compile time and loads nothing.
+let Terminal: typeof XtermTerminal;
+beforeAll(async () => {
+  HTMLCanvasElement.prototype.getContext = (() => null) as never;
+  ({ Terminal } = await import("@xterm/xterm"));
+});
+
+const write = (t: XtermTerminal, data: string) =>
+  new Promise<void>((resolve) => t.write(data, resolve));
+
+let term: XtermTerminal | undefined;
+const makeTerm = () => {
+  term = new Terminal({ cols: 80, rows: 24, allowProposedApi: true });
+  return term;
+};
+afterEach(() => {
+  term?.dispose();
+  term = undefined;
+});
+
+describe("terminalGridIsBlank", () => {
+  it("is blank after construction", () => {
+    expect(terminalGridIsBlank(makeTerm())).toBe(true);
+  });
+
+  it("is blank after reset with zero bytes replayed", async () => {
+    const t = makeTerm();
+    await write(t, "some prior frame");
+    t.reset();
+    expect(terminalGridIsBlank(t)).toBe(true);
+  });
+
+  it("is not blank once any glyph is on the grid", async () => {
+    const t = makeTerm();
+    await write(t, "x");
+    expect(terminalGridIsBlank(t)).toBe(false);
+  });
+
+  it("treats cursor-movement-only output as blank", async () => {
+    const t = makeTerm();
+    // Home + move around, no printable glyphs — visually still empty.
+    await write(t, "\x1b[H\x1b[10;10H");
+    expect(terminalGridIsBlank(t)).toBe(true);
+  });
+
+  it("sees content painted on the alt screen", async () => {
+    const t = makeTerm();
+    await write(t, "\x1b[?1049h");
+    expect(terminalGridIsBlank(t)).toBe(true);
+    await write(t, "\x1b[2;4HTUI frame");
+    expect(terminalGridIsBlank(t)).toBe(false);
+  });
+
+  it("counts scrollback as content even when the viewport is clear", async () => {
+    const t = makeTerm();
+    // Fill past the viewport so lines rotate into scrollback, then
+    // erase the visible region — retained history means the pane is
+    // NOT blank, and the transitional latch keeps its guarantee.
+    await write(t, Array.from({ length: 30 }, (_, i) => `line ${i}`).join("\r\n"));
+    await write(t, "\x1b[2J\x1b[H");
+    expect(terminalGridIsBlank(t)).toBe(false);
+  });
+});
+
+describe("blankDanceDecision", () => {
+  it("dances on a settled blank grid", () => {
+    expect(blankDanceDecision(makeTerm(), 0)).toBe("dance");
+  });
+
+  it("defers while live bytes are queued but unparsed", async () => {
+    const t = makeTerm();
+    // NOT awaited — xterm parses asynchronously, so the buffer still
+    // reads blank right after write() returns. This is the queued-
+    // output race: without the pending-write count the stale read
+    // would dance over an incoming repaint, defeating the
+    // transitional latch's double-repaint guard.
+    const flushed = write(t, "x");
+    expect(terminalGridIsBlank(t)).toBe(true);
+    expect(blankDanceDecision(t, 1)).toBe("defer");
+    // After the flush the deferred re-check must see the content and
+    // fall back to the plain-push path.
+    await flushed;
+    expect(blankDanceDecision(t, 0)).toBe("none");
+  });
+
+  it("does not dance once the grid holds content", async () => {
+    const t = makeTerm();
+    await write(t, "x");
+    expect(blankDanceDecision(t, 0)).toBe("none");
+  });
+
+  it("still dances after a flush that parsed no visible glyphs", async () => {
+    const t = makeTerm();
+    // Control-only bytes (cursor moves) flush without painting — the
+    // re-check after flush must escalate, not stall forever.
+    await write(t, "\x1b[H\x1b[5;5H");
+    expect(blankDanceDecision(t, 0)).toBe("dance");
+  });
+});
+
+describe("createBlankRecheckGate", () => {
+  it("coalesces two defers across a control-only flush into one dancing recheck", async () => {
+    // The reviewer scenario: overlapping refresh passes (an ordinary
+    // wake invokes its refit twice) each observe blank+pending against
+    // the SAME in-flight write. The gate must yield exactly one
+    // recheck at flush — not one dance per observation. Mirrors
+    // writeOutput's production shape: beginWrite before t.write,
+    // endWrite in its parse callback.
+    const t = makeTerm();
+    const gate = createBlankRecheckGate();
+    let rechecks = 0;
+    const flushed = new Promise<void>((resolve) => {
+      gate.beginWrite();
+      t.write("\x1b[H\x1b[5;5H", () => {
+        if (gate.endWrite()) rechecks += 1;
+        resolve();
+      });
+    });
+    expect(blankDanceDecision(t, gate.pendingWrites())).toBe("defer");
+    gate.requestRecheck();
+    expect(blankDanceDecision(t, gate.pendingWrites())).toBe("defer");
+    gate.requestRecheck();
+    await flushed;
+    expect(rechecks).toBe(1);
+    // The single recheck sees a settled, still-blank grid: one dance.
+    expect(blankDanceDecision(t, gate.pendingWrites())).toBe("dance");
+  });
+
+  it("rechecks only once the queue fully drains", () => {
+    const gate = createBlankRecheckGate();
+    gate.beginWrite();
+    gate.beginWrite();
+    gate.requestRecheck();
+    expect(gate.endWrite()).toBe(false);
+    expect(gate.endWrite()).toBe(true);
+  });
+
+  it("does not recheck without a request", () => {
+    const gate = createBlankRecheckGate();
+    gate.beginWrite();
+    expect(gate.endWrite()).toBe(false);
+  });
+
+  it("a flush consumes the request — the next flush is quiet", () => {
+    const gate = createBlankRecheckGate();
+    gate.beginWrite();
+    gate.requestRecheck();
+    expect(gate.endWrite()).toBe(true);
+    gate.beginWrite();
+    expect(gate.endWrite()).toBe(false);
+  });
+
+  it("cancelRecheck drops a stale request (session swap)", () => {
+    const gate = createBlankRecheckGate();
+    gate.beginWrite();
+    gate.requestRecheck();
+    gate.cancelRecheck();
+    expect(gate.endWrite()).toBe(false);
+  });
+});

--- a/src/lib/terminalBlank.ts
+++ b/src/lib/terminalBlank.ts
@@ -1,0 +1,89 @@
+import type { Terminal } from "@xterm/xterm";
+
+/**
+ * True when xterm holds no visible content at all — no glyphs in the
+ * viewport and no scrollback. This is the signature of a replayed
+ * empty output ring (`t.reset()` + zero bytes, e.g. a session stopped
+ * before the last app launch): only the agent's own SIGWINCH-driven
+ * repaint can paint such a pane, so a refresh on a running session
+ * must run the resize dance even when the transitional latch or the
+ * last-pushed dedupe would normally suppress it (#312).
+ */
+export function terminalGridIsBlank(t: Terminal): boolean {
+  const buf = t.buffer.active;
+  // Scrollback implies painted content; only scan viewport-sized buffers.
+  if (buf.length > t.rows) return false;
+  for (let y = 0; y < buf.length; y += 1) {
+    const line = buf.getLine(y);
+    if (line && line.translateToString(true).trim().length > 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * Should a plain backend-size push escalate to the resize dance?
+ *
+ * - `"dance"`: the grid is blank and settled — nothing but the agent's
+ *   SIGWINCH repaint can paint it, so force the dance.
+ * - `"defer"`: the grid reads blank but live bytes are queued in
+ *   xterm's write buffer and not yet parsed — `write()` is async, so a
+ *   synchronous buffer read can't see them. The queued bytes may BE
+ *   the repaint; dancing now would double-SIGWINCH a pane that is
+ *   about to hold content, exactly what the transitional latch guards
+ *   against. The caller must re-check after the queue flushes.
+ * - `"none"`: the grid holds content — keep the plain-push path and
+ *   the latch's guarantee untouched.
+ */
+export function blankDanceDecision(
+  t: Terminal,
+  pendingLiveWrites: number,
+): "dance" | "defer" | "none" {
+  if (!terminalGridIsBlank(t)) return "none";
+  return pendingLiveWrites > 0 ? "defer" : "dance";
+}
+
+/**
+ * Per-terminal bookkeeping behind the `"defer"` decision: counts live
+ * writes queued in xterm's async parser and coalesces any number of
+ * deferred blank rechecks into exactly ONE when the queue drains.
+ *
+ * Coalescing is the point — overlapping refresh passes (an ordinary
+ * wake invokes its refit twice; activation and the ResizeObserver
+ * retry can overlap too) may each observe blank+pending against the
+ * SAME in-flight write. If every observation queued its own recheck,
+ * a flush that parsed only control bytes (grid still blank) would run
+ * them all and each would dance — duplicate SIGWINCHes, the exact
+ * risk the defer exists to prevent.
+ */
+export function createBlankRecheckGate() {
+  let pendingWrites = 0;
+  let recheckPending = false;
+  return {
+    pendingWrites() {
+      return pendingWrites;
+    },
+    beginWrite() {
+      pendingWrites += 1;
+    },
+    /**
+     * Returns true exactly when this write drained the queue AND a
+     * recheck was requested since the last flush — the caller runs
+     * one recheck.
+     */
+    endWrite() {
+      pendingWrites -= 1;
+      if (pendingWrites > 0 || !recheckPending) return false;
+      recheckPending = false;
+      return true;
+    },
+    requestRecheck() {
+      recheckPending = true;
+    },
+    /** Drop a stale request (session swap / listener teardown). */
+    cancelRecheck() {
+      recheckPending = false;
+    },
+  };
+}

--- a/src/lib/terminalSizing.test.ts
+++ b/src/lib/terminalSizing.test.ts
@@ -1,0 +1,74 @@
+/** @vitest-environment jsdom */
+
+// pickRespawnDims: the freshness priority behind mission-wide respawn
+// sizing (reset / resume-all). The load-bearing property is the ORDER —
+// a hidden terminal's measure() returns cached cols that go stale after
+// any rail/sidebar/window width change, and a stale-cols respawn
+// re-arms the ring purge the sized respawn exists to prevent. The
+// cache must therefore lose to every fresh source and never be read
+// when a fresh source measures.
+
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { TerminalGridSize } from "./terminalSizing";
+
+// terminalSizing imports @xterm/xterm at module level; jsdom has no
+// canvas, so stub the probe before the module evaluates (same pattern
+// as terminalBlank.test.ts).
+let pickRespawnDims: typeof import("./terminalSizing").pickRespawnDims;
+beforeAll(async () => {
+  HTMLCanvasElement.prototype.getContext = (() => null) as never;
+  ({ pickRespawnDims } = await import("./terminalSizing"));
+});
+
+const dims = (cols: number): TerminalGridSize => ({ cols, rows: 40 });
+
+describe("pickRespawnDims", () => {
+  it("prefers the active slot's fresh fit over everything", () => {
+    const probe = vi.fn(() => dims(150));
+    const cache = vi.fn(() => dims(120));
+    expect(
+      pickRespawnDims({
+        measureActiveSlot: () => dims(170),
+        probeContainer: probe,
+        readHiddenCache: cache,
+      }),
+    ).toEqual(dims(170));
+    expect(probe).not.toHaveBeenCalled();
+    expect(cache).not.toHaveBeenCalled();
+  });
+
+  it("prefers the container probe over a stale hidden cache", () => {
+    // Feed tab active after a layout change: the probe reads the
+    // CURRENT rect, the hidden cache still holds pre-change cols.
+    const cache = vi.fn(() => dims(120));
+    expect(
+      pickRespawnDims({
+        measureActiveSlot: () => null,
+        probeContainer: () => dims(150),
+        readHiddenCache: cache,
+      }),
+    ).toEqual(dims(150));
+    expect(cache).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the hidden cache only when nothing else measures", () => {
+    expect(
+      pickRespawnDims({
+        measureActiveSlot: () => null,
+        probeContainer: () => null,
+        readHiddenCache: () => dims(120),
+      }),
+    ).toEqual(dims(120));
+  });
+
+  it("returns null when no source measures", () => {
+    expect(
+      pickRespawnDims({
+        measureActiveSlot: () => null,
+        probeContainer: () => null,
+        readHiddenCache: () => null,
+      }),
+    ).toBeNull();
+  });
+});

--- a/src/lib/terminalSizing.ts
+++ b/src/lib/terminalSizing.ts
@@ -73,6 +73,35 @@ export function terminalGridFromElement(
   return terminalGridFromPixels(rect.width, rect.height, framePaddingPx);
 }
 
+/**
+ * Source priority for the dims passed to a mission-wide respawn
+ * (reset / resume-all). Freshness beats availability:
+ *
+ *   1. The active slot tab's terminal — its pane is visible, so
+ *      `measure()` runs a real fit against the current layout.
+ *   2. The pane-container probe — reads the container's CURRENT rect
+ *      (covers the feed tab, where no slot terminal is visible).
+ *   3. A hidden terminal's cached last-fit dims. display:none panes
+ *      can't fit, so `measure()` returns whatever cols the pane had
+ *      when it was last visible — stale after any rail/sidebar/window
+ *      width change, and respawning at stale cols re-arms the ring
+ *      purge the sized respawn exists to prevent. Last resort only.
+ *
+ * Sources are thunks so losing tiers aren't computed (the container
+ * probe opens a throwaway xterm).
+ */
+export function pickRespawnDims(sources: {
+  measureActiveSlot: () => TerminalGridSize | null;
+  probeContainer: () => TerminalGridSize | null;
+  readHiddenCache: () => TerminalGridSize | null;
+}): TerminalGridSize | null {
+  return (
+    sources.measureActiveSlot() ??
+    sources.probeContainer() ??
+    sources.readHiddenCache()
+  );
+}
+
 export function estimateMissionTerminalGrid(): TerminalGridSize | null {
   const main = document.querySelector("main");
   const rect = main?.getBoundingClientRect();

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -71,7 +71,11 @@ import {
   isFreshSpawn,
   snapshotIndicatesTuiReady,
 } from "../lib/sessionLifecycle";
-import { terminalGridFromElement } from "../lib/terminalSizing";
+import {
+  pickRespawnDims,
+  terminalGridFromElement,
+  type TerminalGridSize,
+} from "../lib/terminalSizing";
 import { useDelayedFlag } from "../lib/useDelayedFlag";
 import { useResizableWidth } from "../hooks/useResizableWidth";
 import { useTerminalBg } from "../lib/useTerminalBg";
@@ -573,6 +577,35 @@ export default function MissionWorkspace({
     }
   }, [mission, navigate]);
 
+  // Shared cols/rows source for the respawn paths (reset + resume).
+  // Every slot pane shares the same container rect, so ONE current
+  // measurement serves every slot. Priority lives in
+  // `pickRespawnDims`: the active slot fits fresh, the container
+  // probe reads the current rect, and a hidden terminal's cached
+  // dims — stale after any rail/sidebar/window width change, which
+  // would re-arm the ring purge — are the last resort only.
+  const measureSlotDims = useCallback(
+    (): TerminalGridSize | null =>
+      pickRespawnDims({
+        measureActiveSlot: () =>
+          activeTab !== "feed"
+            ? (terminalsRef.current.get(activeTab)?.measure() ?? null)
+            : null,
+        probeContainer: () =>
+          paneContainerRef.current
+            ? workspaceDimsFromContainer(paneContainerRef.current)
+            : null,
+        readHiddenCache: () => {
+          for (const s of sessions) {
+            const d = terminalsRef.current.get(s.id)?.measure();
+            if (d) return d;
+          }
+          return null;
+        },
+      }),
+    [activeTab, sessions],
+  );
+
   // Reset = wipe the run, respawn slots, keep the mission row. Used
   // for testing — you get the same mission back with a clean event
   // log and fresh PTYs. Confirmed via a modal (`MissionResetConfirm`)
@@ -581,7 +614,11 @@ export default function MissionWorkspace({
   const resetMission = useCallback(async () => {
     if (!mission) return;
     try {
-      const next = await api.mission.reset(mission.id);
+      // Sized respawn: an unsized reset forks PTYs at 80×24 and seeds
+      // the ring purge gate at 80 cols, so the first slot-tab
+      // activation's real-cols push purges the agents' opening output
+      // (see api.mission.reset).
+      const next = await api.mission.reset(mission.id, measureSlotDims());
       setMission(next);
       // Refresh sessions + events. The reset path archives the old
       // session rows and inserts fresh ones, so session_list returns
@@ -610,7 +647,7 @@ export default function MissionWorkspace({
     } catch (e) {
       setError(String(e));
     }
-  }, [mission, setResetConfirmOpen]);
+  }, [mission, setResetConfirmOpen, measureSlotDims]);
 
   // Resume all = iterate stopped/crashed sessions and respawn each.
   // Hits the same `session_resume` path the per-slot Resume button
@@ -621,46 +658,27 @@ export default function MissionWorkspace({
     setResumingAll(true);
     let firstErr: string | null = null;
     try {
-      // Pre-walk for a shared fallback dim. Hidden tabs (display:none
-      // Pane wrappers) have 0×0 rects so their `measure()` may return
-      // null; without a fallback the resume RPC sends (null, null),
+      // ONE current measurement for every stopped slot (see
+      // `measureSlotDims` for the freshness priority). All panes share
+      // the container grid, and a hidden slot's own `measure()` only
+      // returns cached — possibly stale — dims, so per-slot
+      // measurement would just reintroduce the stale-cols respawn.
+      // Without any dims the resume RPC sends (null, null), the
       // backend spawns at 80×24, and the agent paints its `--resume`
-      // conversation history at 80 cols. For main-screen TUIs those
-      // hard-wrapped narrow lines stick in scrollback. Three-tier
-      // fallback:
-      //   1. The clicked-from tab's own `measure()` (always works when
-      //      a slot tab is active).
-      //   2. Any other slot terminal that has been activated before
-      //      and remembers its last-fit dims (every Pane shares the
-      //      same container rect, so any one's dims work for all).
-      //   3. A direct measurement of the Pane container + DOM cell-
-      //      size probe. This catches the "Resume clicked from the
-      //      feed tab with no slot ever activated" path — every slot
-      //      terminal is still at the 80×24 sentinel so (1)/(2) both
-      //      return null.
-      let sharedDims: { cols: number; rows: number } | null = null;
-      for (const s of sessions) {
-        const d = terminalsRef.current.get(s.id)?.measure();
-        if (d) {
-          sharedDims = d;
-          break;
-        }
-      }
-      if (!sharedDims && paneContainerRef.current) {
-        sharedDims = workspaceDimsFromContainer(paneContainerRef.current);
-      }
+      // conversation history at 80 cols — for main-screen TUIs those
+      // hard-wrapped narrow lines stick in scrollback.
+      const sharedDims = measureSlotDims();
       // Best-effort over every stopped slot. Don't bail on the first
       // failure — earlier slots may have already resumed, and the
       // user wants the UI to reflect whatever actually came up.
       // Errors are collected and surfaced after the refresh.
       for (const s of sessions) {
         if (s.status === "running") continue;
-        const dims = terminalsRef.current.get(s.id)?.measure() ?? sharedDims;
         try {
           await api.session.resume(
             s.id,
-            dims?.cols ?? null,
-            dims?.rows ?? null,
+            sharedDims?.cols ?? null,
+            sharedDims?.rows ?? null,
           );
         } catch (e) {
           if (firstErr == null) firstErr = String(e);
@@ -689,7 +707,7 @@ export default function MissionWorkspace({
       if (firstErr != null) setError(firstErr);
       setResumingAll(false);
     }
-  }, [mission, sessions]);
+  }, [mission, sessions, measureSlotDims]);
 
   const archivingMission = useArchivingMission(mission?.id);
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -4,12 +4,17 @@
 // same persisted width, deliberately, so the takeover reads as
 // continuous). Per-window, like any route.
 //
+// Rendered by AppShell's takeover layer, NOT as the matched route
+// element — the shell (and PersistentSurfaces' terminals) must stay
+// mounted underneath. That means `useParams` can't see `:pane?` here;
+// the pane comes from `matchPath` on the location instead.
+//
 // "Back to app" returns to the location the user came from — entry
 // points pass it via navigation state (`{ from }`); direct loads fall
 // back to `/`.
 
 import { useMemo, useRef, useState, type ComponentType } from "react";
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { matchPath, useLocation, useNavigate } from "react-router-dom";
 import {
   Archive,
   ArrowLeft,
@@ -102,7 +107,8 @@ function isPaneKey(value: string | undefined): value is PaneKey {
 export default function SettingsPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  const { pane: paneParam } = useParams();
+  const paneParam = matchPath("/settings/:pane?", location.pathname)?.params
+    .pane;
   const pane: PaneKey = isPaneKey(paneParam) ? paneParam : "general";
   const [query, setQuery] = useState("");
   // Where "Back to app" returns. Captured once — pane switches


### PR DESCRIPTION
## What

Three related terminal-repaint/ring-purge fixes:

1. **Blank grid must dance** (`2e26cd1`, fixes #312). A session stopped before the last app launch replays an empty output ring — grid wiped, zero bytes written — and the resumed agent's repaint was lost to three stacked gates: the transitional latch downgraded activation to a plain push, the push deduped against `lastPushed`, and a same-size `TIOCSWINSZ` is a kernel no-op. A blank grid on a running session now escalates the plain push to the rows-only SIGWINCH dance (cols constant, so the #308 ring purge never fires). Two hardening rounds from review: a blank read taken while live bytes sit unparsed in xterm's async write queue defers instead of dancing (the queued bytes may be the repaint), and `createBlankRecheckGate` coalesces overlapping deferred observations into exactly one recheck per queue drain. Non-blank grids keep the latch behavior unchanged.

2. **Settings keep-alive** (`f632524`). `/settings` was the one route outside AppShell, so a Settings round-trip unmounted PersistentSurfaces and cold-remounted every terminal — the wrong-size-until-manual-resize path #309 closed for list pages. Settings now renders through an AppShell takeover layer; the chrome hides (subtree retained) underneath, hidden chrome shortcuts go inert, and returning is the same active-flip repaint as a list-page visit.

3. **Sized mission-reset respawns** (`e1861b4`). `mission_reset` respawned slots unsized: PTYs forked at 80×24, the purge gate seeded at 80 cols, agents painted launch output at 80 cols, and the first slot-tab activation's real-cols push purged the run's opening history. `initial_cols/rows` now thread through reset exactly like `mission_start` (headless MCP caller stays unsized), with `pickRespawnDims` enforcing freshness priority — active slot fit, then current container probe, hidden cached dims strictly last — and resume-all passing one current measurement to every stopped slot.

## Testing

- New: `terminalBlank.test.ts` (10 cases — blank predicate against a real xterm buffer incl. alt-screen/scrollback, the queued-write race, recheck-gate coalescing) and `terminalSizing.test.ts` (4 selection-priority cases).
- `pnpm test` 152/152, `tsc --noEmit` clean, `eslint` clean, `cargo fmt --check` + `clippy -D warnings` clean, `cargo test --workspace` green.
- Reviewed through four passes in the peer crew (two must-fix rounds on the dance race, one on stale respawn dims); final pass clean with all checks independently re-run.
- Smoke-tested: resumed old claude-code chat paints without a manual resize; running TUI keeps size/content through a Settings round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)