### PR TITLE
feat: slim codex-style workspace headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3847,6 +3847,7 @@ dependencies = [
  "libc",
  "log",
  "notify",
+ "objc2-app-kit",
  "portable-pty",
  "r2d2",
  "r2d2_sqlite",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -63,6 +63,9 @@ toml_edit = "0.25"
 libc = "0.2"
 portable-pty = "0.9"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSButton", "NSControl", "NSResponder", "NSView", "NSWindow"] }
+
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }
 # Used by issue #124's forwarder-contention regression test to hold the

--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -54,8 +54,7 @@ pub fn open_window(
     {
         builder = builder
             .title_bar_style(tauri::TitleBarStyle::Overlay)
-            .hidden_title(true)
-            .traffic_light_position(tauri::LogicalPosition::new(16.0, 22.0));
+            .hidden_title(true);
     }
 
     let window = builder.build().map_err(|e| Error::msg(e.to_string()))?;
@@ -139,4 +138,83 @@ pub fn window_report_subjects(
 #[tauri::command]
 pub fn window_list_subjects(state: State<AppState>) -> Result<Vec<WindowEntry>> {
     Ok(state.windows.snapshot())
+}
+
+#[cfg(any(target_os = "macos", test))]
+const TITLEBAR_HEIGHT: f64 = 44.0;
+#[cfg(target_os = "macos")]
+const TRAFFIC_LIGHT_X: f64 = 16.0;
+
+#[tauri::command]
+pub fn window_set_titlebar_zoom(window: tauri::WebviewWindow, zoom: f64) -> Result<()> {
+    #[cfg(target_os = "macos")]
+    {
+        if window
+            .is_fullscreen()
+            .map_err(|e| Error::msg(e.to_string()))?
+        {
+            return Ok(());
+        }
+
+        let titlebar_height = TITLEBAR_HEIGHT * zoom;
+        window
+            .with_webview(move |webview| {
+                use objc2_app_kit::{NSWindow, NSWindowButton};
+
+                let ns_window: &NSWindow = unsafe { &*webview.ns_window().cast() };
+                let Some(close) = ns_window.standardWindowButton(NSWindowButton::CloseButton)
+                else {
+                    return;
+                };
+                let Some(minimize) =
+                    ns_window.standardWindowButton(NSWindowButton::MiniaturizeButton)
+                else {
+                    return;
+                };
+                let Some(maximize) = ns_window.standardWindowButton(NSWindowButton::ZoomButton)
+                else {
+                    return;
+                };
+                let Some(button_group) = (unsafe { close.superview() }) else {
+                    return;
+                };
+                let Some(titlebar_container) = (unsafe { button_group.superview() }) else {
+                    return;
+                };
+
+                let close_rect = close.frame();
+                let button_height = close_rect.size.height;
+                let spacing = minimize.frame().origin.x - close_rect.origin.x;
+
+                let mut titlebar_rect = titlebar_container.frame();
+                titlebar_rect.size.height = titlebar_height;
+                titlebar_rect.origin.y = ns_window.frame().size.height - titlebar_height;
+                titlebar_container.setFrame(titlebar_rect);
+
+                for (index, button) in [close, minimize, maximize].into_iter().enumerate() {
+                    let mut rect = button.frame();
+                    rect.origin.x = TRAFFIC_LIGHT_X + index as f64 * spacing;
+                    rect.origin.y = (titlebar_height - button_height) / 2.0;
+                    button.setFrameOrigin(rect.origin);
+                }
+            })
+            .map_err(|e| Error::msg(e.to_string()))?;
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    let _ = (window, zoom);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TITLEBAR_HEIGHT;
+
+    #[test]
+    fn titlebar_height_tracks_app_zoom() {
+        assert!((TITLEBAR_HEIGHT * 0.8 - 35.2).abs() < f64::EPSILON);
+        assert!((TITLEBAR_HEIGHT * 1.0 - 44.0).abs() < f64::EPSILON);
+        assert!((TITLEBAR_HEIGHT * 1.5 - 66.0).abs() < f64::EPSILON);
+    }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -401,6 +401,7 @@ pub fn run() {
             commands::window::window_focus_other,
             commands::window::window_report_subjects,
             commands::window::window_list_subjects,
+            commands::window::window_set_titlebar_zoom,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -17,7 +17,6 @@
         "height": 900,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,
-        "trafficLightPosition": { "x": 16, "y": 22 },
         "visible": false,
         "acceptFirstMouse": true
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,7 +13,7 @@ import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { AppShell } from "./components/AppShell";
 import { ToastProvider } from "./contexts/ToastContext";
 import { UpdateProvider, useUpdate } from "./contexts/UpdateContext";
-import { nudgeAppZoom } from "./lib/appZoom";
+import { nudgeAppZoom, syncTitlebarZoom } from "./lib/appZoom";
 import { eventMatchesShortcut } from "./lib/keymap";
 import { readAppZoom } from "./lib/settings";
 import Crews from "./pages/Crews";
@@ -22,29 +22,28 @@ import Runners from "./pages/Runners";
 import RunnerDetail from "./pages/RunnerDetail";
 
 export default function App() {
-  // Tell the backend the first frame has painted so it can show + focus the
-  // main window. Don't wrap this in requestAnimationFrame — macOS pauses rAF
-  // for hidden windows, so the rAF callback would never fire and the window
-  // would stay hidden forever. useEffect runs after React commits, which is
-  // enough to guarantee a non-blank webview before show.
-  useEffect(() => {
-    invoke("app_ready").catch(console.error);
-  }, []);
-
-  // Restore the user's persisted app zoom on boot. Skipped when the stored
-  // value is the default (1.0) so we don't roundtrip through Tauri for a
-  // no-op. Wrapped in try/catch because dev browser preview has no Tauri
-  // webview API.
+  // Restore app zoom and align the native titlebar before revealing this
+  // window. Don't wrap this in requestAnimationFrame — macOS pauses rAF for
+  // hidden windows, so the callback would never fire. Every window runs this
+  // effect, and both commands resolve the invoking window.
   useEffect(() => {
     const zoom = readAppZoom();
-    if (zoom === 1.0) return;
-    try {
-      void getCurrentWebview().setZoom(zoom).catch(() => {
-        // best-effort — webview swap or platform refusal shouldn't block boot.
-      });
-    } catch {
-      // No Tauri runtime (dev browser preview).
+    let webviewZoom = Promise.resolve();
+    if (zoom !== 1.0) {
+      try {
+        webviewZoom = getCurrentWebview()
+          .setZoom(zoom)
+          .catch(() => {
+            // Best-effort — webview swap or platform refusal shouldn't block boot.
+          });
+      } catch {
+        // No Tauri runtime (dev browser preview).
+      }
     }
+
+    void Promise.all([syncTitlebarZoom(zoom), webviewZoom]).finally(() => {
+      invoke("app_ready").catch(console.error);
+    });
   }, []);
 
   // Zoom shortcuts (keymap: zoom-in / zoom-out / zoom-reset). Capture

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -18,17 +18,20 @@
 // hides (display:none, subtree retained) under a Settings layer
 // instead, and returning is the same active-flip the list pages use.
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { matchPath, Outlet, useLocation } from "react-router-dom";
 
 import { PersistentSurfaces } from "./PersistentSurfaces";
+import { PanelToggleGlyph } from "./PanelToggleGlyph";
 import { Sidebar } from "./Sidebar";
 import SettingsPage from "../pages/SettingsPage";
 import {
   STORAGE_SIDEBAR_COLLAPSED,
+  readAppZoom,
   readStoredBool,
   writeStoredBool,
 } from "../lib/settings";
+import { syncTitlebarZoom } from "../lib/appZoom";
 import { eventMatchesShortcut } from "../lib/keymap";
 import { useCurrentWindowFullscreen } from "../hooks/useCurrentWindowFullscreen";
 
@@ -36,9 +39,15 @@ const SIDEBAR_TOGGLE_EVENT = "runner:toggle-sidebar";
 
 export function AppShell({ children }: { children?: ReactNode }) {
   const location = useLocation();
-  const fullscreen = useCurrentWindowFullscreen();
+  const syncWindowTitlebar = useCallback((nextFullscreen: boolean) => {
+    if (!nextFullscreen) void syncTitlebarZoom(readAppZoom());
+  }, []);
+  const fullscreen = useCurrentWindowFullscreen(syncWindowTitlebar);
   const settingsActive =
     matchPath("/settings/:pane?", location.pathname) != null;
+  const workspaceActive =
+    matchPath("/chats/:sessionId", location.pathname) != null ||
+    matchPath("/missions/:id", location.pathname) != null;
   // Sidebar collapsed/expanded lives at the shell so Cmd+S can toggle
   // it from anywhere in the app, not just when the sidebar is the
   // focused subtree.
@@ -113,10 +122,35 @@ export function AppShell({ children }: { children?: ReactNode }) {
             data-tauri-drag-region
             className="pointer-events-auto absolute left-0 right-0 top-0 z-10 h-7"
           />
+          {collapsed && !workspaceActive ? (
+            <div
+              data-tauri-drag-region
+              className={`absolute left-0 top-0 z-20 flex h-11 items-center ${
+                fullscreen
+                  ? "pl-2"
+                  : "pl-[var(--titlebar-sidebar-toggle-gutter)]"
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => setCollapsed(false)}
+                title="Open sidebar (⌘S)"
+                aria-label="Open sidebar"
+                className="flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded text-fg-2 transition-colors hover:bg-raised hover:text-fg"
+              >
+                <PanelToggleGlyph
+                  side="left"
+                  filled={false}
+                  className="h-[12px] w-[15.4px]"
+                />
+              </button>
+            </div>
+          ) : null}
           {children ?? <Outlet />}
           <PersistentSurfaces
             sidebarCollapsed={collapsed}
             fullscreen={fullscreen}
+            onOpenSidebar={() => setCollapsed(false)}
           />
         </main>
       </div>

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -30,11 +30,13 @@ import {
   writeStoredBool,
 } from "../lib/settings";
 import { eventMatchesShortcut } from "../lib/keymap";
+import { useCurrentWindowFullscreen } from "../hooks/useCurrentWindowFullscreen";
 
 const SIDEBAR_TOGGLE_EVENT = "runner:toggle-sidebar";
 
 export function AppShell({ children }: { children?: ReactNode }) {
   const location = useLocation();
+  const fullscreen = useCurrentWindowFullscreen();
   const settingsActive =
     matchPath("/settings/:pane?", location.pathname) != null;
   // Sidebar collapsed/expanded lives at the shell so Cmd+S can toggle
@@ -45,7 +47,7 @@ export function AppShell({ children }: { children?: ReactNode }) {
   );
   const [sidebarPreviewOpen, setSidebarPreviewOpen] = useState(false);
   // Single source of truth for persistence — both the Sidebar's
-  // chevron click (setCollapsed via prop) and the Cmd+S keydown
+  // panel button (setCollapsed via prop) and the Cmd+S keydown
   // funnel through `collapsed`, so one effect keeps localStorage in
   // sync. The harmless one-write at mount with the already-stored
   // value is fine.
@@ -101,6 +103,7 @@ export function AppShell({ children }: { children?: ReactNode }) {
         ) : null}
         <Sidebar
           collapsed={collapsed}
+          fullscreen={fullscreen}
           onCollapsedChange={setCollapsed}
           previewOpen={sidebarPreviewOpen}
           onPreviewOpenChange={setSidebarPreviewOpen}
@@ -111,7 +114,10 @@ export function AppShell({ children }: { children?: ReactNode }) {
             className="pointer-events-auto absolute left-0 right-0 top-0 z-10 h-7"
           />
           {children ?? <Outlet />}
-          <PersistentSurfaces />
+          <PersistentSurfaces
+            sidebarCollapsed={collapsed}
+            fullscreen={fullscreen}
+          />
         </main>
       </div>
       {settingsActive ? (

--- a/src/components/LayoutPicker.tsx
+++ b/src/components/LayoutPicker.tsx
@@ -63,11 +63,11 @@ export function LayoutPicker({
         aria-haspopup="menu"
         aria-expanded={open}
         onClick={() => setOpen((v) => !v)}
-        className={`inline-flex h-7 w-7 items-center justify-center rounded-md border text-fg-2 transition-colors hover:border-line hover:bg-raised hover:text-fg ${
-          open ? "border-line bg-raised text-fg" : "border-transparent"
+        className={`inline-flex h-7 w-7 items-center justify-center rounded text-fg-2 transition-colors hover:bg-raised hover:text-fg ${
+          open ? "bg-raised text-fg" : ""
         }`}
       >
-        <SquareSplitHorizontal aria-hidden className="h-4 w-4" />
+        <SquareSplitHorizontal aria-hidden className="h-[15px] w-[15px]" />
       </button>
       {open ? (
         <div

--- a/src/components/PersistentSurfaces.tsx
+++ b/src/components/PersistentSurfaces.tsx
@@ -35,9 +35,11 @@ import RunnerChat from "../pages/RunnerChat";
 export function PersistentSurfaces({
   sidebarCollapsed,
   fullscreen,
+  onOpenSidebar,
 }: {
   sidebarCollapsed: boolean;
   fullscreen: boolean;
+  onOpenSidebar: () => void;
 }) {
   const location = useLocation();
   const chatId =
@@ -69,6 +71,7 @@ export function PersistentSurfaces({
             visible={chatId !== null}
             sidebarCollapsed={sidebarCollapsed}
             fullscreen={fullscreen}
+            onOpenSidebar={onOpenSidebar}
           />
         </div>
       ) : null}
@@ -79,6 +82,7 @@ export function PersistentSurfaces({
             visible={missionId !== null}
             sidebarCollapsed={sidebarCollapsed}
             fullscreen={fullscreen}
+            onOpenSidebar={onOpenSidebar}
           />
         </div>
       ) : null}

--- a/src/components/PersistentSurfaces.tsx
+++ b/src/components/PersistentSurfaces.tsx
@@ -32,7 +32,13 @@ import { matchPath, useLocation } from "react-router-dom";
 import MissionWorkspace from "../pages/MissionWorkspace";
 import RunnerChat from "../pages/RunnerChat";
 
-export function PersistentSurfaces() {
+export function PersistentSurfaces({
+  sidebarCollapsed,
+  fullscreen,
+}: {
+  sidebarCollapsed: boolean;
+  fullscreen: boolean;
+}) {
   const location = useLocation();
   const chatId =
     matchPath("/chats/:sessionId", location.pathname)?.params.sessionId ??
@@ -58,7 +64,12 @@ export function PersistentSurfaces() {
     <>
       {mountedChatId !== null ? (
         <div className={chatId !== null ? "contents" : "hidden"}>
-          <RunnerChat sessionId={mountedChatId} visible={chatId !== null} />
+          <RunnerChat
+            sessionId={mountedChatId}
+            visible={chatId !== null}
+            sidebarCollapsed={sidebarCollapsed}
+            fullscreen={fullscreen}
+          />
         </div>
       ) : null}
       {mountedMissionId !== null ? (
@@ -66,6 +77,8 @@ export function PersistentSurfaces() {
           <MissionWorkspace
             missionId={mountedMissionId}
             visible={missionId !== null}
+            sidebarCollapsed={sidebarCollapsed}
+            fullscreen={fullscreen}
           />
         </div>
       ) : null}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -60,6 +60,7 @@ import {
   FolderMinus,
   MessageSquarePlus,
   MoreHorizontal,
+  PanelLeft,
   Pin,
   PinOff,
   Plus,
@@ -127,7 +128,6 @@ import {
   SidebarTabIcon,
   SidebarTabRow,
 } from "./SidebarTabRow";
-import { PanelToggleGlyph } from "./PanelToggleGlyph";
 import { PopoverMenu } from "./ui/PopoverMenu";
 import { useResizableWidth } from "../hooks/useResizableWidth";
 import {
@@ -262,6 +262,7 @@ interface SidebarProps {
   // it's preserved across collapse/expand cycles so users get their last
   // full width back when they re-open.
   collapsed: boolean;
+  fullscreen: boolean;
   onCollapsedChange: (collapsed: boolean) => void;
   previewOpen: boolean;
   onPreviewOpenChange: (open: boolean) => void;
@@ -269,6 +270,7 @@ interface SidebarProps {
 
 export function Sidebar({
   collapsed,
+  fullscreen,
   onCollapsedChange,
   previewOpen,
   onPreviewOpenChange,
@@ -1983,11 +1985,35 @@ export function Sidebar({
       >
         {showPanel ? (
           <div className="flex min-h-0 flex-1 flex-col pb-4">
-            <div data-tauri-drag-region className="h-8 shrink-0" />
+            <div
+              data-tauri-drag-region
+              className={`flex h-11 shrink-0 items-center pr-3 transition-[padding] duration-150 ${
+                fullscreen ? "pl-2" : "pl-[82px]"
+              }`}
+            >
+              <button
+                type="button"
+                onClick={() => {
+                  if (sidebarPreview) {
+                    onCollapsedChange(false);
+                    onPreviewOpenChange(false);
+                    return;
+                  }
+                  onCollapsedChange(true);
+                }}
+                title={
+                  sidebarPreview ? "Keep sidebar open" : "Collapse sidebar (⌘S)"
+                }
+                aria-label={
+                  sidebarPreview ? "Keep sidebar open" : "Collapse sidebar"
+                }
+                className="flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded text-fg-2 transition-colors hover:bg-sidebar-selected/60 hover:text-fg focus:bg-sidebar-selected/60 focus:text-fg focus:outline-none"
+              >
+                <PanelLeft aria-hidden className="h-[15px] w-[15px]" />
+              </button>
+            </div>
 
-            {/* Brand row — open state only. The drag region extends
-                below the traffic-light strip so the header band reads
-                as one continuous title bar. The trailing magnifier
+            {/* Brand row — open state only. The trailing magnifier
                 opens the command palette (Codex-style: title left,
                 search icon right) — replaced the old WORKSPACE search
                 nav row to give the lists below one more row of space.
@@ -2323,10 +2349,8 @@ export function Sidebar({
                 column. Mirrors Pencil node `IJsUO` (sidebar settings).
                 Navigates to the full-page settings route (impl 0025),
                 threading the current location through state so "Back
-                to app" can return here. The trailing button collapses
-                the sidebar (or, in a hover-preview, pins it open) via
-                the #246 panel glyph. */}
-            <div className="flex shrink-0 items-center gap-2 border-t border-sidebar-selected-border px-3 pt-2">
+                to app" can return here. */}
+            <div className="flex shrink-0 items-center border-t border-sidebar-selected-border px-3 pt-2">
               <button
                 type="button"
                 onClick={() =>
@@ -2338,30 +2362,6 @@ export function Sidebar({
               >
                 <SettingsIcon aria-hidden className="h-3.5 w-3.5" />
                 <span className="text-[13px]">Settings</span>
-              </button>
-              <button
-                type="button"
-                onClick={() => {
-                  if (sidebarPreview) {
-                    onCollapsedChange(false);
-                    onPreviewOpenChange(false);
-                    return;
-                  }
-                  onCollapsedChange(true);
-                }}
-                title={
-                  sidebarPreview ? "Keep sidebar open" : "Collapse sidebar (⌘S)"
-                }
-                aria-label={
-                  sidebarPreview ? "Keep sidebar open" : "Collapse sidebar"
-                }
-                className="flex h-6 w-6 shrink-0 cursor-pointer items-center justify-center rounded border border-transparent text-fg-2 transition-colors hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg focus:border-sidebar-selected-border focus:bg-sidebar-selected/40 focus:text-fg focus:outline-none"
-              >
-                <PanelToggleGlyph
-                  side="left"
-                  filled={!collapsed}
-                  className="h-[12px] w-[15.4px]"
-                />
               </button>
             </div>
           </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -60,7 +60,6 @@ import {
   FolderMinus,
   MessageSquarePlus,
   MoreHorizontal,
-  PanelLeft,
   Pin,
   PinOff,
   Plus,
@@ -128,6 +127,7 @@ import {
   SidebarTabIcon,
   SidebarTabRow,
 } from "./SidebarTabRow";
+import { PanelToggleGlyph } from "./PanelToggleGlyph";
 import { PopoverMenu } from "./ui/PopoverMenu";
 import { useResizableWidth } from "../hooks/useResizableWidth";
 import {
@@ -1970,7 +1970,7 @@ export function Sidebar({
           width: sidebarVisible ? width : 0,
           opacity: sidebarVisible ? 1 : 0,
         }}
-        className={`flex shrink-0 select-none flex-col overflow-hidden transition-[width,opacity] duration-150 ${
+        className={`flex shrink-0 select-none flex-col overflow-hidden transition-[width,opacity] duration-200 ease-in-out ${
           peekOverlay
             ? // Collapsed peek: a raised, docked overlay with a rounded right
               // edge. Kept absolute (via `peeking`) through the fade-out so it
@@ -1987,8 +1987,10 @@ export function Sidebar({
           <div className="flex min-h-0 flex-1 flex-col pb-4">
             <div
               data-tauri-drag-region
-              className={`flex h-11 shrink-0 items-center pr-3 transition-[padding] duration-150 ${
-                fullscreen ? "pl-2" : "pl-[82px]"
+              className={`flex h-11 shrink-0 items-center pr-3 ${
+                fullscreen
+                  ? "pl-2"
+                  : "pl-[var(--titlebar-sidebar-toggle-gutter)]"
               }`}
             >
               <button
@@ -2009,7 +2011,11 @@ export function Sidebar({
                 }
                 className="flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded text-fg-2 transition-colors hover:bg-sidebar-selected/60 hover:text-fg focus:bg-sidebar-selected/60 focus:text-fg focus:outline-none"
               >
-                <PanelLeft aria-hidden className="h-[15px] w-[15px]" />
+                <PanelToggleGlyph
+                  side="left"
+                  filled={!collapsed}
+                  className="h-[12px] w-[15.4px]"
+                />
               </button>
             </div>
 

--- a/src/components/SidebarRename.test.ts
+++ b/src/components/SidebarRename.test.ts
@@ -253,6 +253,7 @@ async function renderSidebar(root: Root) {
         { initialEntries: ["/chats/A"] },
         createElement(Sidebar, {
           collapsed: false,
+          fullscreen: false,
           onCollapsedChange: () => {},
           previewOpen: false,
           onPreviewOpenChange: () => {},

--- a/src/components/ui/SessionControl.tsx
+++ b/src/components/ui/SessionControl.tsx
@@ -17,10 +17,13 @@ import { Loader2, Play, Square } from "lucide-react";
 
 const PILL_BASE =
   "inline-flex cursor-pointer items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11px] font-semibold transition-colors";
+const HEADER_BUTTON =
+  "inline-flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded transition-colors";
 
 export interface SessionControlProps {
   onClick?: () => void;
   title?: string;
+  variant?: "pill" | "header";
   /** Optional override label. Defaults to "Resume" / "Stop" / etc. */
   children?: ReactNode;
 }
@@ -33,8 +36,24 @@ export interface SessionControlProps {
 export function ResumeButton({
   onClick,
   title,
+  variant = "pill",
   children,
 }: SessionControlProps) {
+  if (variant === "header") {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        title={title ?? "Resume"}
+        aria-label={title ?? "Resume"}
+        className={`${HEADER_BUTTON} text-accent/80 hover:bg-accent/10 hover:text-accent`}
+      >
+        <Play aria-hidden className="h-[13px] w-[13px]" />
+        <span className="sr-only">{children ?? "Resume"}</span>
+      </button>
+    );
+  }
+
   return (
     <button
       type="button"
@@ -54,8 +73,24 @@ export function ResumeButton({
 // failure or a success.
 export function ResumingButton({
   title,
+  variant = "pill",
   children,
 }: Omit<SessionControlProps, "onClick">) {
+  if (variant === "header") {
+    return (
+      <button
+        type="button"
+        disabled
+        title={title ?? "Resuming…"}
+        aria-label={title ?? "Resuming…"}
+        className={`${HEADER_BUTTON} cursor-not-allowed text-info`}
+      >
+        <Loader2 aria-hidden className="h-[13px] w-[13px] animate-spin" />
+        <span className="sr-only">{children ?? "Resuming…"}</span>
+      </button>
+    );
+  }
+
   return (
     <button
       type="button"
@@ -75,9 +110,25 @@ export function ResumingButton({
 export function StopButton({
   onClick,
   title,
+  variant = "pill",
   children,
   iconTone = "danger",
 }: SessionControlProps & { iconTone?: "danger" | "fg" }) {
+  if (variant === "header") {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        title={title ?? "Stop"}
+        aria-label={title ?? "Stop"}
+        className={`${HEADER_BUTTON} text-danger/80 hover:bg-danger/10 hover:text-danger`}
+      >
+        <Square aria-hidden className="h-[13px] w-[13px]" />
+        <span className="sr-only">{children ?? "Stop"}</span>
+      </button>
+    );
+  }
+
   return (
     <button
       type="button"

--- a/src/hooks/useCurrentWindowFullscreen.test.tsx
+++ b/src/hooks/useCurrentWindowFullscreen.test.tsx
@@ -1,0 +1,92 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fullscreen: false,
+  resize: null as (() => void) | null,
+  isFullscreen: vi.fn<() => Promise<boolean>>(),
+  onResized: vi.fn<(callback: () => void) => Promise<() => void>>(),
+  unlisten: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({
+    isFullscreen: mocks.isFullscreen,
+    onResized: mocks.onResized,
+  }),
+}));
+
+import {
+  FULLSCREEN_SETTLE_MS,
+  useCurrentWindowFullscreen,
+} from "./useCurrentWindowFullscreen";
+
+function Probe() {
+  const fullscreen = useCurrentWindowFullscreen();
+  return <div data-fullscreen={fullscreen} />;
+}
+
+describe("useCurrentWindowFullscreen", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.fullscreen = false;
+    mocks.resize = null;
+    mocks.unlisten.mockReset();
+    mocks.isFullscreen.mockReset();
+    mocks.isFullscreen.mockImplementation(async () => mocks.fullscreen);
+    mocks.onResized.mockReset();
+    mocks.onResized.mockImplementation(async (callback) => {
+      mocks.resize = callback;
+      return mocks.unlisten;
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+  });
+
+  it("updates only after the current window resize state settles", async () => {
+    await act(async () => {
+      root.render(<Probe />);
+    });
+    expect(container.firstElementChild?.getAttribute("data-fullscreen")).toBe(
+      "false",
+    );
+
+    mocks.fullscreen = true;
+    await act(async () => {
+      mocks.resize?.();
+      await vi.advanceTimersByTimeAsync(FULLSCREEN_SETTLE_MS - 1);
+    });
+    expect(container.firstElementChild?.getAttribute("data-fullscreen")).toBe(
+      "false",
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(container.firstElementChild?.getAttribute("data-fullscreen")).toBe(
+      "true",
+    );
+  });
+
+  it("unsubscribes from the current window on unmount", async () => {
+    await act(async () => {
+      root.render(<Probe />);
+    });
+    await act(async () => root.unmount());
+
+    expect(mocks.unlisten).toHaveBeenCalledOnce();
+  });
+});

--- a/src/hooks/useCurrentWindowFullscreen.test.tsx
+++ b/src/hooks/useCurrentWindowFullscreen.test.tsx
@@ -24,8 +24,12 @@ import {
   useCurrentWindowFullscreen,
 } from "./useCurrentWindowFullscreen";
 
-function Probe() {
-  const fullscreen = useCurrentWindowFullscreen();
+function Probe({
+  onSettled,
+}: {
+  onSettled?: (fullscreen: boolean) => void;
+}) {
+  const fullscreen = useCurrentWindowFullscreen(onSettled);
   return <div data-fullscreen={fullscreen} />;
 }
 
@@ -79,6 +83,22 @@ describe("useCurrentWindowFullscreen", () => {
     expect(container.firstElementChild?.getAttribute("data-fullscreen")).toBe(
       "true",
     );
+  });
+
+  it("reports settled resizes even when fullscreen state is unchanged", async () => {
+    const onSettled = vi.fn();
+    await act(async () => {
+      root.render(<Probe onSettled={onSettled} />);
+    });
+    expect(onSettled).toHaveBeenLastCalledWith(false);
+
+    await act(async () => {
+      mocks.resize?.();
+      await vi.advanceTimersByTimeAsync(FULLSCREEN_SETTLE_MS);
+    });
+
+    expect(onSettled).toHaveBeenCalledTimes(2);
+    expect(onSettled).toHaveBeenLastCalledWith(false);
   });
 
   it("unsubscribes from the current window on unmount", async () => {

--- a/src/hooks/useCurrentWindowFullscreen.ts
+++ b/src/hooks/useCurrentWindowFullscreen.ts
@@ -4,7 +4,9 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 
 export const FULLSCREEN_SETTLE_MS = 200;
 
-export function useCurrentWindowFullscreen(): boolean {
+export function useCurrentWindowFullscreen(
+  onSettled?: (fullscreen: boolean) => void,
+): boolean {
   const [fullscreen, setFullscreen] = useState(false);
 
   useEffect(() => {
@@ -30,7 +32,10 @@ export function useCurrentWindowFullscreen(): boolean {
         void currentWindow
           .isFullscreen()
           .then((next) => {
-            if (active) setFullscreen(next);
+            if (active) {
+              setFullscreen(next);
+              onSettled?.(next);
+            }
           })
           .catch(() => {});
       } catch {
@@ -59,7 +64,7 @@ export function useCurrentWindowFullscreen(): boolean {
       if (settleTimer) clearTimeout(settleTimer);
       unlisten?.();
     };
-  }, []);
+  }, [onSettled]);
 
   return fullscreen;
 }

--- a/src/hooks/useCurrentWindowFullscreen.ts
+++ b/src/hooks/useCurrentWindowFullscreen.ts
@@ -1,0 +1,65 @@
+import { useEffect, useState } from "react";
+
+import { getCurrentWindow } from "@tauri-apps/api/window";
+
+export const FULLSCREEN_SETTLE_MS = 200;
+
+export function useCurrentWindowFullscreen(): boolean {
+  const [fullscreen, setFullscreen] = useState(false);
+
+  useEffect(() => {
+    let currentWindow: ReturnType<typeof getCurrentWindow>;
+    try {
+      currentWindow = getCurrentWindow();
+    } catch {
+      return;
+    }
+    if (
+      typeof currentWindow.isFullscreen !== "function" ||
+      typeof currentWindow.onResized !== "function"
+    ) {
+      return;
+    }
+
+    let active = true;
+    let settleTimer: ReturnType<typeof setTimeout> | null = null;
+    let unlisten: (() => void) | null = null;
+
+    const refresh = () => {
+      try {
+        void currentWindow
+          .isFullscreen()
+          .then((next) => {
+            if (active) setFullscreen(next);
+          })
+          .catch(() => {});
+      } catch {
+        return;
+      }
+    };
+
+    refresh();
+    try {
+      void currentWindow
+        .onResized(() => {
+          if (settleTimer) clearTimeout(settleTimer);
+          settleTimer = setTimeout(refresh, FULLSCREEN_SETTLE_MS);
+        })
+        .then((stopListening) => {
+          if (active) unlisten = stopListening;
+          else stopListening();
+        })
+        .catch(() => {});
+    } catch {
+      // Browser preview without the Tauri event runtime.
+    }
+
+    return () => {
+      active = false;
+      if (settleTimer) clearTimeout(settleTimer);
+      unlisten?.();
+    };
+  }, []);
+
+  return fullscreen;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,9 @@
 @import "tailwindcss";
 
+:root {
+  --titlebar-sidebar-toggle-gutter: 88px;
+}
+
 /* Carbon & Plasma — dark surfaces, neon-green accent. Mirrors the
    design system frame `hqxnM` in design/runner-mvp-design.pen. Class
    utilities: `bg-bg`, `bg-panel`, `bg-raised`, `border-line`,

--- a/src/lib/appZoom.test.ts
+++ b/src/lib/appZoom.test.ts
@@ -1,0 +1,64 @@
+/** @vitest-environment jsdom */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  setZoom: vi.fn<(zoom: number) => Promise<void>>(),
+  invoke: vi.fn<(command: string, args?: object) => Promise<void>>(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: mocks.invoke,
+}));
+
+vi.mock("@tauri-apps/api/webview", () => ({
+  getCurrentWebview: () => ({
+    setZoom: mocks.setZoom,
+  }),
+}));
+
+import { applyAppZoom, syncTitlebarZoom } from "./appZoom";
+import { ZOOM_STEPS } from "./settings";
+
+describe("app zoom native titlebar", () => {
+  beforeEach(() => {
+    document.documentElement.style.removeProperty(
+      "--titlebar-sidebar-toggle-gutter",
+    );
+    mocks.invoke.mockReset();
+    mocks.invoke.mockResolvedValue();
+    mocks.setZoom.mockReset();
+    mocks.setZoom.mockResolvedValue();
+  });
+
+  it("sends the current zoom to the invoking window", async () => {
+    await syncTitlebarZoom(1.2);
+
+    expect(mocks.invoke).toHaveBeenCalledWith("window_set_titlebar_zoom", {
+      zoom: 1.2,
+    });
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--titlebar-sidebar-toggle-gutter",
+      ),
+    ).toBe("72.2833px");
+  });
+
+  it("updates the native titlebar with the webview zoom", () => {
+    applyAppZoom(0.8);
+
+    expect(mocks.invoke).toHaveBeenCalledWith("window_set_titlebar_zoom", {
+      zoom: 0.8,
+    });
+    expect(mocks.setZoom).toHaveBeenCalledWith(0.8);
+    expect(
+      document.documentElement.style.getPropertyValue(
+        "--titlebar-sidebar-toggle-gutter",
+      ),
+    ).toBe("111.575px");
+  });
+
+  it("uses ten-percent zoom steps", () => {
+    expect(ZOOM_STEPS).toEqual([0.8, 0.9, 1, 1.1, 1.2, 1.3, 1.4, 1.5]);
+  });
+});

--- a/src/lib/appZoom.ts
+++ b/src/lib/appZoom.ts
@@ -3,6 +3,7 @@
 // so the Tauri import stays out of the leaf-level settings helpers.
 
 import { getCurrentWebview } from "@tauri-apps/api/webview";
+import { invoke } from "@tauri-apps/api/core";
 
 import {
   notifySameWindowStorage,
@@ -12,8 +13,29 @@ import {
   ZOOM_STEPS,
 } from "./settings";
 
+const SIDEBAR_TOGGLE_GLYPH_X = 94.3;
+const SIDEBAR_TOGGLE_GLYPH_INSET = 6.3;
+
+export function syncTitlebarZoom(zoom: number): Promise<void> {
+  const gutter =
+    Math.round(
+      (SIDEBAR_TOGGLE_GLYPH_X / zoom - SIDEBAR_TOGGLE_GLYPH_INSET) *
+        10_000,
+    ) / 10_000;
+  document.documentElement.style.setProperty(
+    "--titlebar-sidebar-toggle-gutter",
+    `${gutter}px`,
+  );
+  try {
+    return invoke<void>("window_set_titlebar_zoom", { zoom }).catch(() => {});
+  } catch {
+    return Promise.resolve();
+  }
+}
+
 export function applyAppZoom(next: number): void {
   writeAppZoom(next);
+  void syncTitlebarZoom(next);
   try {
     void getCurrentWebview()
       .setZoom(next)

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -86,7 +86,9 @@ export const BRAND_MARK_PINNED_COLOR = "#00FF9C";
 // in the settings panes) so the readers can snap/clamp to the same domain
 // the UI presents — boot and storage-event consumers can't drift onto
 // off-step or out-of-range values that the panes would never offer.
-export const ZOOM_STEPS: readonly number[] = [0.8, 0.9, 1.0, 1.1, 1.25, 1.5];
+export const ZOOM_STEPS: readonly number[] = [
+  0.8, 0.9, 1.0, 1.1, 1.2, 1.3, 1.4, 1.5,
+];
 export const TERMINAL_FONT_SIZE_MIN = 10;
 export const TERMINAL_FONT_SIZE_MAX = 20;
 

--- a/src/pages/Crews.tsx
+++ b/src/pages/Crews.tsx
@@ -131,7 +131,7 @@ export default function Crews() {
   return (
     <>
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <div className="flex min-h-0 w-full flex-1 flex-col gap-6 px-8 py-8">
+        <div className="flex min-h-0 w-full flex-1 flex-col gap-6 px-8 pb-8 pt-10">
           <header className="flex items-center justify-between gap-4">
             <div className="flex flex-col gap-1">
               <h1 className="text-2xl font-bold tracking-tight text-fg">

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -19,7 +19,6 @@ import {
   Ellipsis,
   Flag,
   Info,
-  PanelRight,
   Pin,
   PinOff,
   RotateCcw,
@@ -52,6 +51,7 @@ import { EventFeed } from "../components/EventFeed";
 import { MissionMetaPanel } from "../components/MissionMetaPanel";
 import { MissionResetConfirm } from "../components/MissionResetConfirm";
 import { RunnersRail } from "../components/RunnersRail";
+import { PanelToggleGlyph } from "../components/PanelToggleGlyph";
 import {
   RunnerTerminal,
   type RunnerTerminalHandle,
@@ -131,11 +131,13 @@ export default function MissionWorkspace({
   visible,
   sidebarCollapsed,
   fullscreen,
+  onOpenSidebar,
 }: {
   missionId: string;
   visible: boolean;
   sidebarCollapsed: boolean;
   fullscreen: boolean;
+  onOpenSidebar: () => void;
 }) {
   const navigate = useNavigate();
   const [mission, setMission] = useState<Mission | null>(null);
@@ -909,13 +911,6 @@ export default function MissionWorkspace({
     [id],
   );
 
-  const startedAt = mission ? formatRelativeTime(mission.started_at) : "";
-  const headerMetadata = [
-    crew?.name ?? null,
-    `${sessions.length} runner${sessions.length === 1 ? "" : "s"}`,
-    startedAt ? `started ${startedAt}` : null,
-    mission?.cwd ?? null,
-  ].filter((part): part is string => !!part);
   const [kebabOpen, setKebabOpen] = useState(false);
   // Right rail (Runners panel) collapse state. Mirrors the RunnerChat
   // side-panel collapse — same localStorage shape for consistency.
@@ -987,86 +982,116 @@ export default function MissionWorkspace({
       <div className="flex min-w-0 flex-1 flex-col">
         <header
           data-tauri-drag-region
-          className={`relative z-20 flex h-11 shrink-0 items-center gap-2 border-b border-line bg-panel pr-4 transition-[padding] duration-150 ${
-            sidebarCollapsed && !fullscreen ? "pl-[90px]" : "pl-4"
+          className={`relative z-20 flex h-11 shrink-0 items-center border-b border-line bg-panel pr-4 ${
+            sidebarCollapsed && !fullscreen
+              ? "pl-[var(--titlebar-sidebar-toggle-gutter)]"
+              : "pl-4"
           }`}
         >
-          <Flag
-            data-tauri-drag-region
-            aria-hidden
-            className="h-[13px] w-[13px] shrink-0 text-fg-2"
-          />
           <div
             data-tauri-drag-region
-            className="flex min-w-0 items-center gap-2"
+            className="flex min-w-0 flex-1 items-center gap-2"
           >
-            <h1
+            {sidebarCollapsed ? (
+              <>
+                <button
+                  type="button"
+                  onClick={onOpenSidebar}
+                  title="Open sidebar"
+                  aria-label="Open sidebar"
+                  className="flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded text-fg-2 transition-colors hover:bg-raised hover:text-fg"
+                >
+                  <PanelToggleGlyph
+                    side="left"
+                    filled={false}
+                    className="h-[12px] w-[15.4px]"
+                  />
+                </button>
+                <div
+                  data-tauri-drag-region
+                  aria-hidden
+                  className="mx-1 h-5 w-px shrink-0 bg-line"
+                />
+              </>
+            ) : null}
+            <Flag
               data-tauri-drag-region
-              className="min-w-0 truncate text-[13px] font-medium text-fg"
+              aria-hidden
+              className="h-[15px] w-[15px] shrink-0 text-accent"
+            />
+            <div
+              data-tauri-drag-region
+              className="flex min-w-0 items-center gap-2"
             >
-              {mission?.title ?? "…"}
-            </h1>
-            {mission?.status === "running" && !resumingAll && !isSecondary ? (
-              <MissionKebab
-                pinned={!!mission.pinned_at}
-                metadata={headerMetadata}
-                open={kebabOpen}
-                onToggle={() => setKebabOpen((v) => !v)}
-                onClose={() => setKebabOpen(false)}
-                onPin={() => {
-                  setKebabOpen(false);
-                  void pinMission();
-                }}
-                onRename={() => {
-                  setKebabOpen(false);
-                  void renameMissionPrompt();
-                }}
-                onReset={() => {
-                  setKebabOpen(false);
-                  setResetConfirmOpen(true);
-                }}
-                onArchive={() => {
-                  setKebabOpen(false);
-                  void archiveMission();
-                }}
-              />
+              <h1
+                data-tauri-drag-region
+                className="min-w-0 truncate text-[13px] font-medium text-fg"
+              >
+                {mission?.title ?? "…"}
+              </h1>
+              {mission?.status === "running" && !resumingAll && !isSecondary ? (
+                <MissionKebab
+                  pinned={!!mission.pinned_at}
+                  open={kebabOpen}
+                  onToggle={() => setKebabOpen((v) => !v)}
+                  onClose={() => setKebabOpen(false)}
+                  onPin={() => {
+                    setKebabOpen(false);
+                    void pinMission();
+                  }}
+                  onRename={() => {
+                    setKebabOpen(false);
+                    void renameMissionPrompt();
+                  }}
+                  onReset={() => {
+                    setKebabOpen(false);
+                    setResetConfirmOpen(true);
+                  }}
+                  onArchive={() => {
+                    setKebabOpen(false);
+                    void archiveMission();
+                  }}
+                />
+              ) : null}
+              {mission?.status === "running" &&
+              !resumingAll &&
+              !isSecondary &&
+              anySessionStopped ? (
+                <ResumeButton
+                  variant="header"
+                  onClick={() => void resumeMission()}
+                  title="Respawn every stopped slot in this mission"
+                />
+              ) : null}
+              {mission?.status === "running" &&
+              !resumingAll &&
+              !isSecondary &&
+              allSessionsLive ? (
+                <StopButton
+                  variant="header"
+                  onClick={() => void stopMission()}
+                  title="Kill all PTYs; mission stays running so you can Resume"
+                />
+              ) : null}
+            </div>
+            {!railOpen ? (
+              <div className="ml-auto flex shrink-0 items-center">
+                <button
+                  type="button"
+                  onClick={() => setRailOpen(true)}
+                  title="Open runners panel"
+                  aria-label="Open runners panel"
+                  aria-pressed={false}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded text-fg-2 transition-colors hover:bg-raised hover:text-fg"
+                >
+                  <PanelToggleGlyph
+                    side="right"
+                    filled={false}
+                    className="h-[12.5px] w-[16px]"
+                  />
+                </button>
+              </div>
             ) : null}
-            {mission?.status === "running" &&
-            !resumingAll &&
-            !isSecondary &&
-            anySessionStopped ? (
-              <ResumeButton
-                variant="header"
-                onClick={() => void resumeMission()}
-                title="Respawn every stopped slot in this mission"
-              />
-            ) : null}
-            {mission?.status === "running" &&
-            !resumingAll &&
-            !isSecondary &&
-            allSessionsLive ? (
-              <StopButton
-                variant="header"
-                onClick={() => void stopMission()}
-                title="Kill all PTYs; mission stays running so you can Resume"
-              />
-            ) : null}
-          </div>
-          <div className="ml-auto flex shrink-0 items-center">
-            <button
-              type="button"
-              onClick={() => setRailOpen((open) => !open)}
-              title={railOpen ? "Collapse runners panel" : "Open runners panel"}
-              aria-label={
-                railOpen ? "Collapse runners panel" : "Open runners panel"
-              }
-              aria-pressed={railOpen}
-              className={`inline-flex h-7 w-7 items-center justify-center rounded transition-colors hover:bg-raised hover:text-fg ${
-                railOpen ? "text-fg" : "text-fg-2"
-              }`}
-            >
-              <PanelRight aria-hidden className="h-[15px] w-[15px]" />
-            </button>
           </div>
         </header>
 
@@ -1269,6 +1294,22 @@ export default function MissionWorkspace({
                 onClick={() => setRailView("meta")}
               />
             </div>
+            {railOpen ? (
+              <button
+                type="button"
+                onClick={() => setRailOpen(false)}
+                title="Collapse runners panel"
+                aria-label="Collapse runners panel"
+                aria-pressed
+                className="ml-auto inline-flex h-7 w-7 items-center justify-center rounded text-fg transition-colors hover:bg-raised"
+              >
+                <PanelToggleGlyph
+                  side="right"
+                  filled
+                  className="h-[12.5px] w-[16px]"
+                />
+              </button>
+            ) : null}
           </header>
           <div className="flex min-h-0 flex-1 flex-col pt-5">
             {railView === "runners" ? (
@@ -1624,7 +1665,6 @@ function PtyTabButton({
 /// `mission_archive` path the parent component owns.
 function MissionKebab({
   pinned,
-  metadata,
   open,
   onToggle,
   onClose,
@@ -1634,7 +1674,6 @@ function MissionKebab({
   onArchive,
 }: {
   pinned: boolean;
-  metadata: string[];
   open: boolean;
   onToggle: () => void;
   onClose: () => void;
@@ -1676,23 +1715,8 @@ function MissionKebab({
       {open ? (
         <div
           role="menu"
-          className="absolute left-0 top-full z-50 mt-1.5 flex w-64 flex-col gap-px rounded-lg border border-line bg-raised p-1.5 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
+          className="absolute left-0 top-full z-50 mt-1.5 flex w-40 flex-col gap-px rounded-lg border border-line bg-raised p-1.5 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
         >
-          {metadata.length > 0 ? (
-            <>
-              <div className="flex flex-col gap-1 px-2.5 py-2 text-[11px] text-fg-3">
-                {metadata.map((part, index) => (
-                  <span
-                    key={`${part}-${index}`}
-                    className={part.startsWith("/") ? "break-all font-mono" : ""}
-                  >
-                    {part}
-                  </span>
-                ))}
-              </div>
-              <div className="mx-1 mb-1 h-px bg-line" />
-            </>
-          ) : null}
           <KebabItem
             icon={pinned ? PinOff : Pin}
             label={pinned ? "Unpin" : "Pin"}
@@ -1763,22 +1787,6 @@ function RailViewButton({
       <Icon aria-hidden className="h-3.5 w-3.5" />
     </button>
   );
-}
-
-function formatRelativeTime(iso: string): string {
-  try {
-    const d = new Date(iso);
-    const diffMs = Date.now() - d.getTime();
-    const minutes = Math.floor(diffMs / 60000);
-    if (minutes < 1) return "just now";
-    if (minutes < 60) return `${minutes}m ago`;
-    const hours = Math.floor(minutes / 60);
-    if (hours < 24) return `${hours}h ago`;
-    const days = Math.floor(hours / 24);
-    return `${days}d ago`;
-  } catch {
-    return iso;
-  }
 }
 
 /// "Mission paused" card — shown in both the mission-feed surface

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -16,9 +16,10 @@ import { useNavigate } from "react-router-dom";
 import { listen } from "@tauri-apps/api/event";
 import {
   Archive,
+  Ellipsis,
   Flag,
   Info,
-  MoreHorizontal,
+  PanelRight,
   Pin,
   PinOff,
   RotateCcw,
@@ -51,7 +52,6 @@ import { EventFeed } from "../components/EventFeed";
 import { MissionMetaPanel } from "../components/MissionMetaPanel";
 import { MissionResetConfirm } from "../components/MissionResetConfirm";
 import { RunnersRail } from "../components/RunnersRail";
-import { PanelToggleGlyph } from "../components/PanelToggleGlyph";
 import {
   RunnerTerminal,
   type RunnerTerminalHandle,
@@ -129,9 +129,13 @@ function workspaceDimsFromContainer(
 export default function MissionWorkspace({
   missionId: id,
   visible,
+  sidebarCollapsed,
+  fullscreen,
 }: {
   missionId: string;
   visible: boolean;
+  sidebarCollapsed: boolean;
+  fullscreen: boolean;
 }) {
   const navigate = useNavigate();
   const [mission, setMission] = useState<Mission | null>(null);
@@ -906,6 +910,12 @@ export default function MissionWorkspace({
   );
 
   const startedAt = mission ? formatRelativeTime(mission.started_at) : "";
+  const headerMetadata = [
+    crew?.name ?? null,
+    `${sessions.length} runner${sessions.length === 1 ? "" : "s"}`,
+    startedAt ? `started ${startedAt}` : null,
+    mission?.cwd ?? null,
+  ].filter((part): part is string => !!part);
   const [kebabOpen, setKebabOpen] = useState(false);
   // Right rail (Runners panel) collapse state. Mirrors the RunnerChat
   // side-panel collapse — same localStorage shape for consistency.
@@ -975,126 +985,31 @@ export default function MissionWorkspace({
     // across the divider — same layout shape as RunnerChat.
     <div className="flex h-full flex-1 flex-row bg-bg">
       <div className="flex min-w-0 flex-1 flex-col">
-      {/* `data-tauri-drag-region` makes the entire header strip drag
-          the window, matching macOS toolbar behavior. Buttons inside
-          (Resume / Stop / kebab / panel toggle) keep their click
-          handlers — Tauri only enters drag mode on mousedowns that
-          land on the bare header, not on interactive children. */}
-      <header
-        data-tauri-drag-region
-        className="flex items-center justify-between gap-4 border-b border-line bg-panel px-6 pb-3.5 pt-9"
-      >
-        <div className="flex min-w-0 items-center gap-3.5">
-          {/* Mission glyph — matches Pencil node `nEpyL`: a 36×36
-              rounded square with a lucide `flag` icon at 18px in the
-              accent green. */}
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-line bg-bg text-accent">
-            <Flag aria-hidden className="h-[18px] w-[18px]" />
-          </div>
-          <div className="flex min-w-0 flex-col gap-0.5">
-            <div className="flex items-center gap-2">
-              <h1 className="truncate text-[14px] font-semibold leading-tight text-fg">
-                {mission?.title ?? "…"}
-              </h1>
-              {/* Type badge mirrors RunnerChat's "Chat" pill so the
-                  workspace surfaces consistently signal what kind of
-                  thing this is, not just its status. */}
-              <span className="rounded bg-line-strong px-2 py-px text-[9px] font-bold uppercase tracking-[0.5px] text-fg-2">
-                Mission
-              </span>
-              {/* Status pill moved to the left so it sits next to
-                  the title instead of competing visually with the
-                  Resume / Stop / kebab cluster on the right — the
-                  action buttons already imply the current state,
-                  and a pill at the same edge read redundant. */}
-              {mission ? (() => {
-                type Display =
-                  | "running"
-                  | "stopped"
-                  | "archived"
-                  | "aborted"
-                  | "resuming";
-                // archived_at short-circuits at the top. The
-                // remaining branches only see non-archived rows, so
-                // any status='completed' here would mean a row that
-                // missed the migration backfill — fall through to
-                // 'aborted' since it's terminal-but-not-archived and
-                // the worker pill copy reads correctly for triage.
-                const display: Display = isArchived
-                  ? "archived"
-                  : resumingAll
-                    ? "resuming"
-                    : mission.status === "running"
-                      ? anySessionLive
-                        ? "running"
-                        : "stopped"
-                      : "aborted";
-                const pillClass =
-                  display === "running"
-                    ? "bg-accent/15 text-accent"
-                    : display === "aborted"
-                      ? "bg-danger/15 text-danger"
-                      : display === "resuming"
-                        ? "bg-info/15 text-info"
-                        : "bg-raised text-fg-2";
-                const dotClass =
-                  display === "running"
-                    ? "bg-accent"
-                    : display === "aborted"
-                      ? "bg-danger"
-                      : display === "resuming"
-                        ? "bg-info"
-                        : "bg-fg-3";
-                return (
-                  <span
-                    className={`inline-flex shrink-0 items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium ${pillClass}`}
-                  >
-                    <span
-                      className={`inline-flex h-1.5 w-1.5 rounded-full ${dotClass}`}
-                    />
-                    {display === "resuming" ? "resuming…" : display}
-                  </span>
-                );
-              })() : null}
-              {/* Unambiguous read-only affordance for archived
-                  missions — the status pill alone reads too easily
-                  as just another state. Muted chip beside the title
-                  so the workspace clearly communicates that nothing
-                  here will accept input. */}
-              {isArchived ? (
-                <span className="inline-flex shrink-0 items-center rounded border border-line bg-raised px-2 py-0.5 text-[10px] font-medium text-fg-2">
-                  Archived · read-only
-                </span>
-              ) : null}
-            </div>
-            <span className="truncate text-[11px] leading-tight text-fg-3">
-              {sessions.length} runner{sessions.length === 1 ? "" : "s"}
-              {startedAt ? ` · started ${startedAt}` : ""}
-            </span>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
-          {/* Secondary windows (impl 0018) are read-only: Resume/Reset
-              respawn PTYs, Stop kills them, Archive ends the mission — all
-              of which act on PTYs the primary window owns. Hide the whole
-              action cluster while secondary; focus the primary to act. */}
-          {mission?.status === "running" && !resumingAll && !isSecondary ? (
-            <>
-              {anySessionStopped ? (
-                <ResumeButton
-                  onClick={() => void resumeMission()}
-                  title="Respawn every stopped slot in this mission"
-                />
-              ) : null}
-              {allSessionsLive ? (
-                <StopButton
-                  onClick={() => void stopMission()}
-                  title="Kill all PTYs; mission stays running so you can Resume"
-                  iconTone="fg"
-                />
-              ) : null}
+        <header
+          data-tauri-drag-region
+          className={`relative z-20 flex h-11 shrink-0 items-center gap-2 border-b border-line bg-panel pr-4 transition-[padding] duration-150 ${
+            sidebarCollapsed && !fullscreen ? "pl-[90px]" : "pl-4"
+          }`}
+        >
+          <Flag
+            data-tauri-drag-region
+            aria-hidden
+            className="h-[13px] w-[13px] shrink-0 text-fg-2"
+          />
+          <div
+            data-tauri-drag-region
+            className="flex min-w-0 items-center gap-2"
+          >
+            <h1
+              data-tauri-drag-region
+              className="min-w-0 truncate text-[13px] font-medium text-fg"
+            >
+              {mission?.title ?? "…"}
+            </h1>
+            {mission?.status === "running" && !resumingAll && !isSecondary ? (
               <MissionKebab
                 pinned={!!mission.pinned_at}
+                metadata={headerMetadata}
                 open={kebabOpen}
                 onToggle={() => setKebabOpen((v) => !v)}
                 onClose={() => setKebabOpen(false)}
@@ -1115,25 +1030,45 @@ export default function MissionWorkspace({
                   void archiveMission();
                 }}
               />
-            </>
-          ) : null}
-          {!railOpen ? (
+            ) : null}
+            {mission?.status === "running" &&
+            !resumingAll &&
+            !isSecondary &&
+            anySessionStopped ? (
+              <ResumeButton
+                variant="header"
+                onClick={() => void resumeMission()}
+                title="Respawn every stopped slot in this mission"
+              />
+            ) : null}
+            {mission?.status === "running" &&
+            !resumingAll &&
+            !isSecondary &&
+            allSessionsLive ? (
+              <StopButton
+                variant="header"
+                onClick={() => void stopMission()}
+                title="Kill all PTYs; mission stays running so you can Resume"
+              />
+            ) : null}
+          </div>
+          <div className="ml-auto flex shrink-0 items-center">
             <button
               type="button"
-              onClick={() => setRailOpen(true)}
-              title="Open runners panel"
-              aria-label="Open runners panel"
-              className="inline-flex h-7 w-7 items-center justify-center rounded text-fg-2 transition-colors hover:bg-raised hover:text-fg"
+              onClick={() => setRailOpen((open) => !open)}
+              title={railOpen ? "Collapse runners panel" : "Open runners panel"}
+              aria-label={
+                railOpen ? "Collapse runners panel" : "Open runners panel"
+              }
+              aria-pressed={railOpen}
+              className={`inline-flex h-7 w-7 items-center justify-center rounded transition-colors hover:bg-raised hover:text-fg ${
+                railOpen ? "text-fg" : "text-fg-2"
+              }`}
             >
-              <PanelToggleGlyph
-                side="right"
-                filled={false}
-                className="h-[12.5px] w-[16px]"
-              />
+              <PanelRight aria-hidden className="h-[15px] w-[15px]" />
             </button>
-          ) : null}
-        </div>
-      </header>
+          </div>
+        </header>
 
       {error ? (
         <div className="mx-8 mt-3 rounded border border-danger/40 bg-danger/10 px-3 py-2 text-sm text-danger">
@@ -1316,19 +1251,11 @@ export default function MissionWorkspace({
           style={{ width: railWidth }}
           className="flex h-full flex-col"
         >
-          {/* Rail header — same px-5 / pt-9 / pb-3.5 / border-b
-              rhythm as the workspace topbar so the divider lines up
-              across the column boundary. The icon strip on the left
-              flips between Runners (roster) and Mission (meta); the
-              collapse button stays on the right.
-              `data-tauri-drag-region` keeps the rail header in the
-              same draggable band as the workspace topbar — anywhere
-              not on a button drags the window. */}
           <header
             data-tauri-drag-region
-            className="flex shrink-0 items-center justify-between gap-2 border-b border-line px-5 pb-3.5 pt-9"
+            className="relative z-20 flex h-11 shrink-0 items-center border-b border-line px-4"
           >
-            <div className="flex h-9 items-center gap-0.5">
+            <div className="flex items-center gap-0.5">
               <RailViewButton
                 icon={UsersIcon}
                 label="Runners"
@@ -1341,21 +1268,6 @@ export default function MissionWorkspace({
                 active={railView === "meta"}
                 onClick={() => setRailView("meta")}
               />
-            </div>
-            <div className="flex h-9 items-center">
-              <button
-                type="button"
-                onClick={() => setRailOpen(false)}
-                title="Collapse panel"
-                aria-label="Collapse panel"
-                className="flex h-7 w-7 cursor-pointer items-center justify-center rounded border border-transparent text-fg-2 transition-colors hover:bg-sidebar-selected/60 hover:text-fg focus:bg-sidebar-selected/60 focus:text-fg focus:outline-none"
-              >
-                <PanelToggleGlyph
-                  side="right"
-                  filled
-                  className="h-[12.5px] w-[16px]"
-                />
-              </button>
             </div>
           </header>
           <div className="flex min-h-0 flex-1 flex-col pt-5">
@@ -1712,6 +1624,7 @@ function PtyTabButton({
 /// `mission_archive` path the parent component owns.
 function MissionKebab({
   pinned,
+  metadata,
   open,
   onToggle,
   onClose,
@@ -1721,6 +1634,7 @@ function MissionKebab({
   onArchive,
 }: {
   pinned: boolean;
+  metadata: string[];
   open: boolean;
   onToggle: () => void;
   onClose: () => void;
@@ -1755,15 +1669,30 @@ function MissionKebab({
         aria-haspopup="menu"
         aria-expanded={open}
         onClick={onToggle}
-        className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-fg-2 transition-colors hover:border-line hover:bg-raised hover:text-fg"
+        className="inline-flex h-7 w-7 items-center justify-center rounded text-fg-3 transition-colors hover:bg-raised hover:text-fg-2"
       >
-        <MoreHorizontal aria-hidden className="h-4 w-4" />
+        <Ellipsis aria-hidden className="h-[14px] w-[14px]" />
       </button>
       {open ? (
         <div
           role="menu"
-          className="absolute right-0 top-full z-50 mt-1.5 flex w-40 flex-col gap-px rounded-lg border border-line bg-raised p-1.5 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
+          className="absolute left-0 top-full z-50 mt-1.5 flex w-64 flex-col gap-px rounded-lg border border-line bg-raised p-1.5 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
         >
+          {metadata.length > 0 ? (
+            <>
+              <div className="flex flex-col gap-1 px-2.5 py-2 text-[11px] text-fg-3">
+                {metadata.map((part, index) => (
+                  <span
+                    key={`${part}-${index}`}
+                    className={part.startsWith("/") ? "break-all font-mono" : ""}
+                  >
+                    {part}
+                  </span>
+                ))}
+              </div>
+              <div className="mx-1 mb-1 h-px bg-line" />
+            </>
+          ) : null}
           <KebabItem
             icon={pinned ? PinOff : Pin}
             label={pinned ? "Unpin" : "Pin"}

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -16,10 +16,10 @@ import { listen } from "@tauri-apps/api/event";
 import {
   Archive,
   Ellipsis,
-  PanelRight,
   Pin,
   PinOff,
   SquarePen,
+  SquareSplitHorizontal,
   Terminal,
 } from "lucide-react";
 
@@ -52,6 +52,7 @@ import {
   useArchivingVersion,
 } from "../lib/archivingState";
 import { ChatPaneGroup } from "../components/ChatPaneGroup";
+import { PanelToggleGlyph } from "../components/PanelToggleGlyph";
 import { createTerminalRegistry } from "../lib/terminalRegistry";
 import { LayoutPicker } from "../components/LayoutPicker";
 import { StartChatModal } from "../components/StartChatModal";
@@ -179,11 +180,13 @@ export default function RunnerChat({
   visible,
   sidebarCollapsed,
   fullscreen,
+  onOpenSidebar,
 }: {
   sessionId: string;
   visible: boolean;
   sidebarCollapsed: boolean;
   fullscreen: boolean;
+  onOpenSidebar: () => void;
 }) {
   const location = useLocation();
   const navigate = useNavigate();
@@ -1369,24 +1372,6 @@ export default function RunnerChat({
   // terminal palette's background so the canvas + frame stay
   // seamless across theme switches.
   const terminalBg = useTerminalBg();
-  const metaParts = [
-    chatMeta
-      ? chatMeta.handle
-        ? `${chatMeta.agent_runtime}-${chatMeta.handle}`
-        : chatMeta.agent_runtime
-      : null,
-    chatMeta?.runner_id &&
-    runner &&
-    chatMeta.agent_runtime !== runner.runtime
-      ? `runtime override · default ${runner.runtime}`
-      : null,
-    chatMeta?.started_at
-      ? `started ${formatRelative(chatMeta.started_at)}`
-      : null,
-    chatMeta?.cwd ?? runner?.working_dir ?? null,
-    exitCode != null ? `exit ${exitCode}` : null,
-  ].filter((s): s is string => !!s);
-
   // ---- pane-group view model (impl 0020) --------------------------------
 
   const paneRow = (sid: string) =>
@@ -1415,24 +1400,12 @@ export default function RunnerChat({
   // group-scoped — Stop all / Resume all / Archive all — so the title,
   // chip, and meta describe the group, not one member). Name:
   // user-given via kebab Rename, else derived from member chat names.
-  const paneCount = splitActive ? leaves(layout.root).length : 0;
   const groupTitle = splitActive
     ? (layout.name ??
       (visiblePaneSessions.length > 0
         ? visiblePaneSessions.map((s) => paneNameFor(s.id)).join(" + ")
         : "Empty group"))
     : null;
-  // Meta: pane count, plus the working dir when every member shares one.
-  const groupCwds = visiblePaneSessions.map((s) => paneRow(s.id)?.cwd ?? null);
-  const sharedGroupCwd =
-    groupCwds.length > 0 && groupCwds.every((c) => c != null && c === groupCwds[0])
-      ? groupCwds[0]
-      : null;
-  const groupMetaParts = [
-    `${paneCount} ${paneCount === 1 ? "pane" : "panes"}`,
-    sharedGroupCwd,
-  ].filter((s): s is string => !!s);
-
   // Per-pane transitional flag: a session mid-resume, or the URL session
   // mid-start. Blanks the canvas so the pill reads on a pristine surface.
   const transitionalFor = (sid: string) =>
@@ -1494,120 +1467,160 @@ export default function RunnerChat({
       <div className="flex min-w-0 flex-1 flex-col">
         <header
           data-tauri-drag-region
-          className={`relative z-20 flex h-11 shrink-0 items-center gap-2 border-b border-line bg-panel pr-4 transition-[padding] duration-150 ${
-            sidebarCollapsed && !fullscreen ? "pl-[90px]" : "pl-4"
+          className={`relative z-20 flex h-11 shrink-0 items-center border-b border-line bg-panel pr-4 ${
+            sidebarCollapsed && !fullscreen
+              ? "pl-[var(--titlebar-sidebar-toggle-gutter)]"
+              : "pl-4"
           }`}
         >
-          <Terminal
-            data-tauri-drag-region
-            aria-hidden
-            className="h-[13px] w-[13px] shrink-0 text-fg-2"
-          />
           <div
             data-tauri-drag-region
-            className="flex min-w-0 items-center gap-2"
+            className="flex min-w-0 flex-1 items-center gap-2"
           >
-            <h1
-              data-tauri-drag-region
-              className="min-w-0 truncate text-[13px] font-medium text-fg"
-            >
-              {splitActive ? groupTitle : titleLabel}
-            </h1>
-            {sessionId && chatMeta && !isArchived && !isSecondary ? (
-              <ChatKebab
-                pinned={chatMeta.pinned}
-                metadata={splitActive ? groupMetaParts : metaParts}
-                open={kebabOpen}
-                onToggle={() => setKebabOpen((v) => !v)}
-                onClose={() => setKebabOpen(false)}
-                showPin={!splitActive}
-                onPin={() => {
-                  setKebabOpen(false);
-                  void togglePin();
-                }}
-                renameLabel={splitActive ? "Rename group" : "Rename"}
-                onRename={() => {
-                  setKebabOpen(false);
-                  if (splitActive) renameGroupPrompt();
-                  else void renameChatPrompt();
-                }}
-                archiveLabel={splitActive ? "Archive all" : "Archive"}
-                onArchive={() => {
-                  setKebabOpen(false);
-                  if (splitActive) void archiveAllPanes();
-                  else if (sessionId) void archiveSession(sessionId);
-                }}
-              />
+            {sidebarCollapsed ? (
+              <>
+                <button
+                  type="button"
+                  onClick={onOpenSidebar}
+                  title="Open sidebar"
+                  aria-label="Open sidebar"
+                  className="flex h-7 w-7 shrink-0 cursor-pointer items-center justify-center rounded text-fg-2 transition-colors hover:bg-raised hover:text-fg"
+                >
+                  <PanelToggleGlyph
+                    side="left"
+                    filled={false}
+                    className="h-[12px] w-[15.4px]"
+                  />
+                </button>
+                <div
+                  data-tauri-drag-region
+                  aria-hidden
+                  className="mx-1 h-5 w-px shrink-0 bg-line"
+                />
+              </>
             ) : null}
-            {isArchived || isSecondary ? (
-              <BackButton onClick={() => navigate(backTarget)}>
-                {backLabel}
-              </BackButton>
-            ) : !sessionId ? (
-              <BackButton onClick={() => navigate(backTarget)}>
-                {backLabel}
-              </BackButton>
-            ) : !isArchived &&
-            !isSecondary &&
-            splitActive &&
-            visiblePaneSessions.length > 0 ? (
-              anyPaneRunning ? (
+            {splitActive ? (
+              <SquareSplitHorizontal
+                data-tauri-drag-region
+                aria-hidden
+                className="h-[15px] w-[15px] shrink-0 text-accent"
+              />
+            ) : (
+              <Terminal
+                data-tauri-drag-region
+                aria-hidden
+                className="h-[15px] w-[15px] shrink-0 text-accent"
+              />
+            )}
+            <div
+              data-tauri-drag-region
+              className="flex min-w-0 items-center gap-2"
+            >
+              <h1
+                data-tauri-drag-region
+                className="min-w-0 truncate text-[13px] font-medium text-fg"
+              >
+                {splitActive ? groupTitle : titleLabel}
+              </h1>
+              {sessionId && chatMeta && !isArchived && !isSecondary ? (
+                <ChatKebab
+                  pinned={chatMeta.pinned}
+                  open={kebabOpen}
+                  onToggle={() => setKebabOpen((v) => !v)}
+                  onClose={() => setKebabOpen(false)}
+                  showPin={!splitActive}
+                  onPin={() => {
+                    setKebabOpen(false);
+                    void togglePin();
+                  }}
+                  renameLabel={splitActive ? "Rename group" : "Rename"}
+                  onRename={() => {
+                    setKebabOpen(false);
+                    if (splitActive) renameGroupPrompt();
+                    else void renameChatPrompt();
+                  }}
+                  archiveLabel={splitActive ? "Archive all" : "Archive"}
+                  onArchive={() => {
+                    setKebabOpen(false);
+                    if (splitActive) void archiveAllPanes();
+                    else if (sessionId) void archiveSession(sessionId);
+                  }}
+                />
+              ) : null}
+              {isArchived || isSecondary ? (
+                <BackButton onClick={() => navigate(backTarget)}>
+                  {backLabel}
+                </BackButton>
+              ) : !sessionId ? (
+                <BackButton onClick={() => navigate(backTarget)}>
+                  {backLabel}
+                </BackButton>
+              ) : !isArchived &&
+                !isSecondary &&
+                splitActive &&
+                visiblePaneSessions.length > 0 ? (
+                anyPaneRunning ? (
+                  <StopButton
+                    variant="header"
+                    onClick={stopAllPanes}
+                    title="Stop all chats"
+                  >
+                    Stop all
+                  </StopButton>
+                ) : anyPaneResuming ? (
+                  <ResumingButton variant="header" />
+                ) : (
+                  <ResumeButton
+                    variant="header"
+                    onClick={resumeAllPanes}
+                    title="Resume all chats"
+                  >
+                    Resume all
+                  </ResumeButton>
+                )
+              ) : !isArchived && !isSecondary && resuming ? (
+                <ResumingButton variant="header" />
+              ) : !isArchived &&
+                !isSecondary &&
+                status === "running" &&
+                sessionId ? (
                 <StopButton
                   variant="header"
-                  onClick={stopAllPanes}
-                  title="Stop all chats"
-                >
-                  Stop all
-                </StopButton>
-              ) : anyPaneResuming ? (
-                <ResumingButton variant="header" />
-              ) : (
+                  onClick={() => void stopSession(sessionId)}
+                  title="Stop chat"
+                />
+              ) : !isArchived && !isSecondary && sessionId ? (
                 <ResumeButton
                   variant="header"
-                  onClick={resumeAllPanes}
-                  title="Resume all chats"
+                  onClick={() => void resumeSession(sessionId)}
+                  title="Resume chat"
+                />
+              ) : null}
+            </div>
+            <div className="ml-auto flex shrink-0 items-center gap-2">
+              {sessionId && metaLoaded && !isArchived ? (
+                <LayoutPicker
+                  active={splitActive ? layout.preset : "single"}
+                  onPick={pickPreset}
+                />
+              ) : null}
+              {!panelOpen ? (
+                <button
+                  type="button"
+                  onClick={() => setPanelOpen(true)}
+                  title="Open side panel"
+                  aria-label="Open side panel"
+                  aria-pressed={false}
+                  className="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-fg-2 transition-colors hover:bg-raised hover:text-fg"
                 >
-                  Resume all
-                </ResumeButton>
-              )
-            ) : !isArchived && !isSecondary && resuming ? (
-              <ResumingButton variant="header" />
-            ) : !isArchived &&
-              !isSecondary &&
-              status === "running" &&
-              sessionId ? (
-              <StopButton
-                variant="header"
-                onClick={() => void stopSession(sessionId)}
-                title="Stop chat"
-              />
-            ) : !isArchived && !isSecondary && sessionId ? (
-              <ResumeButton
-                variant="header"
-                onClick={() => void resumeSession(sessionId)}
-                title="Resume chat"
-              />
-            ) : null}
-          </div>
-          <div className="ml-auto flex shrink-0 items-center gap-2">
-            {sessionId && metaLoaded && !isArchived ? (
-              <LayoutPicker
-                active={splitActive ? layout.preset : "single"}
-                onPick={pickPreset}
-              />
-            ) : null}
-            <button
-              type="button"
-              onClick={() => setPanelOpen((open) => !open)}
-              title={panelOpen ? "Collapse side panel" : "Open side panel"}
-              aria-label={panelOpen ? "Collapse side panel" : "Open side panel"}
-              aria-pressed={panelOpen}
-              className={`flex h-7 w-7 cursor-pointer items-center justify-center rounded transition-colors hover:bg-raised hover:text-fg ${
-                panelOpen ? "text-fg" : "text-fg-2"
-              }`}
-            >
-              <PanelRight aria-hidden className="h-[15px] w-[15px]" />
-            </button>
+                  <PanelToggleGlyph
+                    side="right"
+                    filled={false}
+                    className="h-[12.5px] w-[16px]"
+                  />
+                </button>
+              ) : null}
+            </div>
           </div>
         </header>
 
@@ -1707,6 +1720,7 @@ export default function RunnerChat({
         runner={runner}
         chatMeta={chatMeta}
         open={panelOpen}
+        onCollapse={() => setPanelOpen(false)}
       />
       {/* Empty-pane fill flow (impl 0020): auto-opened when a preset has
           more slots than open chats, or from an empty pane's New chat
@@ -1857,10 +1871,12 @@ function RunnerSidePanel({
   runner,
   chatMeta,
   open,
+  onCollapse,
 }: {
   runner: Runner | null;
   chatMeta: DirectSessionEntry | null;
   open: boolean;
+  onCollapse: () => void;
 }) {
   const asideRef = useRef<HTMLElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
@@ -1896,8 +1912,25 @@ function RunnerSidePanel({
       <div ref={innerRef} style={{ width }} className="flex h-full flex-col">
         <header
           data-tauri-drag-region
-          className="relative z-20 h-11 shrink-0 border-b border-line"
-        />
+          className="relative z-20 flex h-11 shrink-0 items-center justify-end border-b border-line px-4"
+        >
+          {open ? (
+            <button
+              type="button"
+              onClick={onCollapse}
+              title="Collapse side panel"
+              aria-label="Collapse side panel"
+              aria-pressed
+              className="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-fg transition-colors hover:bg-raised"
+            >
+              <PanelToggleGlyph
+                side="right"
+                filled
+                className="h-[12.5px] w-[16px]"
+              />
+            </button>
+          ) : null}
+        </header>
         <div className="flex min-h-0 flex-1 flex-col gap-[18px] overflow-y-auto p-5">
           {runner ? (
             <>
@@ -2034,7 +2067,6 @@ function RunnerSidePanel({
 /// here.
 function ChatKebab({
   pinned,
-  metadata,
   open,
   onToggle,
   onClose,
@@ -2046,7 +2078,6 @@ function ChatKebab({
   archiveLabel = "Archive",
 }: {
   pinned: boolean;
-  metadata: string[];
   open: boolean;
   onToggle: () => void;
   onClose: () => void;
@@ -2095,23 +2126,8 @@ function ChatKebab({
       {open ? (
         <div
           role="menu"
-          className="absolute left-0 top-full z-50 mt-1.5 flex w-64 flex-col gap-px rounded-lg border border-line bg-raised p-1.5 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
+          className="absolute left-0 top-full z-50 mt-1.5 flex w-40 flex-col gap-px rounded-lg border border-line bg-raised p-1.5 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
         >
-          {metadata.length > 0 ? (
-            <>
-              <div className="flex flex-col gap-1 px-2.5 py-2 text-[11px] text-fg-3">
-                {metadata.map((part, index) => (
-                  <span
-                    key={`${part}-${index}`}
-                    className={part.startsWith("/") ? "break-all font-mono" : ""}
-                  >
-                    {part}
-                  </span>
-                ))}
-              </div>
-              <div className="mx-1 mb-1 h-px bg-line" />
-            </>
-          ) : null}
           {showPin ? (
             <KebabItem
               icon={pinned ? PinOff : Pin}
@@ -2159,21 +2175,4 @@ function KebabItem({
       <span>{label}</span>
     </button>
   );
-}
-
-// Compact relative time for the chat header meta line. Mirrors the
-// "started 18m ago" text in the Pencil design. Falls back to a short
-// absolute date for anything older than a week.
-function formatRelative(ts: string): string {
-  const d = new Date(ts);
-  if (Number.isNaN(d.getTime())) return "—";
-  const diffSec = Math.max(0, (Date.now() - d.getTime()) / 1000);
-  if (diffSec < 60) return "just now";
-  const diffMin = Math.floor(diffSec / 60);
-  if (diffMin < 60) return `${diffMin}m ago`;
-  const diffHr = Math.floor(diffMin / 60);
-  if (diffHr < 24) return `${diffHr}h ago`;
-  const diffDay = Math.floor(diffHr / 24);
-  if (diffDay < 7) return `${diffDay}d ago`;
-  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
 }

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -15,11 +15,11 @@ import { useLocation, useNavigate } from "react-router-dom";
 import { listen } from "@tauri-apps/api/event";
 import {
   Archive,
-  MoreHorizontal,
+  Ellipsis,
+  PanelRight,
   Pin,
   PinOff,
   SquarePen,
-  SquareSplitHorizontal,
   Terminal,
 } from "lucide-react";
 
@@ -52,7 +52,6 @@ import {
   useArchivingVersion,
 } from "../lib/archivingState";
 import { ChatPaneGroup } from "../components/ChatPaneGroup";
-import { PanelToggleGlyph } from "../components/PanelToggleGlyph";
 import { createTerminalRegistry } from "../lib/terminalRegistry";
 import { LayoutPicker } from "../components/LayoutPicker";
 import { StartChatModal } from "../components/StartChatModal";
@@ -178,9 +177,13 @@ async function inheritGroupPin(
 export default function RunnerChat({
   sessionId: sessionIdParam,
   visible,
+  sidebarCollapsed,
+  fullscreen,
 }: {
   sessionId: string;
   visible: boolean;
+  sidebarCollapsed: boolean;
+  fullscreen: boolean;
 }) {
   const location = useLocation();
   const navigate = useNavigate();
@@ -1372,6 +1375,11 @@ export default function RunnerChat({
         ? `${chatMeta.agent_runtime}-${chatMeta.handle}`
         : chatMeta.agent_runtime
       : null,
+    chatMeta?.runner_id &&
+    runner &&
+    chatMeta.agent_runtime !== runner.runtime
+      ? `runtime override · default ${runner.runtime}`
+      : null,
     chatMeta?.started_at
       ? `started ${formatRelative(chatMeta.started_at)}`
       : null,
@@ -1484,188 +1492,124 @@ export default function RunnerChat({
   return (
     <div className="flex h-full flex-1 flex-row bg-bg">
       <div className="flex min-w-0 flex-1 flex-col">
-      {/* `data-tauri-drag-region` makes the entire header strip drag
-          the window, matching macOS toolbar behavior. Interactive
-          children (Stop / Resume / kebab / panel toggle) keep their
-          click handlers — Tauri only enters drag mode on mousedowns
-          that land on the bare header, not on buttons. */}
-      <header
-        data-tauri-drag-region
-        className="flex items-center justify-between gap-4 border-b border-line bg-panel px-6 pb-3.5 pt-9"
-      >
-        <div className="flex min-w-0 items-center gap-3.5">
-          {/* Avatar — 36×36, matches MissionWorkspace's mission glyph
-              dimensions so the chat + mission headers line up at the
-              same baseline. */}
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border border-line bg-bg">
-            {splitActive ? (
-              <SquareSplitHorizontal
-                aria-hidden
-                className="h-[18px] w-[18px] text-accent"
+        <header
+          data-tauri-drag-region
+          className={`relative z-20 flex h-11 shrink-0 items-center gap-2 border-b border-line bg-panel pr-4 transition-[padding] duration-150 ${
+            sidebarCollapsed && !fullscreen ? "pl-[90px]" : "pl-4"
+          }`}
+        >
+          <Terminal
+            data-tauri-drag-region
+            aria-hidden
+            className="h-[13px] w-[13px] shrink-0 text-fg-2"
+          />
+          <div
+            data-tauri-drag-region
+            className="flex min-w-0 items-center gap-2"
+          >
+            <h1
+              data-tauri-drag-region
+              className="min-w-0 truncate text-[13px] font-medium text-fg"
+            >
+              {splitActive ? groupTitle : titleLabel}
+            </h1>
+            {sessionId && chatMeta && !isArchived && !isSecondary ? (
+              <ChatKebab
+                pinned={chatMeta.pinned}
+                metadata={splitActive ? groupMetaParts : metaParts}
+                open={kebabOpen}
+                onToggle={() => setKebabOpen((v) => !v)}
+                onClose={() => setKebabOpen(false)}
+                showPin={!splitActive}
+                onPin={() => {
+                  setKebabOpen(false);
+                  void togglePin();
+                }}
+                renameLabel={splitActive ? "Rename group" : "Rename"}
+                onRename={() => {
+                  setKebabOpen(false);
+                  if (splitActive) renameGroupPrompt();
+                  else void renameChatPrompt();
+                }}
+                archiveLabel={splitActive ? "Archive all" : "Archive"}
+                onArchive={() => {
+                  setKebabOpen(false);
+                  if (splitActive) void archiveAllPanes();
+                  else if (sessionId) void archiveSession(sessionId);
+                }}
               />
-            ) : (
-              <Terminal aria-hidden className="h-[18px] w-[18px] text-accent" />
-            )}
-          </div>
-          {/* Title block — typography + gaps mirror
-              MissionWorkspace's header so the bottom border lands at
-              the same y on both pages. Title was previously
-              font-mono text-[15px] which made chat's title row
-              ~2px taller, pushing its meta row down and offsetting
-              the divider visually. */}
-          <div className="flex min-w-0 flex-col gap-0.5">
-            <div className="flex items-center gap-2">
-              {/* While split the topbar describes the GROUP — its
-                  controls (Stop all / Resume all / Archive all) are
-                  group-scoped, so the identity must be too. Name is
-                  user-given (kebab → Rename group) or derived from the
-                  member chats. */}
-              <h1 className="truncate text-[14px] font-semibold leading-tight text-fg">
-                {splitActive ? groupTitle : titleLabel}
-              </h1>
-              <span className="rounded bg-line-strong px-2 py-px text-[9px] font-bold uppercase tracking-[0.5px] text-fg-2">
-                {splitActive ? "Group" : "Chat"}
-              </span>
-              {/* Effective-runtime badge (feature 41): only when this
-                  chat runs an engine other than its runner's default. */}
-              {!splitActive &&
-              chatMeta?.runner_id &&
-              runner &&
-              chatMeta.agent_runtime !== runner.runtime ? (
-                <span
-                  title={`Runtime override — runner default is ${runner.runtime}`}
-                  className="rounded bg-accent/10 px-2 py-px text-[9px] font-bold uppercase tracking-[0.5px] text-accent"
+            ) : null}
+            {isArchived || isSecondary ? (
+              <BackButton onClick={() => navigate(backTarget)}>
+                {backLabel}
+              </BackButton>
+            ) : !sessionId ? (
+              <BackButton onClick={() => navigate(backTarget)}>
+                {backLabel}
+              </BackButton>
+            ) : !isArchived &&
+            !isSecondary &&
+            splitActive &&
+            visiblePaneSessions.length > 0 ? (
+              anyPaneRunning ? (
+                <StopButton
+                  variant="header"
+                  onClick={stopAllPanes}
+                  title="Stop all chats"
                 >
-                  {chatMeta.agent_runtime}
-                </span>
-              ) : null}
-              {isArchived ? (
-                <span className="inline-flex shrink-0 items-center rounded border border-line bg-raised px-2 py-0.5 text-[10px] font-medium text-fg-2">
-                  Archived · read-only
-                </span>
-              ) : null}
-            </div>
-            {(splitActive ? groupMetaParts : metaParts).length > 0 ? (
-              <div className="flex min-w-0 items-center gap-2 text-[11px] leading-tight text-fg-3">
-                {(splitActive ? groupMetaParts : metaParts).map((part, i) => (
-                  <span
-                    key={i}
-                    className={`truncate ${
-                      i > 0 ? "before:mr-2 before:text-line-strong before:content-['·']" : ""
-                    } ${i === 0 || (i > 0 && part.startsWith("/")) ? "font-mono" : ""}`}
-                  >
-                    {part}
-                  </span>
-                ))}
-              </div>
+                  Stop all
+                </StopButton>
+              ) : anyPaneResuming ? (
+                <ResumingButton variant="header" />
+              ) : (
+                <ResumeButton
+                  variant="header"
+                  onClick={resumeAllPanes}
+                  title="Resume all chats"
+                >
+                  Resume all
+                </ResumeButton>
+              )
+            ) : !isArchived && !isSecondary && resuming ? (
+              <ResumingButton variant="header" />
+            ) : !isArchived &&
+              !isSecondary &&
+              status === "running" &&
+              sessionId ? (
+              <StopButton
+                variant="header"
+                onClick={() => void stopSession(sessionId)}
+                title="Stop chat"
+              />
+            ) : !isArchived && !isSecondary && sessionId ? (
+              <ResumeButton
+                variant="header"
+                onClick={() => void resumeSession(sessionId)}
+                title="Resume chat"
+              />
             ) : null}
           </div>
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          {/* Layout button — left of Stop per the Pencil mock (`z1hPN`).
-              Hidden for archived rows (read-only single pane). */}
-          {sessionId && metaLoaded && !isArchived ? (
-            // Highlight reflects the current VIEW: a non-member chat reads
-            // as single-pane even while a group exists in the background.
-            <LayoutPicker
-              active={splitActive ? layout.preset : "single"}
-              onPick={pickPreset}
-            />
-          ) : null}
-          {isArchived ? (
-            // Archived rows are terminal: no Resume / Stop / Archive.
-            // Only surface the navigation escape hatch.
-            <BackButton onClick={() => navigate(backTarget)}>{backLabel}</BackButton>
-          ) : isSecondary ? (
-            // Secondary window (impl 0018): the primary owns the PTY, so no
-            // Stop/Resume here — those call session_kill / session_resume.
-            // Focus the primary (via the overlay) to act on this chat.
-            <BackButton onClick={() => navigate(backTarget)}>{backLabel}</BackButton>
-          ) : splitActive && visiblePaneSessions.length > 0 ? (
-            // Aggregate controls while split — per-pane Stop/Resume live
-            // in the pane headers; the topbar acts on every visible pane.
-            anyPaneRunning ? (
-              <StopButton onClick={stopAllPanes}>Stop all</StopButton>
-            ) : anyPaneResuming ? (
-              <ResumingButton />
-            ) : (
-              <ResumeButton onClick={resumeAllPanes}>Resume all</ResumeButton>
-            )
-          ) : resuming ? (
-            <ResumingButton />
-          ) : status === "running" && sessionId ? (
-            <StopButton onClick={() => void stopSession(sessionId)} />
-          ) : sessionId ? (
-            // Stopped/crashed → Resume, matching
-            // Pencil node `HLXK6` in `vS5ce`. Same action the inline
-            // SessionEndedOverlay card fires; mirroring it in the
-            // topbar lets the user recover without scrolling to the
-            // bottom of the feed. If `agent_session_key` is missing,
-            // the backend resume path starts a fresh agent process
-            // for the same row; the overlay subtitle explains that
-            // history is unavailable.
-            <ResumeButton onClick={() => void resumeSession(sessionId)} />
-          ) : (
-            // Last-resort fallback: no session yet.
-            <BackButton onClick={() => navigate(backTarget)}>{backLabel}</BackButton>
-          )}
-          {/* Topbar overflow menu — Pin / Rename / Archive, matching
-              the design's `session_ctx_menu` (`P5CLA` / `L31Zb`) and
-              the mission topbar's `MissionKebab`. Hidden for archived
-              rows: Pin/Rename make no sense for a terminal row, and
-              Archive is a no-op. */}
-          {sessionId && chatMeta && !isArchived && !isSecondary ? (
-            <ChatKebab
-              pinned={chatMeta.pinned}
-              open={kebabOpen}
-              onToggle={() => setKebabOpen((v) => !v)}
-              onClose={() => setKebabOpen(false)}
-              // Group mode: Pin is a per-chat sidebar concept, so it hides;
-              // Rename names the group; Archive archives every pane.
-              showPin={!splitActive}
-              onPin={() => {
-                setKebabOpen(false);
-                void togglePin();
-              }}
-              renameLabel={splitActive ? "Rename group" : "Rename"}
-              onRename={() => {
-                setKebabOpen(false);
-                if (splitActive) renameGroupPrompt();
-                else void renameChatPrompt();
-              }}
-              archiveLabel={splitActive ? "Archive all" : "Archive"}
-              onArchive={() => {
-                setKebabOpen(false);
-                if (splitActive) void archiveAllPanes();
-                else if (sessionId) void archiveSession(sessionId);
-              }}
-            />
-          ) : null}
-          {/* Panel-toggle button — only rendered in the topbar when
-              the side panel is collapsed (matches Pencil node `QfoJJ`).
-              When the panel is open, the toggle lives inside the
-              panel's own header at the top-right (see
-              RunnerSidePanel). */}
-          {!panelOpen ? (
+          <div className="ml-auto flex shrink-0 items-center gap-2">
+            {sessionId && metaLoaded && !isArchived ? (
+              <LayoutPicker
+                active={splitActive ? layout.preset : "single"}
+                onPick={pickPreset}
+              />
+            ) : null}
             <button
               type="button"
-              onClick={() => setPanelOpen(true)}
-              title="Open side panel"
-              aria-label="Open side panel"
-              className="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-fg-2 hover:bg-raised hover:text-fg"
+              onClick={() => setPanelOpen((open) => !open)}
+              title={panelOpen ? "Collapse side panel" : "Open side panel"}
+              aria-label={panelOpen ? "Collapse side panel" : "Open side panel"}
+              aria-pressed={panelOpen}
+              className={`flex h-7 w-7 cursor-pointer items-center justify-center rounded transition-colors hover:bg-raised hover:text-fg ${
+                panelOpen ? "text-fg" : "text-fg-2"
+              }`}
             >
-              {/* Hollow = "panel exists but is collapsed"; flips to the
-                  filled trailing column when the panel is open. Mirror of
-                  the left sidebar toggle (#246), oriented to the right. */}
-              <PanelToggleGlyph
-                side="right"
-                filled={false}
-                className="h-[12.5px] w-[16px]"
-              />
+              <PanelRight aria-hidden className="h-[15px] w-[15px]" />
             </button>
-          ) : null}
-        </div>
-      </header>
+          </div>
+        </header>
 
       {err ? (
         <div className="mx-8 mt-4 rounded border border-danger/40 bg-danger/10 px-3 py-2 text-sm text-danger">
@@ -1763,7 +1707,6 @@ export default function RunnerChat({
         runner={runner}
         chatMeta={chatMeta}
         open={panelOpen}
-        onClose={() => setPanelOpen(false)}
       />
       {/* Empty-pane fill flow (impl 0020): auto-opened when a preset has
           more slots than open chats, or from an empty pane's New chat
@@ -1914,12 +1857,10 @@ function RunnerSidePanel({
   runner,
   chatMeta,
   open,
-  onClose,
 }: {
   runner: Runner | null;
   chatMeta: DirectSessionEntry | null;
   open: boolean;
-  onClose: () => void;
 }) {
   const asideRef = useRef<HTMLElement>(null);
   const innerRef = useRef<HTMLDivElement>(null);
@@ -1953,29 +1894,10 @@ function RunnerSidePanel({
       }`}
     >
       <div ref={innerRef} style={{ width }} className="flex h-full flex-col">
-        {/* Side-panel header — same draggable-window rules as the
-            workspace topbar. The lone Collapse button keeps its
-            handler; everywhere else the strip drags the window. */}
         <header
           data-tauri-drag-region
-          className="flex shrink-0 items-center justify-end border-b border-line px-5 pb-3.5 pt-9"
-        >
-          <div className="flex h-9 items-center">
-            <button
-              type="button"
-              onClick={onClose}
-              title="Collapse panel"
-              aria-label="Collapse panel"
-              className="flex h-7 w-7 cursor-pointer items-center justify-center rounded text-fg-2 hover:bg-raised hover:text-fg"
-            >
-              <PanelToggleGlyph
-                side="right"
-                filled
-                className="h-[12.5px] w-[16px]"
-              />
-            </button>
-          </div>
-        </header>
+          className="relative z-20 h-11 shrink-0 border-b border-line"
+        />
         <div className="flex min-h-0 flex-1 flex-col gap-[18px] overflow-y-auto p-5">
           {runner ? (
             <>
@@ -2112,6 +2034,7 @@ function RunnerSidePanel({
 /// here.
 function ChatKebab({
   pinned,
+  metadata,
   open,
   onToggle,
   onClose,
@@ -2123,6 +2046,7 @@ function ChatKebab({
   archiveLabel = "Archive",
 }: {
   pinned: boolean;
+  metadata: string[];
   open: boolean;
   onToggle: () => void;
   onClose: () => void;
@@ -2164,15 +2088,30 @@ function ChatKebab({
         aria-haspopup="menu"
         aria-expanded={open}
         onClick={onToggle}
-        className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-fg-2 transition-colors hover:border-line hover:bg-raised hover:text-fg"
+        className="inline-flex h-7 w-7 items-center justify-center rounded text-fg-3 transition-colors hover:bg-raised hover:text-fg-2"
       >
-        <MoreHorizontal aria-hidden className="h-4 w-4" />
+        <Ellipsis aria-hidden className="h-[14px] w-[14px]" />
       </button>
       {open ? (
         <div
           role="menu"
-          className="absolute right-0 top-full z-50 mt-1.5 flex w-40 flex-col gap-px rounded-lg border border-line bg-raised p-1.5 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
+          className="absolute left-0 top-full z-50 mt-1.5 flex w-64 flex-col gap-px rounded-lg border border-line bg-raised p-1.5 shadow-[0_8px_30px_rgba(0,0,0,0.67)]"
         >
+          {metadata.length > 0 ? (
+            <>
+              <div className="flex flex-col gap-1 px-2.5 py-2 text-[11px] text-fg-3">
+                {metadata.map((part, index) => (
+                  <span
+                    key={`${part}-${index}`}
+                    className={part.startsWith("/") ? "break-all font-mono" : ""}
+                  >
+                    {part}
+                  </span>
+                ))}
+              </div>
+              <div className="mx-1 mb-1 h-px bg-line" />
+            </>
+          ) : null}
           {showPin ? (
             <KebabItem
               icon={pinned ? PinOff : Pin}

--- a/src/pages/Runners.tsx
+++ b/src/pages/Runners.tsx
@@ -191,7 +191,7 @@ export default function Runners() {
   return (
     <>
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
-        <div className="flex min-h-0 w-full flex-1 flex-col gap-6 px-8 py-8">
+        <div className="flex min-h-0 w-full flex-1 flex-col gap-6 px-8 pb-8 pt-10">
           <header className="flex items-center justify-between gap-4">
             <div className="flex flex-col gap-1">
               <h1 className="text-2xl font-bold tracking-tight text-fg">

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -204,7 +204,7 @@ export default function SettingsPage() {
                           state: { from: fromRef.current },
                         })
                       }
-                      className={`flex cursor-pointer items-center gap-2.5 rounded border px-2.5 py-1.5 text-left text-sm transition-colors ${
+                      className={`flex cursor-pointer items-center gap-2.5 rounded border px-2.5 py-1 text-left text-sm transition-colors ${
                         active
                           ? "border-sidebar-selected-border bg-sidebar-selected font-semibold text-fg shadow-sm"
                           : "border-transparent text-fg-2 hover:border-sidebar-selected-border hover:bg-sidebar-selected/40 hover:text-fg"


### PR DESCRIPTION
Closes #343.

Summary:
- replace RunnerChat and MissionWorkspace avatar topbars with compact 44px single-line headers
- keep overflow menus operations-only after visual review while preserving each surfaces existing actions and permission semantics
- use the existing two-state panel glyphs for sidebar, chat detail-panel, and mission runners-rail controls; open-panel toggles live in their panel headers
- center the current macOS windows native traffic lights against the zoom-scaled header through an AppKit command, including secondary windows
- reapply native chrome only after resize/fullscreen state settles and reveal hidden windows only after initial zoom/titlebar alignment
- pin the sidebar toggle horizontally across app zoom, restore it on collapsed Runner/Crew/detail routes, and retain fullscreen gutter collapse
- use 10 percent app-zoom steps, tighten Settings navigation rows, and adjust Runner/Crew list top spacing

Final visual-review decisions:
- overflow menus contain actions only; removed subtitle metadata is not repeated there
- panel-right controls relocate into an open panel or rail instead of remaining duplicated in the workspace header
- the existing chat details panel is used rather than a disabled reserved control

Validation:
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm test (23 files, 176 tests)
- pnpm build
- git diff --check
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- cargo test --workspace (454 runner-lib + 8 CLI + 14 roundtrip + 22 runner-core tests)
- final clean working-tree review from the reviewer runner

Implementation note:
- macOS may restore native button frames during a live resize; Runner reapplies the final layout after the existing 200ms settled-resize signal instead of tracking the zoom animation.