### PR TITLE
fix(router): defer mission nudges during local input

### DIFF
--- a/src-tauri/src/router/handlers.rs
+++ b/src-tauri/src/router/handlers.rs
@@ -187,7 +187,7 @@ pub(super) fn message_nudge(router: &Router, event: &Event) {
             return;
         }
         let text = format!("[inbox] new message from @{sender} — run `runner msg read` to view.");
-        if let Err(e) = router.inject_and_submit(target, &submit_body(&text)) {
+        if let Err(e) = router.inject_inbox_nudge(target, &submit_body(&text)) {
             router.warn(format!("message_nudge injection to @{target} failed: {e}"));
         }
         return;
@@ -203,7 +203,7 @@ pub(super) fn message_nudge(router: &Router, event: &Event) {
         .filter(|h| h != sender)
         .collect();
     for handle in handles {
-        if let Err(e) = router.inject_and_submit(&handle, &submit_body(&text)) {
+        if let Err(e) = router.inject_inbox_nudge(&handle, &submit_body(&text)) {
             router.warn(format!("message_nudge broadcast to @{handle} failed: {e}"));
         }
     }

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -22,9 +22,10 @@ mod handlers;
 pub mod prompt;
 pub mod runtime;
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::path::Path;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
+use std::time::Duration;
 
 use runner_core::event_log::EventLog;
 use runner_core::model::{Event, EventKind, SignalType};
@@ -52,6 +53,22 @@ pub trait StdinInjector: Send + Sync + 'static {
     /// xterm.js owns the terminal model and the host has nothing
     /// to capture against. Callers MUST NOT sleep before calling.
     fn inject_paste_with_verify(&self, session_id: &str, body: &[u8]) -> Result<()>;
+
+    /// Snapshot used by diagnostics/tests. Delivery uses the atomic
+    /// reservation below so a keystroke cannot race a separate query.
+    fn input_quiescent(&self, session_id: &str) -> bool;
+
+    fn reserve_delivery(&self, session_id: &str) -> Result<DeliveryReservation>;
+
+    fn inject_reserved(&self, session_id: &str, token: u64, bytes: &[u8]) -> Result<bool>;
+
+    fn finish_delivery(&self, session_id: &str, token: u64);
+
+    fn register_delivery_listener(
+        &self,
+        session_id: &str,
+        listener: Weak<dyn SessionDeliveryListener>,
+    );
 }
 
 impl StdinInjector for SessionManager {
@@ -62,6 +79,51 @@ impl StdinInjector for SessionManager {
     fn inject_paste_with_verify(&self, session_id: &str, body: &[u8]) -> Result<()> {
         SessionManager::inject_paste(self, session_id, body)
     }
+
+    fn input_quiescent(&self, session_id: &str) -> bool {
+        SessionManager::input_quiescent(self, session_id)
+    }
+
+    fn reserve_delivery(&self, session_id: &str) -> Result<DeliveryReservation> {
+        SessionManager::reserve_delivery(self, session_id)
+    }
+
+    fn inject_reserved(&self, session_id: &str, token: u64, bytes: &[u8]) -> Result<bool> {
+        SessionManager::inject_reserved(self, session_id, token, bytes)
+    }
+
+    fn finish_delivery(&self, session_id: &str, token: u64) {
+        SessionManager::finish_delivery(self, session_id, token)
+    }
+
+    fn register_delivery_listener(
+        &self,
+        session_id: &str,
+        listener: Weak<dyn SessionDeliveryListener>,
+    ) {
+        SessionManager::register_delivery_listener(self, session_id, listener)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryReservation {
+    Ready(u64),
+    PendingInput,
+    RecentlyTyping(Duration),
+    InFlight,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionDeliveryEvent {
+    InputCleared,
+    InputQueueDrained,
+    DeliveryFinished,
+    Respawned,
+    Exited,
+}
+
+pub trait SessionDeliveryListener: Send + Sync + 'static {
+    fn session_delivery_event(&self, session_id: &str, event: SessionDeliveryEvent);
 }
 
 // `RunnerStatus` now lives in `session::runtime` because the forwarder
@@ -108,6 +170,54 @@ pub(crate) struct RosterRow {
     lead: bool,
 }
 
+const SUBMIT_DELAY: Duration = Duration::from_millis(80);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum DeliveryKind {
+    InboxNudge,
+    Relay,
+}
+
+#[derive(Clone)]
+struct QueuedDelivery {
+    kind: DeliveryKind,
+    body: Vec<u8>,
+    count: usize,
+}
+
+#[derive(Default)]
+struct SessionOutbox {
+    handle: String,
+    deliveries: VecDeque<QueuedDelivery>,
+    submit_in_flight: bool,
+    retry_scheduled: bool,
+    retry_generation: u64,
+}
+
+impl SessionOutbox {
+    fn enqueue(&mut self, delivery: QueuedDelivery) {
+        if delivery.body.is_empty() {
+            return;
+        }
+        if delivery.kind == DeliveryKind::InboxNudge {
+            if let Some(existing) = self
+                .deliveries
+                .iter_mut()
+                .find(|queued| queued.kind == DeliveryKind::InboxNudge)
+            {
+                existing.count += delivery.count;
+                existing.body = format!(
+                    "[inbox] {} new messages — run `runner msg read` to view.",
+                    existing.count
+                )
+                .into_bytes();
+                return;
+            }
+        }
+        self.deliveries.push_back(delivery);
+    }
+}
+
 /// Mutable per-mission state. Rebuilt on reopen by replaying the log into
 /// `reconstruct_from_log` — no separate persistence layer.
 #[derive(Default)]
@@ -131,6 +241,7 @@ struct RouterState {
     /// opening `mission_goal` event must reach the live dispatcher to
     /// bootstrap the lead.
     replay_high_water: Option<String>,
+    outbox_by_session: HashMap<String, SessionOutbox>,
 }
 
 /// One mission's router. Mounted by `mission_start` after sessions spawn,
@@ -143,6 +254,7 @@ pub struct Router {
     injector: Arc<dyn StdinInjector>,
     launch: LaunchInputs,
     state: Mutex<RouterState>,
+    weak_self: Weak<Router>,
 }
 
 impl Router {
@@ -179,7 +291,7 @@ impl Router {
             })
             .collect();
 
-        Ok(Arc::new(Self {
+        Ok(Arc::new_cyclic(|weak_self| Self {
             mission_id,
             crew_id,
             log,
@@ -192,6 +304,7 @@ impl Router {
                 crew_addendum,
             },
             state: Mutex::new(RouterState::default()),
+            weak_self: weak_self.clone(),
         }))
     }
 
@@ -203,11 +316,18 @@ impl Router {
     /// PTYs (when reattach lands) or skip injection (the workspace
     /// surfaces `mission_warning` from `inject_to_handle` either way).
     pub fn register_sessions(&self, sessions: &[(String, String)]) {
-        let mut state = self.state.lock().unwrap();
-        for (handle, session_id) in sessions {
-            state
-                .session_by_handle
-                .insert(handle.clone(), session_id.clone());
+        {
+            let mut state = self.state.lock().unwrap();
+            for (handle, session_id) in sessions {
+                state
+                    .session_by_handle
+                    .insert(handle.clone(), session_id.clone());
+            }
+        }
+        let listener: Weak<dyn SessionDeliveryListener> = self.weak_self.clone();
+        for (_, session_id) in sessions {
+            self.injector
+                .register_delivery_listener(session_id, listener.clone());
         }
     }
 
@@ -414,36 +534,289 @@ impl Router {
         self.set_status(handle.to_string(), RunnerStatus::Busy);
     }
 
-    /// Inject `body` to the handle's stdin, then send a separate
-    /// carriage-return (`\r`) on a brief delay. claude-code's TUI
-    /// editor treats `\r` as Enter, but bytes arriving in the same
-    /// chunk as the body get appended to the input buffer rather
-    /// than triggering submit — so the chord has to land as a
-    /// distinct read on the slave end. ~80ms is empirically enough
-    /// for the editor to process the body and re-bind its keypress
-    /// reader. Body itself is written verbatim; embedded `\n`
-    /// characters render as line breaks inside the input box.
     pub(crate) fn inject_and_submit(&self, handle: &str, body: &[u8]) -> Result<()> {
-        let session_id = {
-            let state = self.state.lock().unwrap();
-            state.session_by_handle.get(handle).cloned()
+        self.inject_delivery(handle, body, DeliveryKind::Relay)
+    }
+
+    pub(crate) fn inject_inbox_nudge(&self, handle: &str, body: &[u8]) -> Result<()> {
+        self.inject_delivery(handle, body, DeliveryKind::InboxNudge)
+    }
+
+    /// Reserve a clean input box through the delayed Enter, or park the
+    /// payload until the session manager reports that local input cleared.
+    fn inject_delivery(&self, handle: &str, body: &[u8], kind: DeliveryKind) -> Result<()> {
+        let delivery = QueuedDelivery {
+            kind,
+            body: body.to_vec(),
+            count: 1,
         };
-        let Some(session_id) = session_id else {
-            return Err(crate::error::Error::msg(format!(
-                "router: no live session for handle @{handle}"
-            )));
+        // A delayed bare Enter has no payload left to deliver after the
+        // user's draft clears, so parking it would create a stray submit.
+        let deferable = !delivery.body.is_empty();
+        let mut retry = None;
+        let (session_id, ready) = {
+            let mut state = self.state.lock().unwrap();
+            let Some(session_id) = state.session_by_handle.get(handle).cloned() else {
+                return Err(crate::error::Error::msg(format!(
+                    "router: no live session for handle @{handle}"
+                )));
+            };
+            if let Some(outbox) = state.outbox_by_session.get_mut(&session_id) {
+                if outbox.submit_in_flight || !outbox.deliveries.is_empty() {
+                    outbox.enqueue(delivery);
+                    return Ok(());
+                }
+            }
+            match self.injector.reserve_delivery(&session_id)? {
+                DeliveryReservation::Ready(token) => {
+                    let outbox = state
+                        .outbox_by_session
+                        .entry(session_id.clone())
+                        .or_default();
+                    outbox.handle = handle.to_string();
+                    outbox.submit_in_flight = true;
+                    (session_id, Some((delivery, token)))
+                }
+                DeliveryReservation::RecentlyTyping(delay) => {
+                    if deferable {
+                        let outbox = state
+                            .outbox_by_session
+                            .entry(session_id.clone())
+                            .or_default();
+                        outbox.handle = handle.to_string();
+                        outbox.enqueue(delivery);
+                        retry = Some((session_id.clone(), delay));
+                    }
+                    (session_id, None)
+                }
+                DeliveryReservation::PendingInput | DeliveryReservation::InFlight => {
+                    if deferable {
+                        let outbox = state
+                            .outbox_by_session
+                            .entry(session_id.clone())
+                            .or_default();
+                        outbox.handle = handle.to_string();
+                        outbox.enqueue(delivery);
+                    }
+                    (session_id, None)
+                }
+            }
         };
-        self.synthesize_wake_busy(handle);
-        if !body.is_empty() {
-            self.injector.inject(&session_id, body)?;
+        if let Some((session_id, delay)) = retry {
+            self.schedule_outbox_retry(session_id, delay);
+        }
+        match ready {
+            Some((delivery, token)) => {
+                self.start_reserved_delivery(&session_id, handle, delivery, token)
+            }
+            None => Ok(()),
+        }
+    }
+
+    fn start_reserved_delivery(
+        &self,
+        session_id: &str,
+        handle: &str,
+        delivery: QueuedDelivery,
+        token: u64,
+    ) -> Result<()> {
+        if !delivery.body.is_empty() {
+            match self
+                .injector
+                .inject_reserved(session_id, token, &delivery.body)
+            {
+                Ok(true) => {}
+                Ok(false) => {
+                    self.cancel_started_delivery(session_id);
+                    self.injector.finish_delivery(session_id, token);
+                    return Err(crate::error::Error::msg(format!(
+                        "router: session {session_id} changed before delivery"
+                    )));
+                }
+                Err(error) => {
+                    self.injector.finish_delivery(session_id, token);
+                    return Err(error);
+                }
+            }
         }
         let injector = Arc::clone(&self.injector);
-        let sid = session_id.clone();
+        let sid = session_id.to_string();
         std::thread::spawn(move || {
-            std::thread::sleep(std::time::Duration::from_millis(80));
-            let _ = injector.inject(&sid, b"\r");
+            std::thread::sleep(SUBMIT_DELAY);
+            let _ = injector.inject_reserved(&sid, token, b"\r");
+            injector.finish_delivery(&sid, token);
         });
+        self.synthesize_wake_busy(handle);
         Ok(())
+    }
+
+    fn cancel_started_delivery(&self, session_id: &str) {
+        let mut state = self.state.lock().unwrap();
+        let Some(outbox) = state.outbox_by_session.get_mut(session_id) else {
+            return;
+        };
+        outbox.submit_in_flight = false;
+        if outbox.deliveries.is_empty() {
+            state.outbox_by_session.remove(session_id);
+        }
+    }
+
+    fn flush_outbox(&self, session_id: &str) {
+        let handle = {
+            let state = self.state.lock().unwrap();
+            let Some(outbox) = state.outbox_by_session.get(session_id) else {
+                return;
+            };
+            if outbox.submit_in_flight || outbox.deliveries.is_empty() {
+                return;
+            }
+            outbox.handle.clone()
+        };
+
+        let reservation = match self.injector.reserve_delivery(session_id) {
+            Ok(reservation) => reservation,
+            Err(error) => {
+                let dropped = self
+                    .state
+                    .lock()
+                    .unwrap()
+                    .outbox_by_session
+                    .remove(session_id)
+                    .map_or(0, |outbox| outbox.deliveries.len());
+                self.warn(format!(
+                    "router: dropped {dropped} deferred deliveries for {session_id}: {error}"
+                ));
+                return;
+            }
+        };
+        match reservation {
+            DeliveryReservation::Ready(token) => {
+                let delivery = {
+                    let mut state = self.state.lock().unwrap();
+                    let Some(outbox) = state.outbox_by_session.get_mut(session_id) else {
+                        self.injector.finish_delivery(session_id, token);
+                        return;
+                    };
+                    let Some(delivery) = outbox.deliveries.pop_front() else {
+                        self.injector.finish_delivery(session_id, token);
+                        return;
+                    };
+                    outbox.submit_in_flight = true;
+                    delivery
+                };
+                if let Err(error) =
+                    self.start_reserved_delivery(session_id, &handle, delivery, token)
+                {
+                    log::warn!("deferred router delivery to {session_id} failed: {error}");
+                }
+            }
+            DeliveryReservation::RecentlyTyping(delay) => {
+                self.schedule_outbox_retry(session_id.to_string(), delay);
+            }
+            DeliveryReservation::PendingInput | DeliveryReservation::InFlight => {}
+        }
+    }
+
+    fn schedule_outbox_retry(&self, session_id: String, delay: Duration) {
+        let generation = {
+            let mut state = self.state.lock().unwrap();
+            let Some(outbox) = state.outbox_by_session.get_mut(&session_id) else {
+                return;
+            };
+            if outbox.retry_scheduled {
+                return;
+            }
+            outbox.retry_scheduled = true;
+            outbox.retry_generation = outbox.retry_generation.wrapping_add(1);
+            outbox.retry_generation
+        };
+        let router = self.weak_self.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(delay);
+            if let Some(router) = router.upgrade() {
+                {
+                    let mut state = router.state.lock().unwrap();
+                    let Some(outbox) = state.outbox_by_session.get_mut(&session_id) else {
+                        return;
+                    };
+                    if outbox.retry_generation != generation {
+                        return;
+                    }
+                    outbox.retry_scheduled = false;
+                }
+                router.flush_outbox(&session_id);
+            }
+        });
+    }
+
+    fn schedule_outbox_flush(&self, session_id: String, delay: Duration) {
+        let generation = {
+            let mut state = self.state.lock().unwrap();
+            let Some(outbox) = state.outbox_by_session.get_mut(&session_id) else {
+                return;
+            };
+            if outbox.deliveries.is_empty() {
+                return;
+            }
+            outbox.retry_generation = outbox.retry_generation.wrapping_add(1);
+            outbox.retry_scheduled = false;
+            outbox.submit_in_flight = false;
+            outbox.retry_generation
+        };
+        let router = self.weak_self.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(delay);
+            if let Some(router) = router.upgrade() {
+                let current = router
+                    .state
+                    .lock()
+                    .unwrap()
+                    .outbox_by_session
+                    .get(&session_id)
+                    .map(|outbox| outbox.retry_generation);
+                if current != Some(generation) {
+                    return;
+                }
+                router.flush_outbox(&session_id);
+            }
+        });
+    }
+
+    fn schedule_delivery_cooldown(&self, session_id: String) {
+        let generation = {
+            let mut state = self.state.lock().unwrap();
+            let Some(outbox) = state.outbox_by_session.get_mut(&session_id) else {
+                return;
+            };
+            outbox.retry_generation = outbox.retry_generation.wrapping_add(1);
+            outbox.retry_generation
+        };
+        let router = self.weak_self.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(SUBMIT_DELAY);
+            let Some(router) = router.upgrade() else {
+                return;
+            };
+            {
+                let mut state = router.state.lock().unwrap();
+                let Some(outbox) = state.outbox_by_session.get_mut(&session_id) else {
+                    return;
+                };
+                if outbox.retry_generation != generation {
+                    return;
+                }
+                outbox.submit_in_flight = false;
+            }
+            router.flush_outbox(&session_id);
+            let mut state = router.state.lock().unwrap();
+            if state
+                .outbox_by_session
+                .get(&session_id)
+                .is_some_and(|outbox| !outbox.submit_in_flight && outbox.deliveries.is_empty())
+            {
+                state.outbox_by_session.remove(&session_id);
+            }
+        });
     }
 
     /// Lead launch-prompt injection: routes through the verified
@@ -689,6 +1062,48 @@ impl Router {
                     self.mission_id
                 );
                 None
+            }
+        }
+    }
+}
+
+impl SessionDeliveryListener for Router {
+    fn session_delivery_event(&self, session_id: &str, event: SessionDeliveryEvent) {
+        match event {
+            SessionDeliveryEvent::InputCleared => {
+                self.schedule_outbox_flush(session_id.to_string(), SUBMIT_DELAY);
+            }
+            SessionDeliveryEvent::InputQueueDrained => self.flush_outbox(session_id),
+            SessionDeliveryEvent::DeliveryFinished => {
+                self.schedule_delivery_cooldown(session_id.to_string());
+            }
+            SessionDeliveryEvent::Respawned => {
+                if let Some(outbox) = self
+                    .state
+                    .lock()
+                    .unwrap()
+                    .outbox_by_session
+                    .get_mut(session_id)
+                {
+                    outbox.submit_in_flight = false;
+                    outbox.retry_scheduled = false;
+                    outbox.retry_generation = outbox.retry_generation.wrapping_add(1);
+                }
+                self.flush_outbox(session_id);
+            }
+            SessionDeliveryEvent::Exited => {
+                let dropped = self
+                    .state
+                    .lock()
+                    .unwrap()
+                    .outbox_by_session
+                    .remove(session_id)
+                    .map_or(0, |outbox| outbox.deliveries.len());
+                if dropped > 0 {
+                    self.warn(format!(
+                        "router: dropped {dropped} deferred deliveries because session {session_id} exited"
+                    ));
+                }
             }
         }
     }

--- a/src-tauri/src/router/tests.rs
+++ b/src-tauri/src/router/tests.rs
@@ -6,13 +6,17 @@
 // Bus integration is covered separately (mission lifecycle + mission_e2e).
 
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
+use std::time::{Duration, Instant};
 
 use chrono::Utc;
 use runner_core::event_log::EventLog;
 use runner_core::model::{Event, EventDraft, EventKind, SignalType};
 
-use super::{Router, RouterRegistry, StdinInjector};
+use super::{
+    DeliveryReservation, Router, RouterRegistry, SessionDeliveryEvent, SessionDeliveryListener,
+    StdinInjector,
+};
 use crate::error::Result;
 use crate::model::{Runner, Slot, SlotWithRunner};
 
@@ -36,6 +40,16 @@ struct RecordingInjector {
     /// Optional `dead_session` set — `inject` errors when called with one
     /// of these ids, simulating a crashed PTY for `mission_warning` tests.
     dead: Mutex<Vec<String>>,
+    input: Mutex<HashMap<String, RecordingInputState>>,
+    listeners: Mutex<HashMap<String, Vec<Weak<dyn SessionDeliveryListener>>>>,
+}
+
+#[derive(Default)]
+struct RecordingInputState {
+    pending: bool,
+    last_input_at: Option<Instant>,
+    in_flight: bool,
+    generation: u64,
 }
 
 impl RecordingInjector {
@@ -86,8 +100,81 @@ impl RecordingInjector {
             .collect()
     }
 
+    fn submitted_bodies_for(&self, session_id: &str) -> Vec<String> {
+        self.pushes
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(s, kind, bytes)| {
+                s == session_id && *kind == InjectKind::Raw && bytes.as_slice() != b"\r"
+            })
+            .map(|(_, _, bytes)| String::from_utf8_lossy(bytes).into_owned())
+            .collect()
+    }
+
     fn mark_dead(&self, session_id: &str) {
         self.dead.lock().unwrap().push(session_id.to_string());
+    }
+
+    fn set_pending(&self, session_id: &str) {
+        let mut input = self.input.lock().unwrap();
+        let input = input.entry(session_id.to_string()).or_default();
+        input.pending = true;
+        input.last_input_at = Some(Instant::now());
+    }
+
+    fn set_recent_typing(&self, session_id: &str) {
+        let mut input = self.input.lock().unwrap();
+        let input = input.entry(session_id.to_string()).or_default();
+        input.pending = false;
+        input.last_input_at = Some(Instant::now() - Duration::from_millis(1950));
+    }
+
+    fn clear_pending(&self, session_id: &str) {
+        if let Some(input) = self.input.lock().unwrap().get_mut(session_id) {
+            input.pending = false;
+            input.last_input_at = None;
+        }
+        self.notify(session_id, SessionDeliveryEvent::InputCleared);
+    }
+
+    fn respawn(&self, session_id: &str) {
+        self.dead.lock().unwrap().retain(|dead| dead != session_id);
+        {
+            let mut input = self.input.lock().unwrap();
+            let input = input.entry(session_id.to_string()).or_default();
+            input.generation = input.generation.wrapping_add(1);
+            input.in_flight = false;
+            input.pending = false;
+            input.last_input_at = None;
+        }
+        self.notify(session_id, SessionDeliveryEvent::Respawned);
+    }
+
+    fn exit(&self, session_id: &str) {
+        self.mark_dead(session_id);
+        if let Some(input) = self.input.lock().unwrap().get_mut(session_id) {
+            input.generation = input.generation.wrapping_add(1);
+            input.in_flight = false;
+            input.pending = false;
+            input.last_input_at = None;
+        }
+        self.notify(session_id, SessionDeliveryEvent::Exited);
+    }
+
+    fn notify(&self, session_id: &str, event: SessionDeliveryEvent) {
+        let listeners = self
+            .listeners
+            .lock()
+            .unwrap()
+            .get(session_id)
+            .into_iter()
+            .flatten()
+            .filter_map(Weak::upgrade)
+            .collect::<Vec<_>>();
+        for listener in listeners {
+            listener.session_delivery_event(session_id, event);
+        }
     }
 }
 
@@ -117,6 +204,122 @@ impl StdinInjector for RecordingInjector {
             body.to_vec(),
         ));
         Ok(())
+    }
+
+    fn input_quiescent(&self, session_id: &str) -> bool {
+        if self
+            .dead
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|dead| dead == session_id)
+        {
+            return false;
+        }
+        self.input
+            .lock()
+            .unwrap()
+            .get(session_id)
+            .is_some_and(|input| {
+                !input.in_flight
+                    && !input.pending
+                    && input
+                        .last_input_at
+                        .is_none_or(|last| last.elapsed() >= Duration::from_secs(2))
+            })
+    }
+
+    fn reserve_delivery(&self, session_id: &str) -> Result<DeliveryReservation> {
+        if self
+            .dead
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|dead| dead == session_id)
+        {
+            return Err(crate::error::Error::msg(format!(
+                "test: session {session_id} is dead"
+            )));
+        }
+        let mut input = self.input.lock().unwrap();
+        let input = input.entry(session_id.to_string()).or_default();
+        if input.in_flight {
+            return Ok(DeliveryReservation::InFlight);
+        }
+        if input.pending {
+            return Ok(DeliveryReservation::PendingInput);
+        }
+        if let Some(last) = input.last_input_at {
+            let elapsed = last.elapsed();
+            if elapsed < Duration::from_secs(2) {
+                return Ok(DeliveryReservation::RecentlyTyping(
+                    Duration::from_secs(2) - elapsed,
+                ));
+            }
+        }
+        input.in_flight = true;
+        Ok(DeliveryReservation::Ready(input.generation))
+    }
+
+    fn inject_reserved(&self, session_id: &str, token: u64, bytes: &[u8]) -> Result<bool> {
+        if self
+            .dead
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|dead| dead == session_id)
+        {
+            return Ok(false);
+        }
+        let input = self.input.lock().unwrap();
+        let Some(input) = input.get(session_id) else {
+            return Ok(false);
+        };
+        if !input.in_flight || input.generation != token {
+            return Ok(false);
+        }
+        self.pushes
+            .lock()
+            .unwrap()
+            .push((session_id.to_string(), InjectKind::Raw, bytes.to_vec()));
+        Ok(true)
+    }
+
+    fn finish_delivery(&self, session_id: &str, token: u64) {
+        let finished = self
+            .input
+            .lock()
+            .unwrap()
+            .get_mut(session_id)
+            .is_some_and(|input| {
+                if input.in_flight && input.generation == token {
+                    input.in_flight = false;
+                    true
+                } else {
+                    false
+                }
+            });
+        if finished {
+            self.notify(session_id, SessionDeliveryEvent::DeliveryFinished);
+        }
+    }
+
+    fn register_delivery_listener(
+        &self,
+        session_id: &str,
+        listener: Weak<dyn SessionDeliveryListener>,
+    ) {
+        self.input
+            .lock()
+            .unwrap()
+            .entry(session_id.to_string())
+            .or_default();
+        self.listeners
+            .lock()
+            .unwrap()
+            .entry(session_id.to_string())
+            .or_default()
+            .push(listener);
     }
 }
 
@@ -210,6 +413,14 @@ fn read_signals(log: &EventLog) -> Vec<Event> {
         .collect()
 }
 
+fn wait_until(timeout: Duration, predicate: impl Fn() -> bool) {
+    let deadline = Instant::now() + timeout;
+    while !predicate() {
+        assert!(Instant::now() < deadline, "condition did not become true");
+        std::thread::sleep(Duration::from_millis(5));
+    }
+}
+
 #[test]
 fn directed_message_nudges_target_only() {
     // Pull-based inbox routing strands the worker without a stdin
@@ -231,6 +442,172 @@ fn directed_message_nudges_target_only() {
     assert!(impl_pushes[0].contains("runner msg read"));
     // Sender is not nudged.
     assert!(injector.pushes_for("S-LEAD").is_empty());
+}
+
+#[test]
+fn pending_input_parks_delivery_until_clear() {
+    let (router, injector, log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    injector.set_pending("S-IMPL");
+
+    let direct = log.append(message("lead", Some("impl"), "go")).unwrap();
+    router.handle_event(&direct);
+    assert!(injector.pushes_for("S-IMPL").is_empty());
+    assert!(!matches!(
+        router.state.lock().unwrap().status.get("impl"),
+        Some(super::RunnerStatus::Busy)
+    ));
+
+    injector.clear_pending("S-IMPL");
+    assert!(
+        injector.pushes_for("S-IMPL").is_empty(),
+        "flush must leave a post-submit gap before writing the deferred body"
+    );
+    injector.set_pending("S-IMPL");
+    std::thread::sleep(Duration::from_millis(120));
+    assert!(
+        injector.pushes_for("S-IMPL").is_empty(),
+        "typing a new draft during the post-submit gap must keep the delivery parked"
+    );
+    injector.clear_pending("S-IMPL");
+    wait_until(Duration::from_millis(250), || {
+        injector.submitted_bodies_for("S-IMPL").len() == 1
+            && matches!(
+                router.state.lock().unwrap().status.get("impl"),
+                Some(super::RunnerStatus::Busy)
+            )
+    });
+    assert!(injector.submitted_bodies_for("S-IMPL")[0].contains("[inbox]"));
+    assert!(matches!(
+        router.state.lock().unwrap().status.get("impl"),
+        Some(super::RunnerStatus::Busy)
+    ));
+}
+
+#[test]
+fn recent_typing_retries_after_quiet_window() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    injector.set_recent_typing("S-IMPL");
+    router.inject_and_submit("impl", b"after quiet").unwrap();
+    assert!(injector.pushes_for("S-IMPL").is_empty());
+
+    wait_until(Duration::from_millis(300), || {
+        injector.submitted_bodies_for("S-IMPL") == ["after quiet"]
+    });
+}
+
+#[test]
+fn deferred_nudges_coalesce_while_relays_preserve_order() {
+    let (router, injector, log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    injector.set_pending("S-IMPL");
+
+    for event in [
+        log.append(message("lead", Some("impl"), "first")).unwrap(),
+        log.append(signal(
+            "human",
+            "human_said",
+            serde_json::json!({ "target": "impl", "text": "relay one" }),
+        ))
+        .unwrap(),
+        log.append(message("lead", Some("impl"), "second")).unwrap(),
+        log.append(signal(
+            "human",
+            "human_said",
+            serde_json::json!({ "target": "impl", "text": "relay two" }),
+        ))
+        .unwrap(),
+    ] {
+        router.handle_event(&event);
+    }
+    assert!(injector.pushes_for("S-IMPL").is_empty());
+
+    injector.clear_pending("S-IMPL");
+    wait_until(Duration::from_secs(1), || {
+        injector.submitted_bodies_for("S-IMPL").len() == 3
+    });
+    let bodies = injector.submitted_bodies_for("S-IMPL");
+    assert!(bodies[0].contains("2 new messages"));
+    assert_eq!(bodies[1], "relay one");
+    assert_eq!(bodies[2], "relay two");
+}
+
+#[test]
+fn deferred_delivery_flushes_on_respawn() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    injector.set_pending("S-IMPL");
+    router
+        .inject_and_submit("impl", b"relay after respawn")
+        .unwrap();
+    assert!(injector.pushes_for("S-IMPL").is_empty());
+
+    injector.respawn("S-IMPL");
+    wait_until(Duration::from_millis(250), || {
+        injector.submitted_bodies_for("S-IMPL") == ["relay after respawn"]
+    });
+}
+
+#[test]
+fn session_exit_drops_deferred_delivery() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    injector.set_pending("S-IMPL");
+    router
+        .inject_and_submit("impl", b"must be dropped")
+        .unwrap();
+
+    injector.exit("S-IMPL");
+    injector.respawn("S-IMPL");
+    std::thread::sleep(Duration::from_millis(200));
+    assert!(injector.pushes_for("S-IMPL").is_empty());
+}
+
+#[test]
+fn blocked_empty_body_does_not_flush_a_stray_enter() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    injector.set_pending("S-IMPL");
+    router.inject_and_submit("impl", b"").unwrap();
+    injector.clear_pending("S-IMPL");
+    std::thread::sleep(Duration::from_millis(200));
+    assert!(injector.pushes_for("S-IMPL").is_empty());
+
+    router.inject_and_submit("impl", b"").unwrap();
+    wait_until(Duration::from_millis(250), || {
+        injector.raw_pushes_for("S-IMPL") == ["\r"]
+    });
 }
 
 #[test]
@@ -705,6 +1082,8 @@ fn pending_ask_map_reconstructs_from_log_on_reopen() {
         })
         .expect("router #1 must have appended human_question")
         .id;
+    log.append(message("lead", Some("impl"), "historical mail"))
+        .unwrap();
 
     // Reopen: build router #2, fold projection state from history. This
     // is the path mission_resume / mount-on-app-restart will follow.
@@ -1138,6 +1517,7 @@ fn directed_wake_synthesizes_busy_and_idle_clears_it() {
     // exact regression issue #32 calls out.
     let direct_followup = log.append(message("lead", Some("impl"), "next")).unwrap();
     router.handle_event(&direct_followup);
+    wait_until(Duration::from_secs(1), || busy_for_impl(&log) == 2);
     assert_eq!(
         busy_for_impl(&log),
         2,

--- a/src-tauri/src/session/manager/lifecycle.rs
+++ b/src-tauri/src/session/manager/lifecycle.rs
@@ -60,12 +60,21 @@ impl SessionManager {
         }
 
         // Stop succeeded. Now tear down the handle and reconcile.
+        let gate = state.lock().unwrap().delivery_gate.clone();
         let (stop, forwarder) = {
+            let mut delivery = gate.state.lock().unwrap();
             let mut state = state.lock().unwrap();
             match state.handle.take() {
                 Some(mut h) => {
+                    delivery.generation = delivery.generation.wrapping_add(1);
+                    delivery.in_flight = false;
+                    delivery.next_ticket = 0;
+                    delivery.next_served = 0;
+                    gate.ready.notify_all();
                     state.activity = None;
                     state.suppress_local_input_busy = false;
+                    state.local_input_pending = false;
+                    state.last_local_input_at = None;
                     state.mission_status_sink = None;
                     state.completion_armed = false;
                     (h.stop.clone(), h.forwarder.take())
@@ -73,6 +82,7 @@ impl SessionManager {
                 None => return Ok(()), // raced with another caller; no-op
             }
         };
+        self.notify_delivery_event(session_id, router::SessionDeliveryEvent::Exited);
 
         // Flip the explicit cancellation flag so the consumer
         // breaks out within ~500ms regardless of how the reader EOF
@@ -208,17 +218,29 @@ impl SessionManager {
         // Use `purge_session_buffers` for explicit cleanup paths
         // (archive, runner delete).
         if let Some(state) = self.session_state(session_id) {
+            let gate = state.lock().unwrap().delivery_gate.clone();
+            let mut delivery = gate.state.lock().unwrap();
             let mut state = state.lock().unwrap();
             if state
                 .handle
                 .as_ref()
                 .is_some_and(|h| Self::runtime_session_matches(&h.runtime_session, runtime_session))
             {
+                delivery.generation = delivery.generation.wrapping_add(1);
+                delivery.in_flight = false;
+                delivery.next_ticket = 0;
+                delivery.next_served = 0;
+                gate.ready.notify_all();
                 state.handle = None;
                 state.activity = None;
                 state.suppress_local_input_busy = false;
+                state.local_input_pending = false;
+                state.last_local_input_at = None;
                 state.mission_status_sink = None;
                 state.completion_armed = false;
+                drop(state);
+                drop(delivery);
+                self.notify_delivery_event(session_id, router::SessionDeliveryEvent::Exited);
             }
         }
         self.prune_empty_session_state(session_id);

--- a/src-tauri/src/session/manager/mod.rs
+++ b/src-tauri/src/session/manager/mod.rs
@@ -20,7 +20,7 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::RecvTimeoutError;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -48,6 +48,7 @@ mod spawn;
 mod tests;
 
 const MAX_OUTPUT_BUFFER_CHUNKS: usize = 4096;
+const RECENT_LOCAL_INPUT_WINDOW: Duration = Duration::from_secs(2);
 
 /// Minimum spacing between consecutive `claude-code` PTY launches.
 /// Long enough for one claude's OAuth refresh round-trip (network
@@ -466,10 +467,31 @@ struct CodexCaptureContext {
 }
 
 #[derive(Default)]
+struct DeliveryGateState {
+    /// Generation invalidates a delayed Enter when the session exits or
+    /// respawns with the same database id.
+    generation: u64,
+    /// Held from router body injection through its delayed Enter so local
+    /// keystrokes and another router delivery cannot join the same draft.
+    in_flight: bool,
+    next_ticket: u64,
+    next_served: u64,
+}
+
+#[derive(Default)]
+struct DeliveryGate {
+    state: Mutex<DeliveryGateState>,
+    ready: Condvar,
+}
+
+#[derive(Default)]
 struct SessionState {
     handle: Option<SessionHandle>,
     activity: Option<SessionActivityState>,
     suppress_local_input_busy: bool,
+    local_input_pending: bool,
+    last_local_input_at: Option<Instant>,
+    delivery_gate: Arc<DeliveryGate>,
     mission_status_sink: Option<ForwarderEmitCtx>,
     completion_armed: bool,
     output_buffer: VecDeque<OutputEvent>,
@@ -497,6 +519,8 @@ impl SessionState {
         self.handle.is_none()
             && self.activity.is_none()
             && !self.suppress_local_input_busy
+            && !self.local_input_pending
+            && self.last_local_input_at.is_none()
             && self.mission_status_sink.is_none()
             && !self.completion_armed
             && self.output_buffer.is_empty()
@@ -516,6 +540,7 @@ pub struct SessionManager {
     /// PTY output for one busy session does not block lifecycle work on
     /// other sessions.
     sessions: Mutex<HashMap<String, Arc<Mutex<SessionState>>>>,
+    delivery_listeners: Mutex<HashMap<String, Vec<Weak<dyn router::SessionDeliveryListener>>>>,
     /// User's login-shell env snapshot, captured once at app start by
     /// `shell_path::resolve_login_shell_env`. Empty when the resolve
     /// failed/timed out, when running on Windows, or in tests.
@@ -640,6 +665,7 @@ impl SessionManager {
     ) -> Arc<Self> {
         Arc::new(Self {
             sessions: Mutex::new(HashMap::new()),
+            delivery_listeners: Mutex::new(HashMap::new()),
             shell_env,
             claude_launch_gate: Mutex::new(None),
             pending_mission_cancels: Mutex::new(HashMap::new()),
@@ -658,6 +684,113 @@ impl SessionManager {
             .entry(session_id.to_string())
             .or_insert_with(|| Arc::new(Mutex::new(SessionState::default())))
             .clone()
+    }
+
+    pub fn register_delivery_listener(
+        &self,
+        session_id: &str,
+        listener: Weak<dyn router::SessionDeliveryListener>,
+    ) {
+        let mut listeners = self.delivery_listeners.lock().unwrap();
+        let listeners = listeners.entry(session_id.to_string()).or_default();
+        if !listeners.iter().any(|existing| existing.ptr_eq(&listener)) {
+            listeners.push(listener);
+        }
+    }
+
+    fn notify_delivery_event(&self, session_id: &str, event: router::SessionDeliveryEvent) {
+        let listeners = {
+            let mut listeners_by_session = self.delivery_listeners.lock().unwrap();
+            let (live, remove_entry) = {
+                let Some(listeners) = listeners_by_session.get_mut(session_id) else {
+                    return;
+                };
+                let mut live = Vec::with_capacity(listeners.len());
+                listeners.retain(|listener| {
+                    if let Some(listener) = listener.upgrade() {
+                        live.push(listener);
+                        true
+                    } else {
+                        false
+                    }
+                });
+                (live, listeners.is_empty())
+            };
+            if remove_entry {
+                listeners_by_session.remove(session_id);
+            }
+            live
+        };
+        for listener in listeners {
+            listener.session_delivery_event(session_id, event);
+        }
+    }
+
+    pub fn input_quiescent(&self, session_id: &str) -> bool {
+        let Some(session) = self.session_state(session_id) else {
+            return false;
+        };
+        let gate = session.lock().unwrap().delivery_gate.clone();
+        let delivery = gate.state.lock().unwrap();
+        let session = session.lock().unwrap();
+        session.handle.is_some()
+            && !delivery.in_flight
+            && delivery.next_ticket == delivery.next_served
+            && !session.local_input_pending
+            && session
+                .last_local_input_at
+                .is_none_or(|last| last.elapsed() >= RECENT_LOCAL_INPUT_WINDOW)
+    }
+
+    pub fn reserve_delivery(&self, session_id: &str) -> Result<router::DeliveryReservation> {
+        let session = self
+            .session_state(session_id)
+            .ok_or_else(|| Error::msg(format!("session not found: {session_id}")))?;
+        let gate = session.lock().unwrap().delivery_gate.clone();
+        let mut delivery = gate.state.lock().unwrap();
+        let session = session.lock().unwrap();
+        if session.handle.is_none() {
+            return Err(Error::msg(format!("session not found: {session_id}")));
+        }
+        if delivery.in_flight {
+            return Ok(router::DeliveryReservation::InFlight);
+        }
+        if delivery.next_ticket != delivery.next_served {
+            return Ok(router::DeliveryReservation::InFlight);
+        }
+        if session.local_input_pending {
+            return Ok(router::DeliveryReservation::PendingInput);
+        }
+        if let Some(last) = session.last_local_input_at {
+            let elapsed = last.elapsed();
+            if elapsed < RECENT_LOCAL_INPUT_WINDOW {
+                return Ok(router::DeliveryReservation::RecentlyTyping(
+                    RECENT_LOCAL_INPUT_WINDOW - elapsed,
+                ));
+            }
+        }
+        delivery.in_flight = true;
+        Ok(router::DeliveryReservation::Ready(delivery.generation))
+    }
+
+    pub fn finish_delivery(&self, session_id: &str, token: u64) {
+        let Some(session) = self.session_state(session_id) else {
+            return;
+        };
+        let gate = session.lock().unwrap().delivery_gate.clone();
+        let finished = {
+            let mut delivery = gate.state.lock().unwrap();
+            if !delivery.in_flight || delivery.generation != token {
+                false
+            } else {
+                delivery.in_flight = false;
+                gate.ready.notify_all();
+                true
+            }
+        };
+        if finished {
+            self.notify_delivery_event(session_id, router::SessionDeliveryEvent::DeliveryFinished);
+        }
     }
 
     fn prune_empty_session_state(&self, session_id: &str) {
@@ -679,14 +812,26 @@ impl SessionManager {
         initial_size: Option<(u16, u16)>,
     ) {
         let state = self.session_state_or_insert(session_id);
-        let mut state = state.lock().unwrap();
-        state.handle = Some(handle);
-        state.mission_status_sink = mission_status_sink;
-        state.killed = false;
-        // Seed the resize purge gate with the cols the PTY actually opened
-        // at (the runtime defaults unsized spawns to 80×24), so the first
-        // same-width resize after spawn/resume doesn't purge the ring.
-        state.last_pty_cols = Some(initial_size.map_or(80, |(cols, _)| cols));
+        let gate = state.lock().unwrap().delivery_gate.clone();
+        {
+            let mut delivery = gate.state.lock().unwrap();
+            let mut state = state.lock().unwrap();
+            delivery.generation = delivery.generation.wrapping_add(1);
+            delivery.in_flight = false;
+            delivery.next_ticket = 0;
+            delivery.next_served = 0;
+            gate.ready.notify_all();
+            state.local_input_pending = false;
+            state.last_local_input_at = None;
+            state.handle = Some(handle);
+            state.mission_status_sink = mission_status_sink;
+            state.killed = false;
+            // Seed the resize purge gate with the cols the PTY actually opened
+            // at (the runtime defaults unsized spawns to 80×24), so the first
+            // same-width resize after spawn/resume doesn't purge the ring.
+            state.last_pty_cols = Some(initial_size.map_or(80, |(cols, _)| cols));
+        }
+        self.notify_delivery_event(session_id, router::SessionDeliveryEvent::Respawned);
     }
 
     fn install_forwarder(&self, session_id: &str, forwarder: thread::JoinHandle<()>) {

--- a/src-tauri/src/session/manager/output.rs
+++ b/src-tauri/src/session/manager/output.rs
@@ -1,5 +1,59 @@
 use super::*;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum LocalInputClass {
+    SetPending,
+    ClearPending,
+    ActivityOnly,
+}
+
+pub(super) fn classify_local_input(bytes: &[u8]) -> Option<LocalInputClass> {
+    if bytes.is_empty() {
+        return None;
+    }
+    if bytes == b"\r" || bytes == b"\x03" {
+        return Some(LocalInputClass::ClearPending);
+    }
+    if bytes == b"\x16" || bytes.starts_with(b"\x1b[200~") {
+        return Some(LocalInputClass::SetPending);
+    }
+    if bytes.starts_with(b"\x1b") {
+        return Some(LocalInputClass::ActivityOnly);
+    }
+    if bytes
+        .iter()
+        .any(|byte| matches!(byte, 0x20..=0x7e | 0x80..=0xff))
+    {
+        Some(LocalInputClass::SetPending)
+    } else {
+        Some(LocalInputClass::ActivityOnly)
+    }
+}
+
+pub(super) fn update_local_input_state(
+    state: &mut SessionState,
+    input_class: Option<LocalInputClass>,
+    now: Instant,
+) -> bool {
+    match input_class {
+        Some(LocalInputClass::SetPending) => {
+            state.local_input_pending = true;
+            state.last_local_input_at = Some(now);
+            false
+        }
+        Some(LocalInputClass::ClearPending) => {
+            state.local_input_pending = false;
+            state.last_local_input_at = None;
+            true
+        }
+        Some(LocalInputClass::ActivityOnly) => {
+            state.last_local_input_at = Some(now);
+            false
+        }
+        None => false,
+    }
+}
+
 impl SessionManager {
     /// Forwarder thread shared by `spawn`, `spawn_direct`, and `resume`.
     /// Drains the runtime's `OutputStream` into `session/output`
@@ -194,58 +248,128 @@ impl SessionManager {
         self.write_stdin(session_id, &rt_session, bytes)
     }
 
+    pub fn inject_reserved(&self, session_id: &str, token: u64, bytes: &[u8]) -> Result<bool> {
+        let Some(session) = self.session_state(session_id) else {
+            return Ok(false);
+        };
+        let gate = session.lock().unwrap().delivery_gate.clone();
+        let delivery = gate.state.lock().unwrap();
+        let session = session.lock().unwrap();
+        if !delivery.in_flight || delivery.generation != token {
+            return Ok(false);
+        }
+        let Some(rt_session) = session
+            .handle
+            .as_ref()
+            .map(|handle| handle.runtime_session.clone())
+        else {
+            return Ok(false);
+        };
+        self.write_stdin_bytes(&rt_session, bytes)?;
+        drop(session);
+        drop(delivery);
+        if bytes == b"\r" {
+            self.capture_codex_session_key(session_id);
+        }
+        Ok(true)
+    }
+
     pub fn inject_direct_stdin(
         &self,
         session_id: &str,
         bytes: &[u8],
         events: &dyn SessionEvents,
     ) -> Result<()> {
-        let rt_session = self.live_runtime_session(session_id)?;
         let submitted = bytes == b"\r";
-        let session = self.session_state(session_id);
-        let (transition, mission_status_sink, mission_scoped) =
-            if let Some(session) = session.as_ref() {
-                let mut session = session.lock().unwrap();
-                let previous_activity = session.activity;
-                let previous_suppression = session.suppress_local_input_busy;
-                let mission_status_sink = session.mission_status_sink.clone();
-                let mission_scoped = session
-                    .handle
-                    .as_ref()
-                    .is_some_and(|handle| handle.mission_id.is_some());
-                let transition = if previous_activity.is_some() && submitted {
-                    session.suppress_local_input_busy = false;
-                    if previous_activity == Some(SessionActivityState::Idle) {
-                        session.activity = Some(SessionActivityState::Busy);
-                        Some(SessionActivityEvent {
-                            session_id: session_id.to_string(),
-                            state: SessionActivityState::Busy,
-                            source: "input-submit".to_string(),
-                        })
-                    } else {
-                        None
-                    }
+        let input_class = classify_local_input(bytes);
+        let session = self
+            .session_state(session_id)
+            .ok_or_else(|| Error::msg(format!("session not found: {session_id}")))?;
+        let gate = session.lock().unwrap().delivery_gate.clone();
+        let mut delivery = gate.state.lock().unwrap();
+        let generation = delivery.generation;
+        let ticket = delivery.next_ticket;
+        delivery.next_ticket = delivery.next_ticket.wrapping_add(1);
+        while delivery.generation == generation
+            && (delivery.in_flight || delivery.next_served != ticket)
+        {
+            delivery = gate.ready.wait(delivery).unwrap();
+        }
+        if delivery.generation != generation {
+            return Err(Error::msg(format!(
+                "session changed while input was queued: {session_id}"
+            )));
+        }
+
+        let outcome = (|| {
+            let mut session = session.lock().unwrap();
+            let rt_session = session
+                .handle
+                .as_ref()
+                .map(|handle| handle.runtime_session.clone())
+                .ok_or_else(|| Error::msg(format!("session not found: {session_id}")))?;
+            let previous_activity = session.activity;
+            let previous_suppression = session.suppress_local_input_busy;
+            let previous_input_pending = session.local_input_pending;
+            let previous_input_at = session.last_local_input_at;
+            let mission_status_sink = session.mission_status_sink.clone();
+            let mission_scoped = session
+                .handle
+                .as_ref()
+                .is_some_and(|handle| handle.mission_id.is_some());
+            let transition = if previous_activity.is_some() && submitted {
+                session.suppress_local_input_busy = false;
+                if previous_activity == Some(SessionActivityState::Idle) {
+                    session.activity = Some(SessionActivityState::Busy);
+                    Some(SessionActivityEvent {
+                        session_id: session_id.to_string(),
+                        state: SessionActivityState::Busy,
+                        source: "input-submit".to_string(),
+                    })
                 } else {
-                    if previous_activity == Some(SessionActivityState::Idle) {
-                        session.suppress_local_input_busy = true;
-                    }
                     None
-                };
-                if let Err(error) = self.write_stdin_bytes(&rt_session, bytes) {
-                    session.activity = previous_activity;
-                    session.suppress_local_input_busy = previous_suppression;
-                    return Err(error);
                 }
-                if submitted {
-                    session.completion_armed = true;
-                }
-                (transition, mission_status_sink, mission_scoped)
             } else {
-                self.write_stdin_bytes(&rt_session, bytes)?;
-                (None, None, false)
+                if previous_activity == Some(SessionActivityState::Idle) {
+                    session.suppress_local_input_busy = true;
+                }
+                None
             };
+            let input_cleared = update_local_input_state(&mut session, input_class, Instant::now());
+            if let Err(error) = self.write_stdin_bytes(&rt_session, bytes) {
+                session.activity = previous_activity;
+                session.suppress_local_input_busy = previous_suppression;
+                session.local_input_pending = previous_input_pending;
+                session.last_local_input_at = previous_input_at;
+                return Err(error);
+            }
+            if submitted {
+                session.completion_armed = true;
+            }
+            Ok((
+                transition,
+                mission_status_sink,
+                mission_scoped,
+                input_cleared,
+            ))
+        })();
+
+        delivery.next_served = delivery.next_served.wrapping_add(1);
+        let input_queue_drained = delivery.next_served == delivery.next_ticket;
+        let successful_clear = outcome
+            .as_ref()
+            .is_ok_and(|(_, _, _, input_cleared)| *input_cleared);
+        gate.ready.notify_all();
+        drop(delivery);
+        if input_queue_drained && !successful_clear {
+            self.notify_delivery_event(session_id, router::SessionDeliveryEvent::InputQueueDrained);
+        }
+        let (transition, mission_status_sink, mission_scoped, input_cleared) = outcome?;
         if submitted {
             self.capture_codex_session_key(session_id);
+        }
+        if input_cleared {
+            self.notify_delivery_event(session_id, router::SessionDeliveryEvent::InputCleared);
         }
         if let Some(transition) = transition.as_ref() {
             if let Some(sink) = mission_status_sink.as_ref() {

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -793,6 +793,59 @@ fn inject_stdin_on_unknown_session_errors_cleanly() {
     assert!(format!("{err}").contains("session not found"));
 }
 
+#[test]
+fn local_input_byte_classes_drive_pending_state() {
+    use super::output::{classify_local_input, update_local_input_state, LocalInputClass};
+
+    assert_eq!(
+        classify_local_input(b"x"),
+        Some(LocalInputClass::SetPending)
+    );
+    assert_eq!(
+        classify_local_input("界".as_bytes()),
+        Some(LocalInputClass::SetPending)
+    );
+    assert_eq!(
+        classify_local_input(b"\x1b[A"),
+        Some(LocalInputClass::ActivityOnly)
+    );
+    assert_eq!(
+        classify_local_input(b"\x1b[200~pasted text\x1b[201~"),
+        Some(LocalInputClass::SetPending)
+    );
+    assert_eq!(
+        classify_local_input(b"\x16"),
+        Some(LocalInputClass::SetPending)
+    );
+    assert_eq!(
+        classify_local_input(b"\r"),
+        Some(LocalInputClass::ClearPending)
+    );
+    assert_eq!(
+        classify_local_input(b"\x03"),
+        Some(LocalInputClass::ClearPending)
+    );
+
+    let now = Instant::now();
+    let mut state = SessionState::default();
+    update_local_input_state(&mut state, classify_local_input(b"draft"), now);
+    assert!(state.local_input_pending);
+    assert_eq!(state.last_local_input_at, Some(now));
+
+    update_local_input_state(&mut state, classify_local_input(b"\r"), now);
+    assert!(!state.local_input_pending);
+    assert!(state.last_local_input_at.is_none());
+
+    update_local_input_state(&mut state, classify_local_input(b"\x1b[D"), now);
+    assert!(!state.local_input_pending);
+    assert_eq!(state.last_local_input_at, Some(now));
+
+    state.local_input_pending = true;
+    update_local_input_state(&mut state, classify_local_input(b"\x03"), now);
+    assert!(!state.local_input_pending);
+    assert!(state.last_local_input_at.is_none());
+}
+
 // `await_pty_output` was deleted in the Step 9 cutover. Tests
 // that previously observed echoed bytes from /bin/cat through
 // a portable-pty master now assert on FakeRuntime's captured
@@ -1736,8 +1789,62 @@ fn direct_chat_typing_stays_idle_until_submit() {
     wait_for_session_status_event(&cap, &spawned.id, SessionActivityState::Idle);
     cap.status.lock().unwrap().clear();
 
-    mgr.inject_direct_stdin(&spawned.id, b"x", cap.as_ref())
-        .unwrap();
+    let token = match mgr.reserve_delivery(&spawned.id).unwrap() {
+        router::DeliveryReservation::Ready(token) => token,
+        other => panic!("expected delivery reservation, got {other:?}"),
+    };
+    let first_mgr = Arc::clone(&mgr);
+    let first_cap = Arc::clone(&cap);
+    let first_session_id = spawned.id.clone();
+    let first = std::thread::spawn(move || {
+        first_mgr
+            .inject_direct_stdin(&first_session_id, b"h", first_cap.as_ref())
+            .unwrap();
+    });
+    let wait_for_tickets = |expected| {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        loop {
+            let gate = mgr
+                .session_state(&spawned.id)
+                .unwrap()
+                .lock()
+                .unwrap()
+                .delivery_gate
+                .clone();
+            if gate.state.lock().unwrap().next_ticket == expected {
+                break;
+            }
+            assert!(Instant::now() < deadline, "input ticket was not issued");
+            std::thread::sleep(Duration::from_millis(1));
+        }
+    };
+    wait_for_tickets(1);
+
+    let second_mgr = Arc::clone(&mgr);
+    let second_cap = Arc::clone(&cap);
+    let second_session_id = spawned.id.clone();
+    let second = std::thread::spawn(move || {
+        second_mgr
+            .inject_direct_stdin(&second_session_id, b"e", second_cap.as_ref())
+            .unwrap();
+    });
+    wait_for_tickets(2);
+    assert!(
+        !first.is_finished() && !second.is_finished(),
+        "local input must wait behind the reserved body/Enter chord"
+    );
+    assert!(mgr.inject_reserved(&spawned.id, token, b"[inbox]").unwrap());
+    assert!(mgr.inject_reserved(&spawned.id, token, b"\r").unwrap());
+    mgr.finish_delivery(&spawned.id, token);
+    first.join().unwrap();
+    second.join().unwrap();
+    let writes = fake.bytes_writes();
+    assert!(writes.ends_with(&[
+        (spawned.id.clone(), b"[inbox]".to_vec()),
+        (spawned.id.clone(), b"h".to_vec()),
+        (spawned.id.clone(), b"e".to_vec()),
+    ]));
+    assert!(!mgr.input_quiescent(&spawned.id));
     assert!(
         !mgr.take_completion_armed(std::slice::from_ref(&spawned.id)),
         "typing without submit must not arm completion",
@@ -1776,7 +1883,15 @@ fn direct_chat_typing_stays_idle_until_submit() {
         "paste-then-Enter delivery must arm completion",
     );
 
+    let stale_token = match mgr.reserve_delivery(&spawned.id).unwrap() {
+        router::DeliveryReservation::Ready(token) => token,
+        other => panic!("expected delivery reservation, got {other:?}"),
+    };
     mgr.kill(&spawned.id).unwrap();
+    assert!(!mgr
+        .inject_reserved(&spawned.id, stale_token, b"must not reach respawn")
+        .unwrap());
+    mgr.finish_delivery(&spawned.id, stale_token);
 }
 
 #[test]

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2022,7 +2022,7 @@ export function Sidebar({
               </nav>
             </div>
 
-            <div className="mx-5 my-2.5 h-px shrink-0 bg-line" />
+            <div className="mx-4 mb-4 mt-2.5 h-px shrink-0 bg-sidebar-selected-border" />
 
             <div className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-3">
               <DndContext

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2022,7 +2022,7 @@ export function Sidebar({
               </nav>
             </div>
 
-            <div className="h-5 shrink-0" />
+            <div className="mx-5 my-2.5 h-px shrink-0 bg-line" />
 
             <div className="flex min-h-0 flex-1 flex-col overflow-y-auto pb-3">
               <DndContext


### PR DESCRIPTION
## Summary

- track pending and recently active local input per session
- defer router deliveries in a per-session outbox until pane input clears
- coalesce inbox nudges while preserving ordered relay bodies and lifecycle behavior
- serialize router delivery with local keystrokes through a generation-aware FIFO gate
- replace the sidebar spacer after WORKSPACE with an always-visible inset divider

## Validation

- cargo fmt --all
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace
- pnpm exec tsc --noEmit
- pnpm run lint
- reviewer working-tree reviews: clean
- manual mission typing smoke test: passed

Closes #328