### PR TITLE
feat(mission): show blocked inbox delivery

### DIFF
--- a/design/runner-mission.pen
+++ b/design/runner-mission.pen
@@ -8566,7 +8566,7 @@
               "id": "f5WDCX",
               "name": "btnKey",
               "fill": "#FFB454B3",
-              "content": "⌃C",
+              "content": "↵",
               "fontFamily": "JetBrains Mono",
               "fontSize": 10,
               "fontWeight": "normal"
@@ -9603,7 +9603,7 @@
                           "type": "ref",
                           "ref": "w3kaW",
                           "name": "InboxBlockedPill",
-                          "x": 450,
+                          "x": 456,
                           "y": 0
                         }
                       ]
@@ -10089,7 +10089,7 @@
           "fill": "#9A9BA5",
           "textGrowth": "fixed-width",
           "width": 480,
-          "content": "Appears when a runner has unread mission mail and the nudge is parked behind pending terminal input (PendingInput). Floats over the pane below the tab strip — never in layout flow, so the PTY is not resized. The Clear input button emits a single ⌃C through the ordinary local-input write path — identical to pressing the key: ClearPending fires organically and the 500ms grace + fire-time re-check still apply (typing during the grace re-parks delivery). The button is hidden while the runner is busy, since ⌃C mid-turn interrupts the agent; a lone ⌃C never exits claude-code (worst case on an empty box: it primes the exit hint). Copy does not assert a draft exists — backspace-cleared input is undetectable. Clears when delivery proceeds, when unread reaches zero, on session exit, and on mission unmount.",
+          "content": "Appears when a runner has unread mission mail and the nudge is parked behind pending terminal input (PendingInput). Floats over the pane below the tab strip — never in layout flow, so the PTY is not resized. The Clear input button emits a single Enter through the ordinary local-input write path — identical to pressing the key: ClearPending fires organically and the 500ms grace + fire-time re-check still apply. The button is hidden while the runner is busy. Copy does not assert a draft exists — backspace-cleared input is undetectable. Clears when delivery proceeds, when unread reaches zero, on session exit, and on mission unmount.",
           "lineHeight": 1.5,
           "fontFamily": "Inter",
           "fontSize": 12,

--- a/docs/features/50-inbox-delivery-blocked-indicator.md
+++ b/docs/features/50-inbox-delivery-blocked-indicator.md
@@ -12,17 +12,18 @@ Ctrl+U makes the ambiguity visible. Runner sees the keystroke but cannot know wh
 
 - Show a pane-local, non-modal indicator when a live mission session has unread inbox mail and pending local input prevents its wake nudge from being delivered safely.
 - Use mechanism-based copy such as `Inbox waiting (2) — typing detected, delivery paused`, including the unread count when it is greater than one. The copy must not assert that a draft exists (backspace-cleared input is undetectable, so the box may already be empty) and must not claim any action notifies the worker: clearing input releases the parked nudge, and Runner delivers it. No @handle in the copy — the indicator is pane-local, so the affected runner is already unambiguous.
-- Include a `Clear input (⌃C)` button on the indicator that emits a single Ctrl+C through the ordinary local-input write path — byte-identical to the user pressing the key. `ClearPending` fires organically and the existing 500ms flush grace plus fire-time re-check still apply, so typing during the grace re-parks delivery. Show the button only while the runner is idle: Ctrl+C during a busy turn would interrupt the agent. A lone Ctrl+C is safe on an already-empty box (worst case in claude-code it primes the exit hint; the pill's disappearance after delivery removes the second-press risk).
+- Include a `Clear input (↵)` button on the indicator that emits a single Enter through the ordinary local-input write path — byte-identical to the user pressing the key. `ClearPending` fires organically and the existing 500ms flush grace plus fire-time re-check still apply, so typing during the grace re-parks delivery. A leftover draft is submitted rather than discarded; Enter on an already-empty box is a no-op. Show the button only while the runner is idle because Enter during a busy turn could submit or steer pending text into the agent's active turn.
 - Keep the indicator outside the terminal byte stream so it cannot alter, submit, or clear the user's draft.
 - Clear the indicator when unread count reaches zero, input clears and delivery proceeds, the session exits, or the mission unmounts.
 - Drive the UI from ephemeral in-process state transitions; do not persist blocked-delivery state or append coordination-log events for it.
+- Accept that a workspace opened after the blocked transition has already fired will not show the indicator until the unread count changes. There is intentionally no persisted state or snapshot API to hydrate a late subscriber.
 - Preserve the push-not-pull protocol. This is a human-facing explanation of a blocked wake, not agent polling or a new delivery path.
 
 ## Out of scope
 
 - Reconstructing the agent TUI's draft buffer from xterm keystrokes or screen output.
 - Treating Ctrl+U as proof that all input is clear.
-- A force-deliver action that bypasses delivery safety checks or splices a nudge into remaining draft text. The `Clear input` button is not this: it performs the same keystroke the indicator teaches, through the same write path, with every reservation/grace check left in place.
+- A force-deliver action that bypasses delivery safety checks or splices a nudge into remaining draft text. The `Clear input` button is not this: it performs one ordinary Enter keystroke through the same write path, with every reservation/grace check left in place.
 - Direct chats, which have no mission inbox.
 
 ## Implementation phases
@@ -35,10 +36,10 @@ Ctrl+U makes the ambiguity visible. Runner sees the keystroke but cannot know wh
 ## Verification
 
 - [ ] Typing a draft while unread mail arrives parks the nudge and shows the indicator on the correct pane.
-- [ ] Pressing Enter or Ctrl+C clears the input, permits delivery, and removes the indicator.
+- [ ] Pressing Enter clears the input, permits delivery, and removes the indicator.
 - [ ] Ctrl+U does not falsely declare multiline input clear; the indicator remains until an unambiguous clear.
 - [ ] A watermark advance to zero unread removes the indicator without injecting anything.
 - [ ] Empty inboxes, direct chats, busy sessions without blocked local input, and unrelated panes never show the indicator.
 - [ ] Session exit and mission stop remove blocked state with no stale indicator after remount.
-- [ ] The Clear input button sends exactly one Ctrl+C through the local-input path: a leftover draft is cancelled, an empty box is unchanged, ClearPending is observed, and delivery proceeds after the grace; the button is absent while the runner is busy.
+- [ ] The Clear input button sends exactly one Enter through the local-input path: a leftover draft is submitted, an empty box is unchanged, ClearPending is observed, and delivery proceeds after the grace; the button is absent while the runner is busy.
 - [ ] Repeated reconciliation ticks do not duplicate UI events or churn rendering while the blocked state is unchanged.

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -495,6 +495,7 @@ async fn mission_start_impl_with_size(
     use crate::event_bus::{BusEmitter, TauriBusEvents};
     use crate::router::{
         open_log_for_mission, CompositeBusEmitter, Router, RouterSubscriber, StdinInjector,
+        TauriRouterUiNotifier,
     };
     use crate::session::manager::{SessionEvents, TauriSessionEvents};
     use std::sync::Arc;
@@ -636,6 +637,7 @@ async fn mission_start_impl_with_size(
         crew_addendum.clone(),
         Arc::clone(&log_arc),
         injector,
+        Arc::new(TauriRouterUiNotifier(app.clone())),
     ) {
         Ok(r) => r,
         Err(e) => {
@@ -906,6 +908,7 @@ pub(crate) async fn ensure_mission_router_mounted(
     use crate::event_bus::{BusEmitter, TauriBusEvents};
     use crate::router::{
         open_log_for_mission, CompositeBusEmitter, Router, RouterSubscriber, StdinInjector,
+        TauriRouterUiNotifier,
     };
     use std::sync::Arc;
 
@@ -980,6 +983,7 @@ pub(crate) async fn ensure_mission_router_mounted(
         crew_addendum,
         Arc::clone(&log_arc),
         injector,
+        Arc::new(TauriRouterUiNotifier(app.clone())),
     )?;
     router.register_sessions(&session_pairs);
 
@@ -1180,6 +1184,7 @@ pub(crate) async fn mission_reset_impl(
     use crate::event_bus::{BusEmitter, TauriBusEvents};
     use crate::router::{
         open_log_for_mission, CompositeBusEmitter, Router, RouterSubscriber, StdinInjector,
+        TauriRouterUiNotifier,
     };
     use crate::session::manager::{SessionEvents, TauriSessionEvents};
     use std::sync::Arc;
@@ -1375,6 +1380,7 @@ pub(crate) async fn mission_reset_impl(
         crew_addendum.clone(),
         Arc::clone(&log_arc),
         injector,
+        Arc::new(TauriRouterUiNotifier(app.clone())),
     )?;
 
     let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app.clone()));

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -30,6 +30,8 @@ use std::time::{Duration, Instant};
 
 use runner_core::event_log::EventLog;
 use runner_core::model::{Event, EventKind, SignalType};
+use serde::Serialize;
+use tauri::Emitter;
 
 use crate::error::Result;
 use crate::event_bus::{AppendedEvent, BusEmitter, InboxUpdate, WatermarkUpdate};
@@ -72,6 +74,28 @@ pub trait StdinInjector: Send + Sync + 'static {
         session_id: &str,
         listener: Weak<dyn SessionDeliveryListener>,
     );
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DeliveryBlockedEvent {
+    pub mission_id: String,
+    pub session_id: String,
+    pub handle: String,
+    pub unread_count: usize,
+    pub blocked: bool,
+}
+
+pub trait RouterUiNotifier: Send + Sync + 'static {
+    /// Called with the router state locked; implementations must not call back into the router.
+    fn delivery_blocked(&self, event: &DeliveryBlockedEvent);
+}
+
+pub struct TauriRouterUiNotifier<R: tauri::Runtime = tauri::Wry>(pub tauri::AppHandle<R>);
+
+impl<R: tauri::Runtime> RouterUiNotifier for TauriRouterUiNotifier<R> {
+    fn delivery_blocked(&self, event: &DeliveryBlockedEvent) {
+        let _ = self.0.emit("router/delivery-blocked", event);
+    }
 }
 
 impl StdinInjector for SessionManager {
@@ -201,6 +225,7 @@ struct SessionOutbox {
     handle: String,
     deliveries: VecDeque<QueuedDelivery>,
     submit_in_flight: bool,
+    pending_input_blocked: bool,
     retry_scheduled: bool,
     retry_generation: u64,
 }
@@ -253,6 +278,7 @@ struct RouterState {
     /// bootstrap the lead.
     replay_high_water: Option<String>,
     outbox_by_session: HashMap<String, SessionOutbox>,
+    blocked_unread_by_session: HashMap<String, usize>,
     live_sessions: HashSet<String>,
     unread_by_handle: HashMap<String, usize>,
     last_reconciliation_nudge: HashMap<String, Instant>,
@@ -284,6 +310,7 @@ pub struct Router {
     crew_id: String,
     log: Arc<EventLog>,
     injector: Arc<dyn StdinInjector>,
+    ui_notifier: Arc<dyn RouterUiNotifier>,
     launch: LaunchInputs,
     state: Mutex<RouterState>,
     reconciliation_clock: Mutex<Option<ReconciliationClock>>,
@@ -303,6 +330,7 @@ impl Router {
         crew_addendum: Option<String>,
         log: Arc<EventLog>,
         injector: Arc<dyn StdinInjector>,
+        ui_notifier: Arc<dyn RouterUiNotifier>,
     ) -> Result<Arc<Self>> {
         let lead = roster
             .iter()
@@ -329,6 +357,7 @@ impl Router {
             crew_id,
             log,
             injector,
+            ui_notifier,
             launch: LaunchInputs {
                 crew_name,
                 lead,
@@ -631,6 +660,7 @@ impl Router {
             if let Some(outbox) = state.outbox_by_session.get_mut(&session_id) {
                 if outbox.submit_in_flight || !outbox.deliveries.is_empty() {
                     outbox.enqueue(delivery);
+                    self.blocked_transition(&mut state, &session_id);
                     return Ok(true);
                 }
             }
@@ -647,6 +677,8 @@ impl Router {
                         .or_default();
                     outbox.handle = handle.to_string();
                     outbox.submit_in_flight = true;
+                    outbox.pending_input_blocked = false;
+                    self.blocked_transition(&mut state, &session_id);
                     (session_id, Some((delivery, token)))
                 }
                 DeliveryReservation::RecentlyTyping(delay) => {
@@ -659,12 +691,14 @@ impl Router {
                             .entry(session_id.clone())
                             .or_default();
                         outbox.handle = handle.to_string();
+                        outbox.pending_input_blocked = false;
                         outbox.enqueue(delivery);
                         retry = Some((session_id.clone(), delay));
+                        self.blocked_transition(&mut state, &session_id);
                     }
                     (session_id, None)
                 }
-                DeliveryReservation::PendingInput | DeliveryReservation::InFlight => {
+                DeliveryReservation::PendingInput => {
                     if reconciliation.is_some() {
                         return Ok(false);
                     }
@@ -674,7 +708,25 @@ impl Router {
                             .entry(session_id.clone())
                             .or_default();
                         outbox.handle = handle.to_string();
+                        outbox.pending_input_blocked = true;
                         outbox.enqueue(delivery);
+                        self.blocked_transition(&mut state, &session_id);
+                    }
+                    (session_id, None)
+                }
+                DeliveryReservation::InFlight => {
+                    if reconciliation.is_some() {
+                        return Ok(false);
+                    }
+                    if deferable {
+                        let outbox = state
+                            .outbox_by_session
+                            .entry(session_id.clone())
+                            .or_default();
+                        outbox.handle = handle.to_string();
+                        outbox.pending_input_blocked = false;
+                        outbox.enqueue(delivery);
+                        self.blocked_transition(&mut state, &session_id);
                     }
                     (session_id, None)
                 }
@@ -774,12 +826,96 @@ impl Router {
         }
     }
 
+    fn blocked_transition(&self, state: &mut RouterState, session_id: &str) {
+        let Some(handle) = state
+            .outbox_by_session
+            .get(session_id)
+            .map(|outbox| outbox.handle.clone())
+            .or_else(|| {
+                state
+                    .session_by_handle
+                    .iter()
+                    .find_map(|(handle, id)| (id == session_id).then(|| handle.clone()))
+            })
+        else {
+            return;
+        };
+        let unread_count = state.unread_by_handle.get(&handle).copied().unwrap_or(0);
+        let blocked = unread_count > 0
+            && state
+                .outbox_by_session
+                .get(session_id)
+                .is_some_and(|outbox| {
+                    outbox.pending_input_blocked && !outbox.deliveries.is_empty()
+                });
+        let previous = state.blocked_unread_by_session.get(session_id).copied();
+        let event = match (previous, blocked) {
+            (None, false) => None,
+            (Some(previous), true) if previous == unread_count => None,
+            (_, true) => {
+                state
+                    .blocked_unread_by_session
+                    .insert(session_id.to_string(), unread_count);
+                Some(DeliveryBlockedEvent {
+                    mission_id: self.mission_id.clone(),
+                    session_id: session_id.to_string(),
+                    handle,
+                    unread_count,
+                    blocked: true,
+                })
+            }
+            (Some(_), false) => {
+                state.blocked_unread_by_session.remove(session_id);
+                Some(DeliveryBlockedEvent {
+                    mission_id: self.mission_id.clone(),
+                    session_id: session_id.to_string(),
+                    handle,
+                    unread_count,
+                    blocked: false,
+                })
+            }
+        };
+        if let Some(event) = event {
+            self.ui_notifier.delivery_blocked(&event);
+        }
+    }
+
+    fn clear_blocked_transitions(&self) {
+        let mut state = self.state.lock().unwrap();
+        let reported = std::mem::take(&mut state.blocked_unread_by_session);
+        for (session_id, _) in reported {
+            let Some(handle) = state
+                .outbox_by_session
+                .get(&session_id)
+                .map(|outbox| outbox.handle.clone())
+                .or_else(|| {
+                    state
+                        .session_by_handle
+                        .iter()
+                        .find_map(|(handle, id)| (id == &session_id).then(|| handle.clone()))
+                })
+            else {
+                continue;
+            };
+            let event = DeliveryBlockedEvent {
+                mission_id: self.mission_id.clone(),
+                session_id,
+                unread_count: state.unread_by_handle.get(&handle).copied().unwrap_or(0),
+                handle,
+                blocked: false,
+            };
+            self.ui_notifier.delivery_blocked(&event);
+        }
+    }
+
     fn set_unread(&self, handle: &str, unread_count: usize) {
-        self.state
-            .lock()
-            .unwrap()
+        let mut state = self.state.lock().unwrap();
+        state
             .unread_by_handle
             .insert(handle.to_string(), unread_count);
+        if let Some(session_id) = state.session_by_handle.get(handle).cloned() {
+            self.blocked_transition(&mut state, &session_id);
+        }
     }
 
     fn update_inbox(&self, update: &InboxUpdate) {
@@ -832,6 +968,7 @@ impl Router {
         if outbox.deliveries.is_empty() {
             state.outbox_by_session.remove(session_id);
         }
+        self.blocked_transition(&mut state, session_id);
     }
 
     fn flush_outbox(&self, session_id: &str) {
@@ -849,13 +986,15 @@ impl Router {
         let reservation = match self.injector.reserve_delivery(session_id) {
             Ok(reservation) => reservation,
             Err(error) => {
-                let dropped = self
-                    .state
-                    .lock()
-                    .unwrap()
-                    .outbox_by_session
-                    .remove(session_id)
-                    .map_or(0, |outbox| outbox.deliveries.len());
+                let dropped = {
+                    let mut state = self.state.lock().unwrap();
+                    let dropped = state
+                        .outbox_by_session
+                        .remove(session_id)
+                        .map_or(0, |outbox| outbox.deliveries.len());
+                    self.blocked_transition(&mut state, session_id);
+                    dropped
+                };
                 self.warn(format!(
                     "router: dropped {dropped} deferred deliveries for {session_id}: {error}"
                 ));
@@ -875,6 +1014,8 @@ impl Router {
                         return;
                     };
                     outbox.submit_in_flight = true;
+                    outbox.pending_input_blocked = false;
+                    self.blocked_transition(&mut state, session_id);
                     delivery
                 };
                 if let Err(error) =
@@ -884,9 +1025,32 @@ impl Router {
                 }
             }
             DeliveryReservation::RecentlyTyping(delay) => {
+                {
+                    let mut state = self.state.lock().unwrap();
+                    let Some(outbox) = state.outbox_by_session.get_mut(session_id) else {
+                        return;
+                    };
+                    outbox.pending_input_blocked = false;
+                    self.blocked_transition(&mut state, session_id);
+                }
                 self.schedule_outbox_retry(session_id.to_string(), delay);
             }
-            DeliveryReservation::PendingInput | DeliveryReservation::InFlight => {}
+            DeliveryReservation::PendingInput => {
+                let mut state = self.state.lock().unwrap();
+                let Some(outbox) = state.outbox_by_session.get_mut(session_id) else {
+                    return;
+                };
+                outbox.pending_input_blocked = true;
+                self.blocked_transition(&mut state, session_id);
+            }
+            DeliveryReservation::InFlight => {
+                let mut state = self.state.lock().unwrap();
+                let Some(outbox) = state.outbox_by_session.get_mut(session_id) else {
+                    return;
+                };
+                outbox.pending_input_blocked = false;
+                self.blocked_transition(&mut state, session_id);
+            }
         }
     }
 
@@ -1262,13 +1426,16 @@ impl SessionDeliveryListener for Router {
                 self.flush_outbox(session_id);
             }
             SessionDeliveryEvent::Exited => {
-                let mut state = self.state.lock().unwrap();
-                state.live_sessions.remove(session_id);
-                let dropped = state
-                    .outbox_by_session
-                    .remove(session_id)
-                    .map_or(0, |outbox| outbox.deliveries.len());
-                drop(state);
+                let dropped = {
+                    let mut state = self.state.lock().unwrap();
+                    state.live_sessions.remove(session_id);
+                    let dropped = state
+                        .outbox_by_session
+                        .remove(session_id)
+                        .map_or(0, |outbox| outbox.deliveries.len());
+                    self.blocked_transition(&mut state, session_id);
+                    dropped
+                };
                 if dropped > 0 {
                     self.warn(format!(
                         "router: dropped {dropped} deferred deliveries because session {session_id} exited"
@@ -1407,6 +1574,7 @@ impl RouterRegistry {
         if let Some(previous) = previous {
             if !Arc::ptr_eq(&previous, &router) {
                 previous.stop_reconciliation_tick();
+                previous.clear_blocked_transitions();
             }
         }
         router.start_reconciliation_tick_with_timings(interval, backoff);
@@ -1416,6 +1584,7 @@ impl RouterRegistry {
         let router = self.routers.lock().unwrap().remove(mission_id);
         if let Some(router) = router {
             router.stop_reconciliation_tick();
+            router.clear_blocked_transitions();
             log::info!("router unmounted: mission={mission_id}");
         }
     }
@@ -1429,6 +1598,7 @@ impl RouterRegistry {
 impl Drop for Router {
     fn drop(&mut self) {
         self.stop_reconciliation_tick();
+        self.clear_blocked_transitions();
     }
 }
 

--- a/src-tauri/src/router/tests.rs
+++ b/src-tauri/src/router/tests.rs
@@ -14,8 +14,8 @@ use runner_core::event_log::EventLog;
 use runner_core::model::{Event, EventDraft, EventKind, SignalType};
 
 use super::{
-    DeliveryReservation, Router, RouterRegistry, SessionDeliveryEvent, SessionDeliveryListener,
-    StdinInjector,
+    DeliveryBlockedEvent, DeliveryReservation, Router, RouterRegistry, RouterUiNotifier,
+    SessionDeliveryEvent, SessionDeliveryListener, StdinInjector,
 };
 use crate::error::Result;
 use crate::model::{Runner, Slot, SlotWithRunner};
@@ -37,6 +37,7 @@ enum InjectKind {
 #[derive(Default)]
 struct RecordingInjector {
     pushes: Mutex<Vec<(String, InjectKind, Vec<u8>)>>,
+    blocked_events: Mutex<Vec<DeliveryBlockedEvent>>,
     /// Optional `dead_session` set — `inject` errors when called with one
     /// of these ids, simulating a crashed PTY for `mission_warning` tests.
     dead: Mutex<Vec<String>>,
@@ -134,6 +135,15 @@ impl RecordingInjector {
         input.last_input_at = Some(Instant::now() - Duration::from_millis(1950));
     }
 
+    fn set_in_flight(&self, session_id: &str) {
+        let mut input = self.input.lock().unwrap();
+        input.entry(session_id.to_string()).or_default().in_flight = true;
+    }
+
+    fn blocked_events(&self) -> Vec<DeliveryBlockedEvent> {
+        self.blocked_events.lock().unwrap().clone()
+    }
+
     fn clear_pending(&self, session_id: &str) {
         if let Some(input) = self.input.lock().unwrap().get_mut(session_id) {
             input.pending = false;
@@ -179,6 +189,12 @@ impl RecordingInjector {
         for listener in listeners {
             listener.session_delivery_event(session_id, event);
         }
+    }
+}
+
+impl RouterUiNotifier for RecordingInjector {
+    fn delivery_blocked(&self, event: &DeliveryBlockedEvent) {
+        self.blocked_events.lock().unwrap().push(event.clone());
     }
 }
 
@@ -388,6 +404,7 @@ fn fixture(
     let log = Arc::new(EventLog::open(dir.path()).unwrap());
     let injector = Arc::new(RecordingInjector::default());
     let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
+    let notifier: Arc<dyn RouterUiNotifier> = injector.clone();
     let router = Router::new(
         "mission-1".into(),
         "crew-1".into(),
@@ -397,6 +414,7 @@ fn fixture(
         None,
         log.clone(),
         injector_dyn,
+        notifier,
     )
     .unwrap();
     let session_pairs: Vec<(String, String)> = sessions
@@ -432,6 +450,243 @@ fn wait_until(timeout: Duration, predicate: impl Fn() -> bool) {
         assert!(Instant::now() < deadline, "condition did not become true");
         std::thread::sleep(Duration::from_millis(5));
     }
+}
+
+fn set_unread(router: &Router, handle: &str, unread_count: usize) {
+    router.update_inbox(&crate::event_bus::InboxUpdate {
+        mission_id: "mission-1".into(),
+        runner_handle: handle.into(),
+        last_id: None,
+        watermark: None,
+        unread_count,
+    });
+}
+
+#[test]
+fn delivery_blocked_transition_dedupes_repeated_parks_and_reemits_count_changes() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    set_unread(&router, "impl", 1);
+    injector.set_pending("S-IMPL");
+
+    router.inject_inbox_nudge("impl", b"[inbox] first").unwrap();
+    router
+        .inject_inbox_nudge("impl", b"[inbox] second")
+        .unwrap();
+    assert_eq!(
+        injector.blocked_events(),
+        [DeliveryBlockedEvent {
+            mission_id: "mission-1".into(),
+            session_id: "S-IMPL".into(),
+            handle: "impl".into(),
+            unread_count: 1,
+            blocked: true,
+        }]
+    );
+
+    set_unread(&router, "impl", 2);
+    set_unread(&router, "impl", 2);
+    assert_eq!(
+        injector.blocked_events().last(),
+        Some(&DeliveryBlockedEvent {
+            mission_id: "mission-1".into(),
+            session_id: "S-IMPL".into(),
+            handle: "impl".into(),
+            unread_count: 2,
+            blocked: true,
+        })
+    );
+    assert_eq!(injector.blocked_events().len(), 2);
+    injector.exit("S-IMPL");
+}
+
+#[test]
+fn transient_delivery_reservations_do_not_emit_blocked() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    set_unread(&router, "impl", 1);
+    injector.set_recent_typing("S-IMPL");
+    router
+        .inject_inbox_nudge("impl", b"[inbox] recent")
+        .unwrap();
+    std::thread::sleep(Duration::from_millis(100));
+    assert!(injector.blocked_events().is_empty());
+    injector.exit("S-IMPL");
+
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    set_unread(&router, "impl", 1);
+    injector.set_in_flight("S-IMPL");
+    router
+        .inject_inbox_nudge("impl", b"[inbox] in flight")
+        .unwrap();
+    assert!(injector.blocked_events().is_empty());
+    injector.exit("S-IMPL");
+}
+
+#[test]
+fn delivery_blocked_clears_when_parked_delivery_flushes() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    set_unread(&router, "impl", 1);
+    injector.set_pending("S-IMPL");
+    router
+        .inject_inbox_nudge("impl", b"[inbox] waiting")
+        .unwrap();
+
+    injector.clear_pending("S-IMPL");
+    wait_until(Duration::from_secs(1), || {
+        injector
+            .blocked_events()
+            .last()
+            .is_some_and(|event| !event.blocked)
+    });
+    assert_eq!(injector.blocked_events().len(), 2);
+}
+
+#[test]
+fn delivery_blocked_clears_when_watermark_reaches_zero() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    set_unread(&router, "impl", 1);
+    injector.set_pending("S-IMPL");
+    router
+        .inject_inbox_nudge("impl", b"[inbox] waiting")
+        .unwrap();
+
+    set_unread(&router, "impl", 0);
+    assert_eq!(injector.blocked_events().len(), 2);
+    assert_eq!(
+        injector.blocked_events().last(),
+        Some(&DeliveryBlockedEvent {
+            mission_id: "mission-1".into(),
+            session_id: "S-IMPL".into(),
+            handle: "impl".into(),
+            unread_count: 0,
+            blocked: false,
+        })
+    );
+    injector.exit("S-IMPL");
+}
+
+#[test]
+fn delivery_blocked_clears_on_session_exit_and_router_unmount() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    set_unread(&router, "impl", 1);
+    injector.set_pending("S-IMPL");
+    router
+        .inject_inbox_nudge("impl", b"[inbox] waiting")
+        .unwrap();
+    injector.exit("S-IMPL");
+    assert_eq!(injector.blocked_events().len(), 2);
+    assert!(!injector.blocked_events().last().unwrap().blocked);
+
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    set_unread(&router, "impl", 1);
+    injector.set_pending("S-IMPL");
+    router
+        .inject_inbox_nudge("impl", b"[inbox] waiting")
+        .unwrap();
+    let registry = RouterRegistry::new();
+    registry.register("mission-1".into(), router);
+    registry.unregister("mission-1");
+    assert_eq!(injector.blocked_events().len(), 2);
+    assert!(!injector.blocked_events().last().unwrap().blocked);
+}
+
+#[test]
+fn concurrent_parks_emit_one_delivery_blocked_transition() {
+    use std::sync::Barrier;
+
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    set_unread(&router, "impl", 1);
+    injector.set_pending("S-IMPL");
+    let barrier = Arc::new(Barrier::new(5));
+    let mut threads = Vec::new();
+    for _ in 0..4 {
+        let router = Arc::clone(&router);
+        let barrier = Arc::clone(&barrier);
+        threads.push(std::thread::spawn(move || {
+            barrier.wait();
+            router
+                .inject_inbox_nudge("impl", b"[inbox] concurrent")
+                .unwrap();
+        }));
+    }
+    barrier.wait();
+    for thread in threads {
+        thread.join().unwrap();
+    }
+
+    assert_eq!(injector.blocked_events().len(), 1);
+    injector.exit("S-IMPL");
+}
+
+#[test]
+fn reconciliation_tick_does_not_churn_blocked_notifications() {
+    let (router, injector, _log, _dir) = fixture(
+        vec![
+            slot_with_runner("lead", true),
+            slot_with_runner("impl", false),
+        ],
+        &[("lead", "S-LEAD"), ("impl", "S-IMPL")],
+    );
+    set_unread(&router, "impl", 1);
+    injector.set_pending("S-IMPL");
+    router
+        .inject_inbox_nudge("impl", b"[inbox] waiting")
+        .unwrap();
+    router.set_status("impl".into(), super::RunnerStatus::Idle);
+
+    assert_eq!(
+        router.reconcile_inbox_at(Instant::now(), Duration::from_secs(120)),
+        0
+    );
+    assert_eq!(injector.blocked_events().len(), 1);
+    injector.exit("S-IMPL");
 }
 
 #[test]
@@ -1423,6 +1678,7 @@ fn pending_ask_map_reconstructs_from_log_on_reopen() {
             None,
             log.clone(),
             injector_dyn,
+            injector.clone(),
         )
         .unwrap();
         router.register_sessions(&[
@@ -1459,6 +1715,7 @@ fn pending_ask_map_reconstructs_from_log_on_reopen() {
         None,
         log.clone(),
         injector_dyn,
+        injector.clone(),
     )
     .unwrap();
     router2.register_sessions(&[
@@ -1565,6 +1822,7 @@ fn reconstruct_recovers_latest_runner_status_only() {
         None,
         log.clone(),
         injector_dyn,
+        injector.clone(),
     )
     .unwrap();
     router.register_sessions(&[
@@ -1654,6 +1912,7 @@ fn fresh_mission_start_does_not_call_reconstruct() {
         None,
         log.clone(),
         injector_dyn,
+        injector.clone(),
     )
     .unwrap();
     router.register_sessions(&[("lead".into(), "S-LEAD".into())]);
@@ -1751,6 +2010,7 @@ fn reconstruct_tolerates_malformed_lines_like_the_bus() {
             None,
             log.clone(),
             injector_dyn,
+            injector.clone(),
         )
         .unwrap();
         router.register_sessions(&[("lead".into(), "S-LEAD".into())]);
@@ -1779,6 +2039,7 @@ fn reconstruct_tolerates_malformed_lines_like_the_bus() {
         None,
         log.clone(),
         injector_dyn,
+        injector.clone(),
     )
     .unwrap();
     router2.register_sessions(&[("lead".into(), "S-LEAD".into())]);
@@ -1917,6 +2178,7 @@ fn synthetic_busy_replays_through_existing_runner_status_projection() {
             None,
             log.clone(),
             injector_dyn,
+            injector.clone(),
         )
         .unwrap();
         router.register_sessions(&[
@@ -1939,6 +2201,7 @@ fn synthetic_busy_replays_through_existing_runner_status_projection() {
         None,
         log.clone(),
         injector_dyn,
+        injector.clone(),
     )
     .unwrap();
     router2.register_sessions(&[

--- a/src/components/InboxBlockedPill.test.tsx
+++ b/src/components/InboxBlockedPill.test.tsx
@@ -68,7 +68,9 @@ describe("InboxBlockedPill", () => {
         .querySelector("button")
         ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     });
+    expect(mocks.injectStdin).toHaveBeenCalledTimes(1);
     expect(mocks.injectStdin).toHaveBeenCalledWith("S-IMPL", "\r");
+    expect(mocks.injectStdin).not.toHaveBeenCalledWith("S-IMPL", "\x03");
   });
 
   it("omits the count for one unread message", async () => {

--- a/src/components/InboxBlockedPill.test.tsx
+++ b/src/components/InboxBlockedPill.test.tsx
@@ -1,0 +1,97 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  injectStdin: vi.fn(async () => {}),
+}));
+
+vi.mock("../lib/api", () => ({
+  api: {
+    session: {
+      injectStdin: mocks.injectStdin,
+    },
+  },
+}));
+
+import { InboxBlockedPill } from "./InboxBlockedPill";
+
+describe("InboxBlockedPill", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.injectStdin.mockClear();
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  async function render(
+    props: Partial<React.ComponentProps<typeof InboxBlockedPill>> = {},
+  ) {
+    await act(async () => {
+      root.render(
+        <InboxBlockedPill
+          sessionId="S-IMPL"
+          unreadCount={2}
+          idle
+          narrow={false}
+          onError={() => {}}
+          {...props}
+        />,
+      );
+    });
+  }
+
+  it("renders the unread count, body, and Enter action", async () => {
+    await render();
+
+    expect(container.textContent).toContain("Inbox waiting (2)");
+    expect(container.textContent).toContain(
+      "— typing detected, delivery paused",
+    );
+    expect(container.textContent).toContain("Clear input");
+    expect(container.textContent).toContain("↵");
+
+    await act(async () => {
+      container
+        .querySelector("button")
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(mocks.injectStdin).toHaveBeenCalledWith("S-IMPL", "\r");
+  });
+
+  it("omits the count for one unread message", async () => {
+    await render({ unreadCount: 1 });
+
+    expect(container.textContent).toContain("Inbox waiting");
+    expect(container.textContent).not.toContain("Inbox waiting (1)");
+  });
+
+  it("keeps the pill visible but hides the action while busy", async () => {
+    await render({ idle: false });
+
+    expect(container.textContent).toContain("Inbox waiting (2)");
+    expect(container.querySelector("button")).toBeNull();
+  });
+
+  it("hides the body in a narrow pane", async () => {
+    await render({ narrow: true });
+
+    expect(container.textContent).toContain("Inbox waiting (2)");
+    expect(container.textContent).not.toContain(
+      "— typing detected, delivery paused",
+    );
+    expect(container.textContent).toContain("Clear input");
+  });
+});

--- a/src/components/InboxBlockedPill.tsx
+++ b/src/components/InboxBlockedPill.tsx
@@ -1,0 +1,55 @@
+import { Mail } from "lucide-react";
+
+import { api } from "../lib/api";
+
+export function InboxBlockedPill({
+  sessionId,
+  unreadCount,
+  idle,
+  narrow,
+  onError,
+}: {
+  sessionId: string;
+  unreadCount: number;
+  idle: boolean;
+  narrow: boolean;
+  onError: (message: string) => void;
+}) {
+  const clearInput = () => {
+    void api.session.injectStdin(sessionId, "\r").catch((error) => {
+      onError(String(error));
+    });
+  };
+
+  return (
+    <div
+      role="status"
+      aria-label="Inbox delivery waiting"
+      className="pointer-events-none absolute right-4 top-3 z-20 flex items-center gap-2 rounded-lg border border-warn/25 bg-panel px-3 py-2 text-xs shadow-[0_4px_16px_rgba(0,0,0,0.4)]"
+    >
+      <Mail aria-hidden className="h-3.5 w-3.5 shrink-0 text-warn" />
+      <span className="whitespace-nowrap font-semibold text-warn">
+        Inbox waiting{unreadCount > 1 ? ` (${unreadCount})` : ""}
+      </span>
+      {!narrow ? (
+        <span className="whitespace-nowrap text-fg-2">
+          — typing detected, delivery paused
+        </span>
+      ) : null}
+      {idle ? (
+        <button
+          type="button"
+          tabIndex={-1}
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={clearInput}
+          className="pointer-events-auto flex cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md border border-warn/40 bg-warn/10 px-2 py-1 text-[11px] font-semibold leading-none text-warn transition-colors hover:bg-warn/15 focus:outline-none"
+        >
+          Clear input
+          <span className="font-mono text-[10px] font-normal text-warn/70">
+            ↵
+          </span>
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/lib/deliveryBlocked.test.tsx
+++ b/src/lib/deliveryBlocked.test.tsx
@@ -1,0 +1,131 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const eventMocks = vi.hoisted(() => {
+  const handlers = new Map<string, Set<(event: { payload: unknown }) => void>>();
+  const stops: Array<ReturnType<typeof vi.fn>> = [];
+  return {
+    handlers,
+    stops,
+    listen: vi.fn(
+      async (
+        name: string,
+        handler: (event: { payload: unknown }) => void,
+      ) => {
+        const listeners = handlers.get(name) ?? new Set();
+        listeners.add(handler);
+        handlers.set(name, listeners);
+        const stop = vi.fn(() => listeners.delete(handler));
+        stops.push(stop);
+        return stop;
+      },
+    ),
+  };
+});
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: eventMocks.listen,
+}));
+
+import { useMissionDeliveryBlocked } from "./deliveryBlocked";
+import type { DeliveryBlockedEvent } from "./types";
+
+function Harness({
+  missionId,
+  sessionIds,
+}: {
+  missionId: string;
+  sessionIds: string[];
+}) {
+  const blocked = useMissionDeliveryBlocked(missionId, sessionIds);
+  return (
+    <div>
+      {Object.values(blocked)
+        .map((event) => `${event.session_id}:${event.unread_count}`)
+        .join(",")}
+    </div>
+  );
+}
+
+async function emit(name: string, payload: unknown) {
+  await act(async () => {
+    for (const handler of eventMocks.handlers.get(name) ?? []) {
+      handler({ payload });
+    }
+  });
+}
+
+describe("useMissionDeliveryBlocked", () => {
+  let container: HTMLDivElement;
+  let root: Root | null;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    eventMocks.handlers.clear();
+    eventMocks.stops.length = 0;
+    eventMocks.listen.mockClear();
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    if (root) {
+      await act(async () => root?.unmount());
+    }
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  async function render(sessionIds: string[]) {
+    await act(async () => {
+      root?.render(
+        <Harness missionId="mission-1" sessionIds={sessionIds} />,
+      );
+    });
+  }
+
+  const blockedEvent: DeliveryBlockedEvent = {
+    mission_id: "mission-1",
+    session_id: "S-1",
+    handle: "impl",
+    unread_count: 2,
+    blocked: true,
+  };
+
+  it("clears on session exit and pane replacement", async () => {
+    await render(["S-1"]);
+    await emit("router/delivery-blocked", blockedEvent);
+    expect(container.textContent).toBe("S-1:2");
+
+    await emit("session/exit", {
+      session_id: "S-1",
+      mission_id: "mission-1",
+    });
+    expect(container.textContent).toBe("");
+
+    await emit("router/delivery-blocked", blockedEvent);
+    await render(["S-2"]);
+    expect(container.textContent).toBe("");
+  });
+
+  it("unsubscribes on workspace unmount and remounts empty", async () => {
+    await render(["S-1"]);
+    await emit("router/delivery-blocked", blockedEvent);
+    expect(container.textContent).toBe("S-1:2");
+
+    await act(async () => root?.unmount());
+    root = null;
+    expect(eventMocks.stops).toHaveLength(2);
+    expect(eventMocks.stops.every((stop) => stop.mock.calls.length === 1)).toBe(
+      true,
+    );
+
+    root = createRoot(container);
+    await render(["S-1"]);
+    expect(container.textContent).toBe("");
+  });
+});

--- a/src/lib/deliveryBlocked.ts
+++ b/src/lib/deliveryBlocked.ts
@@ -1,0 +1,84 @@
+import { useEffect, useState } from "react";
+
+import { listen } from "@tauri-apps/api/event";
+
+import type { DeliveryBlockedEvent } from "./types";
+
+export function useMissionDeliveryBlocked(
+  missionId: string,
+  sessionIds: string[],
+): Record<string, DeliveryBlockedEvent> {
+  const [blockedBySession, setBlockedBySession] = useState<
+    Record<string, DeliveryBlockedEvent>
+  >({});
+  const sessionIdsKey = [...sessionIds].sort().join("\0");
+
+  useEffect(() => {
+    let cancelled = false;
+    let unlistenBlocked: (() => void) | null = null;
+    let unlistenExit: (() => void) | null = null;
+    setBlockedBySession({});
+
+    void Promise.all([
+      listen<DeliveryBlockedEvent>(
+        "router/delivery-blocked",
+        ({ payload }) => {
+          if (payload.mission_id !== missionId) return;
+          setBlockedBySession((previous) => {
+            if (!payload.blocked) {
+              if (!(payload.session_id in previous)) return previous;
+              const next = { ...previous };
+              delete next[payload.session_id];
+              return next;
+            }
+            return { ...previous, [payload.session_id]: payload };
+          });
+        },
+      ),
+      listen<{ session_id: string; mission_id: string | null }>(
+        "session/exit",
+        ({ payload }) => {
+          if (payload.mission_id !== missionId) return;
+          setBlockedBySession((previous) => {
+            if (!(payload.session_id in previous)) return previous;
+            const next = { ...previous };
+            delete next[payload.session_id];
+            return next;
+          });
+        },
+      ),
+    ]).then(([stopBlocked, stopExit]) => {
+      if (cancelled) {
+        stopBlocked();
+        stopExit();
+        return;
+      }
+      unlistenBlocked = stopBlocked;
+      unlistenExit = stopExit;
+    });
+
+    return () => {
+      cancelled = true;
+      unlistenBlocked?.();
+      unlistenExit?.();
+    };
+  }, [missionId]);
+
+  useEffect(() => {
+    const currentSessionIds = new Set(
+      sessionIdsKey ? sessionIdsKey.split("\0") : [],
+    );
+    setBlockedBySession((previous) => {
+      const next = Object.fromEntries(
+        Object.entries(previous).filter(([sessionId]) =>
+          currentSessionIds.has(sessionId),
+        ),
+      );
+      return Object.keys(next).length === Object.keys(previous).length
+        ? previous
+        : next;
+    });
+  }, [sessionIdsKey]);
+
+  return blockedBySession;
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -149,6 +149,14 @@ export interface SessionActivityEvent {
   source: string;
 }
 
+export interface DeliveryBlockedEvent {
+  mission_id: string;
+  session_id: string;
+  handle: string;
+  unread_count: number;
+  blocked: boolean;
+}
+
 export type MissionStatus = "running" | "completed" | "aborted";
 
 export interface Mission {

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -40,6 +40,7 @@ import type {
   WarningEvent,
 } from "../lib/types";
 import { DuplicateSubjectOverlay } from "../components/DuplicateSubjectOverlay";
+import { InboxBlockedPill } from "../components/InboxBlockedPill";
 import {
   isSecondaryFor,
   useCurrentWindowLabel,
@@ -93,6 +94,7 @@ import {
   useArchivingMission,
 } from "../lib/archivingState";
 import { eventMatchesShortcut } from "../lib/keymap";
+import { useMissionDeliveryBlocked } from "../lib/deliveryBlocked";
 
 const RAIL_STORAGE_WIDTH = "runner.mission.rail.width";
 const RAIL_MIN = 200;
@@ -135,6 +137,10 @@ export default function MissionWorkspace({
   const [mission, setMission] = useState<Mission | null>(null);
   const [crew, setCrew] = useState<Crew | null>(null);
   const [sessions, setSessions] = useState<SessionRow[]>([]);
+  const deliveryBlockedBySession = useMissionDeliveryBlocked(
+    id,
+    sessions.map((session) => session.id),
+  );
   const [events, setEvents] = useState<Event[]>([]);
   const [error, setError] = useState<string | null>(null);
   // Resume-fallback banner; non-blocking advisory (see types.ts WarningEvent).
@@ -1241,6 +1247,10 @@ export default function MissionWorkspace({
                     <Pane key={s.id} active={activeTab === s.id}>
                       <SlotPtyPane
                         session={s}
+                        deliveryBlockedUnreadCount={
+                          deliveryBlockedBySession[s.id]?.unread_count ?? null
+                        }
+                        runnerIdle={runnerStatusMap[s.handle] === "idle"}
                         // `visible` gate: a hidden keep-alive workspace
                         // deactivates even its front tab's terminal so it
                         // releases WebGL and skips geometry pushes.
@@ -1401,6 +1411,8 @@ export default function MissionWorkspace({
 /// so a user reading the prior turn before resuming sees no flash.
 function SlotPtyPane({
   session,
+  deliveryBlockedUnreadCount,
+  runnerIdle,
   active,
   forcedResuming,
   anySessionLive,
@@ -1410,6 +1422,8 @@ function SlotPtyPane({
   registerTerminal,
 }: {
   session: SessionRow;
+  deliveryBlockedUnreadCount: number | null;
+  runnerIdle: boolean;
   active: boolean;
   /** True when the parent's "Resume mission" button is iterating
    *  through every slot. Drives the resuming overlay in this pane. */
@@ -1435,6 +1449,20 @@ function SlotPtyPane({
 }) {
   const resuming = !!forcedResuming;
   const dead = session.status !== "running";
+  const paneRef = useRef<HTMLDivElement | null>(null);
+  const [narrow, setNarrow] = useState(false);
+  useEffect(() => {
+    const pane = paneRef.current;
+    if (!pane || typeof ResizeObserver === "undefined") return;
+    const update = (width: number) => setNarrow(width < 600);
+    update(pane.getBoundingClientRect().width);
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) update(entry.contentRect.width);
+    });
+    observer.observe(pane);
+    return () => observer.disconnect();
+  }, []);
   // Per-slot "warming up" overlay: when the pane first mounts for a
   // genuinely fresh slot, the agent CLI (claude-code / codex) takes
   // a beat to paint its banner. Show the cyan pill over the
@@ -1550,7 +1578,7 @@ function SlotPtyPane({
   // canvas in lockstep across theme switches.
   const terminalBg = useTerminalBg();
   return (
-    <div className="relative flex flex-1 min-h-0 flex-col">
+    <div ref={paneRef} className="relative flex flex-1 min-h-0 flex-col">
       <div
         style={{ backgroundColor: terminalBg }}
         className={`flex flex-1 min-h-0 p-3 transition-opacity ${paneOpacity}`}
@@ -1564,6 +1592,15 @@ function SlotPtyPane({
           disabled={dead || resuming || starting}
         />
       </div>
+      {!dead && deliveryBlockedUnreadCount !== null ? (
+        <InboxBlockedPill
+          sessionId={session.id}
+          unreadCount={deliveryBlockedUnreadCount}
+          idle={runnerIdle}
+          narrow={narrow}
+          onError={onError}
+        />
+      ) : null}
       {resuming ? (
         <ResumingOverlay />
       ) : starting ? (


### PR DESCRIPTION
Closes #336.

Summary:
- project PendingInput-blocked mission inbox delivery through deduplicated router UI events
- render the pane-local inbox waiting pill with idle-only Enter action and narrow-pane state
- clear ephemeral UI state on delivery, watermark zero, session exit, router/workspace unmount, and pane replacement
- update the feature spec and Pencil canvas for the Enter interaction

Validation:
- cargo fmt --all
- cargo clippy --workspace --all-targets
- cargo test --workspace
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm test
- git diff --check