### PR TITLE
fix(session): reap mission siblings after slot exit

### DIFF
--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -764,11 +764,10 @@ async fn mission_start_impl_with_size(
     // sleeping in the gate would spawn into a stopped mission. See
     // `SessionManager::cancel_pending_mission_spawns`.
     //
-    // On per-slot spawn failure we mark just that row crashed and
-    // emit `session/exit` so the workspace's row refresh fires and
-    // the pane flips from "starting" to "session ended" without
-    // a manual refresh. Rest of the mission proceeds — user gets a
-    // Resume button on the broken slot.
+    // On per-slot spawn failure we mark that row crashed, emit
+    // `session/exit`, and reap or cancel the rest of the mission so
+    // the workspace lands in the same all-or-nothing paused state as
+    // a slot that exits after successfully spawning.
     let manager = Arc::clone(&state.sessions);
     let pool_for_task = state.db.clone();
     let mission_id_for_task = out.mission.id.clone();
@@ -824,6 +823,11 @@ async fn mission_start_impl_with_size(
                         exit_code: None,
                         success: false,
                     });
+                    manager.reap_live_mission_siblings(
+                        &mission_id_for_task,
+                        &session_id,
+                        &pool_for_task,
+                    );
                 }
             }
         }
@@ -1513,6 +1517,11 @@ pub(crate) async fn mission_reset_impl(
                         exit_code: None,
                         success: false,
                     });
+                    manager.reap_live_mission_siblings(
+                        &mission_id_for_task,
+                        &session_id,
+                        &pool_for_task,
+                    );
                 }
             }
         }

--- a/src-tauri/src/session/manager/lifecycle.rs
+++ b/src-tauri/src/session/manager/lifecycle.rs
@@ -187,6 +187,60 @@ impl SessionManager {
         Ok(())
     }
 
+    pub(crate) fn reap_live_mission_siblings(
+        &self,
+        mission_id: &str,
+        exited_session_id: &str,
+        pool: &DbPool,
+    ) {
+        let has_live_siblings = {
+            let sessions = self.sessions.lock().unwrap();
+            sessions.values().any(|state| {
+                state
+                    .lock()
+                    .unwrap()
+                    .handle
+                    .as_ref()
+                    .is_some_and(|handle| handle.mission_id.as_deref() == Some(mission_id))
+            })
+        };
+        let has_pending_spawns = self
+            .pending_mission_cancels
+            .lock()
+            .unwrap()
+            .contains_key(mission_id);
+        if !has_live_siblings && !has_pending_spawns {
+            return;
+        }
+
+        let conn = match pool.get() {
+            Ok(conn) => conn,
+            Err(error) => {
+                log::warn!("mission sibling reap pool checkout failed for {mission_id}: {error}");
+                return;
+            }
+        };
+        let mission = match crate::repo::mission::get(&conn, mission_id) {
+            Ok(Some(mission)) => mission,
+            Ok(None) => return,
+            Err(error) => {
+                log::warn!("mission sibling reap status lookup failed for {mission_id}: {error}");
+                return;
+            }
+        };
+        if !matches!(mission.status, crate::model::MissionStatus::Running) {
+            return;
+        }
+        drop(conn);
+
+        log::info!(
+            "mission sibling reap triggered: mission={mission_id} exited_session={exited_session_id}"
+        );
+        if let Err(error) = self.kill_all_for_mission(mission_id) {
+            log::warn!("mission sibling reap failed for {mission_id}: {error}");
+        }
+    }
+
     /// Kill every live session for `runner_id` — both mission-scoped and
     /// direct-chat. Used by `runner_delete` so the cascade dropping the
     /// `sessions` rows doesn't strand the PTY children running underneath.

--- a/src-tauri/src/session/manager/output.rs
+++ b/src-tauri/src/session/manager/output.rs
@@ -235,11 +235,16 @@ impl SessionManager {
             }
             events.exit(&ExitEvent {
                 session_id: session_id.clone(),
-                mission_id,
+                mission_id: mission_id.clone(),
                 exit_code,
                 success,
             });
             let _ = manager_t.forget_runtime_handle(&session_id, &rt_session);
+            if !was_killed {
+                if let Some(mission_id) = mission_id.as_deref() {
+                    manager_t.reap_live_mission_siblings(mission_id, &session_id, &pool);
+                }
+            }
         })
     }
 

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -635,6 +635,223 @@ fn concurrent_missions_on_same_crew_keep_session_state_isolated() {
 }
 
 #[test]
+fn mission_slot_exit_reaps_live_siblings_and_keeps_mission_running() {
+    let pool = pool_with_schema();
+    let mission_id = ulid::Ulid::new().to_string();
+    let runner_id = ulid::Ulid::new().to_string();
+    let slot_id = insert_crew_runner(&pool, &mission_id, &runner_id);
+    let mission = Mission {
+        id: mission_id.clone(),
+        crew_id: "c".into(),
+        ..mission()
+    };
+    let mut runner = runner("/bin/cat", &[]);
+    runner.id = runner_id;
+    let mut slot = slot_for(&runner);
+    slot.id = slot_id;
+    slot.crew_id = "c".into();
+
+    let fake = fake_runtime();
+    let mgr = mgr_with_fake(None, Arc::clone(&fake));
+    let first = mgr
+        .spawn(
+            &mission,
+            &runner,
+            &slot,
+            std::path::Path::new("/tmp"),
+            PathBuf::from("/dev/null"),
+            Arc::clone(&pool),
+            capture(),
+            None,
+        )
+        .unwrap();
+    let sibling = mgr
+        .spawn(
+            &mission,
+            &runner,
+            &slot,
+            std::path::Path::new("/tmp"),
+            PathBuf::from("/dev/null"),
+            Arc::clone(&pool),
+            capture(),
+            None,
+        )
+        .unwrap();
+
+    fake.close_spawn(0);
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        let conn = pool.get().unwrap();
+        let live_sessions: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions
+                  WHERE mission_id = ?1 AND status = 'running'",
+                params![mission_id],
+                |row| row.get(0),
+            )
+            .unwrap();
+        if live_sessions == 0 {
+            break;
+        }
+        if Instant::now() > deadline {
+            panic!("mission siblings were not reaped");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+
+    assert!(
+        fake.stops.lock().unwrap().contains(&sibling.id),
+        "the surviving sibling must be stopped",
+    );
+    for session_id in [&first.id, &sibling.id] {
+        assert!(
+            mgr.session_state(session_id).is_none_or(|state| state
+                .lock()
+                .unwrap()
+                .handle
+                .is_none()),
+            "session {session_id} must not retain a live handle",
+        );
+    }
+    let mission_status: String = pool
+        .get()
+        .unwrap()
+        .query_row(
+            "SELECT status FROM missions WHERE id = ?1",
+            params![mission_id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(mission_status, "running");
+}
+
+#[test]
+fn mission_slot_exit_cancels_pending_sibling_spawns() {
+    let pool = pool_with_schema();
+    let mission_id = ulid::Ulid::new().to_string();
+    let runner_id = ulid::Ulid::new().to_string();
+    let slot_id = insert_crew_runner(&pool, &mission_id, &runner_id);
+    let mission = Mission {
+        id: mission_id.clone(),
+        crew_id: "c".into(),
+        ..mission()
+    };
+    let mut runner = runner("/bin/cat", &[]);
+    runner.id = runner_id;
+    let mut slot = slot_for(&runner);
+    slot.id = slot_id;
+    slot.crew_id = "c".into();
+
+    let fake = fake_runtime();
+    let mgr = mgr_with_fake(None, Arc::clone(&fake));
+    mgr.spawn(
+        &mission,
+        &runner,
+        &slot,
+        std::path::Path::new("/tmp"),
+        PathBuf::from("/dev/null"),
+        Arc::clone(&pool),
+        capture(),
+        None,
+    )
+    .unwrap();
+    let cancel = mgr.register_pending_mission_cancel(&mission_id);
+
+    fake.close_spawn(0);
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    while !cancel.load(std::sync::atomic::Ordering::Acquire) {
+        if Instant::now() > deadline {
+            panic!("pending sibling spawns were not cancelled");
+        }
+        std::thread::sleep(Duration::from_millis(20));
+    }
+    mgr.drop_pending_mission_cancel(&mission_id, &cancel);
+}
+
+#[test]
+fn intentional_mission_kill_does_not_reap_siblings_from_exit_epilogue() {
+    let pool = pool_with_schema();
+    let mission_id = ulid::Ulid::new().to_string();
+    let runner_id = ulid::Ulid::new().to_string();
+    let slot_id = insert_crew_runner(&pool, &mission_id, &runner_id);
+    let mission = Mission {
+        id: mission_id.clone(),
+        crew_id: "c".into(),
+        ..mission()
+    };
+    let mut runner = runner("/bin/cat", &[]);
+    runner.id = runner_id;
+    let mut slot = slot_for(&runner);
+    slot.id = slot_id;
+    slot.crew_id = "c".into();
+
+    let fake = fake_runtime();
+    let mgr = mgr_with_fake(None, Arc::clone(&fake));
+    let first = mgr
+        .spawn(
+            &mission,
+            &runner,
+            &slot,
+            std::path::Path::new("/tmp"),
+            PathBuf::from("/dev/null"),
+            Arc::clone(&pool),
+            capture(),
+            None,
+        )
+        .unwrap();
+    let sibling = mgr
+        .spawn(
+            &mission,
+            &runner,
+            &slot,
+            std::path::Path::new("/tmp"),
+            PathBuf::from("/dev/null"),
+            Arc::clone(&pool),
+            capture(),
+            None,
+        )
+        .unwrap();
+
+    // mission_stop kills sessions one at a time through this path. The
+    // first intentional exit must not recursively start another sweep.
+    mgr.kill(&first.id).unwrap();
+
+    assert!(
+        mgr.session_state(&sibling.id)
+            .is_some_and(|state| state.lock().unwrap().handle.is_some()),
+        "the sibling must stay live until mission_stop reaches it",
+    );
+    assert!(
+        !fake.stops.lock().unwrap().contains(&sibling.id),
+        "the first intentional exit must not stop its sibling",
+    );
+    let sibling_status: String = pool
+        .get()
+        .unwrap()
+        .query_row(
+            "SELECT status FROM sessions WHERE id = ?1",
+            params![sibling.id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(sibling_status, "running");
+    let first_status: String = pool
+        .get()
+        .unwrap()
+        .query_row(
+            "SELECT status FROM sessions WHERE id = ?1",
+            params![first.id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(first_status, "stopped");
+
+    mgr.kill_all_for_mission(&mission_id).unwrap();
+}
+
+#[test]
 fn spawn_marks_session_stopped_after_runtime_channel_closes() {
     // Spawn a mission session through FakeRuntime, then close
     // the runtime's output channel to simulate a clean pane exit.
@@ -728,6 +945,26 @@ fn spawn_marks_session_stopped_after_runtime_channel_closes() {
     let exits = cap.exit.lock().unwrap();
     assert_eq!(exits.len(), 1, "expected 1 exit event, got {}", exits.len());
     assert!(exits[0].success);
+    drop(exits);
+
+    let mission_status: String = pool
+        .get()
+        .unwrap()
+        .query_row(
+            "SELECT status FROM missions WHERE id = ?1",
+            params![mission.id],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(mission_status, "running");
+    assert!(
+        fake.stops
+            .lock()
+            .unwrap()
+            .iter()
+            .all(|session_id| session_id == &spawned.id),
+        "a single-slot exit must not start a mission sweep",
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- reap surviving mission PTYs when any slot exits unexpectedly
- cancel queued slot spawns and apply the same all-or-nothing policy to spawn failures
- preserve the mission `running` status so paused missions remain resumable
- cover spontaneous exits, pending spawn cancellation, deliberate stop behavior, and single-slot exits

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`

Closes #338