### PR TITLE
feat(ui): add sidebar pinned section

### DIFF
--- a/docs/features/43-sidebar-pinned-section.md
+++ b/docs/features/43-sidebar-pinned-section.md
@@ -4,45 +4,43 @@
 
 ## Motivation
 
-Pinned things are scattered. A pinned chat tab sorts to the top of the CHAT section and a pinned mission sorts to the top of the MISSION section, so "the stuff I keep coming back to" lives in two places separated by whatever else the sidebar holds. The user-visible intent of pinning — "keep this at hand" — wants one location.
+Pinned chat tabs and pinned missions need one predictable home. PINNED is a derived view over the node tree that collects the things a user wants to keep at hand without changing their project or root membership.
 
-This is a presentation-layer change only. The discussion that produced this spec explicitly rejected unifying the data models (making missions rows in the `tabs` table): a mission's surface is tab-like (it reuses the pane machinery and the `SidebarTabRow` shell), but its semantics are not — slot-bound composition, reset/respawn lifecycle, feed, and live-activity attention would all need `kind` special-cases in every tab code path (dnd move-not-copy, `ensure_active_sessions`, folder archive, unread watermarks). Missions and tabs stay separate models; the sidebar just re-partitions the rows it already renders.
-
-Builds on #315 (unified nav scroll surface).
+This spec reflects the node-tree model shipped in #318 and supersedes the pre-remodel version of this document. `nodes.pinned_position` is non-NULL for pinned nodes and orders the global PINNED section; pinning remains an overlay on the node's existing `parent_id`.
 
 ## Scope
 
-> **Sequencing update:** spec 44 (#318) lands first. PINNED then renders as the `pinned_position` derived view over the node tree, and pin/unpin writes `pinned_position` on the node — which also retires the `groupPinning.ts` fan-out (pin becomes tab-level naturally). Still no new backend work in this spec; the column ships with #318.
+- Render a PINNED section at the top of the sidebar nav containing every pinned tab and mission, whether its original parent is a project or root, ordered by `pinned_position`.
+- Hide PINNED entirely when no nodes are pinned.
+- Remove pinned rows from their origin project or root scopes. Origin scopes render only unpinned rows in `position` order; the interim pinned-first ordering inside each container is retired.
+- Preserve each row's type-specific rendering, click target, context menu, pin action, and attention state.
+- Support drag-to-reorder inside PINNED through `node_reorder_pinned(ordered_ids)`. The payload must contain every currently pinned node exactly once, and the backend rewrites `pinned_position` to match it.
+- While a pinned row is dragged, other pinned rows act as reorder positions rather than project containers or parent-scope targets.
+- Keep pin and unpin on the context menu. Dragging into or out of PINNED does not pin, unpin, or reparent a node.
+- Keep `parent_id` unchanged while a node is pinned and treat `position` as dormant. Unpinning appends the node to the end of its original parent scope by rewriting `position` to the visible scope's maximum plus one.
+- Make every parent-scope reorder and complete-set validation operate on unpinned members only. This includes the full-root payload used by project reorder, so a pinned root leaf neither invalidates nor participates in a root project reorder.
 
-### In scope (frontend only)
+## Out of scope
 
-- **PINNED section** at the top of the nav column (above PROJECT), holding every pinned chat tab and every pinned mission in one list. The pinnable population spans all of it: unfiled CHAT tabs, tabs nested under a project, and missions (project-bound or not).
-- Pinned rows render **only** in PINNED — they leave their origin sections, including a project's nested list. The pinned-first sort inside CHAT (`Sidebar.tsx` tab ordering) and the pinned-first mission sort are retired; origin sections show only unpinned rows.
-- Rows keep their type-specific rendering, click targets, and context menus (`MissionRow`, `ChatTabGroup`/`SessionRow` adapters unchanged). Pin/unpin via context menu is the only way rows move between sections.
-- Section hidden entirely when nothing anywhere is pinned — no pinned tab, no pinned project-nested tab, no pinned mission.
-- Default ordering: missions and chat tabs interleaved, using each row's existing sort key (missions by `pinned_at` recency, tabs by the existing recent-direct sort). Deterministic, no new state.
+- Pinning or unpinning by dragging into or out of PINNED.
+- Changing `parent_id` or the meaning of parent-scoped `position` while pinning.
+- Merging mission and tab domain models.
 
-### Out of scope
+## Implementation
 
-- **Drag and drop, entirely** — both drag-into-PINNED-to-pin and drag-to-reorder. Doing them now would mean interim special-cases (a `MissionRow` draggable for one interaction; a `pin_position` column bolted onto the current section layout) that the section merge below would rewrite. Drag arrives with that rework, not before.
-- **Merging the MISSION and CHAT sections generally.** The likely end-state is PINNED / PROJECT (holding both chats and missions — missions already carry `project_id`) / one recent list for unfiled items, dissolving the type-based sections. That's a follow-up spec once PINNED has proven out the interleaved rendering; mission dragging (into PINNED, into projects) and pinned reordering belong to it — as does manual ordering *inside* a project group, which doesn't exist today either (tab `position` is folder-scoped; project groups filter the global list). All three consume the same "persisted order for heterogeneous rows" mechanism and should be designed once, together.
-- **Mission-as-tab data unification.** Rejected — see Motivation.
-
-### To be decided
-
-- Whether PINNED shows a small section header like the others or renders headerless above PROJECT.
-- Interleave order tie-breaking (pin time vs. recency) once real usage shows which reads better.
-- Whether pinning the active split group (which fans out to all members) should visually collapse to one PINNED row per tab (expected: yes — reuse the existing `ChatTabGroup` row).
-
-## Implementation phases
-
-Single phase: partition pinned rows out of MISSION/CHAT into a new top section in `Sidebar.tsx`; retire pinned-first sorts in the origin sections; hide-when-empty.
+1. Partition resolved pinned rows into a global PINNED view and omit them from project/root views.
+2. Add the repository operation, Tauri command, and frontend API for `node_reorder_pinned` with complete pinned-set validation.
+3. Reuse the sidebar reorder-position drag pattern for PINNED and submit the complete pinned order.
+4. Exclude pinned nodes from backend parent-scope validation and every frontend parent-scope `ordered_ids` construction.
+5. On unpin, recompute the node's parent-scoped `position` at the visible end rather than restoring its dormant value.
 
 ## Verification
 
-- [ ] Pin a chat tab and a mission → both appear in PINNED, disappear from CHAT/MISSION; unpin returns them.
-- [ ] Group pin fan-out still yields one PINNED row for a split tab.
-- [ ] PINNED hidden when nothing is pinned.
-- [ ] Attention indicators (working/unread) and status dots render unchanged on pinned rows.
-- [ ] Existing chat drag-reorder inside folders is unaffected by the new section.
-- [ ] `pnpm exec tsc --noEmit` and `pnpm run lint` clean.
+- [ ] Pin a root chat tab, a project-nested chat tab, and a mission; all appear once in PINNED in `pinned_position` order and disappear from their origin scopes.
+- [ ] Drag pinned rows to reorder them; reload and confirm the order persists.
+- [ ] Pinned rows cannot be dropped into project/root scopes, and unpinned rows cannot be dropped into PINNED.
+- [ ] Pin a project-nested tab, add and reorder siblings, then unpin it; the tab reappears at the end of that project.
+- [ ] Pin a root tab, reorder projects, and confirm the project reorder succeeds without moving or unpinning the tab.
+- [ ] Unpin the final pinned row and confirm the PINNED section disappears.
+- [ ] Row click targets, context menus, working/unread attention, and status indicators behave unchanged in PINNED.
+- [ ] `cargo fmt`, `cargo clippy --workspace --all-targets`, `cargo test --workspace`, `pnpm test`, `pnpm exec tsc --noEmit`, and `pnpm run lint` pass.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -29,7 +29,7 @@ links to its tracking issue.
   expression; in-process Tokio scheduler, skip-on-overlap, one
   missed-tick catch-up; new sidebar section between MISSION and CHAT.
 - [37 — Agent runtime executable settings](./37-agent-runtime-executable-settings.md) — detect and display Claude Code/Codex executables from the user's login-shell environment, fix slow shell initialization failures, and provide explicit per-runtime path overrides.
-- [43 — Sidebar pinned section](./43-sidebar-pinned-section.md) — unified PINNED section at the top of the nav for pinned chat tabs and missions; presentation-layer only (no mission/tab model merge, no drag — that lands with spec 44).
+- [43 — Sidebar pinned section](./43-sidebar-pinned-section.md) — global PINNED view for tabs and missions, with persisted drag reorder, origin-scope exclusion, and append-on-unpin semantics over the node tree.
 - [44 — Sidebar node tree](./44-sidebar-node-tree.md) — replace `folders`/`tabs` + `project_id` pointer grouping + pin flags with one `nodes` table (`parent_id` + `position` as the single containment/ordering mechanism); merges the MISSION/CHAT sections and unlocks reorder-anywhere, missions-in-containers, and unified drag.
 - [45 — Auto-resume on launch](./45-auto-resume-on-launch.md) — stamp quit-killed running chats and mission-slot sessions with `resume_on_launch`, then auto-resume them (staggered, resume-only, settings-gated) on next open; crash path never stamps.
 - [46 — Sidebar project reorder](./46-sidebar-project-reorder.md) — drag project rows to reorder them within the PROJECTS section; frontend-only wiring over the existing `node_move` root-scope support, with project drags presenting other project rows as positions instead of containers.

--- a/src-tauri/src/commands/node.rs
+++ b/src-tauri/src/commands/node.rs
@@ -139,9 +139,9 @@ pub fn node_delete(state: State<'_, AppState>, app: tauri::AppHandle, id: String
 }
 
 /// The unified reparent/reposition op behind every sidebar drag.
-/// `ordered_ids` is the complete new ordering of the destination
-/// scope's children (moved node included). Crossing a project boundary
-/// writes `sessions.project_id` / `missions.project_id` through.
+/// `ordered_ids` is the complete new ordering of the destination scope's
+/// unpinned children (the moved node included when it is unpinned). Crossing
+/// a project boundary writes domain `project_id` pointers through.
 #[tauri::command]
 pub fn node_move(
     state: State<'_, AppState>,
@@ -176,6 +176,24 @@ pub fn node_move(
         }
         NodeType::Project => {}
     }
+    Ok(rows)
+}
+
+/// Rewrite the complete global PINNED order. Parent-scoped positions remain
+/// dormant and untouched until each row is unpinned.
+#[tauri::command]
+pub fn node_reorder_pinned(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    ordered_ids: Vec<String>,
+) -> Result<Vec<NodeRow>> {
+    let mut conn = state.db.get()?;
+    let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    repo::node::reorder_pinned(&tx, &ordered_ids)
+        .map_err(|error| Error::msg(format!("reorder pinned nodes: {error}")))?;
+    let rows = repo::node::list(&tx)?;
+    tx.commit()?;
+    emit_layout_changed(&app);
     Ok(rows)
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -303,6 +303,7 @@ pub fn run() {
             commands::node::node_tab_upsert,
             commands::node::node_delete,
             commands::node::node_move,
+            commands::node::node_reorder_pinned,
             commands::node::node_set_pinned,
             commands::node::node_mark_viewed,
             commands::node::node_import_once,

--- a/src-tauri/src/repo/node.rs
+++ b/src-tauri/src/repo/node.rs
@@ -7,11 +7,11 @@
 // never nodes — they're content behind a tab's layout slots.
 //
 // `pinned_position` non-NULL = pinned; the value orders the PINNED
-// overlay. Unpinning just clears it, returning the row to its tree
-// position. The tree owns placement/order only: `sessions.project_id` /
-// `missions.project_id` stay authoritative for domain membership, so
-// reparenting across a project boundary writes the pointer through
-// (see `move_and_reorder`).
+// overlay. A pinned node keeps its parent while its tree position is
+// dormant; unpinning appends it to that parent's visible scope. The tree
+// owns placement/order only: `sessions.project_id` / `missions.project_id`
+// stay authoritative for domain membership, so reparenting across a
+// project boundary writes the pointer through (see `move_and_reorder`).
 
 use std::collections::HashSet;
 
@@ -67,14 +67,13 @@ const COLUMNS: &[&str] = &[
     "created_at",
 ];
 
-/// One tree query. Within each parent scope pinned rows sort first by
-/// `pinned_position`, then everything by `position, created_at` — the
-/// same order the sidebar renders, so backend and frontend agree.
+/// One tree query. Pinned rows form one global ordered overlay; unpinned
+/// rows retain their parent-scoped `position, created_at` order.
 pub fn list(conn: &Connection) -> rusqlite::Result<Vec<NodeRow>> {
     let sql = format!(
         "SELECT {} FROM nodes
-         ORDER BY parent_id IS NOT NULL, parent_id,
-                  pinned_position IS NULL, pinned_position,
+         ORDER BY pinned_position IS NULL, pinned_position,
+                  parent_id IS NOT NULL, parent_id,
                   position, created_at",
         select_list(COLUMNS)
     );
@@ -290,8 +289,9 @@ pub fn rename(conn: &Connection, id: &str, name: &str) -> rusqlite::Result<usize
     )
 }
 
-/// Pin appends at the PINNED end (an already-pinned row keeps its
-/// slot); unpin clears — the row returns to its tree position for free.
+/// Pin appends at the PINNED end (an already-pinned row keeps its slot).
+/// Unpin appends the row to the end of its original parent's visible scope;
+/// its old position may have gone stale while the row was pinned away.
 pub fn set_pinned(conn: &Connection, id: &str, pinned: bool) -> rusqlite::Result<usize> {
     if pinned {
         conn.execute(
@@ -303,10 +303,46 @@ pub fn set_pinned(conn: &Connection, id: &str, pinned: bool) -> rusqlite::Result
         )
     } else {
         conn.execute(
-            "UPDATE nodes SET pinned_position = NULL WHERE id = ?1",
+            "UPDATE nodes
+             SET position = (
+                     SELECT COALESCE(MAX(position) + 1, 0)
+                     FROM nodes
+                     WHERE parent_id IS (SELECT parent_id FROM nodes WHERE id = ?1)
+                       AND pinned_position IS NULL
+                       AND id != ?1
+                 ),
+                 pinned_position = NULL
+             WHERE id = ?1 AND pinned_position IS NOT NULL",
             [id],
         )
     }
+}
+
+/// Rewrite the global PINNED overlay order. The caller must submit every
+/// currently-pinned node exactly once so a stale frontend cannot silently
+/// discard or duplicate rows.
+pub fn reorder_pinned(conn: &Connection, ordered_ids: &[String]) -> rusqlite::Result<()> {
+    let actual: Vec<String> = conn
+        .prepare("SELECT id FROM nodes WHERE pinned_position IS NOT NULL")?
+        .query_map([], |row| row.get(0))?
+        .collect::<rusqlite::Result<_>>()?;
+    let expected: HashSet<&str> = actual.iter().map(String::as_str).collect();
+    let provided: HashSet<&str> = ordered_ids.iter().map(String::as_str).collect();
+    if ordered_ids.len() != actual.len()
+        || provided.len() != ordered_ids.len()
+        || provided != expected
+    {
+        return Err(rusqlite::Error::InvalidParameterName(
+            "ordered node ids do not match pinned nodes".to_owned(),
+        ));
+    }
+    for (position, node_id) in ordered_ids.iter().enumerate() {
+        conn.execute(
+            "UPDATE nodes SET pinned_position = ?2 WHERE id = ?1",
+            rusqlite::params![node_id, position as i64],
+        )?;
+    }
+    Ok(())
 }
 
 /// The unified reparent/reposition op behind every sidebar drag.
@@ -361,7 +397,10 @@ pub fn move_and_reorder(
         rusqlite::params![id, parent_id],
     )?;
     let actual: Vec<String> = tx
-        .prepare("SELECT id FROM nodes WHERE parent_id IS ?1")?
+        .prepare(
+            "SELECT id FROM nodes
+             WHERE parent_id IS ?1 AND pinned_position IS NULL",
+        )?
         .query_map([parent_id], |row| row.get(0))?
         .collect::<rusqlite::Result<_>>()?;
     let expected: HashSet<&str> = actual.iter().map(String::as_str).collect();
@@ -974,20 +1013,14 @@ mod tests {
         .unwrap();
         let mut conn = conn;
         let tx = conn.transaction().unwrap();
-        super::move_and_reorder(
-            &tx,
-            &stale.id,
-            Some(&project_node.id),
-            &[peer.id, stale.id.clone()],
-        )
-        .unwrap();
+        super::move_and_reorder(&tx, &stale.id, Some(&project_node.id), &[peer.id]).unwrap();
         tx.commit().unwrap();
 
         let after = super::get(&conn, &stale.id).unwrap().unwrap();
         assert_eq!(after.name.as_deref(), Some("renamed"));
         assert_eq!(after.layout, stale.layout);
         assert_eq!(after.parent_id, Some(project_node.id));
-        assert_eq!(after.position, 1);
+        assert_eq!(after.position, before.position);
         assert_eq!(after.last_completed_at, before.last_completed_at);
         assert_eq!(after.last_viewed_at, before.last_viewed_at);
         assert_eq!(after.pinned_position, before.pinned_position);
@@ -1507,7 +1540,7 @@ mod tests {
     }
 
     #[test]
-    fn pin_appends_and_unpin_returns_to_tree_position() {
+    fn pinned_reorder_requires_the_complete_pinned_set() {
         let pool = db::open_in_memory().unwrap();
         let conn = pool.get().unwrap();
         let a = super::create_tab(
@@ -1526,42 +1559,191 @@ mod tests {
             r#"{"preset":"single","slots":["b"],"sizes":{}}"#,
         )
         .unwrap();
+        let c = super::create_tab(
+            &conn,
+            None,
+            "C",
+            2,
+            r#"{"preset":"single","slots":["c"],"sizes":{}}"#,
+        )
+        .unwrap();
 
-        super::set_pinned(&conn, &b.id, true).unwrap();
         super::set_pinned(&conn, &a.id, true).unwrap();
-        let pinned: Vec<(String, Option<i64>)> = super::list(&conn)
+        super::set_pinned(&conn, &c.id, true).unwrap();
+
+        assert!(super::reorder_pinned(&conn, std::slice::from_ref(&c.id)).is_err());
+        assert!(super::reorder_pinned(&conn, &[c.id.clone(), c.id.clone()]).is_err());
+        assert!(super::reorder_pinned(&conn, &[c.id.clone(), b.id.clone()]).is_err());
+
+        super::reorder_pinned(&conn, &[c.id.clone(), a.id.clone()]).unwrap();
+        let pinned: Vec<_> = super::list(&conn)
             .unwrap()
             .into_iter()
-            .map(|row| (row.id, row.pinned_position))
+            .filter_map(|row| row.pinned_position.map(|position| (row.id, position)))
             .collect();
-        assert_eq!(
-            pinned,
-            [(b.id.clone(), Some(0)), (a.id.clone(), Some(1))],
-            "pinned rows sort first by pin order"
-        );
+        assert_eq!(pinned, [(c.id, 0), (a.id, 1)]);
+    }
 
-        // Re-pinning keeps the slot.
-        super::set_pinned(&conn, &b.id, true).unwrap();
-        assert_eq!(
-            super::get(&conn, &b.id).unwrap().unwrap().pinned_position,
-            Some(0)
-        );
+    #[test]
+    fn unpin_appends_to_the_end_of_the_original_parent() {
+        let pool = db::open_in_memory().unwrap();
+        let mut conn = pool.get().unwrap();
+        let a = super::create_tab(
+            &conn,
+            None,
+            "A",
+            0,
+            r#"{"preset":"single","slots":["a"],"sizes":{}}"#,
+        )
+        .unwrap();
+        let b = super::create_tab(
+            &conn,
+            None,
+            "B",
+            1,
+            r#"{"preset":"single","slots":["b"],"sizes":{}}"#,
+        )
+        .unwrap();
+        let c = super::create_tab(
+            &conn,
+            None,
+            "C",
+            2,
+            r#"{"preset":"single","slots":["c"],"sizes":{}}"#,
+        )
+        .unwrap();
 
-        super::set_pinned(&conn, &b.id, false).unwrap();
-        let order: Vec<String> = super::list(&conn)
+        super::set_pinned(&conn, &a.id, true).unwrap();
+        let tx = conn.transaction().unwrap();
+        super::move_and_reorder(&tx, &b.id, None, &[c.id.clone(), b.id.clone()]).unwrap();
+        tx.commit().unwrap();
+        super::set_pinned(&conn, &a.id, false).unwrap();
+
+        let root_tabs: Vec<_> = super::list(&conn)
             .unwrap()
             .into_iter()
+            .filter(|row| row.parent_id.is_none() && row.node_type == NodeType::Tab)
+            .map(|row| (row.id, row.position))
+            .collect();
+        assert_eq!(root_tabs, [(c.id, 0), (b.id, 1), (a.id.clone(), 2)]);
+
+        assert_eq!(super::set_pinned(&conn, &a.id, false).unwrap(), 0);
+        assert_eq!(super::get(&conn, &a.id).unwrap().unwrap().position, 2);
+    }
+
+    #[test]
+    fn pinned_project_tab_returns_after_newly_reordered_siblings() {
+        let pool = db::open_in_memory().unwrap();
+        let mut conn = pool.get().unwrap();
+        let project = crate::repo::project::create(&conn, "Project", "/tmp/project").unwrap();
+        let parent = super::ensure_project_node(&conn, &project.id).unwrap();
+        let pinned = super::create_tab(
+            &conn,
+            Some(&parent.id),
+            "Pinned",
+            0,
+            r#"{"preset":"single","slots":["pinned"],"sizes":{}}"#,
+        )
+        .unwrap();
+        let sibling = super::create_tab(
+            &conn,
+            Some(&parent.id),
+            "Sibling",
+            1,
+            r#"{"preset":"single","slots":["sibling"],"sizes":{}}"#,
+        )
+        .unwrap();
+
+        super::set_pinned(&conn, &pinned.id, true).unwrap();
+        let added = super::create_tab(
+            &conn,
+            Some(&parent.id),
+            "Added",
+            super::next_position(&conn, Some(&parent.id)).unwrap(),
+            r#"{"preset":"single","slots":["added"],"sizes":{}}"#,
+        )
+        .unwrap();
+        let tx = conn.transaction().unwrap();
+        super::move_and_reorder(
+            &tx,
+            &sibling.id,
+            Some(&parent.id),
+            &[added.id.clone(), sibling.id.clone()],
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        super::set_pinned(&conn, &pinned.id, false).unwrap();
+        let children: Vec<_> = super::list(&conn)
+            .unwrap()
+            .into_iter()
+            .filter(|row| row.parent_id.as_deref() == Some(parent.id.as_str()))
             .map(|row| row.id)
             .collect();
+        assert_eq!(children, [added.id, sibling.id, pinned.id]);
+    }
+
+    #[test]
+    fn root_project_reorder_excludes_a_pinned_root_tab() {
+        let pool = db::open_in_memory().unwrap();
+        let mut conn = pool.get().unwrap();
+        let project_a = crate::repo::project::create(&conn, "A", "/tmp/a").unwrap();
+        let project_b = crate::repo::project::create(&conn, "B", "/tmp/b").unwrap();
+        let node_a = super::ensure_project_node(&conn, &project_a.id).unwrap();
+        let node_b = super::ensure_project_node(&conn, &project_b.id).unwrap();
+        let tab = super::create_tab(
+            &conn,
+            None,
+            "Pinned",
+            2,
+            r#"{"preset":"single","slots":["pinned"],"sizes":{}}"#,
+        )
+        .unwrap();
+        super::set_pinned(&conn, &tab.id, true).unwrap();
+        let before = super::get(&conn, &tab.id).unwrap().unwrap();
+
+        let tx = conn.transaction().unwrap();
+        super::move_and_reorder(
+            &tx,
+            &node_b.id,
+            None,
+            &[node_b.id.clone(), node_a.id.clone()],
+        )
+        .unwrap();
+        tx.commit().unwrap();
+
+        let after = super::get(&conn, &tab.id).unwrap().unwrap();
+        assert_eq!(after.parent_id, before.parent_id);
+        assert_eq!(after.position, before.position);
+        assert_eq!(after.pinned_position, before.pinned_position);
+        let projects: Vec<_> = super::list(&conn)
+            .unwrap()
+            .into_iter()
+            .filter(|row| row.node_type == NodeType::Project)
+            .map(|row| row.id)
+            .collect();
+        assert_eq!(projects, [node_b.id, node_a.id]);
+    }
+
+    #[test]
+    fn repinning_keeps_the_existing_pinned_slot() {
+        let pool = db::open_in_memory().unwrap();
+        let conn = pool.get().unwrap();
+        let tab = super::create_tab(
+            &conn,
+            None,
+            "Pinned",
+            0,
+            r#"{"preset":"single","slots":["pinned"],"sizes":{}}"#,
+        )
+        .unwrap();
+        super::set_pinned(&conn, &tab.id, true).unwrap();
+
+        // Re-pinning keeps the slot.
+        super::set_pinned(&conn, &tab.id, true).unwrap();
         assert_eq!(
-            order,
-            [a.id.clone(), b.id.clone()],
-            "unpinned row returns behind the remaining pinned row"
-        );
-        assert_eq!(
-            super::get(&conn, &b.id).unwrap().unwrap().position,
-            1,
-            "tree position untouched by pin round-trip"
+            super::get(&conn, &tab.id).unwrap().unwrap().pinned_position,
+            Some(0)
         );
     }
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -90,10 +90,13 @@ import {
 import {
   chatTabArchiveLabel,
   chatTabIsLive,
-  isChatTabDropIndexAllowed,
-  orderedChatTabIdsAfterDrop,
 } from "../lib/chatTabs";
-import { orderedRootNodeIdsAfterProjectDrop } from "../lib/sidebarDnd";
+import {
+  completeUnpinnedScopeOrder,
+  orderedPinnedNodeIdsAfterDrop,
+  orderedRootNodeIdsAfterProjectDrop,
+  orderedVisibleNodeIdsAfterDrop,
+} from "../lib/sidebarDnd";
 import {
   missionAttentionState,
   rollupAttentionState,
@@ -111,6 +114,7 @@ import {
   removeArchivedSessionFromLayout,
   hydratePaneLayoutsFromDb,
   moveNode,
+  reorderPinnedNodes,
   setGroupNameForSession,
   useNavNodes,
   usePaneLayouts,
@@ -154,11 +158,11 @@ const STORAGE_SESSION_OPEN = "runner.sidebar.session.open";
 const SIDEBAR_NAVIGATE_EVENT = "runner:navigate-sidebar-page";
 const SIDEBAR_NAVIGATION_HISTORY_LIMIT = 64;
 
-// One dnd vocabulary for every draggable sidebar row: leaf positions are
-// per-scope, project positions reorder root projects, and project containers
-// accept tab/mission drops at the child scope's end.
+// One dnd vocabulary for every draggable sidebar row: pinned positions are
+// global, leaf positions are per-scope, project positions reorder root
+// projects, and project containers accept unpinned leaves at the child end.
 type RowDropTarget = {
-  dropKind: "leaf" | "project";
+  dropKind: "pinned" | "leaf" | "project";
   parentId: string | null;
   index: number;
   markerKey: string;
@@ -400,10 +404,7 @@ export function Sidebar({
   const paneLayouts = usePaneLayouts();
   const navNodes = useNavNodes();
 
-  // Sidebar rows per scope, in render order (the tree query already
-  // sorts pinned-first within each parent, then by position). Root
-  // scope excludes project nodes — those render as the PROJECT section.
-  const rowsByParent = useMemo(() => {
+  const rowsByNodeId = useMemo(() => {
     const sessionById = new Map(
       directSessions.map((session) => [session.session_id, session]),
     );
@@ -411,7 +412,7 @@ export function Sidebar({
       paneLayouts.filter((layout) => layout.id).map((l) => [l.id, l]),
     );
     const missionById = new Map(missions.map((m) => [m.id, m]));
-    const map = new Map<string | null, NavRowModel[]>();
+    const map = new Map<string, NavRowModel>();
     for (const node of navNodes) {
       let row: NavRowModel | null = null;
       if (node.type === "tab") {
@@ -444,12 +445,37 @@ export function Sidebar({
         if (mission) row = { kind: "mission", node, mission };
       }
       if (!row) continue;
+      map.set(node.id, row);
+    }
+    return map;
+  }, [directSessionActivity, directSessions, missions, navNodes, paneLayouts]);
+
+  // PINNED is a global overlay. Origin scopes contain only unpinned rows,
+  // preserving their parent-local position order from the tree query.
+  const pinnedRows = useMemo(
+    () =>
+      navNodes
+        .filter((node) => node.pinned_position !== null)
+        .sort(
+          (a, b) =>
+            (a.pinned_position ?? 0) - (b.pinned_position ?? 0),
+        )
+        .map((node) => rowsByNodeId.get(node.id))
+        .filter((row): row is NavRowModel => row !== undefined),
+    [navNodes, rowsByNodeId],
+  );
+  const rowsByParent = useMemo(() => {
+    const map = new Map<string | null, NavRowModel[]>();
+    for (const node of navNodes) {
+      if (node.pinned_position !== null) continue;
+      const row = rowsByNodeId.get(node.id);
+      if (!row) continue;
       const list = map.get(node.parent_id);
       if (list) list.push(row);
       else map.set(node.parent_id, [row]);
     }
     return map;
-  }, [directSessionActivity, directSessions, missions, navNodes, paneLayouts]);
+  }, [navNodes, rowsByNodeId]);
 
   const scopeRows = useCallback(
     (parentId: string | null): NavRowModel[] => rowsByParent.get(parentId) ?? [],
@@ -498,14 +524,10 @@ export function Sidebar({
       ),
     [projectNodes, rowAttention, scopeRows],
   );
-  const draggedRow = useMemo(() => {
-    if (!draggedNodeId) return null;
-    for (const rows of rowsByParent.values()) {
-      const row = rows.find((candidate) => candidate.node.id === draggedNodeId);
-      if (row) return row;
-    }
-    return null;
-  }, [draggedNodeId, rowsByParent]);
+  const draggedRow = useMemo(
+    () => (draggedNodeId ? (rowsByNodeId.get(draggedNodeId) ?? null) : null),
+    [draggedNodeId, rowsByNodeId],
+  );
   const activeProject = useMemo(
     () => projects.find((project) => project.id === activeProjectId) ?? null,
     [activeProjectId, projects],
@@ -527,8 +549,7 @@ export function Sidebar({
     [newMissionProjectId, projects],
   );
 
-  // Page-back/forward candidates in display order: project children
-  // first (as the PROJECT section renders above), then the recent list.
+  // Page-back/forward candidates follow the rendered section order.
   const sidebarNavigationEntries = useMemo<SidebarNavigationEntry[]>(() => {
     const entries: SidebarNavigationEntry[] = [];
     const pushRow = (row: NavRowModel) => {
@@ -542,12 +563,13 @@ export function Sidebar({
         });
       }
     };
+    for (const row of pinnedRows) pushRow(row);
     for (const node of projectNodes) {
       for (const row of scopeRows(node.id)) pushRow(row);
     }
     for (const row of recentRows) pushRow(row);
     return entries;
-  }, [projectNodes, recentRows, scopeRows]);
+  }, [pinnedRows, projectNodes, recentRows, scopeRows]);
 
   const refreshProjects = useCallback(async () => {
     try {
@@ -1286,27 +1308,16 @@ export function Sidebar({
     rowDropTargetRef.current = null;
   }, []);
 
-  // Draggable-row lookup + the pin-tier list of a destination scope.
-  // Only visible rows participate in drop index math; hidden siblings
-  // (non-running mission nodes, tabs whose rows are mid-refresh) are
-  // appended behind the visible ordering when the move commits.
+  // Only visible rows participate in drop index math; hidden siblings are
+  // appended behind visible rows when a parent-scope move commits.
   const draggedRowFor = useCallback(
-    (nodeId: string): NavRowModel | null => {
-      for (const rows of rowsByParent.values()) {
-        const row = rows.find((candidate) => candidate.node.id === nodeId);
-        if (row) return row;
-      }
-      return null;
-    },
-    [rowsByParent],
+    (nodeId: string): NavRowModel | null => rowsByNodeId.get(nodeId) ?? null,
+    [rowsByNodeId],
   );
 
-  const scopeOrderedRows = useCallback(
+  const scopeOrderedIds = useCallback(
     (parentId: string | null) =>
-      scopeRows(parentId).map((row) => ({
-        id: row.node.id,
-        pinned: row.node.pinned_position !== null,
-      })),
+      scopeRows(parentId).map((row) => row.node.id),
     [scopeRows],
   );
 
@@ -1318,7 +1329,7 @@ export function Sidebar({
   const canDropInScope = useCallback(
     (nodeId: string, parentId: string | null): boolean => {
       const dragged = navNodes.find((node) => node.id === nodeId);
-      if (!dragged) return false;
+      if (!dragged || dragged.pinned_position !== null) return false;
       const draggedParent = dragged.parent_id
         ? navNodes.find((node) => node.id === dragged.parent_id)
         : undefined;
@@ -1364,43 +1375,40 @@ export function Sidebar({
         }
         return;
       }
-      const orderedVisible = orderedChatTabIdsAfterDrop(
-        scopeOrderedRows(parentId),
+      if (dragged.pinned_position !== null) {
+        const orderedIds = orderedPinnedNodeIdsAfterDrop(
+          navNodes,
+          pinnedRows.map((row) => row.node.id),
+          nodeId,
+          requestedIndex,
+        );
+        clearRowDrag();
+        try {
+          await reorderPinnedNodes(orderedIds);
+        } catch (error) {
+          console.error("sidebar: reorder pinned nodes failed", error);
+        }
+        return;
+      }
+      const orderedVisible = orderedVisibleNodeIdsAfterDrop(
+        scopeOrderedIds(parentId),
         nodeId,
-        dragged.pinned_position !== null,
         requestedIndex,
       );
-      // The backend validates the COMPLETE child set of the scope:
-      // project nodes keep their lead positions at root, and hidden
-      // siblings follow the visible ordering.
-      const visibleSet = new Set(orderedVisible);
-      const siblings = navNodes.filter(
-        (node) => node.parent_id === parentId && node.id !== nodeId,
+      const orderedIds = completeUnpinnedScopeOrder(
+        navNodes,
+        parentId,
+        nodeId,
+        orderedVisible,
       );
-      const projectsFirst =
-        parentId === null
-          ? siblings
-              .filter((node) => node.type === "project")
-              .map((node) => node.id)
-          : [];
-      const hidden = siblings
-        .filter(
-          (node) => !(parentId === null && node.type === "project"),
-        )
-        .map((node) => node.id)
-        .filter((id) => !visibleSet.has(id));
       clearRowDrag();
       try {
-        await moveNode(nodeId, parentId, [
-          ...projectsFirst,
-          ...orderedVisible,
-          ...hidden,
-        ]);
+        await moveNode(nodeId, parentId, orderedIds);
       } catch (error) {
         console.error("sidebar: move node failed", error);
       }
     },
-    [clearRowDrag, navNodes, scopeOrderedRows],
+    [clearRowDrag, navNodes, pinnedRows, scopeOrderedIds],
   );
 
   const resolveRowDropTarget = useCallback(
@@ -1439,6 +1447,7 @@ export function Sidebar({
         };
 
         if (overData.kind === "position") {
+          if (overData.dropKind === "pinned") return null;
           if (overData.dropKind === "project") {
             return {
               dropKind: "project",
@@ -1450,6 +1459,8 @@ export function Sidebar({
           return targetAfterProject(overData.parentId);
         }
         if (overData.kind !== "row") return null;
+        const overNode = navNodes.find((node) => node.id === overData.nodeId);
+        if (!overNode || overNode.pinned_position !== null) return null;
         const overIndex = projectNodes.findIndex(
           (node) => node.id === overData.nodeId,
         );
@@ -1469,20 +1480,52 @@ export function Sidebar({
         return projectTargetAt(originalIndex);
       }
 
+      if (activeNode.pinned_position !== null) {
+        const pinnedTargetAt = (originalIndex: number): RowDropTarget => {
+          const index = pinnedRows
+            .slice(0, originalIndex)
+            .filter((row) => row.node.id !== activeNode.id).length;
+          return {
+            dropKind: "pinned",
+            parentId: null,
+            index,
+            markerKey:
+              originalIndex < pinnedRows.length
+                ? `pinned-before-${pinnedRows[originalIndex].node.id}`
+                : "pinned-after",
+          };
+        };
+        if (overData.kind === "position") {
+          return overData.dropKind === "pinned"
+            ? {
+                dropKind: "pinned",
+                parentId: null,
+                index: overData.index,
+                markerKey: overData.markerKey,
+              }
+            : null;
+        }
+        if (overData.kind !== "row" || !event.over) return null;
+        const overIndex = pinnedRows.findIndex(
+          (row) => row.node.id === overData.nodeId,
+        );
+        if (overIndex < 0) return null;
+        const activeRect =
+          event.active.rect.current.translated ??
+          event.active.rect.current.initial;
+        const after = activeRect
+          ? activeRect.top + activeRect.height / 2 >=
+            event.over.rect.top + event.over.rect.height / 2
+          : false;
+        return pinnedTargetAt(overIndex + (after ? 1 : 0));
+      }
+
       const dragged = draggedRowFor(activeData.nodeId);
       if (!dragged) return null;
-      const draggedPinned = dragged.node.pinned_position !== null;
 
       if (overData.kind === "position") {
         if (overData.dropKind !== "leaf") return null;
-        const allowed =
-          canDropInScope(dragged.node.id, overData.parentId) &&
-          isChatTabDropIndexAllowed(
-            scopeOrderedRows(overData.parentId),
-            dragged.node.id,
-            draggedPinned,
-            overData.index,
-          );
+        const allowed = canDropInScope(dragged.node.id, overData.parentId);
         return allowed
           ? {
               dropKind: "leaf",
@@ -1494,6 +1537,8 @@ export function Sidebar({
       }
 
       if (overData.kind !== "row") return null;
+      const overNode = navNodes.find((node) => node.id === overData.nodeId);
+      if (!overNode || overNode.pinned_position !== null) return null;
       if (!canDropInScope(dragged.node.id, overData.parentId)) return null;
       const targetRows = scopeRows(overData.parentId);
       const overIndex = targetRows.findIndex(
@@ -1512,16 +1557,6 @@ export function Sidebar({
       const index = targetRows
         .slice(0, originalIndex)
         .filter((row) => row.node.id !== dragged.node.id).length;
-      if (
-        !isChatTabDropIndexAllowed(
-          scopeOrderedRows(overData.parentId),
-          dragged.node.id,
-          draggedPinned,
-          index,
-        )
-      ) {
-        return null;
-      }
 
       return {
         dropKind: "leaf",
@@ -1537,8 +1572,8 @@ export function Sidebar({
       canDropInScope,
       draggedRowFor,
       navNodes,
+      pinnedRows,
       projectNodes,
-      scopeOrderedRows,
       scopeRows,
     ],
   );
@@ -1548,10 +1583,9 @@ export function Sidebar({
       if (!canDropInScope(nodeId, containerId)) return null;
       const dragged = draggedRowFor(nodeId);
       if (!dragged) return null;
-      const orderedIds = orderedChatTabIdsAfterDrop(
-        scopeOrderedRows(containerId),
+      const orderedIds = orderedVisibleNodeIdsAfterDrop(
+        scopeOrderedIds(containerId),
         nodeId,
-        dragged.node.pinned_position !== null,
         Number.MAX_SAFE_INTEGER,
       );
       const index = orderedIds.indexOf(nodeId);
@@ -1569,7 +1603,7 @@ export function Sidebar({
             : `after-${containerId}`,
       };
     },
-    [canDropInScope, draggedRowFor, scopeOrderedRows, scopeRows],
+    [canDropInScope, draggedRowFor, scopeOrderedIds, scopeRows],
   );
 
   const handleRowDragStart = useCallback((event: DragStartEvent) => {
@@ -1720,17 +1754,7 @@ export function Sidebar({
       .slice(0, originalIndex)
       .filter((row) => row.node.id !== draggedNodeId).length;
     const enabled = Boolean(
-      dragged &&
-        canDropInScope(dragged.node.id, parentId) &&
-        isChatTabDropIndexAllowed(
-          rows.map((row) => ({
-            id: row.node.id,
-            pinned: row.node.pinned_position !== null,
-          })),
-          dragged.node.id,
-          dragged.node.pinned_position !== null,
-          index,
-        ),
+      dragged && canDropInScope(dragged.node.id, parentId),
     );
     return (
       <RowDropDivider
@@ -1744,6 +1768,33 @@ export function Sidebar({
         active={
           rowDropTarget?.dropKind === "leaf" &&
           rowDropTarget.parentId === parentId &&
+          rowDropTarget.index === index &&
+          rowDropTarget.markerKey === key
+        }
+      />
+    );
+  };
+
+  const renderPinnedDropDivider = (
+    originalIndex: number,
+    key: string,
+  ) => {
+    const index = pinnedRows
+      .slice(0, originalIndex)
+      .filter((row) => row.node.id !== draggedNodeId).length;
+    return (
+      <RowDropDivider
+        key={key}
+        id={rowDropDndId(null, key)}
+        enabled={
+          draggedNode !== null && draggedNode.pinned_position !== null
+        }
+        dropKind="pinned"
+        parentId={null}
+        index={index}
+        markerKey={key}
+        active={
+          rowDropTarget?.dropKind === "pinned" &&
           rowDropTarget.index === index &&
           rowDropTarget.markerKey === key
         }
@@ -1853,6 +1904,30 @@ export function Sidebar({
     );
   };
 
+  const renderPinnedRows = () => (
+    <SortableContext
+      items={pinnedRows.map((row) => rowDndId(row.node.id))}
+      strategy={verticalListSortingStrategy}
+    >
+      {pinnedRows.map((row, originalIndex) => {
+        const parent = row.node.parent_id
+          ? navNodes.find((node) => node.id === row.node.parent_id)
+          : null;
+        const projectId = parent?.type === "project" ? parent.ref_id : null;
+        return (
+          <Fragment key={row.node.id}>
+            {renderPinnedDropDivider(
+              originalIndex,
+              `pinned-before-${row.node.id}`,
+            )}
+            {renderNavRow(row, null, projectId)}
+          </Fragment>
+        );
+      })}
+      {renderPinnedDropDivider(pinnedRows.length, "pinned-after")}
+    </SortableContext>
+  );
+
   const sidebarVisible = !collapsed || previewOpen;
   const sidebarPreview = collapsed && previewOpen;
   // Keep the panel mounted through the collapse width-animation so it
@@ -1958,7 +2033,20 @@ export function Sidebar({
                 onDragEnd={handleRowDragEnd}
                 onDragCancel={clearRowDrag}
               >
-              <section className="flex shrink-0 flex-col">
+              {pinnedRows.length > 0 ? (
+                <section className="flex shrink-0 flex-col">
+                  <SectionHeader>PINNED</SectionHeader>
+                  <div className="flex flex-col gap-0.5 px-3 pt-1">
+                    {renderPinnedRows()}
+                  </div>
+                </section>
+              ) : null}
+
+              <section
+                className={`flex shrink-0 flex-col ${
+                  pinnedRows.length > 0 ? "mt-5" : ""
+                }`}
+              >
                 <CollapsibleSectionHeader
                   label="PROJECTS"
                   open={projectsOpen}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -144,9 +144,8 @@ export const api = {
     delete: (id: string) => invoke<void>("project_delete", { id }),
   },
   node: {
-    /** The whole sidebar tree, one query: parent-grouped, pinned rows
-     *  first within their scope, then `position, created_at`. Runs the
-     *  invariant repair (project/mission/tab node seeding) first. */
+    /** The whole sidebar tree, one query: the global PINNED order followed
+     *  by unpinned parent scopes. Runs invariant repair first. */
     list: () => invoke<NodeRow[]>("node_list"),
     /** Rename a tab node (projects/missions rename through their domain commands). */
     rename: (id: string, name: string) =>
@@ -155,11 +154,12 @@ export const api = {
       invoke<NodeRow>("node_tab_upsert", { input }),
     delete: (id: string) => invoke<void>("node_delete", { id }),
     /** The unified reparent/reposition op behind every sidebar drag.
-     *  `orderedIds` is the complete new ordering of the destination
-     *  scope's children, moved node included. Crossing a project
-     *  boundary writes `project_id` pointers through. */
+     *  `orderedIds` is the complete unpinned destination scope, with an
+     *  unpinned moved node included. */
     move: (id: string, parentId: string | null, orderedIds: string[]) =>
       invoke<NodeRow[]>("node_move", { id, parentId, orderedIds }),
+    reorderPinned: (orderedIds: string[]) =>
+      invoke<NodeRow[]>("node_reorder_pinned", { orderedIds }),
     setPinned: (id: string, pinned: boolean) =>
       invoke<NodeRow>("node_set_pinned", { id, pinned }),
     importOnce: (tabs: NodeTabImportInput[]) =>

--- a/src/lib/chatTabs.test.ts
+++ b/src/lib/chatTabs.test.ts
@@ -5,8 +5,6 @@ import {
   chatTabArchiveLabel,
   chatTabIsLive,
   derivedChatTabTitle,
-  isChatTabDropIndexAllowed,
-  orderedChatTabIdsAfterDrop,
   type ChatListItem,
 } from "./chatTabs";
 import { applyPresetPure } from "./paneLayout";
@@ -149,68 +147,6 @@ describe("chatTabIsLive", () => {
       true,
     );
     expect(chatTabIsLive([{ status: "stopped" }, { status: "crashed" }])).toBe(
-      false,
-    );
-  });
-});
-
-describe("chat tab drop ordering", () => {
-  const tabs = [
-    { id: "p1", pinned: true },
-    { id: "p2", pinned: true },
-    { id: "a", pinned: false },
-    { id: "b", pinned: false },
-  ];
-
-  it("reorders within a pinned tier", () => {
-    expect(orderedChatTabIdsAfterDrop(tabs, "p2", true, 0)).toEqual([
-      "p2",
-      "p1",
-      "a",
-      "b",
-    ]);
-    expect(isChatTabDropIndexAllowed(tabs, "p2", true, 2)).toBe(false);
-  });
-
-  it("keeps an unpinned tab below every pinned tab", () => {
-    expect(orderedChatTabIdsAfterDrop(tabs, "b", false, 0)).toEqual([
-      "p1",
-      "p2",
-      "b",
-      "a",
-    ]);
-    expect(isChatTabDropIndexAllowed(tabs, "b", false, 1)).toBe(false);
-  });
-
-  it("clamps cross-list appends to the dragged tab's pin tier", () => {
-    const target = [
-      { id: "p1", pinned: true },
-      { id: "a", pinned: false },
-    ];
-
-    expect(
-      orderedChatTabIdsAfterDrop(
-        target,
-        "incoming-pinned",
-        true,
-        Number.MAX_SAFE_INTEGER,
-      ),
-    ).toEqual(["p1", "incoming-pinned", "a"]);
-    expect(
-      orderedChatTabIdsAfterDrop(
-        target,
-        "incoming",
-        false,
-        Number.MAX_SAFE_INTEGER,
-      ),
-    ).toEqual(["p1", "a", "incoming"]);
-    expect(
-      orderedChatTabIdsAfterDrop(target, "incoming", false, 0),
-    ).toEqual(["p1", "incoming", "a"]);
-    expect(
-      isChatTabDropIndexAllowed(target, "incoming-pinned", true, 2),
-    ).toBe(false);
-    expect(isChatTabDropIndexAllowed(target, "incoming", false, 0)).toBe(
       false,
     );
   });

--- a/src/lib/chatTabs.ts
+++ b/src/lib/chatTabs.ts
@@ -37,11 +37,6 @@ export function derivedChatTabTitle<
   return members.map(chatTabMemberLabel).join(" + ");
 }
 
-export interface OrderedChatTab {
-  id: string;
-  pinned: boolean;
-}
-
 export function chatTabIsLive(
   members: readonly { status: string }[],
 ): boolean {
@@ -50,33 +45,6 @@ export function chatTabIsLive(
 
 export function chatTabArchiveLabel(layout: PaneLayout): string {
   return leaves(layout.root).length > 1 ? "Archive all" : "Archive";
-}
-
-export function isChatTabDropIndexAllowed(
-  targetTabs: readonly OrderedChatTab[],
-  draggedId: string,
-  draggedPinned: boolean,
-  index: number,
-): boolean {
-  const remaining = targetTabs.filter((tab) => tab.id !== draggedId);
-  const pinnedCount = remaining.filter((tab) => tab.pinned).length;
-  return draggedPinned ? index <= pinnedCount : index >= pinnedCount;
-}
-
-export function orderedChatTabIdsAfterDrop(
-  targetTabs: readonly OrderedChatTab[],
-  draggedId: string,
-  draggedPinned: boolean,
-  requestedIndex: number,
-): string[] {
-  const remaining = targetTabs.filter((tab) => tab.id !== draggedId);
-  const pinnedCount = remaining.filter((tab) => tab.pinned).length;
-  const index = draggedPinned
-    ? Math.max(0, Math.min(requestedIndex, pinnedCount))
-    : Math.max(pinnedCount, Math.min(requestedIndex, remaining.length));
-  const orderedIds = remaining.map((tab) => tab.id);
-  orderedIds.splice(index, 0, draggedId);
-  return orderedIds;
 }
 
 /**

--- a/src/lib/paneLayout.ts
+++ b/src/lib/paneLayout.ts
@@ -810,10 +810,8 @@ export function usePaneLayouts(): PaneLayout[] {
   );
 }
 
-/** The sidebar navigation tree, in render order (parent-grouped, pinned
- *  rows first within their scope, then position). The reference swaps
- *  whole on each authoritative snapshot, so it is a sound
- *  `useSyncExternalStore` snapshot. */
+/** The sidebar navigation tree in authoritative backend order. The reference
+ *  swaps whole on each snapshot, so it is a sound store snapshot. */
 export function getNavNodes(): NodeRow[] {
   return navNodes;
 }
@@ -824,9 +822,8 @@ export function useNavNodes(): NodeRow[] {
 
 /**
  * The unified reparent/reposition op behind every sidebar drag.
- * `orderedIds` must be the complete new ordering of the destination
- * scope's children (moved node included) — the backend validates set
- * equality and returns the authoritative tree, which is adopted here.
+ * `orderedIds` must be the complete unpinned destination scope (including
+ * an unpinned moved node). The authoritative returned tree is adopted here.
  */
 export async function moveNode(
   nodeId: string,
@@ -840,16 +837,35 @@ export async function moveNode(
   applyNodeRows(rows);
 }
 
+/** Rewrite the complete global PINNED order and adopt the authoritative tree. */
+export async function reorderPinnedNodes(orderedIds: string[]): Promise<void> {
+  hydrationSequence += 1;
+  const rows = await api.node.reorderPinned(orderedIds);
+  applyNodeRows(rows);
+}
+
 /** Append a node at the end of a new scope — the move-to-project menu
  *  path uses this; drags carry an explicit order. */
 export async function moveNodeToParentEnd(
   nodeId: string,
   parentId: string | null,
 ): Promise<void> {
+  const moved = navNodes.find((node) => node.id === nodeId);
   const siblings = navNodes
-    .filter((node) => node.parent_id === parentId && node.id !== nodeId)
+    .filter(
+      (node) =>
+        node.parent_id === parentId &&
+        node.id !== nodeId &&
+        node.pinned_position === null,
+    )
     .map((node) => node.id);
-  await moveNode(nodeId, parentId, [...siblings, nodeId]);
+  await moveNode(
+    nodeId,
+    parentId,
+    (moved?.pinned_position ?? null) === null
+      ? [...siblings, nodeId]
+      : siblings,
+  );
 }
 
 /**

--- a/src/lib/sidebarDnd.test.ts
+++ b/src/lib/sidebarDnd.test.ts
@@ -1,21 +1,60 @@
 import { describe, expect, it } from "vitest";
 
-import { orderedRootNodeIdsAfterProjectDrop } from "./sidebarDnd";
+import {
+  completeUnpinnedScopeOrder,
+  orderedPinnedNodeIdsAfterDrop,
+  orderedRootNodeIdsAfterProjectDrop,
+  orderedVisibleNodeIdsAfterDrop,
+} from "./sidebarDnd";
 
 describe("project drop ordering", () => {
   const nodes = [
-    { id: "pinned-chat", parent_id: null, type: "tab" as const },
-    { id: "project-a", parent_id: null, type: "project" as const },
-    { id: "mission-a", parent_id: null, type: "mission" as const },
-    { id: "project-b", parent_id: null, type: "project" as const },
-    { id: "chat-b", parent_id: null, type: "tab" as const },
-    { id: "project-c", parent_id: null, type: "project" as const },
-    { id: "nested-chat", parent_id: "project-a", type: "tab" as const },
+    {
+      id: "pinned-chat",
+      parent_id: null,
+      type: "tab" as const,
+      pinned_position: 0,
+    },
+    {
+      id: "project-a",
+      parent_id: null,
+      type: "project" as const,
+      pinned_position: null,
+    },
+    {
+      id: "mission-a",
+      parent_id: null,
+      type: "mission" as const,
+      pinned_position: null,
+    },
+    {
+      id: "project-b",
+      parent_id: null,
+      type: "project" as const,
+      pinned_position: null,
+    },
+    {
+      id: "chat-b",
+      parent_id: null,
+      type: "tab" as const,
+      pinned_position: null,
+    },
+    {
+      id: "project-c",
+      parent_id: null,
+      type: "project" as const,
+      pinned_position: null,
+    },
+    {
+      id: "nested-chat",
+      parent_id: "project-a",
+      type: "tab" as const,
+      pinned_position: null,
+    },
   ];
 
-  it("reorders project slots while preserving non-project root order", () => {
+  it("reorders project slots while excluding a pinned root tab", () => {
     expect(orderedRootNodeIdsAfterProjectDrop(nodes, "project-b", 0)).toEqual([
-      "pinned-chat",
       "project-b",
       "mission-a",
       "project-a",
@@ -26,7 +65,6 @@ describe("project drop ordering", () => {
 
   it("moves a project to the final project slot without nested nodes", () => {
     expect(orderedRootNodeIdsAfterProjectDrop(nodes, "project-a", 2)).toEqual([
-      "pinned-chat",
       "project-b",
       "mission-a",
       "project-c",
@@ -43,12 +81,103 @@ describe("project drop ordering", () => {
         Number.MAX_SAFE_INTEGER,
       ),
     ).toEqual([
-      "pinned-chat",
       "project-a",
       "mission-a",
       "project-c",
       "chat-b",
       "project-b",
     ]);
+  });
+});
+
+describe("sidebar ordered-id construction", () => {
+  it("builds the complete pinned order while preserving hidden pinned slots", () => {
+    const nodes = [
+      {
+        id: "root-pinned",
+        parent_id: null,
+        type: "tab" as const,
+        pinned_position: 0,
+      },
+      {
+        id: "hidden-pinned",
+        parent_id: null,
+        type: "mission" as const,
+        pinned_position: 1,
+      },
+      {
+        id: "nested-pinned",
+        parent_id: "project-a",
+        type: "tab" as const,
+        pinned_position: 2,
+      },
+      {
+        id: "ordinary",
+        parent_id: null,
+        type: "tab" as const,
+        pinned_position: null,
+      },
+    ];
+
+    expect(
+      orderedPinnedNodeIdsAfterDrop(
+        nodes,
+        ["root-pinned", "nested-pinned"],
+        "nested-pinned",
+        0,
+      ),
+    ).toEqual(["nested-pinned", "hidden-pinned", "root-pinned"]);
+    expect(
+      orderedPinnedNodeIdsAfterDrop(
+        nodes,
+        ["root-pinned", "nested-pinned"],
+        "hidden-pinned",
+        0,
+      ),
+    ).toEqual(["root-pinned", "hidden-pinned", "nested-pinned"]);
+  });
+
+  it("excludes pinned members from complete root scope payloads", () => {
+    const nodes = [
+      {
+        id: "pinned-chat",
+        parent_id: null,
+        type: "tab" as const,
+        pinned_position: 0,
+      },
+      {
+        id: "project",
+        parent_id: null,
+        type: "project" as const,
+        pinned_position: null,
+      },
+      {
+        id: "visible-chat",
+        parent_id: null,
+        type: "tab" as const,
+        pinned_position: null,
+      },
+      {
+        id: "hidden-mission",
+        parent_id: null,
+        type: "mission" as const,
+        pinned_position: null,
+      },
+    ];
+
+    expect(
+      completeUnpinnedScopeOrder(
+        nodes,
+        null,
+        "visible-chat",
+        ["visible-chat"],
+      ),
+    ).toEqual(["project", "visible-chat", "hidden-mission"]);
+  });
+
+  it("reorders visible unpinned rows without pin-tier constraints", () => {
+    expect(
+      orderedVisibleNodeIdsAfterDrop(["a", "b", "c"], "c", 0),
+    ).toEqual(["c", "a", "b"]);
   });
 });

--- a/src/lib/sidebarDnd.ts
+++ b/src/lib/sidebarDnd.ts
@@ -1,21 +1,101 @@
 import type { NodeRow } from "./api";
 
-type RootOrderNode = Pick<NodeRow, "id" | "parent_id" | "type">;
+type SidebarOrderNode = Pick<
+  NodeRow,
+  "id" | "parent_id" | "type" | "pinned_position"
+>;
 
-export function orderedRootNodeIdsAfterProjectDrop(
-  nodes: readonly RootOrderNode[],
+export function orderedVisibleNodeIdsAfterDrop(
+  targetIds: readonly string[],
   draggedId: string,
   requestedIndex: number,
 ): string[] {
-  const rootNodes = nodes.filter((node) => node.parent_id === null);
+  const remaining = targetIds.filter((id) => id !== draggedId);
+  const index = Math.max(0, Math.min(requestedIndex, remaining.length));
+  remaining.splice(index, 0, draggedId);
+  return remaining;
+}
+
+export function completeUnpinnedScopeOrder(
+  nodes: readonly SidebarOrderNode[],
+  parentId: string | null,
+  draggedId: string,
+  orderedVisibleIds: readonly string[],
+): string[] {
+  const pinnedIds = new Set(
+    nodes
+      .filter((node) => node.pinned_position !== null)
+      .map((node) => node.id),
+  );
+  const visible = orderedVisibleIds.filter((id) => !pinnedIds.has(id));
+  const visibleSet = new Set(visible);
+  const siblings = nodes.filter(
+    (node) =>
+      node.parent_id === parentId &&
+      node.id !== draggedId &&
+      node.pinned_position === null,
+  );
+  // Root leaf moves deliberately keep project rows ahead of the leaf section;
+  // project-only moves preserve the existing interleaved slots below.
+  const projectsFirst =
+    parentId === null
+      ? siblings
+          .filter((node) => node.type === "project")
+          .map((node) => node.id)
+      : [];
+  const hidden = siblings
+    .filter((node) => !(parentId === null && node.type === "project"))
+    .map((node) => node.id)
+    .filter((id) => !visibleSet.has(id));
+  return [...projectsFirst, ...visible, ...hidden];
+}
+
+export function orderedPinnedNodeIdsAfterDrop(
+  nodes: readonly SidebarOrderNode[],
+  visiblePinnedIds: readonly string[],
+  draggedId: string,
+  requestedIndex: number,
+): string[] {
+  const allPinnedIds = nodes
+    .filter((node) => node.pinned_position !== null)
+    .sort(
+      (a, b) =>
+        (a.pinned_position ?? 0) - (b.pinned_position ?? 0),
+    )
+    .map((node) => node.id);
+  const pinnedSet = new Set(allPinnedIds);
+  const visible = visiblePinnedIds.filter(
+    (id, index) => pinnedSet.has(id) && visiblePinnedIds.indexOf(id) === index,
+  );
+  const visibleSet = new Set(visible);
+  if (!visibleSet.has(draggedId)) return allPinnedIds;
+  const reorderedVisible = orderedVisibleNodeIdsAfterDrop(
+    visible,
+    draggedId,
+    requestedIndex,
+  );
+  let visibleIndex = 0;
+  return allPinnedIds.map((id) =>
+    visibleSet.has(id) ? reorderedVisible[visibleIndex++] : id,
+  );
+}
+
+export function orderedRootNodeIdsAfterProjectDrop(
+  nodes: readonly SidebarOrderNode[],
+  draggedId: string,
+  requestedIndex: number,
+): string[] {
+  const rootNodes = nodes.filter(
+    (node) => node.parent_id === null && node.pinned_position === null,
+  );
   const projectIds = rootNodes
     .filter((node) => node.type === "project" && node.id !== draggedId)
     .map((node) => node.id);
   const index = Math.max(0, Math.min(requestedIndex, projectIds.length));
   projectIds.splice(index, 0, draggedId);
 
-  // Both sidebar sections share this root scope, so only replace project
-  // slots instead of rebuilding the payload from the filtered PROJECTS list.
+  // Both origin sections share this root scope, so only replace project
+  // slots instead of rebuilding from the filtered PROJECTS list.
   let projectIndex = 0;
   return rootNodes.map((node) =>
     node.type === "project" ? projectIds[projectIndex++] : node.id,


### PR DESCRIPTION
## Summary

- render a global PINNED section for pinned tabs and missions and remove those rows from origin scopes
- add persisted pinned drag reorder plus pinned-aware parent-scope validation and payload construction
- append unpinned nodes to the end of their original scope and sync feature 43 to the shipped node-tree model

## Validation

- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets
- cargo test --workspace
- pnpm test
- pnpm exec tsc --noEmit
- pnpm run lint
- human smoke test passed
- reviewer reported no must-fix findings

Closes #317