### PR TITLE
fix(ui): unify sidebar navigation scrolling

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1778,9 +1778,7 @@ export function Sidebar({
 
             <div className="h-5 shrink-0" />
 
-            {/* Projects and Mission are capped independent trays; Chat fills
-                the remaining height. */}
-            <div className="flex min-h-0 flex-1 flex-col pb-3">
+            <div className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-3">
               <section className="flex shrink-0 flex-col">
                 <CollapsibleSectionHeader
                   label="PROJECT"
@@ -1791,7 +1789,7 @@ export function Sidebar({
                   plusTitle="Add project"
                 />
                 {projectsOpen ? (
-                  <div className="flex max-h-[34vh] flex-col gap-0.5 overflow-y-auto px-3 pt-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                  <div className="flex flex-col gap-0.5 px-3 pt-1">
                     {projects.length === 0 ? (
                       <p className="px-2.5 py-1 text-xs text-fg-3">
                         No projects yet.
@@ -1950,7 +1948,7 @@ export function Sidebar({
                   plusTitle="Start mission"
                 />
                 {missionsOpen ? (
-                  <div className="flex max-h-[38vh] flex-col gap-0.5 overflow-y-auto px-3 pt-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                  <div className="flex flex-col gap-0.5 px-3 pt-1">
                     {ungroupedMissions.length === 0 ? (
                       <p className="px-2.5 py-1 text-xs text-fg-3">
                         No live missions.
@@ -1978,7 +1976,7 @@ export function Sidebar({
                 ) : null}
               </section>
 
-              <section className="mt-5 flex min-h-0 flex-1 flex-col">
+              <section className="mt-5 flex flex-1 flex-col">
                 <CollapsibleSectionHeader
                   label="CHAT"
                   open={sessionsOpen}
@@ -2026,7 +2024,7 @@ export function Sidebar({
                         y: event.clientY,
                       });
                     }}
-                    className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto px-3 pt-1 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+                    className="flex flex-1 flex-col gap-0.5 px-3 pt-1"
                   >
                     <DndContext
                       sensors={tabDragSensors}

--- a/src/components/SidebarRename.test.ts
+++ b/src/components/SidebarRename.test.ts
@@ -197,7 +197,24 @@ async function press(input: HTMLInputElement, key: string) {
   });
 }
 
-describe("Sidebar chat tab rename", () => {
+async function renderSidebar(root: Root) {
+  await act(async () => {
+    root.render(
+      createElement(
+        MemoryRouter,
+        { initialEntries: ["/chats/A"] },
+        createElement(Sidebar, {
+          collapsed: false,
+          onCollapsedChange: () => {},
+          previewOpen: false,
+          onPreviewOpenChange: () => {},
+        }),
+      ),
+    );
+  });
+}
+
+describe("Sidebar", () => {
   let container: HTMLDivElement;
   let root: Root;
 
@@ -228,20 +245,7 @@ describe("Sidebar chat tab rename", () => {
   });
 
   it("renames and clears a background durable tab without activating or moving it", async () => {
-    await act(async () => {
-      root.render(
-        createElement(
-          MemoryRouter,
-          { initialEntries: ["/chats/A"] },
-          createElement(Sidebar, {
-            collapsed: false,
-            onCollapsedChange: () => {},
-            previewOpen: false,
-            onPreviewOpenChange: () => {},
-          }),
-        ),
-      );
-    });
+    await renderSidebar(root);
     const originalPlacement = getPaneLayouts().map((layout) => ({
       id: layout.id,
       folderId: layout.folderId,
@@ -299,5 +303,42 @@ describe("Sidebar chat tab rename", () => {
       })),
     ).toEqual(originalPlacement);
     expect(mocks.sessionPin).not.toHaveBeenCalled();
+  });
+
+  it("scrolls project, mission, and chat sections in one container", async () => {
+    await renderSidebar(root);
+
+    const sections = ["PROJECT", "MISSION", "CHAT"].map((label) => {
+      const toggle = Array.from(
+        container.querySelectorAll<HTMLButtonElement>("button"),
+      ).find((button) => button.textContent?.trim() === label);
+      const section = toggle?.closest("section");
+      if (!section) throw new Error(`missing section: ${label}`);
+      return section;
+    });
+    const scroller = sections[0].parentElement;
+
+    expect(scroller).toBe(sections[1].parentElement);
+    expect(scroller).toBe(sections[2].parentElement);
+    expect(scroller?.classList).toContain("overflow-y-auto");
+    expect(scroller?.classList).not.toContain("[scrollbar-width:none]");
+    expect(scroller?.classList).not.toContain(
+      "[&::-webkit-scrollbar]:hidden",
+    );
+
+    for (const section of sections) {
+      const content = section.children[1];
+      expect(content.classList).not.toContain("overflow-y-auto");
+      expect(
+        Array.from(content.classList).some((name) =>
+          name.startsWith("max-h-["),
+        ),
+      ).toBe(false);
+    }
+    expect(sections[2].classList).toContain("flex-1");
+    expect(sections[2].children[1].classList).toContain("flex-1");
+    expect(scroller?.contains(buttonWithTitle(container, "@alpha + @beta"))).toBe(
+      true,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- remove independent PROJECT and MISSION height caps
- scroll PROJECT, MISSION, and CHAT in one nav container with an overflow scrollbar
- preserve CHAT blank-area context actions and dnd-kit scroll ancestry
- add sidebar layout regression coverage

## Validation
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm test` (153 tests)
- `git diff --check`

Closes #315