### PR TITLE
feat(router): reconcile unread mission inboxes

### DIFF
--- a/docs/features/48-mission-inbox-reconciliation-tick.md
+++ b/docs/features/48-mission-inbox-reconciliation-tick.md
@@ -12,11 +12,24 @@ Push delivery is the latency path; it needs a correctness net. A per-mission sys
 
 - **Per-mission clock in the runner system** — an in-process timer mounted alongside the mission's bus/router (started on mission start / router mount, stopped on mission stop). Not an agent behavior: the crew protocol's "delivery is push, not pull; never poll" stands unchanged.
 - **Tick = pure in-memory check, no messages.** On each tick, for every live session in the mission, read the handle's `unread_count` from the existing bus projection. An empty inbox costs nothing — no injection, no agent wake, no tokens.
-- **Nudge only when non-empty**: if `unread_count > 0` AND the session is idle (activity state) AND no nudge for that handle is in flight, parked in the #328 outbox, or within the backoff window — re-fire the standard inbox nudge through the normal delivery path (#328's pending-input deferral and coalescing apply unchanged).
+- **Nudge only when non-empty**: if `unread_count > 0` AND the session is idle (activity state) AND no delivery for that handle is in flight, parked in the #328 outbox, or within the backoff window, attempt the standard inbox nudge through the normal atomic reservation/injection path. A clock nudge injects only when the reservation is immediately ready; typing, another in-flight delivery, or an outbox backlog makes that tick a no-op so the next tick can re-evaluate idle and unread state. Existing push delivery still uses #328's pending-input deferral and coalescing unchanged.
 - **Self-quieting**: the agent's `runner msg read` advances the `inbox_read` watermark, `unread_count` drops to zero, and the tick goes silent. Redelivery is idempotent by construction — nudges are wake-only, bodies live in the inbox projection, a redundant nudge at worst shows an agent an empty unread tail.
-- **Re-nudge backoff** so a stuck agent isn't nagged every tick — see To be decided.
+- **Re-nudge backoff** so a stuck agent isn't nagged every tick: clock-initiated re-nudges for the same handle are at least two minutes apart.
 
 This retroactively closes #328's drop-on-exit window: an outbox lost at session exit leaves `unread_count > 0`, and the first tick after respawn re-covers it. Together with #328, wake delivery becomes at-least-once.
+
+## Flush grace after input-clear
+
+The #328 outbox flush on `InputCleared` currently uses `SUBMIT_DELAY` (80ms), but that constant exists for the injected body/Enter chord rather than flush pacing. A parked nudge can therefore land as the user hits Enter or Ctrl+C and begins the next draft.
+
+Input-cleared flushes use a separate `INPUT_CLEAR_FLUSH_GRACE` of 500ms. `SUBMIT_DELAY` remains 80ms everywhere else. When the grace expires, the existing `reserve_delivery` / `inject_reserved` path re-checks pending input; if typing resumed during the grace window, the delivery stays parked. Ctrl+U is not treated as input-cleared because the host cannot distinguish an empty single-line draft from one removed line with multiline content remaining. The reconciliation tick is the backstop after a parked delivery is lost with its exiting session, so no additional retry mechanism is needed.
+
+## Timing
+
+- Reconciliation tick interval: 30 seconds.
+- Per-handle backoff between clock-initiated re-nudges: at least two minutes.
+- Input-clear flush grace: 500ms.
+- All timing values are module constants; none are persisted or configurable.
 
 ## Out of scope
 
@@ -24,18 +37,14 @@ This retroactively closes #328's drop-on-exit window: an outbox lost at session 
 - Changes to `inbox_read` / watermark semantics or the inbox projection — the tick is a pure consumer of existing state.
 - Direct chats — no inbox, no router; mission-only.
 - Busy sessions — never re-nudge a busy agent; if it finishes its turn without reading, the next tick catches it.
-
-## To be decided
-
-- Tick interval — likely 30–60s; this is a safety net, not the delivery mechanism, so err long.
-- Backoff policy for repeated re-nudges to the same handle — e.g. every 3rd tick, or exponential capped at a few minutes.
-- Whether the tick also emits a UI-visible warning after N failed re-nudges (agent repeatedly woken but never reads — likely wedged).
+- UI warnings for an agent that repeatedly wakes without reading.
 
 ## Implementation phases
 
-1. **Tick loop** — per-mission timer mounted with the router/bus; per-live-session check of `unread_count` × activity state × nudge-recency; re-nudge via the existing delivery path. Unit tests with a fake clock: no-op on empty inbox, no-op on busy session, re-nudge on idle+unread, backoff honored, quiesce after watermark advance.
-2. **Lifecycle wiring** — start/stop with mission mount/stop; no ticking for stopped missions; tick state dropped with the mission.
-3. **Validation** — `cargo test --workspace`; manual: send mail to a runner, kill its session before it reads, resume it, confirm the nudge re-arrives on the next tick without any human message.
+1. **Tick loop** — per-mission timer mounted with the router/bus; per-live-session check of `unread_count` × activity state × nudge-recency; re-nudge through an immediately ready delivery reservation without parking clock nudges. Unit tests with a fake clock cover no-op on empty inbox, no-op on busy sessions, re-nudge on idle sessions with unread mail, pending-input deferral to a later tick, outbox suppression, backoff, and quiescence after a watermark advance.
+2. **Lifecycle wiring** — start/stop with mission mount/stop; no ticking for stopped missions or reaped sessions; tick state drops with the mission.
+3. **Input-clear flush grace** — schedule the existing outbox flush after 500ms and rely on its delivery reservation to re-check pending input.
+4. **Validation** — `cargo test --workspace`; manually send mail to a runner, kill its session before it reads, resume it, and confirm the nudge re-arrives on the next tick without any human message.
 
 ## Verification
 
@@ -43,6 +52,8 @@ This retroactively closes #328's drop-on-exit window: an outbox lost at session 
 - [ ] An idle session with an empty inbox is never nudged by the clock.
 - [ ] A busy session with unread mail is not nudged until it goes idle.
 - [ ] After the agent reads (`inbox_read` advances), ticks go silent.
-- [ ] Backoff: a stuck agent is re-nudged at the decided cadence, not every tick.
+- [ ] Backoff: clock-initiated re-nudges for a stuck agent are at least two minutes apart.
 - [ ] Mission stop halts the clock; no ticks against stopped sessions.
+- [ ] A parked delivery does not flush when typing resumes during the 500ms input-clear grace.
+- [ ] A parked delivery flushes after a quiet 500ms input-clear grace.
 - [ ] `cargo fmt`, `cargo clippy --workspace --all-targets`, `cargo test --workspace` pass.

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -22,10 +22,11 @@ mod handlers;
 pub mod prompt;
 pub mod runtime;
 
-use std::collections::{HashMap, VecDeque};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::path::Path;
-use std::sync::{Arc, Mutex, Weak};
-use std::time::Duration;
+use std::sync::{Arc, Condvar, Mutex, Weak};
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 use runner_core::event_log::EventLog;
 use runner_core::model::{Event, EventKind, SignalType};
@@ -58,6 +59,8 @@ pub trait StdinInjector: Send + Sync + 'static {
     /// reservation below so a keystroke cannot race a separate query.
     fn input_quiescent(&self, session_id: &str) -> bool;
 
+    fn session_live(&self, session_id: &str) -> bool;
+
     fn reserve_delivery(&self, session_id: &str) -> Result<DeliveryReservation>;
 
     fn inject_reserved(&self, session_id: &str, token: u64, bytes: &[u8]) -> Result<bool>;
@@ -82,6 +85,10 @@ impl StdinInjector for SessionManager {
 
     fn input_quiescent(&self, session_id: &str) -> bool {
         SessionManager::input_quiescent(self, session_id)
+    }
+
+    fn session_live(&self, session_id: &str) -> bool {
+        SessionManager::session_live(self, session_id)
     }
 
     fn reserve_delivery(&self, session_id: &str) -> Result<DeliveryReservation> {
@@ -171,6 +178,10 @@ pub(crate) struct RosterRow {
 }
 
 const SUBMIT_DELAY: Duration = Duration::from_millis(80);
+const INPUT_CLEAR_FLUSH_GRACE: Duration = Duration::from_millis(500);
+const RECONCILIATION_TICK_INTERVAL: Duration = Duration::from_secs(30);
+const RECONCILIATION_RENUDGE_BACKOFF: Duration = Duration::from_secs(2 * 60);
+const RECONCILIATION_NUDGE: &str = "[inbox] unread messages — run `runner msg read` to view.";
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum DeliveryKind {
@@ -242,6 +253,27 @@ struct RouterState {
     /// bootstrap the lead.
     replay_high_water: Option<String>,
     outbox_by_session: HashMap<String, SessionOutbox>,
+    live_sessions: HashSet<String>,
+    unread_by_handle: HashMap<String, usize>,
+    last_reconciliation_nudge: HashMap<String, Instant>,
+}
+
+struct ReconciliationClock {
+    shutdown: Arc<(Mutex<bool>, Condvar)>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl ReconciliationClock {
+    fn stop(mut self) {
+        let (shutdown, wake) = self.shutdown.as_ref();
+        *shutdown.lock().unwrap() = true;
+        wake.notify_all();
+        if let Some(handle) = self.handle.take() {
+            if handle.thread().id() != std::thread::current().id() {
+                let _ = handle.join();
+            }
+        }
+    }
 }
 
 /// One mission's router. Mounted by `mission_start` after sessions spawn,
@@ -254,6 +286,7 @@ pub struct Router {
     injector: Arc<dyn StdinInjector>,
     launch: LaunchInputs,
     state: Mutex<RouterState>,
+    reconciliation_clock: Mutex<Option<ReconciliationClock>>,
     weak_self: Weak<Router>,
 }
 
@@ -304,6 +337,7 @@ impl Router {
                 crew_addendum,
             },
             state: Mutex::new(RouterState::default()),
+            reconciliation_clock: Mutex::new(None),
             weak_self: weak_self.clone(),
         }))
     }
@@ -322,6 +356,9 @@ impl Router {
                 state
                     .session_by_handle
                     .insert(handle.clone(), session_id.clone());
+                if self.injector.session_live(session_id) {
+                    state.live_sessions.insert(session_id.clone());
+                }
             }
         }
         let listener: Weak<dyn SessionDeliveryListener> = self.weak_self.clone();
@@ -536,15 +573,27 @@ impl Router {
 
     pub(crate) fn inject_and_submit(&self, handle: &str, body: &[u8]) -> Result<()> {
         self.inject_delivery(handle, body, DeliveryKind::Relay)
+            .map(|_| ())
     }
 
     pub(crate) fn inject_inbox_nudge(&self, handle: &str, body: &[u8]) -> Result<()> {
         self.inject_delivery(handle, body, DeliveryKind::InboxNudge)
+            .map(|_| ())
     }
 
     /// Reserve a clean input box through the delayed Enter, or park the
     /// payload until the session manager reports that local input cleared.
-    fn inject_delivery(&self, handle: &str, body: &[u8], kind: DeliveryKind) -> Result<()> {
+    fn inject_delivery(&self, handle: &str, body: &[u8], kind: DeliveryKind) -> Result<bool> {
+        self.inject_delivery_at(handle, body, kind, None)
+    }
+
+    fn inject_delivery_at(
+        &self,
+        handle: &str,
+        body: &[u8],
+        kind: DeliveryKind,
+        reconciliation: Option<(Instant, Duration)>,
+    ) -> Result<bool> {
         let delivery = QueuedDelivery {
             kind,
             body: body.to_vec(),
@@ -561,14 +610,37 @@ impl Router {
                     "router: no live session for handle @{handle}"
                 )));
             };
+            if let Some((now, backoff)) = reconciliation {
+                let delivery_pending = state
+                    .outbox_by_session
+                    .get(&session_id)
+                    .is_some_and(|outbox| outbox.submit_in_flight || !outbox.deliveries.is_empty());
+                let backoff_active = state
+                    .last_reconciliation_nudge
+                    .get(handle)
+                    .is_some_and(|last| now.saturating_duration_since(*last) < backoff);
+                if !state.live_sessions.contains(&session_id)
+                    || state.unread_by_handle.get(handle).copied().unwrap_or(0) == 0
+                    || !matches!(state.status.get(handle), Some(RunnerStatus::Idle))
+                    || delivery_pending
+                    || backoff_active
+                {
+                    return Ok(false);
+                }
+            }
             if let Some(outbox) = state.outbox_by_session.get_mut(&session_id) {
                 if outbox.submit_in_flight || !outbox.deliveries.is_empty() {
                     outbox.enqueue(delivery);
-                    return Ok(());
+                    return Ok(true);
                 }
             }
             match self.injector.reserve_delivery(&session_id)? {
                 DeliveryReservation::Ready(token) => {
+                    if let Some((now, _)) = reconciliation {
+                        state
+                            .last_reconciliation_nudge
+                            .insert(handle.to_string(), now);
+                    }
                     let outbox = state
                         .outbox_by_session
                         .entry(session_id.clone())
@@ -578,6 +650,9 @@ impl Router {
                     (session_id, Some((delivery, token)))
                 }
                 DeliveryReservation::RecentlyTyping(delay) => {
+                    if reconciliation.is_some() {
+                        return Ok(false);
+                    }
                     if deferable {
                         let outbox = state
                             .outbox_by_session
@@ -590,6 +665,9 @@ impl Router {
                     (session_id, None)
                 }
                 DeliveryReservation::PendingInput | DeliveryReservation::InFlight => {
+                    if reconciliation.is_some() {
+                        return Ok(false);
+                    }
                     if deferable {
                         let outbox = state
                             .outbox_by_session
@@ -605,12 +683,107 @@ impl Router {
         if let Some((session_id, delay)) = retry {
             self.schedule_outbox_retry(session_id, delay);
         }
-        match ready {
-            Some((delivery, token)) => {
-                self.start_reserved_delivery(&session_id, handle, delivery, token)
+        if let Some((delivery, token)) = ready {
+            if let Err(error) = self.start_reserved_delivery(&session_id, handle, delivery, token) {
+                if reconciliation.is_some() {
+                    self.state
+                        .lock()
+                        .unwrap()
+                        .last_reconciliation_nudge
+                        .remove(handle);
+                }
+                return Err(error);
             }
-            None => Ok(()),
         }
+        Ok(true)
+    }
+
+    fn reconcile_inbox_at(&self, now: Instant, backoff: Duration) -> usize {
+        let handles: Vec<String> = self
+            .state
+            .lock()
+            .unwrap()
+            .session_by_handle
+            .keys()
+            .cloned()
+            .collect();
+        handles
+            .into_iter()
+            .filter(|handle| {
+                match self.inject_delivery_at(
+                    handle,
+                    RECONCILIATION_NUDGE.as_bytes(),
+                    DeliveryKind::InboxNudge,
+                    Some((now, backoff)),
+                ) {
+                    Ok(nudged) => nudged,
+                    Err(error) => {
+                        log::warn!(
+                            "inbox reconciliation nudge to @{handle} on mission {} failed: {error}",
+                            self.mission_id
+                        );
+                        false
+                    }
+                }
+            })
+            .count()
+    }
+
+    fn start_reconciliation_tick_with_timings(
+        self: &Arc<Self>,
+        interval: Duration,
+        backoff: Duration,
+    ) {
+        let mut clock = self.reconciliation_clock.lock().unwrap();
+        if clock.is_some() {
+            return;
+        }
+        let shutdown = Arc::new((Mutex::new(false), Condvar::new()));
+        let shutdown_for_thread = Arc::clone(&shutdown);
+        let router = Arc::downgrade(self);
+        let mission_id = self.mission_id.clone();
+        let handle = std::thread::Builder::new()
+            .name(format!("inbox-reconcile-{mission_id}"))
+            .spawn(move || {
+                let (stopped, wake) = shutdown_for_thread.as_ref();
+                loop {
+                    let guard = stopped.lock().unwrap();
+                    let (guard, _) = wake
+                        .wait_timeout_while(guard, interval, |stopped| !*stopped)
+                        .unwrap();
+                    if *guard {
+                        return;
+                    }
+                    drop(guard);
+                    let Some(router) = router.upgrade() else {
+                        return;
+                    };
+                    router.reconcile_inbox_at(Instant::now(), backoff);
+                }
+            })
+            .expect("spawn inbox reconciliation clock");
+        *clock = Some(ReconciliationClock {
+            shutdown,
+            handle: Some(handle),
+        });
+    }
+
+    fn stop_reconciliation_tick(&self) {
+        if let Some(clock) = self.reconciliation_clock.lock().unwrap().take() {
+            clock.stop();
+        }
+    }
+
+    fn set_unread(&self, handle: &str, unread_count: usize) {
+        self.state
+            .lock()
+            .unwrap()
+            .unread_by_handle
+            .insert(handle.to_string(), unread_count);
+    }
+
+    fn update_inbox(&self, update: &InboxUpdate) {
+        self.set_unread(&update.runner_handle, update.unread_count);
     }
 
     fn start_reserved_delivery(
@@ -1071,34 +1244,31 @@ impl SessionDeliveryListener for Router {
     fn session_delivery_event(&self, session_id: &str, event: SessionDeliveryEvent) {
         match event {
             SessionDeliveryEvent::InputCleared => {
-                self.schedule_outbox_flush(session_id.to_string(), SUBMIT_DELAY);
+                self.schedule_outbox_flush(session_id.to_string(), INPUT_CLEAR_FLUSH_GRACE);
             }
             SessionDeliveryEvent::InputQueueDrained => self.flush_outbox(session_id),
             SessionDeliveryEvent::DeliveryFinished => {
                 self.schedule_delivery_cooldown(session_id.to_string());
             }
             SessionDeliveryEvent::Respawned => {
-                if let Some(outbox) = self
-                    .state
-                    .lock()
-                    .unwrap()
-                    .outbox_by_session
-                    .get_mut(session_id)
-                {
+                let mut state = self.state.lock().unwrap();
+                state.live_sessions.insert(session_id.to_string());
+                if let Some(outbox) = state.outbox_by_session.get_mut(session_id) {
                     outbox.submit_in_flight = false;
                     outbox.retry_scheduled = false;
                     outbox.retry_generation = outbox.retry_generation.wrapping_add(1);
                 }
+                drop(state);
                 self.flush_outbox(session_id);
             }
             SessionDeliveryEvent::Exited => {
-                let dropped = self
-                    .state
-                    .lock()
-                    .unwrap()
+                let mut state = self.state.lock().unwrap();
+                state.live_sessions.remove(session_id);
+                let dropped = state
                     .outbox_by_session
                     .remove(session_id)
                     .map_or(0, |outbox| outbox.deliveries.len());
+                drop(state);
                 if dropped > 0 {
                     self.warn(format!(
                         "router: dropped {dropped} deferred deliveries because session {session_id} exited"
@@ -1152,16 +1322,20 @@ impl RosterRow {
 }
 
 /// `BusEmitter` adapter so the existing `BusRegistry::mount` machinery can
-/// drive the router. Only `appended` carries the work; the inbox/watermark
-/// methods are no-ops because those are projections owned by the bus.
+/// drive the router. Appended events feed the dispatcher; inbox and watermark
+/// projections keep the reconciliation clock's unread snapshot current.
 pub struct RouterSubscriber(pub Arc<Router>);
 
 impl BusEmitter for RouterSubscriber {
     fn appended(&self, ev: &AppendedEvent) {
         self.0.handle_event(&ev.event);
     }
-    fn inbox_updated(&self, _ev: &InboxUpdate) {}
-    fn watermark_advanced(&self, _ev: &WatermarkUpdate) {}
+    fn inbox_updated(&self, ev: &InboxUpdate) {
+        self.0.update_inbox(ev);
+    }
+    fn watermark_advanced(&self, ev: &WatermarkUpdate) {
+        self.0.set_unread(&ev.runner_handle, ev.unread_count);
+    }
 }
 
 /// Fan a single bus emission to multiple subscribers. The bus accepts only
@@ -1209,12 +1383,39 @@ impl RouterRegistry {
     }
 
     pub fn register(&self, mission_id: String, router: Arc<Router>) {
+        self.register_with_timings(
+            mission_id,
+            router,
+            RECONCILIATION_TICK_INTERVAL,
+            RECONCILIATION_RENUDGE_BACKOFF,
+        );
+    }
+
+    fn register_with_timings(
+        &self,
+        mission_id: String,
+        router: Arc<Router>,
+        interval: Duration,
+        backoff: Duration,
+    ) {
         log::info!("router mounted: mission={mission_id}");
-        self.routers.lock().unwrap().insert(mission_id, router);
+        let previous = self
+            .routers
+            .lock()
+            .unwrap()
+            .insert(mission_id, Arc::clone(&router));
+        if let Some(previous) = previous {
+            if !Arc::ptr_eq(&previous, &router) {
+                previous.stop_reconciliation_tick();
+            }
+        }
+        router.start_reconciliation_tick_with_timings(interval, backoff);
     }
 
     pub fn unregister(&self, mission_id: &str) {
-        if self.routers.lock().unwrap().remove(mission_id).is_some() {
+        let router = self.routers.lock().unwrap().remove(mission_id);
+        if let Some(router) = router {
+            router.stop_reconciliation_tick();
             log::info!("router unmounted: mission={mission_id}");
         }
     }
@@ -1222,6 +1423,12 @@ impl RouterRegistry {
     #[allow(dead_code)] // Exposed for the future workspace UI bridge.
     pub fn get(&self, mission_id: &str) -> Option<Arc<Router>> {
         self.routers.lock().unwrap().get(mission_id).cloned()
+    }
+}
+
+impl Drop for Router {
+    fn drop(&mut self) {
+        self.stop_reconciliation_tick();
     }
 }
 

--- a/src-tauri/src/router/tests.rs
+++ b/src-tauri/src/router/tests.rs
@@ -112,6 +112,10 @@ impl RecordingInjector {
             .collect()
     }
 
+    fn clear_pushes(&self) {
+        self.pushes.lock().unwrap().clear();
+    }
+
     fn mark_dead(&self, session_id: &str) {
         self.dead.lock().unwrap().push(session_id.to_string());
     }
@@ -227,6 +231,15 @@ impl StdinInjector for RecordingInjector {
                         .last_input_at
                         .is_none_or(|last| last.elapsed() >= Duration::from_secs(2))
             })
+    }
+
+    fn session_live(&self, session_id: &str) -> bool {
+        !self
+            .dead
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|dead| dead == session_id)
     }
 
     fn reserve_delivery(&self, session_id: &str) -> Result<DeliveryReservation> {
@@ -422,6 +435,344 @@ fn wait_until(timeout: Duration, predicate: impl Fn() -> bool) {
 }
 
 #[test]
+fn reconciliation_tick_is_silent_for_empty_inbox() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    router.set_status("impl".into(), super::RunnerStatus::Idle);
+
+    assert_eq!(
+        router.reconcile_inbox_at(Instant::now(), Duration::from_secs(120)),
+        0
+    );
+    assert!(injector.pushes_for("S-IMPL").is_empty());
+}
+
+#[test]
+fn reconciliation_tick_is_silent_for_busy_session() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    router.update_inbox(&crate::event_bus::InboxUpdate {
+        mission_id: "mission-1".into(),
+        runner_handle: "impl".into(),
+        last_id: None,
+        watermark: None,
+        unread_count: 1,
+    });
+    router.set_status("impl".into(), super::RunnerStatus::Busy);
+
+    assert_eq!(
+        router.reconcile_inbox_at(Instant::now(), Duration::from_secs(120)),
+        0
+    );
+    assert!(injector.pushes_for("S-IMPL").is_empty());
+}
+
+#[test]
+fn reconciliation_tick_renudges_idle_session_with_unread_mail() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    router.update_inbox(&crate::event_bus::InboxUpdate {
+        mission_id: "mission-1".into(),
+        runner_handle: "impl".into(),
+        last_id: None,
+        watermark: None,
+        unread_count: 1,
+    });
+    router.set_status("impl".into(), super::RunnerStatus::Idle);
+
+    assert_eq!(
+        router.reconcile_inbox_at(Instant::now(), Duration::from_secs(120)),
+        1
+    );
+    assert_eq!(
+        injector.submitted_bodies_for("S-IMPL"),
+        ["[inbox] unread messages — run `runner msg read` to view."]
+    );
+    assert!(matches!(
+        router.state.lock().unwrap().status.get("impl"),
+        Some(super::RunnerStatus::Busy)
+    ));
+}
+
+#[test]
+fn reconciliation_tick_does_not_park_when_input_is_pending() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    injector.set_pending("S-IMPL");
+    router.update_inbox(&crate::event_bus::InboxUpdate {
+        mission_id: "mission-1".into(),
+        runner_handle: "impl".into(),
+        last_id: None,
+        watermark: None,
+        unread_count: 1,
+    });
+    router.set_status("impl".into(), super::RunnerStatus::Idle);
+
+    assert_eq!(
+        router.reconcile_inbox_at(Instant::now(), Duration::from_secs(120)),
+        0
+    );
+    {
+        let state = router.state.lock().unwrap();
+        assert!(!state.outbox_by_session.contains_key("S-IMPL"));
+        assert!(!state.last_reconciliation_nudge.contains_key("impl"));
+    }
+
+    router.update_inbox(&crate::event_bus::InboxUpdate {
+        mission_id: "mission-1".into(),
+        runner_handle: "impl".into(),
+        last_id: None,
+        watermark: Some("watermark".into()),
+        unread_count: 0,
+    });
+    router.set_status("impl".into(), super::RunnerStatus::Busy);
+    injector.clear_pending("S-IMPL");
+    std::thread::sleep(Duration::from_millis(550));
+    assert!(
+        injector.pushes_for("S-IMPL").is_empty(),
+        "a deferred clock nudge must not escape the busy and unread gates"
+    );
+}
+
+#[test]
+fn reconciliation_tick_does_not_duplicate_a_parked_nudge() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    injector.set_pending("S-IMPL");
+    router
+        .inject_inbox_nudge("impl", b"[inbox] original nudge")
+        .unwrap();
+    router.update_inbox(&crate::event_bus::InboxUpdate {
+        mission_id: "mission-1".into(),
+        runner_handle: "impl".into(),
+        last_id: None,
+        watermark: None,
+        unread_count: 1,
+    });
+    router.set_status("impl".into(), super::RunnerStatus::Idle);
+
+    assert_eq!(
+        router.reconcile_inbox_at(Instant::now(), Duration::from_secs(120)),
+        0
+    );
+    let state = router.state.lock().unwrap();
+    let outbox = state.outbox_by_session.get("S-IMPL").unwrap();
+    assert_eq!(outbox.deliveries.len(), 1);
+    assert_eq!(outbox.deliveries.front().unwrap().count, 1);
+    assert!(!state.last_reconciliation_nudge.contains_key("impl"));
+    drop(state);
+    injector.exit("S-IMPL");
+}
+
+#[test]
+fn reconciliation_reservation_error_does_not_start_backoff() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    router.update_inbox(&crate::event_bus::InboxUpdate {
+        mission_id: "mission-1".into(),
+        runner_handle: "impl".into(),
+        last_id: None,
+        watermark: None,
+        unread_count: 1,
+    });
+    router.set_status("impl".into(), super::RunnerStatus::Idle);
+    injector.mark_dead("S-IMPL");
+
+    assert_eq!(
+        router.reconcile_inbox_at(Instant::now(), Duration::from_secs(120)),
+        0
+    );
+    assert!(!router
+        .state
+        .lock()
+        .unwrap()
+        .last_reconciliation_nudge
+        .contains_key("impl"));
+}
+
+#[test]
+fn reconciliation_tick_honors_per_handle_backoff() {
+    let (router, _injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    router.update_inbox(&crate::event_bus::InboxUpdate {
+        mission_id: "mission-1".into(),
+        runner_handle: "impl".into(),
+        last_id: None,
+        watermark: None,
+        unread_count: 1,
+    });
+    router.set_status("impl".into(), super::RunnerStatus::Idle);
+    let now = Instant::now();
+    let backoff = Duration::from_secs(120);
+
+    assert_eq!(router.reconcile_inbox_at(now, backoff), 1);
+    wait_until(Duration::from_millis(300), || {
+        !router
+            .state
+            .lock()
+            .unwrap()
+            .outbox_by_session
+            .contains_key("S-IMPL")
+    });
+    router.set_status("impl".into(), super::RunnerStatus::Idle);
+    assert_eq!(
+        router.reconcile_inbox_at(now + Duration::from_secs(119), backoff),
+        0
+    );
+    assert_eq!(
+        router.reconcile_inbox_at(now + Duration::from_secs(120), backoff),
+        1
+    );
+}
+
+#[test]
+fn reconciliation_tick_quiesces_after_watermark_advance() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    let now = Instant::now();
+    router.update_inbox(&crate::event_bus::InboxUpdate {
+        mission_id: "mission-1".into(),
+        runner_handle: "impl".into(),
+        last_id: None,
+        watermark: None,
+        unread_count: 1,
+    });
+    router.set_status("impl".into(), super::RunnerStatus::Idle);
+    assert_eq!(router.reconcile_inbox_at(now, Duration::from_secs(120)), 1);
+    wait_until(Duration::from_millis(300), || {
+        !router
+            .state
+            .lock()
+            .unwrap()
+            .outbox_by_session
+            .contains_key("S-IMPL")
+    });
+    injector.clear_pushes();
+    router.update_inbox(&crate::event_bus::InboxUpdate {
+        mission_id: "mission-1".into(),
+        runner_handle: "impl".into(),
+        last_id: None,
+        watermark: Some("watermark".into()),
+        unread_count: 0,
+    });
+    router.set_status("impl".into(), super::RunnerStatus::Idle);
+
+    assert_eq!(
+        router.reconcile_inbox_at(now + Duration::from_secs(120), Duration::from_secs(120)),
+        0
+    );
+    assert!(injector.pushes_for("S-IMPL").is_empty());
+}
+
+#[test]
+fn reconciliation_clock_stops_with_mission_and_skips_stopped_sessions() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    router.update_inbox(&crate::event_bus::InboxUpdate {
+        mission_id: "mission-1".into(),
+        runner_handle: "impl".into(),
+        last_id: None,
+        watermark: None,
+        unread_count: 1,
+    });
+    router.set_status("impl".into(), super::RunnerStatus::Idle);
+    let registry = RouterRegistry::new();
+    registry.register_with_timings(
+        "mission-1".into(),
+        Arc::clone(&router),
+        Duration::from_millis(10),
+        Duration::ZERO,
+    );
+    wait_until(Duration::from_millis(100), || {
+        injector.submitted_bodies_for("S-IMPL").len() == 1
+    });
+    wait_until(Duration::from_millis(300), || {
+        !router
+            .state
+            .lock()
+            .unwrap()
+            .outbox_by_session
+            .contains_key("S-IMPL")
+    });
+
+    injector.clear_pushes();
+    router.set_status("impl".into(), super::RunnerStatus::Idle);
+    injector.exit("S-IMPL");
+    std::thread::sleep(Duration::from_millis(40));
+    assert!(
+        injector.pushes_for("S-IMPL").is_empty(),
+        "clock must not nudge an exited session"
+    );
+
+    injector.respawn("S-IMPL");
+    router.set_status("impl".into(), super::RunnerStatus::Idle);
+    wait_until(Duration::from_millis(100), || {
+        injector.submitted_bodies_for("S-IMPL").len() == 1
+    });
+    wait_until(Duration::from_millis(300), || {
+        !router
+            .state
+            .lock()
+            .unwrap()
+            .outbox_by_session
+            .contains_key("S-IMPL")
+    });
+    registry.unregister("mission-1");
+    injector.clear_pushes();
+    router.set_status("impl".into(), super::RunnerStatus::Idle);
+    std::thread::sleep(Duration::from_millis(40));
+    assert!(
+        injector.pushes_for("S-IMPL").is_empty(),
+        "clock must halt when the mission router unmounts"
+    );
+}
+
+#[test]
 fn directed_message_nudges_target_only() {
     // Pull-based inbox routing strands the worker without a stdin
     // poke. A directed message must wake the target with a one-line
@@ -445,7 +796,7 @@ fn directed_message_nudges_target_only() {
 }
 
 #[test]
-fn pending_input_parks_delivery_until_clear() {
+fn input_clear_flush_reparks_when_typing_resumes_during_grace() {
     let (router, injector, log, _dir) = fixture(
         vec![
             slot_with_runner("lead", true),
@@ -466,27 +817,37 @@ fn pending_input_parks_delivery_until_clear() {
     injector.clear_pending("S-IMPL");
     assert!(
         injector.pushes_for("S-IMPL").is_empty(),
-        "flush must leave a post-submit gap before writing the deferred body"
+        "flush must leave a grace period before writing the deferred body"
     );
     injector.set_pending("S-IMPL");
-    std::thread::sleep(Duration::from_millis(120));
+    std::thread::sleep(Duration::from_millis(550));
     assert!(
         injector.pushes_for("S-IMPL").is_empty(),
-        "typing a new draft during the post-submit gap must keep the delivery parked"
+        "typing a new draft during the grace period must keep the delivery parked"
     );
+    injector.exit("S-IMPL");
+}
+
+#[test]
+fn input_clear_flushes_after_quiet_500ms_grace() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    injector.set_pending("S-IMPL");
+    router.inject_and_submit("impl", b"deferred relay").unwrap();
+
+    let cleared_at = Instant::now();
     injector.clear_pending("S-IMPL");
-    wait_until(Duration::from_millis(250), || {
-        injector.submitted_bodies_for("S-IMPL").len() == 1
-            && matches!(
-                router.state.lock().unwrap().status.get("impl"),
-                Some(super::RunnerStatus::Busy)
-            )
+    std::thread::sleep(Duration::from_millis(450));
+    assert!(injector.submitted_bodies_for("S-IMPL").is_empty());
+    wait_until(Duration::from_millis(200), || {
+        injector.submitted_bodies_for("S-IMPL") == ["deferred relay"]
     });
-    assert!(injector.submitted_bodies_for("S-IMPL")[0].contains("[inbox]"));
-    assert!(matches!(
-        router.state.lock().unwrap().status.get("impl"),
-        Some(super::RunnerStatus::Busy)
-    ));
+    assert!(cleared_at.elapsed() >= Duration::from_millis(500));
 }
 
 #[test]

--- a/src-tauri/src/session/manager/mod.rs
+++ b/src-tauri/src/session/manager/mod.rs
@@ -742,6 +742,11 @@ impl SessionManager {
                 .is_none_or(|last| last.elapsed() >= RECENT_LOCAL_INPUT_WINDOW)
     }
 
+    pub fn session_live(&self, session_id: &str) -> bool {
+        self.session_state(session_id)
+            .is_some_and(|session| session.lock().unwrap().handle.is_some())
+    }
+
     pub fn reserve_delivery(&self, session_id: &str) -> Result<router::DeliveryReservation> {
         let session = self
             .session_state(session_id)


### PR DESCRIPTION
Closes #332.

## Summary
- mount a stoppable per-mission reconciliation clock that re-nudges live idle sessions with unread inbox mail
- enforce a two-minute per-handle backoff and never park clock-triggered nudges behind pending input
- add a 500ms input-clear flush grace with delivery-time input revalidation
- sync feature 48 to the implemented timing and Ctrl+U behavior

## Validation
- cargo fmt
- cargo clippy --workspace --all-targets
- cargo test --workspace
- focused manual smoke test passed
- working-tree review clean