### PR TITLE
feat(updates): add periodic update checks

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 #[cfg(target_os = "macos")]
 use tauri::menu::{AboutMetadataBuilder, PredefinedMenuItem};
 use tauri::menu::{Menu, MenuBuilder, MenuItemBuilder, SubmenuBuilder};
-use tauri::{AppHandle, Emitter, Manager, Wry};
+use tauri::{AppHandle, Emitter, EventTarget, Manager, Wry};
 use tauri_plugin_log::{Builder as LogBuilder, RotationStrategy, Target, TargetKind};
 
 /// Bundle identifier as declared in `tauri.conf.json`. Used by:
@@ -268,17 +268,43 @@ pub fn run() {
 
             app.manage(state);
 
-            // Build the app menu and wire the `runner_logs_reveal`
-            // menu item to the same handler the Settings →
-            // Diagnostics button calls. Done in `setup` (not at the
-            // builder level) so we get a real `AppHandle` for the
-            // menu's child item builders.
+            // Build the app menu in `setup` so its actions can use the
+            // live AppHandle.
             let menu = build_menu(app.handle())?;
             app.set_menu(menu)?;
             app.on_menu_event(|app, ev| {
                 if ev.id() == "runner_logs_reveal" {
                     if let Err(e) = commands::app::reveal_logs_dir(app) {
                         log::error!("reveal logs failed: {e}");
+                    }
+                } else if ev.id() == "runner_check_for_updates" {
+                    let target = app
+                        .webview_windows()
+                        .into_iter()
+                        .find_map(|(_, window)| {
+                            window.is_focused().ok().filter(|focused| *focused)?;
+                            Some(window)
+                        })
+                        .or_else(|| app.get_webview_window("main"));
+                    if let Some(window) = target {
+                        if let Err(e) = window.show() {
+                            log::error!("show update-check window failed: {e}");
+                        }
+                        if let Err(e) = window.unminimize() {
+                            log::error!("unminimize update-check window failed: {e}");
+                        }
+                        if let Err(e) = window.set_focus() {
+                            log::error!("focus update-check window failed: {e}");
+                        }
+                        if let Err(e) = app.emit_to(
+                            EventTarget::webview_window(window.label()),
+                            "runner/check-for-updates",
+                            (),
+                        ) {
+                            log::error!("check for updates event failed: {e}");
+                        }
+                    } else {
+                        log::warn!("check for updates requested with no webview window");
                     }
                 } else if ev.id() == "window_new" {
                     let state = app.state::<AppState>();
@@ -591,9 +617,13 @@ fn build_menu(app: &AppHandle) -> tauri::Result<Menu<Wry>> {
             .version(Some(pkg.version.to_string()))
             .build();
         let about = PredefinedMenuItem::about(app, Some("About Runner"), Some(about_meta))?;
+        let check_for_updates =
+            MenuItemBuilder::with_id("runner_check_for_updates", "Check for Updates…")
+                .build(app)?;
 
         let app_menu = SubmenuBuilder::new(app, "Runner")
             .item(&about)
+            .item(&check_for_updates)
             .separator()
             .services()
             .separator()

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import {
   BrowserRouter,
   Routes,
@@ -8,10 +8,11 @@ import {
   useNavigate,
 } from "react-router-dom";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { AppShell } from "./components/AppShell";
 import { ToastProvider } from "./contexts/ToastContext";
-import { UpdateProvider } from "./contexts/UpdateContext";
+import { UpdateProvider, useUpdate } from "./contexts/UpdateContext";
 import { nudgeAppZoom } from "./lib/appZoom";
 import { eventMatchesShortcut } from "./lib/keymap";
 import { readAppZoom } from "./lib/settings";
@@ -74,6 +75,7 @@ export default function App() {
         <BrowserRouter>
           <InitialRouteBootstrap />
           <SettingsShortcut />
+          <UpdateMenuListener />
           <Routes>
             <Route element={<AppShell />}>
               <Route path="/" element={<Navigate to="/runners" replace />} />
@@ -113,6 +115,7 @@ export default function App() {
 // RunnerTerminal's re-dispatched custom event for keys WKWebView
 // delivers straight to xterm.
 const OPEN_SETTINGS_EVENT = "runner:open-settings";
+const CHECK_FOR_UPDATES_EVENT = "runner/check-for-updates";
 
 function SettingsShortcut() {
   const navigate = useNavigate();
@@ -136,6 +139,55 @@ function SettingsShortcut() {
       window.removeEventListener(OPEN_SETTINGS_EVENT, openSettings);
     };
   }, [navigate, location.pathname]);
+  return null;
+}
+
+function UpdateMenuListener() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const locationRef = useRef(location);
+  const { checkForUpdate } = useUpdate();
+
+  useEffect(() => {
+    locationRef.current = location;
+  }, [location]);
+
+  useEffect(() => {
+    let unlisten: (() => void) | null = null;
+    let cancelled = false;
+    let target: { target: { kind: "WebviewWindow"; label: string } } | undefined;
+    try {
+      target = {
+        target: { kind: "WebviewWindow", label: getCurrentWebview().label },
+      };
+    } catch {
+      target = undefined;
+    }
+    void listen(CHECK_FOR_UPDATES_EVENT, () => {
+      const current = locationRef.current;
+      const from = current.pathname.startsWith("/settings")
+        ? ((current.state as { from?: string } | null)?.from ?? "/")
+        : current.pathname;
+      void checkForUpdate();
+      if (current.pathname !== "/settings/updates") {
+        navigate("/settings/updates", { state: { from } });
+      }
+    }, target)
+      .then((stop) => {
+        if (cancelled) {
+          stop();
+          return;
+        }
+        unlisten = stop;
+      })
+      .catch(() => {
+        // Browser preview has no Tauri event runtime.
+      });
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [checkForUpdate, navigate]);
   return null;
 }
 

--- a/src/components/UpdatePromptCard.tsx
+++ b/src/components/UpdatePromptCard.tsx
@@ -8,7 +8,7 @@
 //
 // Dismissal is per launch (sessionStorage), so the pill reappears on
 // the next launch until the update is installed. The checkbox writes
-// the same persisted setting as About's toggle — one storage key,
+// the same persisted setting as the Updates pane's toggle — one storage key,
 // two surfaces.
 
 import { useCallback, useState } from "react";
@@ -69,7 +69,7 @@ export function UpdatePromptCard() {
           (`bottom-0`), so it covers the pill and grows upward over
           the list above. No gap to hover across, and the pill is
           never visible alongside the card. */}
-      <div className="invisible absolute bottom-0 left-0 right-0 z-40 translate-y-1 opacity-0 transition-all duration-150 group-focus-within:visible group-focus-within:translate-y-0 group-focus-within:opacity-100 group-hover:visible group-hover:translate-y-0 group-hover:opacity-100">
+      <div className="invisible absolute bottom-0 left-0 right-0 z-40 translate-y-1 opacity-0 transition-[opacity,transform,visibility] duration-200 ease-out group-focus-within:visible group-focus-within:translate-y-0 group-focus-within:opacity-100 group-focus-within:delay-0 group-hover:visible group-hover:translate-y-0 group-hover:opacity-100 group-hover:delay-150">
         <div className="overflow-hidden rounded-lg border border-line-strong bg-[radial-gradient(140%_120%_at_50%_0%,var(--color-sidebar-selected)_0%,var(--color-panel)_100%)] shadow-[0_8px_24px_rgba(0,0,0,0.35)]">
           {/* Header band — title centered per spec; the × dismiss
               (now specced) stays pinned to the band's right, with px-6

--- a/src/components/settings/AboutPane.tsx
+++ b/src/components/settings/AboutPane.tsx
@@ -1,87 +1,21 @@
-// About pane — version, updates, and links (impl 0025 decision 3:
-// Updates merged in, the Updates tab is gone). Leads with a hero card:
-// real app icon, name + version chip, status line, and the stateful
-// update button. Button ladder per spec `IKGNz` in
-// `design/runner-setting.pen`: IDLE → CHECKING → AVAILABLE →
-// DOWNLOADING → READY; READY is the one solid-accent moment in
-// settings. Auto-checks on mount — without a dedicated tab, a
-// manual-only check means nobody ever sees AVAILABLE.
+// About pane — app identity, version, credits, and links.
 
 import { useEffect, useState } from "react";
-import {
-  BookText,
-  Download,
-  ExternalLink,
-  Loader2,
-  RefreshCw,
-  RotateCcw,
-  Scale,
-} from "lucide-react";
+import { BookText, ExternalLink, Scale } from "lucide-react";
 
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { getVersion } from "@tauri-apps/api/app";
 
 import appIcon from "../../assets/app-icon.png";
-import { STORAGE_AUTO_INSTALL_UPDATES } from "../../lib/settings";
-import { useStoredBool } from "../../lib/useStoredBool";
-import { useUpdate } from "../../contexts/UpdateContext";
-import { Toggle } from "../ui/Toggle";
-import { PaneHeader, SettingsCard, SettingsRow } from "./shared";
+import { PaneHeader, SettingsCard } from "./shared";
 
 export function AboutPane() {
   const [version, setVersion] = useState<string>("");
-  const [autoInstall, setAutoInstall] = useStoredBool(
-    STORAGE_AUTO_INSTALL_UPDATES,
-    true,
-  );
-  const {
-    status,
-    update,
-    progress,
-    error,
-    checkForUpdate,
-    downloadAndInstall,
-    restart,
-  } = useUpdate();
   useEffect(() => {
     void getVersion()
       .then((v) => setVersion(v))
       .catch(() => setVersion(""));
   }, []);
-  // Auto-check on mount, but only from a resting state — kicking a
-  // check while an update is already available/downloading/ready
-  // would reset shared updater state the user may be acting on.
-  useEffect(() => {
-    if (status === "idle" || status === "error") void checkForUpdate();
-    // Run once per mount; `status` at mount time is what matters.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-  // Status-driven copy — the hero's status line always narrates the
-  // update ladder's current rung.
-  const statusLine = (() => {
-    switch (status) {
-      case "checking":
-        return "Checking for updates…";
-      case "available":
-        return update?.version
-          ? `v${update.version} is available.`
-          : "An update is available.";
-      case "downloading":
-        return `Downloading update… ${progress}%`;
-      case "ready":
-        return "Update ready — restart to apply.";
-      case "error":
-        return error ? `Couldn't check: ${error}` : "Couldn't check for updates.";
-      default:
-        return "You're up to date.";
-    }
-  })();
-  const statusTone =
-    status === "available" || status === "ready"
-      ? "text-accent"
-      : status === "error"
-        ? "text-danger"
-        : "text-fg-2";
   const openLink = (url: string) => {
     void openUrl(url).catch(() => {
       // Fallback: window.open works in dev (browser preview) when
@@ -91,7 +25,7 @@ export function AboutPane() {
   };
   return (
     <>
-      <PaneHeader title="About" subtitle="Version, updates, and links." />
+      <PaneHeader title="About" subtitle="Version, credits, and links." />
 
       {/* Hero card — the in-app identity matches what users see in the
           Dock / file-explorer: the icon mirrors the bundled `.icns`,
@@ -112,36 +46,12 @@ export function AboutPane() {
                 v{version || "0.0.0"}
               </span>
             </div>
-            <span className={`truncate text-[12px] ${statusTone}`}>
-              {statusLine}
+            <span className="truncate text-[12px] text-fg-2">
+              Local cockpit for coding agents.
             </span>
           </div>
-          <UpdateAction
-            status={status}
-            version={update?.version}
-            onCheck={() => void checkForUpdate()}
-            onDownload={() => void downloadAndInstall()}
-            onRestart={() => void restart()}
-          />
         </div>
-        {status === "downloading" ? (
-          <div className="h-[3px] w-full bg-raised">
-            <div
-              className="h-full bg-accent transition-[width] duration-200"
-              style={{ width: `${progress}%` }}
-            />
-          </div>
-        ) : null}
       </div>
-
-      <SettingsCard>
-        <SettingsRow
-          label="Install updates automatically"
-          sub="Download and apply updates in the background. Restart needed to finish."
-        >
-          <Toggle on={autoInstall} onChange={setAutoInstall} />
-        </SettingsRow>
-      </SettingsCard>
 
       <SettingsCard>
         <LinkRow
@@ -167,77 +77,6 @@ export function AboutPane() {
         © 2026 wyc studios
       </div>
     </>
-  );
-}
-
-// The five-state update button (spec `IKGNz`). Neutral for states,
-// accent for meaning: AVAILABLE is quiet accent (tinted fill, accent
-// text/border), READY is solid accent, everything else stays neutral.
-// No cancel during download — the plugin exposes no abort handle, so
-// we don't pretend to offer one.
-function UpdateAction({
-  status,
-  version,
-  onCheck,
-  onDownload,
-  onRestart,
-}: {
-  status: ReturnType<typeof useUpdate>["status"];
-  version: string | undefined;
-  onCheck: () => void;
-  onDownload: () => void;
-  onRestart: () => void;
-}) {
-  if (status === "checking") {
-    return (
-      <div className="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-line bg-raised px-3 py-1.5 text-[12px] font-medium text-fg-3">
-        <Loader2 aria-hidden className="h-3 w-3 animate-spin" />
-        Checking…
-      </div>
-    );
-  }
-  if (status === "available") {
-    return (
-      <button
-        type="button"
-        onClick={onDownload}
-        className="flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md border border-accent/40 bg-accent/10 px-3 py-1.5 text-[12px] font-semibold text-accent transition-colors hover:bg-accent/15"
-      >
-        <Download aria-hidden className="h-3 w-3" />
-        {version ? `Download v${version}` : "Download update"}
-      </button>
-    );
-  }
-  if (status === "downloading") {
-    return (
-      <div className="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-line bg-raised px-3 py-1.5 text-[12px] font-medium text-fg-3">
-        <Loader2 aria-hidden className="h-3 w-3 animate-spin" />
-        Downloading…
-      </div>
-    );
-  }
-  if (status === "ready") {
-    return (
-      <button
-        type="button"
-        onClick={onRestart}
-        className="flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-accent-ink transition-colors hover:bg-accent/90"
-      >
-        <RotateCcw aria-hidden className="h-3 w-3" />
-        Restart to update
-      </button>
-    );
-  }
-  // idle / error → manual re-check
-  return (
-    <button
-      type="button"
-      onClick={onCheck}
-      className="flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md border border-line bg-raised px-3 py-1.5 text-[12px] font-medium text-fg-2 transition-colors hover:border-line-strong hover:text-fg"
-    >
-      <RefreshCw aria-hidden className="h-3 w-3" />
-      Check for updates
-    </button>
   );
 }
 

--- a/src/components/settings/UpdatesPane.tsx
+++ b/src/components/settings/UpdatesPane.tsx
@@ -1,0 +1,184 @@
+import { useEffect, useState } from "react";
+import {
+  Download,
+  Loader2,
+  RefreshCw,
+  RotateCcw,
+} from "lucide-react";
+
+import { getVersion } from "@tauri-apps/api/app";
+
+import { useUpdate } from "../../contexts/UpdateContext";
+import { STORAGE_AUTO_INSTALL_UPDATES } from "../../lib/settings";
+import { useStoredBool } from "../../lib/useStoredBool";
+import { Toggle } from "../ui/Toggle";
+import { PaneHeader, SettingsCard, SettingsRow } from "./shared";
+
+export function UpdatesPane() {
+  const [version, setVersion] = useState("");
+  const [autoInstall, setAutoInstall] = useStoredBool(
+    STORAGE_AUTO_INSTALL_UPDATES,
+    true,
+  );
+  const {
+    status,
+    update,
+    progress,
+    error,
+    checkForUpdate,
+    downloadAndInstall,
+    restart,
+  } = useUpdate();
+
+  useEffect(() => {
+    void getVersion()
+      .then((value) => setVersion(value))
+      .catch(() => setVersion(""));
+  }, []);
+
+  useEffect(() => {
+    if (status === "idle" || status === "error") void checkForUpdate();
+    // Check once when the pane opens. The shared updater guard handles
+    // overlap with launch, interval, focus, and menu-triggered checks.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const statusLine = (() => {
+    switch (status) {
+      case "checking":
+        return "Checking for updates…";
+      case "available":
+        return update?.version
+          ? `v${update.version} is available.`
+          : "An update is available.";
+      case "downloading":
+        return `Downloading update… ${progress}%`;
+      case "ready":
+        return "Update ready — restart to apply.";
+      case "error":
+        return error ? `Couldn't check: ${error}` : "Couldn't check for updates.";
+      default:
+        return "You're up to date.";
+    }
+  })();
+  const statusTone =
+    status === "available" || status === "ready"
+      ? "text-accent"
+      : status === "error"
+        ? "text-danger"
+        : "text-fg-2";
+
+  return (
+    <>
+      <PaneHeader
+        title="Updates"
+        subtitle="Check for new versions and choose how they download."
+      />
+
+      <div className="overflow-hidden rounded-xl border border-line bg-panel">
+        <div className="flex items-center gap-4 p-5">
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            <span className="text-[11px] font-medium text-fg-3">
+              Current version
+            </span>
+            <span className="font-mono text-[16px] font-semibold text-fg">
+              v{version || "0.0.0"}
+            </span>
+            <span className={`truncate text-[12px] ${statusTone}`}>
+              {statusLine}
+            </span>
+          </div>
+          <UpdateAction
+            status={status}
+            version={update?.version}
+            onCheck={() => void checkForUpdate()}
+            onDownload={() => void downloadAndInstall()}
+            onRestart={() => void restart()}
+          />
+        </div>
+        {status === "downloading" ? (
+          <div className="h-[3px] w-full bg-raised">
+            <div
+              className="h-full bg-accent transition-[width] duration-200"
+              style={{ width: `${progress}%` }}
+            />
+          </div>
+        ) : null}
+      </div>
+
+      <SettingsCard>
+        <SettingsRow
+          label="Install updates automatically"
+          sub="Download and apply updates in the background. Restart needed to finish."
+        >
+          <Toggle on={autoInstall} onChange={setAutoInstall} />
+        </SettingsRow>
+      </SettingsCard>
+    </>
+  );
+}
+
+function UpdateAction({
+  status,
+  version,
+  onCheck,
+  onDownload,
+  onRestart,
+}: {
+  status: ReturnType<typeof useUpdate>["status"];
+  version: string | undefined;
+  onCheck: () => void;
+  onDownload: () => void;
+  onRestart: () => void;
+}) {
+  if (status === "checking") {
+    return (
+      <div className="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-line bg-raised px-3 py-1.5 text-[12px] font-medium text-fg-3">
+        <Loader2 aria-hidden className="h-3 w-3 animate-spin" />
+        Checking…
+      </div>
+    );
+  }
+  if (status === "available") {
+    return (
+      <button
+        type="button"
+        onClick={onDownload}
+        className="flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md border border-accent/40 bg-accent/10 px-3 py-1.5 text-[12px] font-semibold text-accent transition-colors hover:bg-accent/15"
+      >
+        <Download aria-hidden className="h-3 w-3" />
+        {version ? `Download v${version}` : "Download update"}
+      </button>
+    );
+  }
+  if (status === "downloading") {
+    return (
+      <div className="flex shrink-0 items-center gap-1.5 whitespace-nowrap rounded-md border border-line bg-raised px-3 py-1.5 text-[12px] font-medium text-fg-3">
+        <Loader2 aria-hidden className="h-3 w-3 animate-spin" />
+        Downloading…
+      </div>
+    );
+  }
+  if (status === "ready") {
+    return (
+      <button
+        type="button"
+        onClick={onRestart}
+        className="flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md bg-accent px-3 py-1.5 text-[12px] font-semibold text-accent-ink transition-colors hover:bg-accent/90"
+      >
+        <RotateCcw aria-hidden className="h-3 w-3" />
+        Restart to update
+      </button>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onCheck}
+      className="flex shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md border border-line bg-raised px-3 py-1.5 text-[12px] font-medium text-fg-2 transition-colors hover:border-line-strong hover:text-fg"
+    >
+      <RefreshCw aria-hidden className="h-3 w-3" />
+      Check for updates
+    </button>
+  );
+}

--- a/src/contexts/UpdateContext.test.tsx
+++ b/src/contexts/UpdateContext.test.tsx
@@ -1,0 +1,223 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  check: vi.fn<() => Promise<unknown>>(),
+  downloadAndInstall: vi.fn<() => Promise<void>>(),
+  onFocusChanged: vi.fn(async () => () => {}),
+  windowLabel: "main",
+}));
+
+vi.mock("@tauri-apps/plugin-updater", () => ({
+  check: mocks.check,
+}));
+
+vi.mock("@tauri-apps/plugin-process", () => ({
+  relaunch: vi.fn(async () => {}),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    label: mocks.windowLabel,
+    onFocusChanged: mocks.onFocusChanged,
+  }),
+}));
+
+import {
+  UpdateProvider,
+  useUpdate,
+} from "./UpdateContext";
+import type { UpdateState } from "../hooks/useUpdateChecker";
+import { STORAGE_AUTO_INSTALL_UPDATES } from "../lib/settings";
+
+const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+describe("UpdateProvider trigger policy", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: UpdateState | null;
+  let storage: Map<string, string>;
+
+  function Probe() {
+    latest = useUpdate();
+    return null;
+  }
+
+  function state(): UpdateState {
+    if (!latest) throw new Error("update state is unavailable");
+    return latest;
+  }
+
+  async function renderProvider() {
+    await act(async () => {
+      root.render(
+        <UpdateProvider>
+          <Probe />
+        </UpdateProvider>,
+      );
+    });
+  }
+
+  async function runLaunchCheck() {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(3000);
+    });
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-22T00:00:00Z"));
+    storage = new Map();
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+      clear: () => storage.clear(),
+    });
+    localStorage.setItem("runner.dev.updateStatus", "idle");
+    mocks.check.mockReset();
+    mocks.check.mockResolvedValue(null);
+    mocks.downloadAndInstall.mockReset();
+    mocks.downloadAndInstall.mockResolvedValue();
+    mocks.onFocusChanged.mockClear();
+    mocks.windowLabel = "main";
+    latest = null;
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    localStorage.clear();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("checks again when a focused window is stale", async () => {
+    await renderProvider();
+    await runLaunchCheck();
+    expect(mocks.check).toHaveBeenCalledTimes(1);
+
+    vi.setSystemTime(Date.now() + UPDATE_CHECK_INTERVAL_MS + 1);
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await Promise.resolve();
+    });
+
+    expect(mocks.check).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not check again when a focused window is fresh", async () => {
+    await renderProvider();
+    await runLaunchCheck();
+
+    vi.setSystemTime(Date.now() + UPDATE_CHECK_INTERVAL_MS - 1);
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await Promise.resolve();
+    });
+
+    expect(mocks.check).toHaveBeenCalledTimes(1);
+  });
+
+  it("checks again when the interval elapses", async () => {
+    await renderProvider();
+    await runLaunchCheck();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(UPDATE_CHECK_INTERVAL_MS - 3000);
+    });
+
+    expect(mocks.check).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not schedule background checks in secondary windows", async () => {
+    mocks.windowLabel = "window-secondary";
+    await renderProvider();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(UPDATE_CHECK_INTERVAL_MS * 2);
+      window.dispatchEvent(new Event("focus"));
+      await Promise.resolve();
+    });
+
+    expect(mocks.check).not.toHaveBeenCalled();
+  });
+
+  it("checks without downloading when automatic updates are off", async () => {
+    localStorage.setItem(STORAGE_AUTO_INSTALL_UPDATES, "0");
+    mocks.check.mockResolvedValue({
+      version: "0.4.0",
+      downloadAndInstall: mocks.downloadAndInstall,
+    });
+
+    await renderProvider();
+    await runLaunchCheck();
+
+    expect(mocks.check).toHaveBeenCalledTimes(1);
+    expect(mocks.downloadAndInstall).not.toHaveBeenCalled();
+    expect(state().status).toBe("available");
+  });
+
+  it("keeps automatic download enabled for opted-in users", async () => {
+    localStorage.setItem(STORAGE_AUTO_INSTALL_UPDATES, "1");
+    mocks.check.mockResolvedValue({
+      version: "0.4.0",
+      downloadAndInstall: mocks.downloadAndInstall,
+    });
+
+    await renderProvider();
+    await runLaunchCheck();
+
+    expect(mocks.downloadAndInstall).toHaveBeenCalledTimes(1);
+    expect(state().status).toBe("ready");
+  });
+
+  it("keeps background errors silent but surfaces explicit failures", async () => {
+    mocks.check.mockRejectedValue(new Error("offline"));
+    await renderProvider();
+    await runLaunchCheck();
+
+    expect(state().status).toBe("idle");
+    expect(state().error).toBeNull();
+
+    await act(async () => {
+      await state().checkForUpdate();
+    });
+
+    expect(state().status).toBe("error");
+    expect(state().error).toBe("offline");
+  });
+
+  it("surfaces failure when an explicit check joins a silent check", async () => {
+    let rejectCheck: ((reason: Error) => void) | null = null;
+    mocks.check.mockReturnValue(
+      new Promise((_, reject) => {
+        rejectCheck = reject;
+      }),
+    );
+    await renderProvider();
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+    expect(state().status).toBe("checking");
+
+    await act(async () => {
+      await state().checkForUpdate();
+      if (!rejectCheck) throw new Error("missing pending update check");
+      rejectCheck(new Error("offline"));
+      await Promise.resolve();
+    });
+
+    expect(mocks.check).toHaveBeenCalledTimes(1);
+    expect(state().status).toBe("error");
+    expect(state().error).toBe("offline");
+  });
+});

--- a/src/contexts/UpdateContext.tsx
+++ b/src/contexts/UpdateContext.tsx
@@ -1,53 +1,109 @@
 // Auto-update context — single source of update state shared by the
-// sidebar prompt card (`UpdatePromptCard`) and the Settings → About
+// sidebar prompt card (`UpdatePromptCard`) and the Settings → Updates
 // pane. Mirrors Quill's pattern so card → settings is just two views
 // over the same status, no duplicated polling.
 
 import {
+  useCallback,
   createContext,
   useContext,
   useEffect,
   useRef,
+  useState,
   type ReactNode,
 } from "react";
 
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+import { readStoredBool, STORAGE_AUTO_INSTALL_UPDATES } from "../lib/settings";
 import {
-  readStoredBool,
-  STORAGE_AUTO_INSTALL_UPDATES,
-} from "../lib/settings";
-import { useUpdateChecker, type UpdateState } from "../hooks/useUpdateChecker";
+  useUpdateChecker,
+  type UpdateCheckOptions,
+  type UpdateState,
+} from "../hooks/useUpdateChecker";
+
+const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+const LAUNCH_CHECK_DELAY_MS = 3000;
 
 const UpdateContext = createContext<UpdateState | null>(null);
 
 export function UpdateProvider({ children }: { children: ReactNode }) {
   const state = useUpdateChecker();
-  // The auto-install toggle owns two separate behaviors: (1) whether
-  // we even kick off a check on app start, and (2) whether we go
-  // straight to download once an update is detected. Persistent
-  // store is plain localStorage for now (same key the About pane
-  // toggle and the prompt card checkbox write to).
-  const checkedRef = useRef(false);
+  const [runsBackgroundChecks] = useState(() => {
+    try {
+      return getCurrentWindow().label === "main";
+    } catch {
+      return true;
+    }
+  });
+  const runCheck = state.checkForUpdate;
+  const lastCheckAt = useRef<number | null>(null);
+  const checkForUpdate = useCallback(
+    (options?: UpdateCheckOptions) => {
+      lastCheckAt.current = Date.now();
+      return runCheck(options);
+    },
+    [runCheck],
+  );
 
-  // Run a single check ~3s after mount. The delay keeps the launch
-  // path quiet — first paint, navigation, sidebar load all happen
-  // before we hit the network.
+  // Check after first paint on every launch, unless an explicit check
+  // already ran during the delay.
   useEffect(() => {
-    if (checkedRef.current) return;
-    checkedRef.current = true;
-    if (!readStoredBool(STORAGE_AUTO_INSTALL_UPDATES, true)) return;
+    if (!runsBackgroundChecks) return;
     const timer = setTimeout(() => {
-      void state.checkForUpdate();
-    }, 3000);
+      if (lastCheckAt.current === null) {
+        void checkForUpdate({ silent: true });
+      }
+    }, LAUNCH_CHECK_DELAY_MS);
     return () => clearTimeout(timer);
-    // checkForUpdate is stable (useCallback with []), so it's safe
-    // to omit from deps; running this exactly once per mount is the
-    // intent.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [checkForUpdate, runsBackgroundChecks]);
+
+  useEffect(() => {
+    if (!runsBackgroundChecks) return;
+    const timer = setInterval(() => {
+      void checkForUpdate({ silent: true });
+    }, UPDATE_CHECK_INTERVAL_MS);
+    const checkWhenStale = () => {
+      const checkedAt = lastCheckAt.current;
+      if (
+        checkedAt !== null &&
+        Date.now() - checkedAt >= UPDATE_CHECK_INTERVAL_MS
+      ) {
+        void checkForUpdate({ silent: true });
+      }
+    };
+    window.addEventListener("focus", checkWhenStale);
+    let unlistenFocus: (() => void) | null = null;
+    let cancelled = false;
+    try {
+      void getCurrentWindow()
+        .onFocusChanged(({ payload: focused }) => {
+          if (focused) checkWhenStale();
+        })
+        .then((stop) => {
+          if (cancelled) {
+            stop();
+            return;
+          }
+          unlistenFocus = stop;
+        })
+        .catch(() => {
+          // DOM focus remains available in browser preview.
+        });
+    } catch {
+      // DOM focus remains available in browser preview.
+    }
+    return () => {
+      cancelled = true;
+      unlistenFocus?.();
+      clearInterval(timer);
+      window.removeEventListener("focus", checkWhenStale);
+    };
+  }, [checkForUpdate, runsBackgroundChecks]);
 
   // When the user has auto-install on, advance from "available" →
   // "downloading" automatically. Otherwise the user has to click
-  // Download in Settings → About.
+  // Download in Settings → Updates.
   useEffect(() => {
     if (state.status !== "available") return;
     if (!readStoredBool(STORAGE_AUTO_INSTALL_UPDATES, true)) return;
@@ -56,7 +112,9 @@ export function UpdateProvider({ children }: { children: ReactNode }) {
   }, [state.status]);
 
   return (
-    <UpdateContext.Provider value={state}>{children}</UpdateContext.Provider>
+    <UpdateContext.Provider value={{ ...state, checkForUpdate }}>
+      {children}
+    </UpdateContext.Provider>
   );
 }
 

--- a/src/hooks/useUpdateChecker.ts
+++ b/src/hooks/useUpdateChecker.ts
@@ -1,9 +1,9 @@
 // Auto-update hook — wraps `@tauri-apps/plugin-updater` into a simple
 // state machine: idle → checking → available → downloading → ready.
 // Mirrors Quill's `useUpdateChecker` so the surfaces (sidebar prompt
-// card + About pane) can share one context and the same UI states.
+// card + Updates pane) can share one context and the same UI states.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 
 import { check, type Update } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
@@ -15,6 +15,10 @@ export type UpdateStatus =
   | "downloading"
   | "ready"
   | "error";
+
+export interface UpdateCheckOptions {
+  silent?: boolean;
+}
 
 const UPDATE_STATUSES: readonly UpdateStatus[] = [
   "idle",
@@ -51,7 +55,7 @@ export interface UpdateState {
   update: Update | null;
   progress: number;
   error: string | null;
-  checkForUpdate: () => Promise<void>;
+  checkForUpdate: (options?: UpdateCheckOptions) => Promise<void>;
   downloadAndInstall: () => Promise<void>;
   restart: () => Promise<void>;
 }
@@ -69,48 +73,61 @@ export function useUpdateChecker(): UpdateState {
   const [error, setError] = useState<string | null>(null);
   // Guard against concurrent checks — auto-check + manual click can race.
   const checking = useRef(false);
+  // A manual request that overlaps a silent background check upgrades
+  // that in-flight check so a failure is visible to the user.
+  const surfaceCheckError = useRef(false);
   // Mirror of `status` readable from the stable `checkForUpdate`
-  // closure (its useCallback deps stay empty so consumers can treat it
-  // as stable).
+  // closure. Update it synchronously with React state so another
+  // trigger cannot slip into the render gap after a check finishes.
   const statusRef = useRef<UpdateStatus>(status);
-  useEffect(() => {
-    statusRef.current = status;
-  }, [status]);
+  const setCurrentStatus = useCallback((next: UpdateStatus) => {
+    statusRef.current = next;
+    setStatus(next);
+  }, []);
 
-  const checkForUpdate = useCallback(async () => {
-    if (checking.current) return;
+  const checkForUpdate = useCallback(async (options?: UpdateCheckOptions) => {
+    const silent = options?.silent ?? false;
+    if (checking.current) {
+      if (!silent) surfaceCheckError.current = true;
+      return;
+    }
     // Only re-check from resting states. Multiple surfaces auto-check
-    // (UpdateContext's launch timer, About on mount) and they can
+    // (UpdateContext's launch/interval/focus triggers, Updates on mount)
+    // and they can
     // overlap — a late check must not clobber an already-found update
     // or an in-flight/finished download back to "checking".
-    if (
-      statusRef.current !== "idle" &&
-      statusRef.current !== "error"
-    ) {
+    if (statusRef.current !== "idle" && statusRef.current !== "error") {
       return;
     }
     checking.current = true;
-    setStatus("checking");
+    surfaceCheckError.current = !silent;
+    setCurrentStatus("checking");
     setError(null);
     try {
       const result = await check();
       if (result) {
         setUpdate(result);
-        setStatus("available");
+        setCurrentStatus("available");
       } else {
-        setStatus("idle");
+        setCurrentStatus("idle");
       }
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-      setStatus("error");
+      if (surfaceCheckError.current) {
+        setError(e instanceof Error ? e.message : String(e));
+        setCurrentStatus("error");
+      } else {
+        setError(null);
+        setCurrentStatus("idle");
+      }
     } finally {
       checking.current = false;
+      surfaceCheckError.current = false;
     }
-  }, []);
+  }, [setCurrentStatus]);
 
   const downloadAndInstall = useCallback(async () => {
     if (!update) return;
-    setStatus("downloading");
+    setCurrentStatus("downloading");
     setProgress(0);
     try {
       let totalLen = 0;
@@ -127,12 +144,12 @@ export function useUpdateChecker(): UpdateState {
           setProgress(100);
         }
       });
-      setStatus("ready");
+      setCurrentStatus("ready");
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
-      setStatus("error");
+      setCurrentStatus("error");
     }
-  }, [update]);
+  }, [setCurrentStatus, update]);
 
   const restart = useCallback(async () => {
     await relaunch();

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -23,6 +23,7 @@ import {
   Keyboard,
   MessageSquare,
   Plug,
+  RefreshCw,
   Search,
   Settings as SettingsIcon,
   Sun,
@@ -38,6 +39,7 @@ import { GeneralPane } from "../components/settings/GeneralPane";
 import { McpPane } from "../components/settings/McpPane";
 import { ShortcutsPane } from "../components/settings/ShortcutsPane";
 import { TerminalPane } from "../components/settings/TerminalPane";
+import { UpdatesPane } from "../components/settings/UpdatesPane";
 import { useResizableWidth } from "../hooks/useResizableWidth";
 
 // Same domain and storage key as the app sidebar (Sidebar.tsx — keep
@@ -55,6 +57,7 @@ type PaneKey =
   | "terminal"
   | "shortcuts"
   | "mcp"
+  | "updates"
   | "diagnostics"
   | "about"
   | "archived";
@@ -77,6 +80,7 @@ const PANES: Record<
     render: () => <ShortcutsPane />,
   },
   mcp: { label: "MCP", icon: Plug, render: () => <McpPane /> },
+  updates: { label: "Updates", icon: RefreshCw, render: () => <UpdatesPane /> },
   diagnostics: {
     label: "Diagnostics",
     icon: FileText,
@@ -96,7 +100,7 @@ const NAV_GROUPS: { label: string; panes: PaneKey[] }[] = [
     panes: ["general", "chat", "appearance", "terminal", "shortcuts"],
   },
   { label: "Integrations", panes: ["mcp"] },
-  { label: "System", panes: ["diagnostics", "about"] },
+  { label: "System", panes: ["updates", "diagnostics", "about"] },
   { label: "Archived", panes: ["archived"] },
 ];
 


### PR DESCRIPTION
Closes #333

## Summary

- add main-window launch, six-hour interval, and stale-focus update checks with silent background failures
- make auto-install govern downloading only and move updater controls into Settings → Updates
- add the macOS Check for Updates… menu action with focused-window navigation
- soften the sidebar update prompt reveal after the human smoke-test follow-up

## Validation

- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm test (164 tests)
- cargo fmt --all
- cargo clippy --workspace --all-targets
- cargo test --workspace
- git diff --check