### PR TITLE
feat(runtime): discover and override agent executables

### DIFF
--- a/design/runner-setting.pen
+++ b/design/runner-setting.pen
@@ -11390,6 +11390,2415 @@
       "width": 300,
       "height": 230,
       "content": "Delete all — confirm dialog (replaces native confirm()):\n\nSingle step. Instances component/confirm-dialog — the per-row trash (also on this screen) reuses the same component later, so styling stays synced.\n\nCopy names the exact archived count and that mission event logs go too; danger button stays quiet-tinted, same family as the Delete all trigger in the title row.\n\nBehavior: centered over the settings surface with a dim scrim; Esc or Cancel aborts; on confirm the danger button disables and reads 'Deleting…' while the loop runs."
+    },
+    {
+      "type": "frame",
+      "id": "Zes2l",
+      "x": 17500,
+      "y": 0,
+      "name": "Settings — Agents",
+      "clip": true,
+      "width": 1440,
+      "height": 900,
+      "fill": "$bg",
+      "children": [
+        {
+          "type": "frame",
+          "id": "L5Kj6r",
+          "name": "sidebar",
+          "width": 280,
+          "height": "fill_container",
+          "fill": "$sidebar",
+          "stroke": "$line",
+          "strokeWidth": {
+            "right": 1
+          },
+          "strokeAlignment": "inner",
+          "layout": "vertical",
+          "padding": [
+            14,
+            12
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "M0y5P",
+              "name": "traffic_lights",
+              "gap": 8,
+              "padding": [
+                6,
+                8,
+                16,
+                8
+              ],
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "Yruam",
+                  "name": "tl_r",
+                  "fill": "#FF5F57",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "olG8o",
+                  "name": "tl_y",
+                  "fill": "#FEBC2E",
+                  "width": 12,
+                  "height": 12
+                },
+                {
+                  "type": "ellipse",
+                  "id": "v8O7b",
+                  "name": "tl_g",
+                  "fill": "#28C840",
+                  "width": 12,
+                  "height": 12
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Y5Fj7b",
+              "name": "back_btn",
+              "width": "fill_container",
+              "fill": "$panel",
+              "cornerRadius": 8,
+              "gap": 10,
+              "padding": [
+                9,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "JPnkg",
+                  "name": "back_ic",
+                  "width": 15,
+                  "height": 15,
+                  "icon": "arrow-left",
+                  "library": "lucide",
+                  "fill": "$text-2"
+                },
+                {
+                  "type": "text",
+                  "id": "C9x1J",
+                  "name": "back_t",
+                  "fill": "$text-1",
+                  "content": "Back to app",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zDNK3",
+              "name": "sp1",
+              "width": "fill_container",
+              "height": 10
+            },
+            {
+              "type": "frame",
+              "id": "eb2mQ",
+              "name": "search",
+              "width": "fill_container",
+              "fill": "$panel",
+              "cornerRadius": 8,
+              "stroke": "$line",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "gap": 8,
+              "padding": [
+                9,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "EymOC",
+                  "name": "search_ic",
+                  "width": 14,
+                  "height": 14,
+                  "icon": "search",
+                  "library": "lucide",
+                  "fill": "$text-3"
+                },
+                {
+                  "type": "text",
+                  "id": "CE2ry",
+                  "name": "search_t",
+                  "fill": "$text-3",
+                  "content": "Search settings…",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "bi3z9",
+              "name": "sp2",
+              "width": "fill_container",
+              "height": 16
+            },
+            {
+              "type": "frame",
+              "id": "b633R",
+              "name": "grp_App",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "BBzLY",
+                  "name": "grp_label_wrap",
+                  "width": "fill_container",
+                  "padding": [
+                    8,
+                    10,
+                    6,
+                    10
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "XWzZS",
+                      "name": "grp_label",
+                      "fill": "$text-3",
+                      "content": "App",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "lrqFW",
+                  "name": "nav_general",
+                  "width": "fill_container",
+                  "fill": "#27293000",
+                  "cornerRadius": 8,
+                  "stroke": "$sidebar-selected-border",
+                  "strokeAlignment": "inner",
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "f4Wux",
+                      "name": "nav_general_ic",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "settings",
+                      "library": "lucide",
+                      "fill": "$text-2"
+                    },
+                    {
+                      "type": "text",
+                      "id": "v2w0i",
+                      "name": "nav_general_t",
+                      "fill": "#B8B9C0",
+                      "content": "General",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "TVszM",
+                  "name": "nav_chat",
+                  "width": "fill_container",
+                  "fill": "#15161B00",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "G91Z9",
+                      "name": "nav_chat_ic",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "message-square",
+                      "library": "lucide",
+                      "fill": "$text-2"
+                    },
+                    {
+                      "type": "text",
+                      "id": "VFhhJ",
+                      "name": "nav_chat_t",
+                      "fill": "#B8B9C0",
+                      "content": "Chat",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "odNub",
+                  "name": "nav_appearance",
+                  "width": "fill_container",
+                  "fill": "#15161B00",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "wVKR4",
+                      "name": "nav_appearance_ic",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "sun",
+                      "library": "lucide",
+                      "fill": "$text-2"
+                    },
+                    {
+                      "type": "text",
+                      "id": "JVMpi",
+                      "name": "nav_appearance_t",
+                      "fill": "#B8B9C0",
+                      "content": "Appearance",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "EA1Qp",
+                  "name": "nav_terminal",
+                  "width": "fill_container",
+                  "fill": "#15161B00",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "ECvVQ",
+                      "name": "nav_terminal_ic",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "terminal",
+                      "library": "lucide",
+                      "fill": "$text-2"
+                    },
+                    {
+                      "type": "text",
+                      "id": "XS0yp",
+                      "name": "nav_terminal_t",
+                      "fill": "#B8B9C0",
+                      "content": "Terminal",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "iLdRc",
+                  "name": "nav_shortcuts",
+                  "width": "fill_container",
+                  "fill": "#15161B00",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "YsMWp",
+                      "name": "nav_shortcuts_ic",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "keyboard",
+                      "library": "lucide",
+                      "fill": "$text-2"
+                    },
+                    {
+                      "type": "text",
+                      "id": "UtQIL",
+                      "name": "nav_shortcuts_t",
+                      "fill": "#B8B9C0",
+                      "content": "Keyboard shortcuts",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "W6ZLN",
+              "name": "sp3",
+              "width": "fill_container",
+              "height": 14
+            },
+            {
+              "type": "frame",
+              "id": "i4YhS",
+              "name": "grp_Integrations",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "BrZxW",
+                  "name": "grp_label_wrap",
+                  "width": "fill_container",
+                  "padding": [
+                    8,
+                    10,
+                    6,
+                    10
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "K105iq",
+                      "name": "grp_label",
+                      "fill": "$text-3",
+                      "content": "Integrations",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "UUbDe",
+                  "name": "nav_agents",
+                  "width": "fill_container",
+                  "fill": "$sidebar-selected",
+                  "cornerRadius": 8,
+                  "stroke": "$sidebar-selected-border",
+                  "strokeWidth": 1,
+                  "strokeAlignment": "inner",
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "LEzgL",
+                      "name": "nav_agents_ic",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "bot",
+                      "library": "lucide",
+                      "fill": "$text-1"
+                    },
+                    {
+                      "type": "text",
+                      "id": "w2uHr",
+                      "name": "nav_agents_t",
+                      "fill": "$text-1",
+                      "content": "Agents",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "f7knSR",
+                  "name": "nav_mcp",
+                  "width": "fill_container",
+                  "fill": "#15161B00",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "jZs16",
+                      "name": "nav_mcp_ic",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "plug",
+                      "library": "lucide",
+                      "fill": "$text-2"
+                    },
+                    {
+                      "type": "text",
+                      "id": "wXrQ1",
+                      "name": "nav_mcp_t",
+                      "fill": "#B8B9C0",
+                      "content": "MCP",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "ItWKk",
+              "name": "sp4",
+              "width": "fill_container",
+              "height": 14
+            },
+            {
+              "type": "frame",
+              "id": "HFoGI",
+              "name": "grp_System",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "qMZLA",
+                  "name": "grp_label_wrap",
+                  "width": "fill_container",
+                  "padding": [
+                    8,
+                    10,
+                    6,
+                    10
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "W2zkem",
+                      "name": "grp_label",
+                      "fill": "$text-3",
+                      "content": "System",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "J2XCih",
+                  "name": "nav_diagnostics",
+                  "width": "fill_container",
+                  "fill": "#15161B00",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "P4cSJ",
+                      "name": "nav_diagnostics_ic",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "activity",
+                      "library": "lucide",
+                      "fill": "$text-2"
+                    },
+                    {
+                      "type": "text",
+                      "id": "qWmjK",
+                      "name": "nav_diagnostics_t",
+                      "fill": "#B8B9C0",
+                      "content": "Diagnostics",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Q8OOnm",
+                  "name": "nav_about",
+                  "width": "fill_container",
+                  "fill": "#15161B00",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "FgK0t",
+                      "name": "nav_about_ic",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "info",
+                      "library": "lucide",
+                      "fill": "$text-2"
+                    },
+                    {
+                      "type": "text",
+                      "id": "xlMNo",
+                      "name": "nav_about_t",
+                      "fill": "#B8B9C0",
+                      "content": "About",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "k3xPR",
+              "name": "sp5_5",
+              "width": "fill_container",
+              "height": 14
+            },
+            {
+              "type": "frame",
+              "id": "v0SFp",
+              "name": "grp_Archived_5",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "zYOaj",
+                  "name": "grp_label_wrap_5",
+                  "width": "fill_container",
+                  "padding": [
+                    8,
+                    10,
+                    6,
+                    10
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "eUOcI",
+                      "name": "grp_label_5",
+                      "fill": "$text-3",
+                      "content": "Archived",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 12,
+                      "fontWeight": "500"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "O8PG2",
+                  "name": "nav_archived_5",
+                  "width": "fill_container",
+                  "fill": "#15161B00",
+                  "cornerRadius": 8,
+                  "gap": 10,
+                  "padding": [
+                    8,
+                    10
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "D3bVZ",
+                      "name": "nav_archived_ic_5",
+                      "width": 16,
+                      "height": 16,
+                      "icon": "archive",
+                      "library": "lucide",
+                      "fill": "$text-2"
+                    },
+                    {
+                      "type": "text",
+                      "id": "XOstC",
+                      "name": "nav_archived_t_5",
+                      "fill": "#B8B9C0",
+                      "content": "Archived chats & missions",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "xCIFF",
+          "name": "content",
+          "width": "fill_container",
+          "height": "fill_container",
+          "layout": "vertical",
+          "padding": [
+            56,
+            160,
+            40,
+            120
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "AQseY",
+              "name": "page_title",
+              "fill": "$text-1",
+              "content": "Agents",
+              "fontFamily": "$font-ui",
+              "fontSize": 30,
+              "fontWeight": "600"
+            },
+            {
+              "type": "frame",
+              "id": "bh89T",
+              "name": "sp",
+              "width": "fill_container",
+              "height": 28
+            },
+            {
+              "type": "frame",
+              "id": "wQJnF",
+              "name": "card_env",
+              "width": "fill_container",
+              "fill": "$panel",
+              "cornerRadius": 14,
+              "stroke": "$line",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "P7QSEo",
+                  "name": "row_shell_env",
+                  "width": "fill_container",
+                  "gap": 32,
+                  "padding": [
+                    16,
+                    20
+                  ],
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "rjh8J",
+                      "name": "lbl",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "p3xzV",
+                          "name": "t",
+                          "fill": "$text-1",
+                          "content": "Shell environment",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "text",
+                          "id": "RJOGk",
+                          "name": "d",
+                          "fill": "$text-2",
+                          "textGrowth": "fixed-width",
+                          "width": "fill_container",
+                          "content": "PATH captured from your login shell (/bin/zsh) in 0.8 s. Spawned agents inherit it.",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "X14MO",
+                      "name": "btn_refresh",
+                      "fill": "$raised",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        7,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "jL9Tw",
+                          "name": "ic",
+                          "width": 13,
+                          "height": 13,
+                          "icon": "refresh-cw",
+                          "library": "lucide",
+                          "fill": "$text-2"
+                        },
+                        {
+                          "type": "text",
+                          "id": "xEyMf",
+                          "name": "t",
+                          "fill": "$text-1",
+                          "content": "Refresh",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "W3eTu",
+              "name": "sp",
+              "width": "fill_container",
+              "height": 16
+            },
+            {
+              "type": "frame",
+              "id": "rL5ZQ",
+              "name": "card_runtimes",
+              "width": "fill_container",
+              "fill": "$panel",
+              "cornerRadius": 14,
+              "stroke": "$line",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "DLYlO",
+                  "name": "block_claude",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": [
+                    18,
+                    20
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "MNPiz",
+                      "name": "hdr",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "lcDgB",
+                          "name": "name_t",
+                          "fill": "$text-1",
+                          "content": "Claude Code",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "xsdFp",
+                          "name": "badge",
+                          "fill": "#00FF9C1A",
+                          "cornerRadius": 10,
+                          "gap": 6,
+                          "padding": [
+                            3,
+                            9
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "ellipse",
+                              "id": "tlgb0",
+                              "name": "dot",
+                              "fill": "$accent",
+                              "width": 5,
+                              "height": 5
+                            },
+                            {
+                              "type": "text",
+                              "id": "xYXu6",
+                              "name": "badge_t",
+                              "fill": "$accent",
+                              "content": "Detected",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "CIKyV",
+                          "name": "flex",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "text",
+                          "id": "flJcX",
+                          "name": "cmd_t",
+                          "fill": "$text-3",
+                          "content": "claude",
+                          "fontFamily": "$font-mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UeNJF",
+                      "name": "ctl",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "fPK1Z",
+                          "name": "input",
+                          "width": "fill_container",
+                          "fill": "$bg",
+                          "cornerRadius": 8,
+                          "stroke": "$line",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
+                          "padding": [
+                            9,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "NxGMV",
+                              "name": "input_t",
+                              "fill": "$text-3",
+                              "content": "Auto — /opt/homebrew/bin/claude",
+                              "fontFamily": "$font-mono",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "wrgYc",
+                          "name": "btn_Browse…",
+                          "fill": "$raised",
+                          "cornerRadius": 8,
+                          "gap": 6,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "b9dwA",
+                              "name": "btn_t",
+                              "fill": "$text-1",
+                              "content": "Browse…",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "rz6m6",
+                  "name": "hairline",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "$hairline"
+                },
+                {
+                  "type": "frame",
+                  "id": "SW9uc",
+                  "name": "block_codex",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 12,
+                  "padding": [
+                    18,
+                    20
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "MVHgY",
+                      "name": "hdr",
+                      "width": "fill_container",
+                      "gap": 10,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "lbFXL",
+                          "name": "name_t",
+                          "fill": "$text-1",
+                          "content": "Codex",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 14,
+                          "fontWeight": "500"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "w96Ocf",
+                          "name": "badge",
+                          "fill": "#DCDCE014",
+                          "cornerRadius": 10,
+                          "gap": 6,
+                          "padding": [
+                            3,
+                            9
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "ellipse",
+                              "id": "SVE3l",
+                              "name": "dot",
+                              "fill": "$text-1",
+                              "width": 5,
+                              "height": 5
+                            },
+                            {
+                              "type": "text",
+                              "id": "JwfHI",
+                              "name": "badge_t",
+                              "fill": "$text-1",
+                              "content": "Override",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 11,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "AudBV",
+                          "name": "flex",
+                          "width": "fill_container",
+                          "height": 1
+                        },
+                        {
+                          "type": "text",
+                          "id": "bM05H",
+                          "name": "cmd_t",
+                          "fill": "$text-3",
+                          "content": "codex",
+                          "fontFamily": "$font-mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "uDl8U",
+                      "name": "ctl",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "ETfUm",
+                          "name": "input",
+                          "width": "fill_container",
+                          "fill": "$bg",
+                          "cornerRadius": 8,
+                          "stroke": "$line",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
+                          "padding": [
+                            9,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "xRXTd",
+                              "name": "input_t",
+                              "fill": "$text-1",
+                              "content": "/Users/jason/.local/share/mise/installs/codex/0.145.0/bin/codex",
+                              "fontFamily": "$font-mono",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "x0lg9",
+                          "name": "btn_Browse…",
+                          "fill": "$raised",
+                          "cornerRadius": 8,
+                          "gap": 6,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "fdGZH",
+                              "name": "btn_t",
+                              "fill": "$text-1",
+                              "content": "Browse…",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "OpPO7",
+                          "name": "btn_Reset to auto",
+                          "cornerRadius": 8,
+                          "padding": [
+                            8,
+                            10
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "r1WGha",
+                              "name": "btn_t",
+                              "fill": "$text-2",
+                              "content": "Reset to auto",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "Pa9PN",
+                      "name": "caption",
+                      "fill": "$text-3",
+                      "content": "Detected: /opt/homebrew/bin/codex",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Ioonj",
+              "name": "sp",
+              "width": "fill_container",
+              "height": 12
+            },
+            {
+              "type": "text",
+              "id": "Krl1P",
+              "name": "footnote",
+              "fill": "$text-3",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "Overrides apply to new sessions in direct chats, runners, and missions that use the runtime's default command. Runners with a custom command keep it.",
+              "fontFamily": "$font-ui",
+              "fontSize": 12,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "cXdkp",
+      "x": 17500,
+      "y": 980,
+      "name": "Spec — Agent runtime row states",
+      "width": 860,
+      "fill": "$panel",
+      "cornerRadius": 14,
+      "stroke": "$line",
+      "strokeWidth": 1,
+      "strokeAlignment": "inner",
+      "layout": "vertical",
+      "gap": 18,
+      "padding": [
+        20,
+        24
+      ],
+      "children": [
+        {
+          "type": "text",
+          "id": "wb3EJ",
+          "name": "spec_title",
+          "fill": "$text-1",
+          "content": "Agent runtime row — states",
+          "fontFamily": "$font-ui",
+          "fontSize": 14,
+          "fontWeight": "600"
+        },
+        {
+          "type": "frame",
+          "id": "C7igS",
+          "name": "state_DETECTED",
+          "width": "fill_container",
+          "gap": 24,
+          "children": [
+            {
+              "type": "frame",
+              "id": "e22qY",
+              "name": "meta",
+              "width": 200,
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "f2dFCF",
+                  "name": "state_t",
+                  "fill": "$text-3",
+                  "content": "DETECTED",
+                  "fontFamily": "$font-mono",
+                  "fontSize": 11,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "WdptR",
+                  "name": "sub_t",
+                  "fill": "$text-2",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Auto discovery found the catalog command on the captured PATH.",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "zDbee",
+              "name": "example",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "KuoHl",
+                  "name": "hdr",
+                  "width": "fill_container",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "G20lli",
+                      "name": "name_t",
+                      "fill": "$text-1",
+                      "content": "Claude Code",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "oBiey",
+                      "name": "badge",
+                      "fill": "#00FF9C1A",
+                      "cornerRadius": 10,
+                      "gap": 6,
+                      "padding": [
+                        3,
+                        9
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "op01s",
+                          "name": "dot",
+                          "fill": "$accent",
+                          "width": 5,
+                          "height": 5
+                        },
+                        {
+                          "type": "text",
+                          "id": "xxaF5",
+                          "name": "badge_t",
+                          "fill": "$accent",
+                          "content": "Detected",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "qGXpP",
+                      "name": "flex",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "MJjIZ",
+                      "name": "cmd_t",
+                      "fill": "$text-3",
+                      "content": "claude",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Jxneg",
+                  "name": "ctl",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "bzG2h",
+                      "name": "input",
+                      "width": "fill_container",
+                      "fill": "$bg",
+                      "cornerRadius": 8,
+                      "stroke": "$line",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        9,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "D2FBY",
+                          "name": "input_t",
+                          "fill": "$text-3",
+                          "content": "Auto — /opt/homebrew/bin/claude",
+                          "fontFamily": "$font-mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "dtiGe",
+                      "name": "btn_Browse…",
+                      "fill": "$raised",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "y5BQV",
+                          "name": "btn_t",
+                          "fill": "$text-1",
+                          "content": "Browse…",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "z3eLiY",
+          "name": "state_OVERRIDE",
+          "width": "fill_container",
+          "gap": 24,
+          "children": [
+            {
+              "type": "frame",
+              "id": "IzsXZ",
+              "name": "meta",
+              "width": 200,
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "IYeLj",
+                  "name": "state_t",
+                  "fill": "$text-3",
+                  "content": "OVERRIDE",
+                  "fontFamily": "$font-mono",
+                  "fontSize": 11,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "RYCLo",
+                  "name": "sub_t",
+                  "fill": "$text-2",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "User-set absolute path wins over discovery. Reset to auto clears it.",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "fGTkP",
+              "name": "example",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "jxrNU",
+                  "name": "hdr",
+                  "width": "fill_container",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "WqNx9",
+                      "name": "name_t",
+                      "fill": "$text-1",
+                      "content": "Codex",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gWz5S",
+                      "name": "badge",
+                      "fill": "#DCDCE014",
+                      "cornerRadius": 10,
+                      "gap": 6,
+                      "padding": [
+                        3,
+                        9
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "RneSg",
+                          "name": "dot",
+                          "fill": "$text-1",
+                          "width": 5,
+                          "height": 5
+                        },
+                        {
+                          "type": "text",
+                          "id": "OTGtD",
+                          "name": "badge_t",
+                          "fill": "$text-1",
+                          "content": "Override",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "eovVR",
+                      "name": "flex",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "bXR8y",
+                      "name": "cmd_t",
+                      "fill": "$text-3",
+                      "content": "codex",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Abfl9",
+                  "name": "ctl",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ZBJVT",
+                      "name": "input",
+                      "width": "fill_container",
+                      "fill": "$bg",
+                      "cornerRadius": 8,
+                      "stroke": "$line",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        9,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Z9A5jb",
+                          "name": "input_t",
+                          "fill": "$text-1",
+                          "content": "~/.local/share/mise/installs/codex/bin/codex",
+                          "fontFamily": "$font-mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "i3Xtw",
+                      "name": "btn_Browse…",
+                      "fill": "$raised",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Z6DO2Q",
+                          "name": "btn_t",
+                          "fill": "$text-1",
+                          "content": "Browse…",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "QPlv7",
+                      "name": "btn_Reset to auto",
+                      "cornerRadius": 8,
+                      "padding": [
+                        8,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "N5spGH",
+                          "name": "btn_t",
+                          "fill": "$text-2",
+                          "content": "Reset to auto",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "UCAN3",
+                  "name": "caption",
+                  "fill": "$text-3",
+                  "content": "Detected: /opt/homebrew/bin/codex",
+                  "fontFamily": "$font-mono",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "NuIja",
+          "name": "state_NOT FOUND",
+          "width": "fill_container",
+          "gap": 24,
+          "children": [
+            {
+              "type": "frame",
+              "id": "VK7Uc",
+              "name": "meta",
+              "width": 200,
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "G3zkIG",
+                  "name": "state_t",
+                  "fill": "$text-3",
+                  "content": "NOT FOUND",
+                  "fontFamily": "$font-mono",
+                  "fontSize": 11,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "ovUP4",
+                  "name": "sub_t",
+                  "fill": "$text-2",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Probe OK but command missing. Spawn fails pre-PTY with a link here.",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "C35pYE",
+              "name": "example",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "qs4am",
+                  "name": "hdr",
+                  "width": "fill_container",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "u3pyLR",
+                      "name": "name_t",
+                      "fill": "$text-1",
+                      "content": "Claude Code",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "eButN",
+                      "name": "badge",
+                      "fill": "#FF5F571A",
+                      "cornerRadius": 10,
+                      "gap": 6,
+                      "padding": [
+                        3,
+                        9
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "AKzof",
+                          "name": "dot",
+                          "fill": "#FF5F57",
+                          "width": 5,
+                          "height": 5
+                        },
+                        {
+                          "type": "text",
+                          "id": "L9vYoQ",
+                          "name": "badge_t",
+                          "fill": "#FF5F57",
+                          "content": "Not found",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Ktt1I",
+                      "name": "flex",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "RDfZy",
+                      "name": "cmd_t",
+                      "fill": "$text-3",
+                      "content": "claude",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "aWaMr",
+                  "name": "ctl",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "l1AMdZ",
+                      "name": "input",
+                      "width": "fill_container",
+                      "fill": "$bg",
+                      "cornerRadius": 8,
+                      "stroke": "$line",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        9,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "W16yDi",
+                          "name": "input_t",
+                          "fill": "$text-3",
+                          "content": "Auto — claude not found on PATH",
+                          "fontFamily": "$font-mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "rRRIi",
+                      "name": "btn_Browse…",
+                      "fill": "$raised",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "E0lEx",
+                          "name": "btn_t",
+                          "fill": "$text-1",
+                          "content": "Browse…",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "fl3hN",
+                  "name": "caption",
+                  "fill": "$text-3",
+                  "content": "Install Claude Code or set an explicit executable path.",
+                  "fontFamily": "$font-mono",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Nckxj",
+          "name": "state_CHECKING",
+          "width": "fill_container",
+          "gap": 24,
+          "children": [
+            {
+              "type": "frame",
+              "id": "JaY4V",
+              "name": "meta",
+              "width": 200,
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "pmHLN",
+                  "name": "state_t",
+                  "fill": "$text-3",
+                  "content": "CHECKING",
+                  "fontFamily": "$font-mono",
+                  "fontSize": 11,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "ORjZr",
+                  "name": "sub_t",
+                  "fill": "$text-2",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Startup or refresh probe in flight. Last known result stays active.",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "KQ5FD",
+              "name": "example",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "bE6kn",
+                  "name": "hdr",
+                  "width": "fill_container",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "RCfiq",
+                      "name": "name_t",
+                      "fill": "$text-1",
+                      "content": "Codex",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "EGNUM",
+                      "name": "badge",
+                      "fill": "#5A5C661A",
+                      "cornerRadius": 10,
+                      "gap": 6,
+                      "padding": [
+                        3,
+                        9
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "mX2z1",
+                          "name": "badge_ic",
+                          "width": 11,
+                          "height": 11,
+                          "icon": "loader",
+                          "library": "lucide",
+                          "fill": "$text-3"
+                        },
+                        {
+                          "type": "text",
+                          "id": "qtyIV",
+                          "name": "badge_t",
+                          "fill": "$text-3",
+                          "content": "Checking…",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hF7kl",
+                      "name": "flex",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "pvyA3",
+                      "name": "cmd_t",
+                      "fill": "$text-3",
+                      "content": "codex",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "KGtuR",
+                  "name": "ctl",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "HP8S3",
+                      "name": "input",
+                      "width": "fill_container",
+                      "fill": "$bg",
+                      "cornerRadius": 8,
+                      "stroke": "$line",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        9,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "wwtXB",
+                          "name": "input_t",
+                          "fill": "$text-3",
+                          "content": "Auto — detecting…",
+                          "fontFamily": "$font-mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "SH8bk",
+                      "name": "btn_Browse…",
+                      "fill": "$raised",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "jTKkI",
+                          "name": "btn_t",
+                          "fill": "$text-1",
+                          "content": "Browse…",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "oy9sU",
+          "name": "state_PROBE TIMED OUT",
+          "width": "fill_container",
+          "gap": 24,
+          "children": [
+            {
+              "type": "frame",
+              "id": "bmVad",
+              "name": "meta",
+              "width": 200,
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "ZFAgU",
+                  "name": "state_t",
+                  "fill": "$text-3",
+                  "content": "PROBE TIMED OUT",
+                  "fontFamily": "$font-mono",
+                  "fontSize": 11,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "IfiNB",
+                  "name": "sub_t",
+                  "fill": "$text-2",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Shell trouble, distinct from Not installed. Refresh retries.",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "z66O6L",
+              "name": "example",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "TE1TK",
+                  "name": "hdr",
+                  "width": "fill_container",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "gTjc6",
+                      "name": "name_t",
+                      "fill": "$text-1",
+                      "content": "Claude Code",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "UnXjO",
+                      "name": "badge",
+                      "fill": "#FEBC2E1A",
+                      "cornerRadius": 10,
+                      "gap": 6,
+                      "padding": [
+                        3,
+                        9
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "C6dAzq",
+                          "name": "dot",
+                          "fill": "#FEBC2E",
+                          "width": 5,
+                          "height": 5
+                        },
+                        {
+                          "type": "text",
+                          "id": "b0iRL",
+                          "name": "badge_t",
+                          "fill": "#FEBC2E",
+                          "content": "Probe timed out",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "qbL1o",
+                      "name": "flex",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "kVZtQ",
+                      "name": "cmd_t",
+                      "fill": "$text-3",
+                      "content": "claude",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ZKFmX",
+                  "name": "ctl",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "GRy7b",
+                      "name": "input",
+                      "width": "fill_container",
+                      "fill": "$bg",
+                      "cornerRadius": 8,
+                      "stroke": "$line",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        9,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Snr1p",
+                          "name": "input_t",
+                          "fill": "$text-3",
+                          "content": "Auto — /opt/homebrew/bin/claude",
+                          "fontFamily": "$font-mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "gtjKo",
+                      "name": "btn_Browse…",
+                      "fill": "$raised",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "vb8s4",
+                          "name": "btn_t",
+                          "fill": "$text-1",
+                          "content": "Browse…",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "xEjJy",
+                  "name": "caption",
+                  "fill": "$text-3",
+                  "content": "Login shell didn't respond in 8 s — using last saved PATH.",
+                  "fontFamily": "$font-mono",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "rxsC3",
+          "name": "state_INVALID OVERRIDE",
+          "width": "fill_container",
+          "gap": 24,
+          "children": [
+            {
+              "type": "frame",
+              "id": "RrhC2",
+              "name": "meta",
+              "width": 200,
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "Efgn2",
+                  "name": "state_t",
+                  "fill": "$text-3",
+                  "content": "INVALID OVERRIDE",
+                  "fontFamily": "$font-mono",
+                  "fontSize": 11,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "t9eZoV",
+                  "name": "sub_t",
+                  "fill": "$text-2",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Save rejected inline; runtime keeps its previous value.",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "fvIzF",
+              "name": "example",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 10,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "u458q",
+                  "name": "hdr",
+                  "width": "fill_container",
+                  "gap": 10,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "A3UCTw",
+                      "name": "name_t",
+                      "fill": "$text-1",
+                      "content": "Codex",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 14,
+                      "fontWeight": "500"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "bV1Ze",
+                      "name": "badge",
+                      "fill": "#FF5F571A",
+                      "cornerRadius": 10,
+                      "gap": 6,
+                      "padding": [
+                        3,
+                        9
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "ellipse",
+                          "id": "WCQNj",
+                          "name": "dot",
+                          "fill": "#FF5F57",
+                          "width": 5,
+                          "height": 5
+                        },
+                        {
+                          "type": "text",
+                          "id": "b8sxvz",
+                          "name": "badge_t",
+                          "fill": "#FF5F57",
+                          "content": "Invalid",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 11,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hf8F2",
+                      "name": "flex",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "PXlR3",
+                      "name": "cmd_t",
+                      "fill": "$text-3",
+                      "content": "codex",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 12,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "vjjQX",
+                  "name": "ctl",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "c1zZ1",
+                      "name": "input",
+                      "width": "fill_container",
+                      "fill": "$bg",
+                      "cornerRadius": 8,
+                      "stroke": "#FF5F57",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "padding": [
+                        9,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "dJznM",
+                          "name": "input_t",
+                          "fill": "$text-1",
+                          "content": "/Users/jason/notes/codex.txt",
+                          "fontFamily": "$font-mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ZyG26",
+                      "name": "btn_Browse…",
+                      "fill": "$raised",
+                      "cornerRadius": 8,
+                      "gap": 6,
+                      "padding": [
+                        8,
+                        12
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "EG06P",
+                          "name": "btn_t",
+                          "fill": "$text-1",
+                          "content": "Browse…",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "C4Pge",
+                      "name": "btn_Reset to auto",
+                      "cornerRadius": 8,
+                      "padding": [
+                        8,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "WAEGo",
+                          "name": "btn_t",
+                          "fill": "$text-2",
+                          "content": "Reset to auto",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 12,
+                          "fontWeight": "500"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "wTD9H",
+                  "name": "caption",
+                  "fill": "#FF5F57",
+                  "content": "Not an executable file.",
+                  "fontFamily": "$font-mono",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
     }
   ],
   "variables": {

--- a/docs/arch/arch.md
+++ b/docs/arch/arch.md
@@ -372,13 +372,17 @@ A pseudo-terminal gives the child a real terminal on stdin/stdout/ stderr (full 
 
 `portable-pty` is the in-process PTY library. The session runtime is encapsulated behind a `SessionRuntime` trait so the storage layer (SessionManager) doesn't know whether the runtime is in-process PTY, a tmux multiplexer, or anything else; today only `PtyRuntime` is shipped.
 
+Login-shell discovery is startup-safe and shared. Setup seeds `SessionManager` from the last successful `LoginShellEnv` snapshot in `_app_state.login_shell_env_lkg`, paints the app, then runs the configured shell probe on a background thread with a five-second deadline. A successful probe atomically swaps the environment used by future spawns, persists the new snapshot, and emits `runtime/changed`; timeout, spawn failure, empty capture, or a missing shell leaves the prior snapshot active and records the typed outcome for Settings → Agents. Refresh is explicit after launch and follows the same path.
+
+Built-in runtime commands are resolved in Rust against the same direct-chat PATH the child receives. Precedence is a valid backend-persisted runtime override, then the first regular executable with an executable bit found by walking the composed PATH, then the bare catalog command only while discovery is still in flight. Once discovery completes, a missing executable fails before PTY creation with a pointer to Settings → Agents. Resolution substitutes only a runner command that still equals the runtime catalog default; legacy custom commands remain byte-for-byte unchanged. Runtime-only sessions record the effective command, reuse a still-valid recorded absolute path on resume, and re-resolve when that file disappears.
+
 ```
 portable_pty::openpty(rows, cols)
   ├─ master handle  → kept by SessionManager
   └─ slave handle   → given to child via spawn_command()
 
 Child inherits (mission session):
-  PATH              = $APPDATA/runner/bin:<login-shell PATH>
+  PATH              = <mission shim>:$APPDATA/runner/bin:<login-shell PATH>:<curated CLI dirs>:<process PATH>
   RUNNER_CREW_ID    = <ulid>
   RUNNER_MISSION_ID = <ulid>
   RUNNER_HANDLE     = <slot_handle>
@@ -754,7 +758,7 @@ sessions (
   -- continue the prior conversation after a stop or app restart.
   agent_session_key TEXT,
   agent_runtime TEXT,                 -- runtime-only direct chat identity
-  agent_command TEXT,
+  agent_command TEXT,                 -- effective executable for runtime-only/pinned sessions
   archived_at TEXT,
   title TEXT,                         -- direct-chat title; null for mission sessions
   pinned_at TEXT

--- a/docs/features/37-agent-runtime-executable-settings.md
+++ b/docs/features/37-agent-runtime-executable-settings.md
@@ -13,7 +13,7 @@ Runtime-only direct chats have no configurable command, and the create/edit runn
 
 ### In scope
 
-- **Agent runtimes settings pane.** Add an Agent runtimes pane under Settings → Integrations. Show one row/card for each first-class runtime returned by the backend registry, initially Claude Code and Codex.
+- **Agents settings pane.** Add an Agents pane to the Integrations group in Settings, next to MCP. Show one row for each first-class runtime returned by the backend registry, initially Claude Code and Codex.
 - **Detected executable.** Resolve each runtime's catalog command against Runner's composed user `$PATH` and show the resulting absolute executable path, or a clear Not found / Detection failed state.
 - **Executable override.** Let the user enter or pick an absolute executable path per runtime. An empty override means automatic discovery. Validate that a non-empty path exists, is a regular file, and is executable before saving.
 - **Resolution precedence.** Use the explicit runtime override first, then the automatically detected executable, then the catalog command only when it can be resolved through the effective child `$PATH`. Do not silently report a configured runtime as available when none of those paths resolves.
@@ -24,10 +24,11 @@ Runtime-only direct chats have no configurable command, and the create/edit runn
 - **Slow shell initialization.** Replace the current all-or-nothing two-second startup probe with a non-blocking or otherwise startup-safe discovery flow that accommodates realistic zsh/Oh My Zsh initialization. Preserve the last known good result on timeout and expose the timeout as a diagnosable state instead of silently dropping to launchd's stripped environment.
 - **Diagnostics.** Log the selected shell, discovery duration, success/failure reason, and resolved runtime executable paths without logging unrelated environment values. Surface enough status in Settings for a user to distinguish Not installed from Shell probe timed out.
 - **Backend persistence.** Store overrides in backend-owned app settings so all windows and all Rust spawn paths share the same value; do not make localStorage the source of truth for executable selection.
-- **Design first.** Add the settings pane and its detected/override/error/refresh states to `design/runner-mvp-design.pen` before implementation.
+- **Design first.** The pane and its states are designed in `design/runner-setting.pen`: frame `Settings — Agents` (node `Zes2l`) for the pane layout, and `Spec — Agent runtime row states` (node `cXdkp`) for the six row states (detected, override, not-found, checking, probe-timed-out, invalid-override).
 
 ### Out of scope
 
+- User-defined custom runtimes (the registry-as-data extension in #279). Deliberately cut for now: built-ins only, so the pane stays simple. The backend registry shape should not preclude adding custom rows later.
 - Installing, upgrading, or authenticating Claude Code or Codex.
 - Accepting aliases or shell functions as runtime executables; Runner spawns a real process and requires an executable file.
 - General-purpose editing of the child process `$PATH`.
@@ -39,7 +40,7 @@ Runtime-only direct chats have no configurable command, and the create/edit runn
 
 ### Phase 1 — UX design and settings contract
 
-- Design Settings → Integrations → Agent runtimes in `design/runner-mvp-design.pen`, including detected, overridden, not-found, probing, timeout, validation-error, and refresh states.
+- ~~Design the Agents pane~~ — done in `design/runner-setting.pen` (`Settings — Agents` + `Spec — Agent runtime row states`), covering detected, overridden, not-found, checking, probe-timed-out, invalid-override, and refresh states.
 - Define a backend runtime-settings shape keyed by stable runtime name with an optional executable override.
 - Define the effective-command precedence and legacy `runner.command` compatibility rules in tests before changing spawn behavior.
 
@@ -74,21 +75,23 @@ Runtime-only direct chats have no configurable command, and the create/edit runn
 
 ## Verification
 
-- [ ] Settings → Integrations → Agent runtimes shows Claude Code and Codex from the backend registry.
+Unchecked items below require manual app verification.
+
+- [ ] Settings → Agents (Integrations group) shows Claude Code and Codex from the backend registry.
 - [ ] A standard executable on the captured login-shell `$PATH` is displayed as an absolute detected path.
 - [ ] A slow zsh/Oh My Zsh startup does not silently discard a previously valid `$PATH` after two seconds.
-- [ ] Bash, zsh, and other explicitly supported shells use documented, tested startup semantics.
+- [x] Bash, zsh, and other explicitly supported shells use documented, tested startup semantics.
 - [ ] Missing, invalid, or unsupported login shells produce a visible detection failure rather than a misleading Not installed state.
 - [ ] A user can refresh discovery after installing Codex without restarting Runner.
-- [ ] A valid absolute override is persisted and used by runtime-only direct chats.
-- [ ] The override is used by runner and mission spawns whose stored command is the runtime's catalog default.
-- [ ] A runner with a custom non-default command continues using that command.
-- [ ] Clearing an override returns the runtime to automatic discovery.
+- [x] A valid absolute override is persisted and used by runtime-only direct chats.
+- [x] The override is used by runner and mission spawns whose stored command is the runtime's catalog default.
+- [x] A runner with a custom non-default command continues using that command.
+- [x] Clearing an override returns the runtime to automatic discovery.
 - [ ] Nonexistent, non-file, and non-executable overrides are rejected with inline errors.
-- [ ] Aliases and shell functions are not accepted as executable paths.
-- [ ] A missing runtime fails before PTY spawn with actionable copy pointing to Agent runtimes settings.
+- [x] Aliases and shell functions are not accepted as executable paths.
+- [x] A missing runtime fails before PTY spawn with actionable copy pointing to Agents settings.
 - [ ] Discovery logs include shell, duration, outcome, and resolved executable without dumping the user's full environment.
 - [ ] Settings and effective command behavior remain consistent across multiple app windows.
-- [ ] `pnpm exec tsc --noEmit` passes.
-- [ ] `pnpm run lint` passes.
-- [ ] Relevant Rust tests pass, followed by `cargo test --workspace` when implementation is complete.
+- [x] `pnpm exec tsc --noEmit` passes.
+- [x] `pnpm run lint` passes.
+- [x] Relevant Rust tests pass, followed by `cargo test --workspace` when implementation is complete.

--- a/docs/impls/0033-runtime-executable-discovery-and-overrides.md
+++ b/docs/impls/0033-runtime-executable-discovery-and-overrides.md
@@ -1,0 +1,94 @@
+# Runtime executable discovery + overrides
+
+## Status
+
+Implemented. Tracking issue [#279](https://github.com/yicheng47/runner/issues/279), scoped to built-in runtimes only — the user-defined custom-runtime extension is explicitly cut (see spec 37 "Out of scope"). Spec: `docs/features/37-agent-runtime-executable-settings.md`. Design: `design/runner-setting.pen`, frame `Settings — Agents` (node `Zes2l`) and `Spec — Agent runtime row states` (node `cXdkp`).
+
+## Problem
+
+Runner launches agent CLIs by bare catalog names (`claude`, `codex`) resolved inside the child PTY against a PATH composed at spawn time (`launch.rs:78`). The PATH's best ingredient comes from a login-shell probe (`shell_path.rs:84`) that is fragile in four ways:
+
+1. **It blocks startup.** `resolve_login_shell_env()` runs synchronously inside Tauri `setup` (`lib.rs:171`) before the first window paint; worst case adds ~2.5 s (2 s deadline + 500 ms drain grace) to every cold start.
+2. **It is all-or-nothing with no memory.** On timeout the app silently falls to launchd's stripped env — one `log::warn` no user ever sees. A launch that timed out loses the PATH a previous launch captured successfully. Slow zsh/Oh My Zsh inits are exactly the setups that also rely on version managers, so the users most likely to time out are the users most hurt by the fallback.
+3. **The fallback seed is thin.** `FALLBACK_CLI_DIRS` (`launch.rs:32`) covers Homebrew, `~/.local/bin`, `~/.cargo/bin`, `~/.npm-global/bin` — but not the version-manager shim dirs (mise, asdf, volta, fnm, nvm, pnpm, bun) where agent CLIs increasingly live.
+4. **Nothing is observable or fixable.** Runner never resolves the executable itself, so "not installed", "probe timed out", and "PATH missing one dir" all present identically: `command not found` printed by the shell into a freshly spawned dead PTY. There is no refresh short of relaunching the app, and no override of any kind.
+
+Reference point: Orca converged on the same architecture-level answers (probe `$SHELL -ilc`, no shell/PATH configuration on POSIX, per-agent executable override as the escape hatch) but hardened the probe: non-blocking startup, 5 s timeout, typed failure reasons, sync seed covering version-manager dirs, on-demand refresh from their settings pane. This impl adopts those refinements without adopting their agent-inside-login-shell spawn model — Runner keeps the agent as PTY root (clean exit observation, byte-quiescence idle detection).
+
+## Key Decisions
+
+1. **Discovery becomes a background service with a persisted last-known-good result.** `resolve_login_shell_env` grows into a small discovery module that returns a structured `DiscoveryResult { shell, outcome, duration, env }` where `outcome ∈ {Ok, Timeout, SpawnError, EmptyCapture, NoShell}`. At startup, `setup` seeds the manager synchronously from the last-known-good snapshot persisted in `_app_state` (key `login_shell_env_lkg`, JSON: env + shell + captured_at) — a fast SQLite read — then fires the real probe on a background thread. On success the probe swaps the live env, persists the new snapshot, and emits `runtime/changed`. On failure the last-known-good stays in effect and the failure reason is kept for the settings pane. Timeout goes from 2 s to 5 s — it no longer costs startup anything. Never re-probe implicitly beyond launch; explicit refresh only.
+2. **`SessionManager.shell_env` becomes shared and swappable.** Today it is a plain owned field set once by `SessionManager::new` (`manager/mod.rs:606,714`). It becomes `Arc<RwLock<LoginShellEnv>>` (std `RwLock`; reads clone, writes are rare). The discovery service holds the same handle. `base_spawn_spec` (`spawn.rs:66,89`) reads through the lock. No spawn ever blocks on discovery: if the probe is still pending, spawn proceeds with the seeded env (last-known-good or default) exactly as today.
+3. **Runner resolves executables itself, in Rust, by walking the composed PATH.** New resolver: split the same PATH `compose_path` produces for a direct chat (no shim/bundled dirs), test each `dir/<command>` for regular-file + executable bit (`0o111`), first hit wins. No shell involvement — aliases and functions can mask binaries from `command -v`, and the child never sees them anyway (same reasoning Orca documents in `posix-command-path-lookup.ts`). This resolution is what the settings pane displays and what spawn substitutes, so "what settings shows" and "what spawn does" cannot drift.
+4. **Fatter sync seed.** Extend `FALLBACK_CLI_DIRS` composition with the version-manager dirs: `~/.local/share/mise/shims`, `~/.asdf/shims`, `~/.volta/bin`, `~/.bun/bin`, `~/.deno/bin`, `~/Library/pnpm`, `~/.local/share/fnm/aliases/default/bin`, and enumerated `~/.nvm/versions/node/*/bin` (newest first, only when the dir exists). Rationale: agent CLIs are typically `#!/usr/bin/env node` scripts — the shim dirs cover both the CLI and the `node` it needs. Keep the list curated and home-relative; dedup already happens in `compose_path`.
+5. **Overrides live in `_app_state`, one JSON key, no migration.** `runtime_overrides` → `{"claude-code": "/abs/path", ...}`. `_app_state` (`db.rs:191`) is the existing backend KV store and overrides are exactly key/value app state. Set validates absolute + regular file + executable and returns a structured error for inline display; empty/None clears back to auto. localStorage is never the source of truth (spec 37 requirement — all windows and all Rust spawn paths must agree).
+6. **Effective-command precedence is one function, applied at the existing choke points.** `effective_runtime_command(runtime) -> {command, source}` with precedence: valid override → detected absolute path → bare catalog name (only while discovery has produced nothing — the child PATH then does its best, as today). A vanished override (file deleted since set) is skipped for spawn — fall through to detected — and surfaced as the Invalid state in the pane; spawning something that works beats failing loudly on a stale preference, but the pane must not pretend the override is in effect. Substitution applies only when the stored command equals the runtime's catalog default: `runtime_direct_runner` (`manager/mod.rs:1153`, already the single choke point for runtime-only chats and runner-less resume), `resolve_runtime_override` (`manager/mod.rs:1119`, slot overrides), and the runner-backed spawn/resume paths where `runner.command` is loaded. A legacy runner row with a genuinely custom command is never touched.
+7. **Not-found fails before the PTY, with a pointer.** When discovery has completed and neither override nor detection resolves the runtime, spawn commands return a structured error naming the runtime and directing to Settings → Agents, instead of forking a PTY that prints `command not found`. If discovery is still pending, spawn proceeds (decision 2) — never block or reject on an unfinished probe.
+8. **Sessions keep recording the effective command; resume re-validates it.** `spawn_direct_inner` already stamps `sessions.agent_command` (`spawn.rs:755-770`) and runner-less resume already honors it (`spawn.rs:1067-1081` → `runtime_direct_runner(runtime, snap.agent_command)`). With substitution, the stamped value becomes an absolute path. Resume adds one check: if the stored command is an absolute path that no longer exists, re-resolve through `effective_runtime_command` instead of failing on a dead path (spec 37: "resume uses the same executable unless the file no longer exists").
+9. **New Tauri surface follows the `<domain>/<verb>` event convention — and actually emits.** Commands: `runtime_status_list` (per-runtime: catalog fields + detected path + override + state + probe diagnostics), `runtime_set_override`, `runtime_clear_override`, `runtime_refresh` (force re-probe + re-resolve). All mutations and every probe completion emit `runtime/changed` with an empty payload; listeners refetch (the `runner/changed` pattern from `Runners.tsx:85`). Note the counter-precedent to avoid: the Tauri `runner_create/update` handlers mutate without emitting — do not copy that.
+10. **The pane is read-mostly and mirrors the design nodes exactly.** New `AgentsPane` under Integrations (above MCP, icon `bot`, PaneKey `"agents"`): a shell-environment card (shell, probe outcome, duration, refresh) and one row per built-in runtime with the six states from `Spec — Agent runtime row states`: detected, override, not-found, checking, probe-timed-out, invalid-override. No shell picker, no PATH editor — the probe stays configuration-free.
+
+## Goals
+
+- Cold start never waits on the shell probe; a probe timeout on this launch cannot lose the PATH captured on a previous launch.
+- Settings → Agents shows, for each built-in runtime, the absolute executable Runner will actually spawn, or a state that distinguishes "not installed" from "shell probe failed" from "override is broken".
+- A user whose CLI lives behind a version manager can fix Runner without touching their shell: install → Refresh → detected, or Browse → override.
+- Spawning a runtime whose executable cannot resolve fails before the PTY with actionable copy, not `command not found` in a dead terminal.
+- A runner row with a custom command, and an existing session's recorded command, behave exactly as before.
+
+## Non-Goals
+
+- User-defined custom runtimes (registry-as-data, capability profiles) — cut from #279's scope for now; nothing here may preclude them, and nothing here builds them.
+- Shell selection or PATH editing UI. `$SHELL` + fallback is the probe; the override is the escape hatch.
+- Accepting aliases, shell functions, or non-absolute overrides.
+- Changing the spawn model (agent stays PTY root; no login-shell wrapper à la Orca).
+- Windows support beyond keeping the existing unsupported state.
+- Unifying the hardcoded frontend `RUNTIME_OPTIONS` mirror (`src/components/ui/runtimes.ts`) with the backend catalog. Its `defaultCommand` values are the bare catalog names, which is precisely what new runner rows should keep storing (no frozen absolute paths) — leave it.
+
+## Implementation Phases
+
+### Phase 1 — backend: discovery service + shared env
+
+- `shell_path.rs`: restructure around `DiscoveryResult` (shell, outcome enum, duration, `LoginShellEnv`); keep the marker probe and parser as-is; timeout 2 s → 5 s. Log line per probe: shell, duration, outcome, nothing else from the env (spec 37 diagnostics rule).
+- `db.rs` / small store helper: read/write the `login_shell_env_lkg` and `runtime_overrides` keys in `_app_state`.
+- `session/manager/mod.rs`: `shell_env` → `Arc<RwLock<LoginShellEnv>>`; constructor takes the handle; `base_spawn_spec` and `compose` read through it.
+- `lib.rs` setup: synchronous seed from last-known-good → construct manager → spawn background probe thread → on completion swap env + persist + emit `runtime/changed`. Startup no longer blocks (delete the inline resolve at `:171`).
+- `launch.rs`: extend the fallback seed per decision 4 (a `version_manager_dirs(home)` helper feeding `compose_path`; nvm enumeration behind an exists-check).
+- Tests: LKG round-trip; timeout keeps prior env; probe outcome mapping; seed dirs dedup and ordering (shell PATH still wins over seed); manager reads swapped env on next spawn.
+
+### Phase 2 — backend: resolution, overrides, spawn integration
+
+- New `runtime_status` module (or extend `router/runtime.rs`): the PATH-walk resolver (decision 3), `effective_runtime_command` (decision 6), and per-runtime status assembly for the pane.
+- Override store: get/set/clear with validation (absolute, regular file, executable bit) and structured validation errors.
+- Choke-point integration: `runtime_direct_runner` (`manager/mod.rs:1153`) resolves through `effective_runtime_command` when no explicit command is passed; `resolve_runtime_override` (`:1119`) substitutes the effective command instead of raw `def.command`; runner-backed spawn/resume substitute only when `runner.command == catalog default`; resume re-validates a stored absolute `agent_command` (decision 8).
+- Pre-spawn not-found error (decision 7) returned from `session_start_runtime`, `session_start_direct`, mission spawn, and resume paths.
+- Watch item: `command_line_matches_recorded_agent` (`pty_runtime.rs:1094`) must keep matching when `agent_command` is an absolute path — add a test against a `ps`-style command line for both bare and absolute spawn forms.
+- Watch item: the launch script must quote an absolute command path containing spaces the same way it already quotes args.
+- Tests: precedence (override > detected > catalog); vanished-override fallthrough; custom runner command untouched; catalog-default runner substituted; resume with live stored path (no re-resolution), with dead stored path (re-resolves), runner-backed vs runtime-only; not-found error carries runtime name; probe-pending spawn proceeds with bare name.
+
+### Phase 3 — Tauri commands + frontend Agents pane
+
+- `commands/runtime.rs`: `runtime_status_list`, `runtime_set_override`, `runtime_clear_override`, `runtime_refresh`; register in `lib.rs`; every mutation and probe completion emits `runtime/changed`.
+- `src/lib/api.ts`: `api.runtime.status()/setOverride()/clearOverride()/refresh()` + types.
+- `src/components/settings/AgentsPane.tsx`: shell-environment card + per-runtime rows per the design nodes; `PaneHeader`/`SettingsCard`/`SettingsRow` primitives where they fit, `McpPane`'s row/status-line shapes for the richer rows; Browse via `@tauri-apps/plugin-dialog` file picker; inline validation errors from `runtime_set_override`; listen on `runtime/changed`.
+- `src/pages/SettingsPage.tsx`: PaneKey `"agents"`, `PANES` entry (label "Agents", icon `Bot`), Integrations group before `mcp` (`:102`).
+- Frontend checks: `pnpm exec tsc --noEmit`, `pnpm run lint`.
+
+### Phase 4 — diagnostics, docs, verification
+
+- Startup + spawn log lines that make timeout / not-found / active-override distinguishable in `runner_logs_reveal` output.
+- `docs/arch/`: update the login-shell environment capture description (background probe, LKG, refresh) and document the command precedence.
+- Spec 37 verification checklist pass; `cargo fmt` + `clippy` + `cargo test --workspace`.
+
+## Verification
+
+Unchecked items below require manual app verification.
+
+- [ ] Cold start paints without waiting on the probe; probe result lands afterwards and the pane updates via `runtime/changed`.
+- [ ] Kill the probe artificially (bogus slow rc) → previous launch's PATH still spawns agents; pane shows probe-timed-out with duration.
+- [x] `runtime_status_list` detected path equals what a spawned PTY actually execs (same composed PATH).
+- [ ] Override set/clear round-trips through `_app_state` and takes effect for direct chat, runner-backed chat (default command), mission slot, and resume — without app restart, in all windows.
+- [x] Runner row with custom command spawns that command unchanged.
+- [x] Vanished override: spawn falls back to detected; pane shows invalid state.
+- [x] Not-found runtime: spawn fails pre-PTY naming the runtime; no dead terminal.
+- [ ] Full checklist in spec 37 § Verification.

--- a/src-tauri/src/commands/node.rs
+++ b/src-tauri/src/commands/node.rs
@@ -598,10 +598,20 @@ mod tests {
 
     fn test_app_in(app_data_dir: PathBuf) -> tauri::App<tauri::test::MockRuntime> {
         let app = tauri::test::mock_app();
+        let runtime_shell_env = Arc::new(std::sync::RwLock::new(LoginShellEnv::default()));
+        let runtime_discovery = Arc::new(std::sync::RwLock::new(
+            crate::shell_path::DiscoveryState::pending(),
+        ));
         app.manage(AppState {
             db: Arc::new(db::open_in_memory().unwrap()),
             app_data_dir,
-            sessions: SessionManager::new(LoginShellEnv::default(), Arc::new(InertRuntime)),
+            sessions: SessionManager::new(
+                Arc::clone(&runtime_shell_env),
+                Arc::clone(&runtime_discovery),
+                Arc::new(InertRuntime),
+            ),
+            runtime_shell_env,
+            runtime_discovery,
             buses: BusRegistry::new(),
             routers: RouterRegistry::new(),
             mcp: Arc::new(McpHandle::new()),

--- a/src-tauri/src/commands/runtime.rs
+++ b/src-tauri/src/commands/runtime.rs
@@ -1,4 +1,9 @@
 use serde::Serialize;
+use tauri::{Emitter, State};
+
+use crate::error::{Error, Result};
+use crate::runtime_status::{OverrideValidationError, RuntimeStatusResponse};
+use crate::AppState;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct RuntimeDefinition {
@@ -17,4 +22,90 @@ pub async fn runtime_list() -> Vec<RuntimeDefinition> {
             command: runtime.command.to_string(),
         })
         .collect()
+}
+
+#[tauri::command]
+pub async fn runtime_status_list(state: State<'_, AppState>) -> Result<RuntimeStatusResponse> {
+    crate::runtime_status::status_list(
+        &state.db,
+        &state.runtime_shell_env,
+        &state.runtime_discovery,
+    )
+}
+
+#[tauri::command]
+pub async fn runtime_set_override(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    runtime: String,
+    path: String,
+) -> std::result::Result<RuntimeStatusResponse, OverrideValidationError> {
+    let path = path.trim();
+    if crate::router::runtime::runtime_definition(&runtime).is_none() {
+        return Err(OverrideValidationError {
+            code: "unknown_runtime".into(),
+            message: format!("Unknown runtime: {runtime}."),
+        });
+    }
+    if path.is_empty() {
+        crate::db::set_runtime_override(&state.db, &runtime, None).map_err(persistence_error)?;
+    } else {
+        crate::runtime_status::validate_override(&runtime, path)?;
+        crate::db::set_runtime_override(&state.db, &runtime, Some(path))
+            .map_err(persistence_error)?;
+        log::info!("runtime override saved: runtime={} path={}", runtime, path);
+    }
+    app.emit("runtime/changed", ())
+        .map_err(|error| persistence_error(Error::msg(error.to_string())))?;
+    crate::runtime_status::status_list(
+        &state.db,
+        &state.runtime_shell_env,
+        &state.runtime_discovery,
+    )
+    .map_err(persistence_error)
+}
+
+#[tauri::command]
+pub async fn runtime_clear_override(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+    runtime: String,
+) -> Result<RuntimeStatusResponse> {
+    if crate::router::runtime::runtime_definition(&runtime).is_none() {
+        return Err(Error::msg(format!("unknown runtime: {runtime}")));
+    }
+    crate::db::set_runtime_override(&state.db, &runtime, None)?;
+    log::info!("runtime override cleared: runtime={runtime}");
+    app.emit("runtime/changed", ())
+        .map_err(|error| Error::msg(format!("emit runtime/changed: {error}")))?;
+    crate::runtime_status::status_list(
+        &state.db,
+        &state.runtime_shell_env,
+        &state.runtime_discovery,
+    )
+}
+
+#[tauri::command]
+pub async fn runtime_refresh(
+    state: State<'_, AppState>,
+    app: tauri::AppHandle,
+) -> Result<RuntimeStatusResponse> {
+    crate::runtime_status::refresh_background_discovery(
+        app,
+        state.db.clone(),
+        state.runtime_shell_env.clone(),
+        state.runtime_discovery.clone(),
+    )?;
+    crate::runtime_status::status_list(
+        &state.db,
+        &state.runtime_shell_env,
+        &state.runtime_discovery,
+    )
+}
+
+fn persistence_error(error: Error) -> OverrideValidationError {
+    OverrideValidationError {
+        code: "persistence_failed".into(),
+        message: error.to_string(),
+    }
 }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -4,11 +4,13 @@
 // The pool is opened once at app start with WAL mode + foreign keys; later
 // chunks pull connections from it via Tauri state.
 
+use std::collections::BTreeMap;
 use std::path::Path;
 
 use r2d2::Pool;
 use r2d2_sqlite::SqliteConnectionManager;
-use rusqlite::{params, Connection};
+use rusqlite::{params, Connection, OptionalExtension};
+use serde::{Deserialize, Serialize};
 
 use crate::error::Result;
 
@@ -31,6 +33,7 @@ fn build_pool(manager: SqliteConnectionManager, max_size: u32, seed: bool) -> Re
     let pool = Pool::builder().max_size(max_size).build(manager)?;
     let mut conn = pool.get()?;
     run_migrations(&mut conn)?;
+    ensure_app_state_table(&conn)?;
     if seed {
         seed_defaults(&mut conn)?;
     }
@@ -159,6 +162,92 @@ const MIGRATIONS: &[(i64, &str)] = &[
 // starting state.
 
 const SEED_MARKER_KEY: &str = "default_crew_seeded";
+const LOGIN_SHELL_ENV_LKG_KEY: &str = "login_shell_env_lkg";
+const RUNTIME_OVERRIDES_KEY: &str = "runtime_overrides";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LoginShellEnvLkg {
+    pub env: crate::shell_path::LoginShellEnv,
+    pub shell: String,
+    pub captured_at: String,
+}
+
+fn ensure_app_state_table(conn: &Connection) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS _app_state (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+         )",
+    )?;
+    Ok(())
+}
+
+fn app_state_get(conn: &Connection, key: &str) -> Result<Option<String>> {
+    conn.query_row(
+        "SELECT value FROM _app_state WHERE key = ?1",
+        params![key],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(Into::into)
+}
+
+fn app_state_set(conn: &Connection, key: &str, value: &str) -> Result<()> {
+    conn.execute(
+        "INSERT INTO _app_state (key, value) VALUES (?1, ?2)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        params![key, value],
+    )?;
+    Ok(())
+}
+
+pub fn login_shell_env_lkg(pool: &DbPool) -> Result<Option<LoginShellEnvLkg>> {
+    let conn = pool.get()?;
+    app_state_get(&conn, LOGIN_SHELL_ENV_LKG_KEY)?
+        .map(|value| serde_json::from_str(&value).map_err(Into::into))
+        .transpose()
+}
+
+pub fn set_login_shell_env_lkg(pool: &DbPool, snapshot: &LoginShellEnvLkg) -> Result<()> {
+    let conn = pool.get()?;
+    app_state_set(
+        &conn,
+        LOGIN_SHELL_ENV_LKG_KEY,
+        &serde_json::to_string(snapshot)?,
+    )
+}
+
+pub fn runtime_overrides(pool: &DbPool) -> Result<BTreeMap<String, String>> {
+    let conn = pool.get()?;
+    Ok(app_state_get(&conn, RUNTIME_OVERRIDES_KEY)?
+        .map(|value| serde_json::from_str(&value))
+        .transpose()?
+        .unwrap_or_default())
+}
+
+pub fn set_runtime_override(pool: &DbPool, runtime: &str, path: Option<&str>) -> Result<()> {
+    let mut conn = pool.get()?;
+    let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    let mut overrides: BTreeMap<String, String> = app_state_get(&tx, RUNTIME_OVERRIDES_KEY)?
+        .map(|value| serde_json::from_str(&value))
+        .transpose()?
+        .unwrap_or_default();
+    match path {
+        Some(path) => {
+            overrides.insert(runtime.to_string(), path.to_string());
+        }
+        None => {
+            overrides.remove(runtime);
+        }
+    }
+    app_state_set(
+        &tx,
+        RUNTIME_OVERRIDES_KEY,
+        &serde_json::to_string(&overrides)?,
+    )?;
+    tx.commit()?;
+    Ok(())
+}
 
 // Pinned IDs for the seeded rows. These are referenced by
 // `0002_persona_only_seeds.sql`'s WHERE clauses, so they must match
@@ -702,6 +791,41 @@ mod tests {
             )
             .unwrap();
         assert_eq!(count, 5);
+    }
+
+    #[test]
+    fn login_shell_lkg_round_trips_through_app_state() {
+        let pool = open_in_memory().unwrap();
+        let snapshot = LoginShellEnvLkg {
+            env: crate::shell_path::LoginShellEnv {
+                path: Some("/custom/bin:/usr/bin".into()),
+                vars: BTreeMap::from([("HTTPS_PROXY".into(), "http://proxy".into())]),
+            },
+            shell: "/bin/zsh".into(),
+            captured_at: "2026-07-25T00:00:00Z".into(),
+        };
+        assert_eq!(login_shell_env_lkg(&pool).unwrap(), None);
+        set_login_shell_env_lkg(&pool, &snapshot).unwrap();
+        assert_eq!(login_shell_env_lkg(&pool).unwrap(), Some(snapshot));
+    }
+
+    #[test]
+    fn runtime_overrides_set_clear_as_one_json_value() {
+        let pool = open_in_memory().unwrap();
+        set_runtime_override(&pool, "codex", Some("/opt/codex")).unwrap();
+        set_runtime_override(&pool, "claude-code", Some("/opt/claude")).unwrap();
+        assert_eq!(
+            runtime_overrides(&pool).unwrap(),
+            BTreeMap::from([
+                ("claude-code".into(), "/opt/claude".into()),
+                ("codex".into(), "/opt/codex".into()),
+            ])
+        );
+        set_runtime_override(&pool, "codex", None).unwrap();
+        assert_eq!(
+            runtime_overrides(&pool).unwrap(),
+            BTreeMap::from([("claude-code".into(), "/opt/claude".into())])
+        );
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -8,13 +8,14 @@ mod model;
 mod panic_hook;
 mod repo;
 mod router;
+mod runtime_status;
 mod session;
 mod shell_path;
 mod window_state;
 mod windows;
 
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 #[cfg(target_os = "macos")]
 use tauri::menu::{AboutMetadataBuilder, PredefinedMenuItem};
@@ -42,6 +43,8 @@ pub struct AppState {
     /// start, shared across all Tauri commands and the per-session
     /// forwarder threads it spawns.
     pub sessions: Arc<session::SessionManager>,
+    pub runtime_shell_env: runtime_status::SharedShellEnv,
+    pub runtime_discovery: runtime_status::SharedDiscoveryState,
     /// Live per-mission event-bus watchers. Mounted by `mission_start` once
     /// the opening events are durable; unmounted by `mission_stop` and on
     /// any rollback path.
@@ -159,16 +162,27 @@ pub fn run() {
                 log::error!("failed to install bundled MCP CLI: {e}");
             }
 
-            // Snapshot the user's login-shell env once at startup so
-            // child PTYs see the same PATH + proxy vars that
-            // Terminal.app's children would. Covers both the
-            // GUI-launch shim-discovery problem (Homebrew /
-            // mise / asdf / fnm / npm-global on a launchd-stripped
-            // PATH) and the claude/codex-login-behind-VPN problem
-            // (HTTPS_PROXY / NO_PROXY etc. set in rc files).
-            // Best-effort: a failure or timeout just leaves the
-            // snapshot empty and we fall back to launchd's env.
-            let login_shell_env = shell_path::resolve_login_shell_env();
+            let login_shell_lkg = match db::login_shell_env_lkg(&pool) {
+                Ok(snapshot) => snapshot,
+                Err(error) => {
+                    log::warn!("runtime discovery LKG read failed: {error}");
+                    None
+                }
+            };
+            let runtime_shell_env = Arc::new(RwLock::new(
+                login_shell_lkg
+                    .as_ref()
+                    .map(|snapshot| snapshot.env.clone())
+                    .unwrap_or_default(),
+            ));
+            let runtime_discovery = Arc::new(RwLock::new(shell_path::DiscoveryState::startup(
+                login_shell_lkg
+                    .as_ref()
+                    .map(|snapshot| snapshot.shell.clone()),
+                login_shell_lkg
+                    .as_ref()
+                    .map(|snapshot| snapshot.captured_at.clone()),
+            )));
 
             // Construct the in-process PTY runtime
             // (docs/impls/archive/0011). v1 is unix-only — Windows fails at
@@ -188,7 +202,11 @@ pub fn run() {
                 }
             };
 
-            let sessions = session::SessionManager::new(login_shell_env, runtime);
+            let sessions = session::SessionManager::new(
+                Arc::clone(&runtime_shell_env),
+                Arc::clone(&runtime_discovery),
+                runtime,
+            );
 
             // Build the AppState up front so the startup mission-bus
             // remount has access to the bus + router registries it
@@ -206,6 +224,8 @@ pub fn run() {
                 db: Arc::clone(&pool),
                 app_data_dir: app_data_dir.clone(),
                 sessions: Arc::clone(&sessions),
+                runtime_shell_env: Arc::clone(&runtime_shell_env),
+                runtime_discovery: Arc::clone(&runtime_discovery),
                 buses: Arc::clone(&buses),
                 routers: Arc::clone(&routers),
                 mcp: Arc::clone(&mcp_handle),
@@ -220,6 +240,8 @@ pub fn run() {
                 db: Arc::clone(&pool),
                 app_data_dir,
                 sessions: Arc::clone(&sessions),
+                runtime_shell_env: Arc::clone(&runtime_shell_env),
+                runtime_discovery: Arc::clone(&runtime_discovery),
                 buses,
                 routers,
                 mcp: mcp_handle,
@@ -270,6 +292,12 @@ pub fn run() {
             }
 
             app.manage(state);
+            runtime_status::start_background_discovery(
+                app.handle().clone(),
+                Arc::clone(&pool),
+                runtime_shell_env,
+                runtime_discovery,
+            );
 
             // Build the app menu in `setup` so its actions can use the
             // live AppHandle.
@@ -351,6 +379,10 @@ pub fn run() {
             commands::runner::runner_delete,
             commands::runner::runner_activity,
             commands::runtime::runtime_list,
+            commands::runtime::runtime_status_list,
+            commands::runtime::runtime_set_override,
+            commands::runtime::runtime_clear_override,
+            commands::runtime::runtime_refresh,
             commands::slot::slot_list,
             commands::slot::runner_crews_list,
             commands::slot::slot_create,

--- a/src-tauri/src/mcp/state.rs
+++ b/src-tauri/src/mcp/state.rs
@@ -4,8 +4,14 @@ use std::sync::Arc;
 use tauri::AppHandle;
 
 use crate::{
-    db::DbPool, event_bus::BusRegistry, mcp::McpHandle, router::RouterRegistry,
-    session::SessionManager, windows::WindowRegistry, AppState,
+    db::DbPool,
+    event_bus::BusRegistry,
+    mcp::McpHandle,
+    router::RouterRegistry,
+    runtime_status::{SharedDiscoveryState, SharedShellEnv},
+    session::SessionManager,
+    windows::WindowRegistry,
+    AppState,
 };
 
 #[derive(Clone)]
@@ -13,6 +19,8 @@ pub(crate) struct McpState {
     pub db: Arc<DbPool>,
     pub app_data_dir: PathBuf,
     pub sessions: Arc<SessionManager>,
+    pub runtime_shell_env: SharedShellEnv,
+    pub runtime_discovery: SharedDiscoveryState,
     pub buses: Arc<BusRegistry>,
     pub routers: Arc<RouterRegistry>,
     pub mcp: Arc<McpHandle>,
@@ -26,6 +34,8 @@ impl McpState {
             db: Arc::clone(&self.db),
             app_data_dir: self.app_data_dir.clone(),
             sessions: Arc::clone(&self.sessions),
+            runtime_shell_env: Arc::clone(&self.runtime_shell_env),
+            runtime_discovery: Arc::clone(&self.runtime_discovery),
             buses: Arc::clone(&self.buses),
             routers: Arc::clone(&self.routers),
             mcp: Arc::clone(&self.mcp),

--- a/src-tauri/src/runtime_status.rs
+++ b/src-tauri/src/runtime_status.rs
@@ -1,0 +1,592 @@
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+
+use serde::Serialize;
+use tauri::Emitter;
+
+use crate::db::{self, DbPool, LoginShellEnvLkg};
+use crate::error::{Error, Result};
+use crate::router::runtime::{runtime_definition, runtime_definitions};
+use crate::session::launch;
+use crate::shell_path::{DiscoveryOutcome, DiscoveryResult, DiscoveryState, LoginShellEnv};
+
+pub type SharedShellEnv = Arc<RwLock<LoginShellEnv>>;
+pub type SharedDiscoveryState = Arc<RwLock<DiscoveryState>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeCommandSource {
+    Override,
+    Detected,
+    Catalog,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EffectiveRuntimeCommand {
+    pub command: String,
+    pub source: RuntimeCommandSource,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeRowState {
+    Detected,
+    Override,
+    NotFound,
+    Checking,
+    ProbeTimedOut,
+    InvalidOverride,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ShellDiscoveryStatus {
+    pub shell: Option<String>,
+    pub outcome: Option<DiscoveryOutcome>,
+    pub duration_ms: Option<u64>,
+    pub checking: bool,
+    pub using_last_known_good: bool,
+    pub last_known_good_captured_at: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeExecutableStatus {
+    pub name: String,
+    pub display_name: String,
+    pub command: String,
+    pub detected_path: Option<String>,
+    pub override_path: Option<String>,
+    pub effective_command: Option<String>,
+    pub effective_source: Option<RuntimeCommandSource>,
+    pub state: RuntimeRowState,
+    pub invalid_reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeStatusResponse {
+    pub shell: ShellDiscoveryStatus,
+    pub runtimes: Vec<RuntimeExecutableStatus>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OverrideValidationError {
+    pub code: String,
+    pub message: String,
+}
+
+impl std::fmt::Display for OverrideValidationError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for OverrideValidationError {}
+
+pub fn status_list(
+    pool: &DbPool,
+    shell_env: &SharedShellEnv,
+    discovery: &SharedDiscoveryState,
+) -> Result<RuntimeStatusResponse> {
+    let shell_env = shell_env
+        .read()
+        .map_err(|_| Error::msg("runtime shell environment lock poisoned"))?
+        .clone();
+    let discovery = discovery
+        .read()
+        .map_err(|_| Error::msg("runtime discovery lock poisoned"))?
+        .clone();
+    let overrides = db::runtime_overrides(pool)?;
+    let path = direct_chat_path(&shell_env);
+
+    let runtimes = runtime_definitions()
+        .iter()
+        .map(|runtime| {
+            let detected_path =
+                find_executable(runtime.command, &path).map(|path| path.display().to_string());
+            let override_path = overrides.get(runtime.name).cloned();
+            let invalid_reason = override_path
+                .as_deref()
+                .and_then(|path| validate_executable_path(Path::new(path)).err())
+                .map(|error| error.message);
+            let valid_override = override_path
+                .as_deref()
+                .filter(|_| invalid_reason.is_none())
+                .map(str::to_string);
+            let (effective_command, effective_source) = if let Some(path) = valid_override {
+                (Some(path), Some(RuntimeCommandSource::Override))
+            } else if let Some(path) = detected_path.clone() {
+                (Some(path), Some(RuntimeCommandSource::Detected))
+            } else if discovery.checking {
+                (
+                    Some(runtime.command.to_string()),
+                    Some(RuntimeCommandSource::Catalog),
+                )
+            } else {
+                (None, None)
+            };
+            let state = if invalid_reason.is_some() {
+                RuntimeRowState::InvalidOverride
+            } else if override_path.is_some() {
+                RuntimeRowState::Override
+            } else if discovery.checking {
+                RuntimeRowState::Checking
+            } else if discovery
+                .result
+                .as_ref()
+                .is_some_and(|result| result.outcome != DiscoveryOutcome::Ok)
+            {
+                RuntimeRowState::ProbeTimedOut
+            } else if detected_path.is_some() {
+                RuntimeRowState::Detected
+            } else {
+                RuntimeRowState::NotFound
+            };
+            RuntimeExecutableStatus {
+                name: runtime.name.to_string(),
+                display_name: runtime.display_name.to_string(),
+                command: runtime.command.to_string(),
+                detected_path,
+                override_path,
+                effective_command,
+                effective_source,
+                state,
+                invalid_reason,
+            }
+        })
+        .collect();
+
+    let result = discovery.result.as_ref();
+    let failed = result.is_some_and(|result| result.outcome != DiscoveryOutcome::Ok);
+    Ok(RuntimeStatusResponse {
+        shell: ShellDiscoveryStatus {
+            shell: result
+                .and_then(|result| result.shell.clone())
+                .or(discovery.seeded_shell),
+            outcome: result.map(|result| result.outcome),
+            duration_ms: result.map(|result| result.duration_ms),
+            checking: discovery.checking,
+            using_last_known_good: discovery.last_known_good_captured_at.is_some()
+                && (discovery.checking || failed),
+            last_known_good_captured_at: discovery.last_known_good_captured_at,
+        },
+        runtimes,
+    })
+}
+
+pub fn effective_runtime_command(
+    runtime: &str,
+    pool: &DbPool,
+    shell_env: &SharedShellEnv,
+    discovery: &SharedDiscoveryState,
+) -> Result<EffectiveRuntimeCommand> {
+    let overrides = db::runtime_overrides(pool)?;
+    let shell_env = shell_env
+        .read()
+        .map_err(|_| Error::msg("runtime shell environment lock poisoned"))?
+        .clone();
+    let checking = discovery
+        .read()
+        .map_err(|_| Error::msg("runtime discovery lock poisoned"))?
+        .checking;
+    effective_runtime_command_on_path(runtime, &overrides, &direct_chat_path(&shell_env), checking)
+}
+
+fn effective_runtime_command_on_path(
+    runtime: &str,
+    overrides: &std::collections::BTreeMap<String, String>,
+    path: &str,
+    checking: bool,
+) -> Result<EffectiveRuntimeCommand> {
+    let definition = runtime_definition(runtime)
+        .ok_or_else(|| Error::msg(format!("unknown runtime: {runtime}")))?;
+    if let Some(path) = overrides.get(runtime) {
+        if validate_executable_path(Path::new(path)).is_ok() {
+            log::info!(
+                "runtime executable: runtime={} source=override command={}",
+                runtime,
+                path
+            );
+            return Ok(EffectiveRuntimeCommand {
+                command: path.clone(),
+                source: RuntimeCommandSource::Override,
+            });
+        }
+    }
+
+    if let Some(path) = find_executable(definition.command, path) {
+        let command = path.display().to_string();
+        log::info!(
+            "runtime executable: runtime={} source=detected command={}",
+            runtime,
+            command
+        );
+        return Ok(EffectiveRuntimeCommand {
+            command,
+            source: RuntimeCommandSource::Detected,
+        });
+    }
+
+    if checking {
+        return Ok(EffectiveRuntimeCommand {
+            command: definition.command.to_string(),
+            source: RuntimeCommandSource::Catalog,
+        });
+    }
+
+    log::warn!(
+        "runtime executable not found: runtime={} catalog_command={}",
+        runtime,
+        definition.command
+    );
+    Err(runtime_not_found_error(runtime))
+}
+
+pub fn runtime_not_found_error(runtime: &str) -> Error {
+    let name = runtime_definition(runtime)
+        .map(|definition| definition.display_name)
+        .unwrap_or(runtime);
+    Error::msg(format!(
+        "{name} executable was not found. Open Settings → Agents to refresh discovery or set an override."
+    ))
+}
+
+pub fn validate_override(
+    runtime: &str,
+    path: &str,
+) -> std::result::Result<(), OverrideValidationError> {
+    if runtime_definition(runtime).is_none() {
+        return Err(validation_error(
+            "unknown_runtime",
+            format!("Unknown runtime: {runtime}."),
+        ));
+    }
+    validate_executable_path(Path::new(path))
+}
+
+fn validate_executable_path(path: &Path) -> std::result::Result<(), OverrideValidationError> {
+    if !path.is_absolute() {
+        return Err(validation_error(
+            "not_absolute",
+            "Choose an absolute executable path.",
+        ));
+    }
+    let metadata = std::fs::metadata(path)
+        .map_err(|_| validation_error("not_found", "File does not exist."))?;
+    if !metadata.is_file() {
+        return Err(validation_error("not_file", "Not a regular file."));
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if metadata.permissions().mode() & 0o111 == 0 {
+            return Err(validation_error(
+                "not_executable",
+                "Not an executable file.",
+            ));
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn executable_path_is_valid(path: &Path) -> bool {
+    validate_executable_path(path).is_ok()
+}
+
+fn validation_error(code: &str, message: impl Into<String>) -> OverrideValidationError {
+    OverrideValidationError {
+        code: code.to_string(),
+        message: message.into(),
+    }
+}
+
+pub fn direct_chat_path(shell_env: &LoginShellEnv) -> String {
+    let process_path = std::env::var("PATH").ok();
+    let home = std::env::var_os("HOME").map(PathBuf::from);
+    launch::compose_path(
+        None,
+        None,
+        shell_env.path.as_deref(),
+        home.as_deref(),
+        process_path.as_deref(),
+    )
+}
+
+pub fn find_executable(command: &str, path: &str) -> Option<PathBuf> {
+    path.split(':')
+        .filter(|entry| !entry.is_empty())
+        .map(|entry| Path::new(entry).join(command))
+        .find(|candidate| validate_executable_path(candidate).is_ok())
+}
+
+pub fn apply_discovery_result(
+    pool: &DbPool,
+    shell_env: &SharedShellEnv,
+    discovery: &SharedDiscoveryState,
+    result: DiscoveryResult,
+) -> Result<()> {
+    let mut persistence_error = None;
+    let captured_at = if result.outcome == DiscoveryOutcome::Ok {
+        let captured_at = chrono::Utc::now().to_rfc3339();
+        *shell_env
+            .write()
+            .map_err(|_| Error::msg("runtime shell environment lock poisoned"))? =
+            result.env.clone();
+        let snapshot = LoginShellEnvLkg {
+            env: result.env.clone(),
+            shell: result.shell.clone().unwrap_or_default(),
+            captured_at: captured_at.clone(),
+        };
+        if let Err(error) = db::set_login_shell_env_lkg(pool, &snapshot) {
+            persistence_error = Some(error);
+        }
+        Some(captured_at)
+    } else {
+        None
+    };
+
+    let mut state = discovery
+        .write()
+        .map_err(|_| Error::msg("runtime discovery lock poisoned"))?;
+    state.checking = false;
+    state.seeded_shell = result.shell.clone().or_else(|| state.seeded_shell.clone());
+    state.result = Some(result);
+    if let Some(captured_at) = captured_at {
+        state.last_known_good_captured_at = Some(captured_at);
+    }
+    drop(state);
+    match persistence_error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+pub fn start_background_discovery(
+    app: tauri::AppHandle,
+    pool: Arc<DbPool>,
+    shell_env: SharedShellEnv,
+    discovery: SharedDiscoveryState,
+) {
+    std::thread::spawn(move || {
+        let result = crate::shell_path::resolve_login_shell_env();
+        if let Err(error) = apply_discovery_result(&pool, &shell_env, &discovery, result) {
+            log::warn!("runtime discovery state update failed: {error}");
+            if let Ok(mut state) = discovery.write() {
+                state.checking = false;
+            }
+        }
+        log_runtime_paths(&pool, &shell_env);
+        if let Err(error) = app.emit("runtime/changed", ()) {
+            log::warn!("runtime discovery event emit failed: {error}");
+        }
+    });
+}
+
+pub fn refresh_background_discovery(
+    app: tauri::AppHandle,
+    pool: Arc<DbPool>,
+    shell_env: SharedShellEnv,
+    discovery: SharedDiscoveryState,
+) -> Result<bool> {
+    {
+        let mut state = discovery
+            .write()
+            .map_err(|_| Error::msg("runtime discovery lock poisoned"))?;
+        if state.checking {
+            return Ok(false);
+        }
+        state.checking = true;
+    }
+    if let Err(error) = app.emit("runtime/changed", ()) {
+        log::warn!("runtime discovery start event emit failed: {error}");
+    }
+    start_background_discovery(app, pool, shell_env, discovery);
+    Ok(true)
+}
+
+fn log_runtime_paths(pool: &DbPool, shell_env: &SharedShellEnv) {
+    let Ok(shell_env) = shell_env.read() else {
+        return;
+    };
+    let path = direct_chat_path(&shell_env);
+    for runtime in runtime_definitions() {
+        match find_executable(runtime.command, &path) {
+            Some(found) => log::info!(
+                "runtime discovery result: runtime={} detected={}",
+                runtime.name,
+                found.display()
+            ),
+            None => log::info!(
+                "runtime discovery result: runtime={} detected=not_found",
+                runtime.name
+            ),
+        }
+    }
+    if let Ok(overrides) = db::runtime_overrides(pool) {
+        for (runtime, path) in overrides {
+            log::info!(
+                "runtime override configured: runtime={} valid={}",
+                runtime,
+                validate_executable_path(Path::new(&path)).is_ok()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+
+    fn executable(dir: &Path, name: &str) -> PathBuf {
+        let path = dir.join(name);
+        std::fs::write(&path, "#!/bin/sh\n").unwrap();
+        let mut permissions = std::fs::metadata(&path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&path, permissions).unwrap();
+        path
+    }
+
+    fn completed_discovery() -> SharedDiscoveryState {
+        Arc::new(RwLock::new(DiscoveryState {
+            checking: false,
+            result: Some(DiscoveryResult {
+                shell: Some("/bin/zsh".into()),
+                outcome: DiscoveryOutcome::Ok,
+                duration_ms: 10,
+                env: LoginShellEnv::default(),
+            }),
+            seeded_shell: None,
+            last_known_good_captured_at: None,
+        }))
+    }
+
+    #[test]
+    fn resolver_requires_regular_executable_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let executable = executable(dir.path(), "codex");
+        assert_eq!(
+            find_executable("codex", &dir.path().display().to_string()),
+            Some(executable.clone())
+        );
+        let mut permissions = std::fs::metadata(&executable).unwrap().permissions();
+        permissions.set_mode(0o644);
+        std::fs::set_permissions(&executable, permissions).unwrap();
+        assert_eq!(
+            find_executable("codex", &dir.path().display().to_string()),
+            None
+        );
+    }
+
+    #[test]
+    fn override_validation_rejects_relative_missing_directory_and_non_executable_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(
+            validate_override("codex", "codex").unwrap_err().code,
+            "not_absolute"
+        );
+        assert_eq!(
+            validate_override("codex", "/definitely/missing/codex")
+                .unwrap_err()
+                .code,
+            "not_found"
+        );
+        assert_eq!(
+            validate_override("codex", dir.path().to_str().unwrap())
+                .unwrap_err()
+                .code,
+            "not_file"
+        );
+        let file = dir.path().join("codex");
+        std::fs::write(&file, "#!/bin/sh\n").unwrap();
+        assert_eq!(
+            validate_override("codex", file.to_str().unwrap())
+                .unwrap_err()
+                .code,
+            "not_executable"
+        );
+    }
+
+    #[test]
+    fn effective_command_precedence_and_stale_override_fallthrough() {
+        let pool = crate::db::open_in_memory().unwrap();
+        let detected_dir = tempfile::tempdir().unwrap();
+        let override_dir = tempfile::tempdir().unwrap();
+        let detected = executable(detected_dir.path(), "codex");
+        let override_path = executable(override_dir.path(), "codex-custom");
+        let shell_env = Arc::new(RwLock::new(LoginShellEnv {
+            path: Some(detected_dir.path().display().to_string()),
+            vars: Default::default(),
+        }));
+        let discovery = completed_discovery();
+
+        db::set_runtime_override(&pool, "codex", Some(override_path.to_str().unwrap())).unwrap();
+        assert_eq!(
+            effective_runtime_command("codex", &pool, &shell_env, &discovery)
+                .unwrap()
+                .command,
+            override_path.display().to_string()
+        );
+        std::fs::remove_file(&override_path).unwrap();
+        assert_eq!(
+            effective_runtime_command("codex", &pool, &shell_env, &discovery)
+                .unwrap()
+                .command,
+            detected.display().to_string()
+        );
+        assert_eq!(
+            status_list(&pool, &shell_env, &discovery).unwrap().runtimes[0].state,
+            RuntimeRowState::InvalidOverride
+        );
+    }
+
+    #[test]
+    fn pending_probe_allows_catalog_but_completed_missing_probe_errors() {
+        assert_eq!(
+            effective_runtime_command_on_path(
+                "codex",
+                &Default::default(),
+                "/definitely/missing",
+                true,
+            )
+            .unwrap()
+            .command,
+            "codex"
+        );
+        let error = effective_runtime_command_on_path(
+            "codex",
+            &Default::default(),
+            "/definitely/missing",
+            false,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("Settings → Agents"));
+        assert!(error.to_string().contains("Codex"));
+    }
+
+    #[test]
+    fn failed_probe_keeps_prior_environment() {
+        let pool = crate::db::open_in_memory().unwrap();
+        let prior = LoginShellEnv {
+            path: Some("/prior/bin".into()),
+            vars: Default::default(),
+        };
+        let shell_env = Arc::new(RwLock::new(prior.clone()));
+        let discovery = Arc::new(RwLock::new(DiscoveryState::pending()));
+        apply_discovery_result(
+            &pool,
+            &shell_env,
+            &discovery,
+            DiscoveryResult {
+                shell: Some("/bin/zsh".into()),
+                outcome: DiscoveryOutcome::Timeout,
+                duration_ms: 5_000,
+                env: LoginShellEnv::default(),
+            },
+        )
+        .unwrap();
+        assert_eq!(*shell_env.read().unwrap(), prior);
+        assert_eq!(
+            discovery.read().unwrap().result.as_ref().unwrap().outcome,
+            DiscoveryOutcome::Timeout
+        );
+    }
+}

--- a/src-tauri/src/session/launch.rs
+++ b/src-tauri/src/session/launch.rs
@@ -33,9 +33,16 @@ const FALLBACK_CLI_DIRS: &[&str] = &[
     "~/.local/bin",
     "~/.cargo/bin",
     "~/.npm-global/bin",
-    "/opt/homebrew/bin",
-    "/usr/local/bin",
+    "~/.local/share/mise/shims",
+    "~/.asdf/shims",
+    "~/.volta/bin",
+    "~/.bun/bin",
+    "~/.deno/bin",
+    "~/Library/pnpm",
+    "~/.local/share/fnm/aliases/default/bin",
 ];
+
+const FALLBACK_SYSTEM_DIRS: &[&str] = &["/opt/homebrew/bin", "/usr/local/bin"];
 
 /// Inputs `render_launch_script` needs that aren't already on
 /// `SpawnSpec`. Kept separate from `SpawnSpec` because the runtime
@@ -100,9 +107,8 @@ pub fn compose_path(
             push(entry.to_string());
         }
     }
-    for fallback in FALLBACK_CLI_DIRS {
-        let expanded = expand_home(fallback, home);
-        push(expanded);
+    for fallback in fallback_cli_dirs(home) {
+        push(fallback);
     }
     if let Some(pp) = process_path {
         for entry in pp.split(':') {
@@ -111,6 +117,51 @@ pub fn compose_path(
     }
 
     parts.join(":")
+}
+
+fn fallback_cli_dirs(home: Option<&Path>) -> Vec<String> {
+    let mut dirs = FALLBACK_CLI_DIRS
+        .iter()
+        .map(|path| expand_home(path, home))
+        .collect::<Vec<_>>();
+    dirs.extend(nvm_node_bin_dirs(home));
+    dirs.extend(
+        FALLBACK_SYSTEM_DIRS
+            .iter()
+            .map(|path| expand_home(path, home)),
+    );
+    dirs
+}
+
+fn nvm_node_bin_dirs(home: Option<&Path>) -> Vec<String> {
+    let Some(versions_dir) = home.map(|home| home.join(".nvm/versions/node")) else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(versions_dir) else {
+        return Vec::new();
+    };
+    let mut versions = entries
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let bin = entry.path().join("bin");
+            bin.is_dir().then(|| {
+                (
+                    node_version_key(&entry.file_name().to_string_lossy()),
+                    bin.display().to_string(),
+                )
+            })
+        })
+        .collect::<Vec<_>>();
+    versions.sort_by(|left, right| right.0.cmp(&left.0).then_with(|| right.1.cmp(&left.1)));
+    versions.into_iter().map(|(_, path)| path).collect()
+}
+
+fn node_version_key(version: &str) -> Vec<u64> {
+    version
+        .trim_start_matches('v')
+        .split('.')
+        .map(|part| part.parse().unwrap_or(0))
+        .collect()
 }
 
 /// Expand a leading `~/` against the caller's HOME. Non-tilde paths
@@ -307,9 +358,10 @@ mod tests {
             Some(Path::new("/Users/test")),
             Some("/usr/bin:/bin"),
         );
-        assert!(!path.contains("shims"), "path = {path}");
-        // Doesn't contain "/runner/bin" (the bundled-bin path
-        // shape) — it wasn't passed in.
+        // Doesn't contain the per-mission shim or "/runner/bin"
+        // bundled-bin path shapes — neither was passed in. Version
+        // manager fallback paths may legitimately contain "shims".
+        assert!(!path.contains("/data/shims/build/bin"), "path = {path}");
         assert!(!path.contains("runner/bin"), "path = {path}");
         assert!(path.contains("/opt/homebrew/bin"), "path = {path}");
     }
@@ -354,11 +406,56 @@ mod tests {
             "/h/.local/bin",
             "/h/.cargo/bin",
             "/h/.npm-global/bin",
+            "/h/.local/share/mise/shims",
+            "/h/.asdf/shims",
+            "/h/.volta/bin",
+            "/h/.bun/bin",
+            "/h/.deno/bin",
+            "/h/Library/pnpm",
+            "/h/.local/share/fnm/aliases/default/bin",
             "/opt/homebrew/bin",
             "/usr/local/bin",
         ] {
             assert!(path.contains(d), "fallback {d} missing from {path}");
         }
+    }
+
+    #[test]
+    fn compose_path_keeps_shell_entries_before_seed_and_orders_nvm_newest_first() {
+        let home = tempfile::tempdir().unwrap();
+        for version in ["v9.9.9", "v20.12.1", "v18.20.0"] {
+            std::fs::create_dir_all(
+                home.path()
+                    .join(".nvm/versions/node")
+                    .join(version)
+                    .join("bin"),
+            )
+            .unwrap();
+        }
+        let path = compose_path(
+            None,
+            None,
+            Some("/shell/bin:/opt/homebrew/bin"),
+            Some(home.path()),
+            Some("/usr/bin"),
+        );
+        let parts = path.split(':').collect::<Vec<_>>();
+        assert_eq!(parts[0], "/shell/bin");
+        assert_eq!(
+            parts
+                .iter()
+                .filter(|entry| **entry == "/opt/homebrew/bin")
+                .count(),
+            1
+        );
+        let nvm = parts
+            .iter()
+            .filter(|entry| entry.contains(".nvm/versions/node"))
+            .copied()
+            .collect::<Vec<_>>();
+        assert!(nvm[0].contains("v20.12.1"), "{nvm:?}");
+        assert!(nvm[1].contains("v18.20.0"), "{nvm:?}");
+        assert!(nvm[2].contains("v9.9.9"), "{nvm:?}");
     }
 
     #[test]
@@ -427,6 +524,19 @@ mod tests {
         let body = render_launch_script(&script).unwrap();
         assert!(!body.contains("\ncd "), "no cd line expected: {body}");
         assert!(body.contains("exec 'claude'\n"));
+    }
+
+    #[test]
+    fn render_launch_script_quotes_command_path_with_spaces() {
+        let script = LaunchScript {
+            command: "/Applications/Agent Tools/codex".into(),
+            args: vec!["resume".into()],
+            cwd: None,
+            env: BTreeMap::new(),
+            path: "/usr/bin".into(),
+        };
+        let body = render_launch_script(&script).unwrap();
+        assert!(body.contains("exec '/Applications/Agent Tools/codex' 'resume'\n"));
     }
 
     #[test]

--- a/src-tauri/src/session/manager/mod.rs
+++ b/src-tauri/src/session/manager/mod.rs
@@ -20,7 +20,7 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::RecvTimeoutError;
-use std::sync::{Arc, Condvar, Mutex, Weak};
+use std::sync::{Arc, Condvar, Mutex, RwLock, Weak};
 use std::thread;
 use std::time::{Duration, Instant};
 
@@ -593,9 +593,9 @@ pub struct SessionManager {
     /// other sessions.
     sessions: Mutex<HashMap<String, Arc<Mutex<SessionState>>>>,
     delivery_listeners: Mutex<HashMap<String, Vec<Weak<dyn router::SessionDeliveryListener>>>>,
-    /// User's login-shell env snapshot, captured once at app start by
-    /// `shell_path::resolve_login_shell_env`. Empty when the resolve
-    /// failed/timed out, when running on Windows, or in tests.
+    /// User's current login-shell env snapshot. Discovery swaps this
+    /// handle after a successful background probe; spawns clone one
+    /// coherent value under a short read lock.
     ///
     /// `path` is composed into every child PTY's PATH (so GUI-launched
     /// apps can find tools like claude / codex / mise that aren't on
@@ -603,7 +603,8 @@ pub struct SessionManager {
     /// proxy quartet in both cases) is layered into every spawn's env
     /// under `runner.env` so the child can reach the network the same
     /// way Terminal.app's children would (issues #109 / #152).
-    shell_env: crate::shell_path::LoginShellEnv,
+    shell_env: Arc<RwLock<crate::shell_path::LoginShellEnv>>,
+    discovery_state: crate::runtime_status::SharedDiscoveryState,
     /// Timestamp of the most recent claude-code spawn through the
     /// launch gate. `None` until the first claude-code spawn lands.
     /// Each new claude-code spawn reads this, sleeps the remainder
@@ -712,13 +713,15 @@ fn compute_gate_wait(last: Option<Instant>, now: Instant, grace: Duration) -> Du
 
 impl SessionManager {
     pub fn new(
-        shell_env: crate::shell_path::LoginShellEnv,
+        shell_env: crate::runtime_status::SharedShellEnv,
+        discovery_state: crate::runtime_status::SharedDiscoveryState,
         runtime: Arc<dyn SessionRuntime>,
     ) -> Arc<Self> {
         Arc::new(Self {
             sessions: Mutex::new(HashMap::new()),
             delivery_listeners: Mutex::new(HashMap::new()),
             shell_env,
+            discovery_state,
             claude_launch_gate: Mutex::new(None),
             pending_mission_cancels: Mutex::new(HashMap::new()),
             runtime,

--- a/src-tauri/src/session/manager/spawn.rs
+++ b/src-tauri/src/session/manager/spawn.rs
@@ -1,6 +1,48 @@
 use super::*;
 
 impl SessionManager {
+    fn resolve_runner_executable(&self, runner: &Runner, pool: &DbPool) -> Result<Runner> {
+        let Some(definition) = router::runtime::runtime_definition(&runner.runtime) else {
+            return Ok(runner.clone());
+        };
+        if runner.command != definition.command {
+            return Ok(runner.clone());
+        }
+        let effective = crate::runtime_status::effective_runtime_command(
+            definition.name,
+            pool,
+            &self.shell_env,
+            &self.discovery_state,
+        )?;
+        let mut resolved = runner.clone();
+        resolved.command = effective.command;
+        Ok(resolved)
+    }
+
+    fn resolve_runtime_only_resume_runner(
+        &self,
+        runtime: &str,
+        recorded_command: Option<&str>,
+        pool: &DbPool,
+    ) -> Result<Runner> {
+        let definition = router::runtime::runtime_definition(runtime)
+            .ok_or_else(|| Error::msg(format!("unknown runtime: {runtime}")))?;
+        let recorded = recorded_command
+            .map(str::trim)
+            .filter(|command| !command.is_empty());
+        if let Some(command) = recorded {
+            let path = Path::new(command);
+            if path.is_absolute() && crate::runtime_status::executable_path_is_valid(path) {
+                return runtime_direct_runner(runtime, Some(command));
+            }
+            if !path.is_absolute() && command != definition.command {
+                return runtime_direct_runner(runtime, Some(command));
+            }
+        }
+        let runner = runtime_direct_runner(runtime, None)?;
+        self.resolve_runner_executable(&runner, pool)
+    }
+
     /// Gate a fresh `claude-code` spawn before calling
     /// `runtime.spawn()`. No-op for any other runtime — those
     /// bypass the gate.
@@ -59,11 +101,16 @@ impl SessionManager {
         initial_size: Option<(u16, u16)>,
         extra_env: BTreeMap<String, String>,
     ) -> SpawnSpec {
+        let shell_env = self
+            .shell_env
+            .read()
+            .expect("runtime shell environment lock poisoned")
+            .clone();
         // Bottom layer: login-shell vars (proxy quartet, both cases)
         // captured at app start. A runner row can override any of these
         // by setting the same name in its own env map — the runner row
         // is the most specific configuration surface.
-        let mut env: BTreeMap<String, String> = self.shell_env.vars.clone();
+        let mut env: BTreeMap<String, String> = shell_env.vars;
         for (k, v) in &runner.env {
             env.insert(k.clone(), v.clone());
         }
@@ -86,7 +133,7 @@ impl SessionManager {
             mission,
             shim_dir,
             bundled_bin_dir,
-            shell_path: self.shell_env.path.clone(),
+            shell_path: shell_env.path,
             initial_size,
         }
     }
@@ -192,7 +239,8 @@ impl SessionManager {
         // matching override spawns byte-identically but still pins.
         let resolution = resolve_runtime_override(runner, slot.runtime_override.as_deref())?;
         let pinned = resolution.pinned;
-        let runner = resolution.effective.as_ref().unwrap_or(runner);
+        let runner =
+            self.resolve_runner_executable(resolution.effective.as_ref().unwrap_or(runner), &pool)?;
 
         // Agent-native session resume: this is a *fresh* session row, so
         // there's no prior key to inherit. The runtime adapter still
@@ -248,7 +296,7 @@ impl SessionManager {
             Self::codex_capture_prompt_marker(&runner.runtime, &session_id, first_turn);
         let mut spec = self.base_spawn_spec(
             session_id.clone(),
-            runner,
+            &runner,
             resolved_cwd.clone(),
             true,
             shim_dir,
@@ -260,7 +308,7 @@ impl SessionManager {
             runner_core::event_log::path::mission_dir(app_data_dir, &mission.crew_id, &mission.id);
         let first_turn_delivered_via_argv = Self::apply_runtime_args(
             &mut spec,
-            runner,
+            &runner,
             &plan,
             first_turn.as_deref(),
             Some(&mission_bus_dir),
@@ -706,7 +754,8 @@ impl SessionManager {
         // rule as mission spawns.
         let resolution = resolve_runtime_override(runner, runtime_override)?;
         let pinned = resolution.pinned;
-        let runner = resolution.effective.as_ref().unwrap_or(runner);
+        let runner =
+            self.resolve_runner_executable(resolution.effective.as_ref().unwrap_or(runner), &pool)?;
 
         // Agent-native session resume: `spawn_direct` always opens a *new*
         // chat. The runtime adapter self-assigns a fresh
@@ -734,7 +783,7 @@ impl SessionManager {
 
         let mut spec = self.base_spawn_spec(
             session_id.clone(),
-            runner,
+            &runner,
             resolved_cwd.clone(),
             false,
             None, // shim_dir — off-bus
@@ -743,7 +792,7 @@ impl SessionManager {
             direct_env,
         );
         let first_turn_delivered_via_argv =
-            Self::apply_runtime_args(&mut spec, runner, &plan, first_turn.as_deref(), None);
+            Self::apply_runtime_args(&mut spec, &runner, &plan, first_turn.as_deref(), None);
 
         // Insert the row first so a fast-failing spawn doesn't leave
         // a half-row. Runtime-only chats (no persisted runner template)
@@ -882,7 +931,7 @@ impl SessionManager {
         }
 
         if emit_activity {
-            emit_runner_activity(&pool, runner, events.as_ref());
+            emit_runner_activity(&pool, &runner, events.as_ref());
         }
         if matches!(runner.runtime.as_str(), "claude-code" | "codex")
             && !plan.resuming
@@ -1067,17 +1116,19 @@ impl SessionManager {
         let runner = if let Some(runner_id) = snap.runner_id.as_deref() {
             let conn = pool.get()?;
             let runner = crate::commands::runner::get(&conn, runner_id)?;
-            match resolve_runtime_override(&runner, snap.agent_runtime.as_deref())?.effective {
-                Some(effective) => effective,
-                None => runner,
-            }
+            let runner =
+                match resolve_runtime_override(&runner, snap.agent_runtime.as_deref())?.effective {
+                    Some(effective) => effective,
+                    None => runner,
+                };
+            self.resolve_runner_executable(&runner, &pool)?
         } else {
             let runtime = snap.agent_runtime.as_deref().ok_or_else(|| {
                 Error::msg(format!(
                     "runtime-only session {session_id} missing agent_runtime"
                 ))
             })?;
-            runtime_direct_runner(runtime, snap.agent_command.as_deref())?
+            self.resolve_runtime_only_resume_runner(runtime, snap.agent_command.as_deref(), &pool)?
         };
 
         // Resume plan: hand the prior agent_session_key back to the

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -257,10 +257,23 @@ fn fake_runtime() -> Arc<FakeRuntime> {
     Arc::new(FakeRuntime::new())
 }
 
+fn mgr_with_runtime(
+    shell_env: crate::shell_path::LoginShellEnv,
+    runtime: Arc<dyn SessionRuntime>,
+) -> Arc<SessionManager> {
+    SessionManager::new(
+        Arc::new(std::sync::RwLock::new(shell_env)),
+        Arc::new(std::sync::RwLock::new(
+            crate::shell_path::DiscoveryState::pending(),
+        )),
+        runtime,
+    )
+}
+
 /// Build a manager backed by the supplied FakeRuntime. Returns
 /// the Arc so tests can introspect the captured calls.
 fn mgr_with_fake(shell: Option<String>, fake: Arc<FakeRuntime>) -> Arc<SessionManager> {
-    SessionManager::new(
+    mgr_with_runtime(
         crate::shell_path::LoginShellEnv {
             path: shell,
             vars: Default::default(),
@@ -402,6 +415,16 @@ fn join_forwarder_for_test(mgr: &SessionManager, session_id: &str) {
 
 fn has_arg_pair(args: &[String], flag: &str, value: &str) -> bool {
     args.windows(2).any(|w| w[0] == flag && w[1] == value)
+}
+
+fn assert_effective_command(command: &str, catalog_name: &str) {
+    assert_eq!(
+        std::path::Path::new(command)
+            .file_name()
+            .and_then(|name| name.to_str()),
+        Some(catalog_name),
+        "expected {catalog_name} or an absolute path ending in {catalog_name}, got {command}",
+    );
 }
 
 fn pool_with_schema() -> Arc<DbPool> {
@@ -1048,7 +1071,7 @@ fn inject_stdin_roundtrip_routes_through_runtime() {
 
 #[test]
 fn inject_stdin_on_unknown_session_errors_cleanly() {
-    let mgr = SessionManager::new(crate::shell_path::LoginShellEnv::default(), inert_runtime());
+    let mgr = mgr_with_runtime(crate::shell_path::LoginShellEnv::default(), inert_runtime());
     let err = mgr.inject_stdin("nope", b"x").unwrap_err();
     assert!(format!("{err}").contains("session not found"));
 }
@@ -1625,7 +1648,7 @@ fn spawn_failure_after_spawn_command_reaps_the_child() {
         .execute("DROP TABLE sessions", [])
         .unwrap();
 
-    let mgr = SessionManager::new(crate::shell_path::LoginShellEnv::default(), inert_runtime());
+    let mgr = mgr_with_runtime(crate::shell_path::LoginShellEnv::default(), inert_runtime());
     let slot = slot_for(&runner);
     let err = mgr
         .spawn(
@@ -2506,7 +2529,7 @@ fn login_shell_proxy_env_reaches_spawn_with_runner_env_taking_precedence() {
     vars.insert("HTTPS_PROXY".into(), "http://login-shell:7890".into());
     vars.insert("https_proxy".into(), "http://login-shell:7890".into());
     vars.insert("NO_PROXY".into(), "localhost,127.0.0.1,*.byted.org".into());
-    let mgr = SessionManager::new(
+    let mgr = mgr_with_runtime(
         crate::shell_path::LoginShellEnv { path: None, vars },
         Arc::clone(&fake) as Arc<dyn SessionRuntime>,
     );
@@ -3215,7 +3238,7 @@ fn resume_refuses_running_and_archived_rows() {
         )
         .unwrap();
     }
-    let mgr = SessionManager::new(crate::shell_path::LoginShellEnv::default(), inert_runtime());
+    let mgr = mgr_with_runtime(crate::shell_path::LoginShellEnv::default(), inert_runtime());
     for (sid, needle) in [
         ("running-sid", "already running"),
         ("archived-sid", "archived"),
@@ -3568,7 +3591,7 @@ fn scan_mouse_modes_detects_enable_disable_and_full_reset() {
 fn output_snapshot_prepends_alt_screen_enter_when_session_in_alt_screen() {
     let pool = pool_with_schema();
     let fake = fake_runtime();
-    let mgr = SessionManager::new(
+    let mgr = mgr_with_runtime(
         crate::shell_path::LoginShellEnv::default(),
         Arc::clone(&fake) as Arc<dyn SessionRuntime>,
     );
@@ -3635,7 +3658,7 @@ fn output_snapshot_prepends_alt_screen_enter_when_session_in_alt_screen() {
 fn output_snapshot_prepends_bracketed_paste_enable_when_session_has_it_enabled() {
     let pool = pool_with_schema();
     let fake = fake_runtime();
-    let mgr = SessionManager::new(
+    let mgr = mgr_with_runtime(
         crate::shell_path::LoginShellEnv::default(),
         Arc::clone(&fake) as Arc<dyn SessionRuntime>,
     );
@@ -3695,7 +3718,7 @@ fn output_snapshot_prepends_bracketed_paste_enable_when_session_has_it_enabled()
 fn output_snapshot_combines_alt_screen_and_bracketed_paste_prefixes() {
     let pool = pool_with_schema();
     let fake = fake_runtime();
-    let mgr = SessionManager::new(
+    let mgr = mgr_with_runtime(
         crate::shell_path::LoginShellEnv::default(),
         Arc::clone(&fake) as Arc<dyn SessionRuntime>,
     );
@@ -4082,10 +4105,7 @@ fn mission_spawn_with_slot_override_uses_registry_engine_and_records_runtime() {
         .unwrap();
 
     let spec = fake.last_spawn_spec().expect("spawn was called");
-    assert_eq!(
-        spec.command, "claude",
-        "override must use the registry command"
-    );
+    assert_effective_command(&spec.command, "claude");
     assert!(
         !spec.args.contains(&"--custom-flag".to_string()),
         "runner args are engine flags and must not carry across runtimes: {:?}",
@@ -4125,7 +4145,7 @@ fn mission_spawn_with_slot_override_uses_registry_engine_and_records_runtime() {
         )
         .unwrap();
     assert_eq!(agent_runtime.as_deref(), Some("claude-code"));
-    assert_eq!(agent_command.as_deref(), Some("claude"));
+    assert_effective_command(agent_command.as_deref().unwrap(), "claude");
 
     mgr.kill(&spawned.id).unwrap();
 }
@@ -4270,10 +4290,7 @@ fn resume_keeps_pinned_runtime_after_runner_template_edit() {
     .unwrap();
 
     let spec = fake.last_spawn_spec().expect("resume should have spawned");
-    assert_eq!(
-        spec.command, "codex",
-        "resume must stay on the pinned engine (registry command), not the edited template's",
-    );
+    assert_effective_command(&spec.command, "codex");
     assert!(
         !spec.args.contains(&"--custom-flag".to_string()) && spec.command != "claude-custom",
         "neither the template's new engine nor its old flags may leak in: {:?}",
@@ -4318,7 +4335,7 @@ fn direct_spawn_with_override_uses_registry_engine_and_records_runtime() {
         .unwrap();
 
     let spec = fake.last_spawn_spec().expect("spawn was called");
-    assert_eq!(spec.command, "claude");
+    assert_effective_command(&spec.command, "claude");
     assert!(!spec.args.contains(&"--custom-flag".to_string()));
 
     let (row_runner_id, agent_runtime, agent_command): (
@@ -4340,7 +4357,7 @@ fn direct_spawn_with_override_uses_registry_engine_and_records_runtime() {
         "overridden chats stay runner-backed",
     );
     assert_eq!(agent_runtime.as_deref(), Some("claude-code"));
-    assert_eq!(agent_command.as_deref(), Some("claude"));
+    assert_effective_command(agent_command.as_deref().unwrap(), "claude");
 
     mgr.kill(&spawned.id).unwrap();
 }
@@ -4389,10 +4406,7 @@ fn resume_respawns_recorded_override_runtime() {
     .unwrap();
 
     let spec = fake.last_spawn_spec().expect("resume should have spawned");
-    assert_eq!(
-        spec.command, "claude",
-        "resume must respawn the recorded effective runtime",
-    );
+    assert_effective_command(&spec.command, "claude");
     assert!(
         !spec.args.contains(&"--custom-flag".to_string()),
         "runner engine flags must not leak into an overridden resume: {:?}",
@@ -4407,4 +4421,178 @@ fn resume_respawns_recorded_override_runtime() {
     );
 
     mgr.kill("ovr-sid").unwrap();
+}
+
+#[test]
+fn catalog_default_runner_uses_detected_command_while_custom_command_stays_untouched() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let pool = pool_with_schema();
+    let bin = tempfile::tempdir().unwrap();
+    let detected = bin.path().join("codex");
+    std::fs::write(&detected, "#!/bin/sh\n").unwrap();
+    let mut permissions = std::fs::metadata(&detected).unwrap().permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&detected, permissions).unwrap();
+
+    let now = Utc::now().to_rfc3339();
+    let default_id = ulid::Ulid::new().to_string();
+    let custom_id = ulid::Ulid::new().to_string();
+    {
+        let conn = pool.get().unwrap();
+        for (id, handle, command) in [
+            (&default_id, "default-runtime", "codex"),
+            (&custom_id, "custom-runtime", "codex-wrapper"),
+        ] {
+            conn.execute(
+                "INSERT INTO runners
+                    (id, handle, display_name, runtime, command, created_at, updated_at)
+                 VALUES (?1, ?2, ?2, 'codex', ?3, ?4, ?4)",
+                params![id, handle, command, now],
+            )
+            .unwrap();
+        }
+    }
+
+    let fake = fake_runtime();
+    let mgr = mgr_with_fake(Some(bin.path().display().to_string()), Arc::clone(&fake));
+    let mut default_runner = runner("codex", &[]);
+    default_runner.id = default_id;
+    default_runner.handle = "default-runtime".into();
+    default_runner.runtime = "codex".into();
+    let default_session = mgr
+        .spawn_direct(
+            &default_runner,
+            None,
+            None,
+            Some("/tmp"),
+            None,
+            None,
+            std::path::Path::new("/tmp"),
+            Arc::clone(&pool),
+            capture(),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        fake.last_spawn_spec().unwrap().command,
+        detected.display().to_string()
+    );
+
+    let mut custom_runner = runner("codex-wrapper", &[]);
+    custom_runner.id = custom_id;
+    custom_runner.handle = "custom-runtime".into();
+    custom_runner.runtime = "codex".into();
+    let custom_session = mgr
+        .spawn_direct(
+            &custom_runner,
+            None,
+            None,
+            Some("/tmp"),
+            None,
+            None,
+            std::path::Path::new("/tmp"),
+            Arc::clone(&pool),
+            capture(),
+            None,
+        )
+        .unwrap();
+    assert_eq!(fake.last_spawn_spec().unwrap().command, "codex-wrapper");
+
+    mgr.shell_env.write().unwrap().path = Some("/swapped/bin".into());
+    let swapped_session = mgr
+        .spawn_direct(
+            &custom_runner,
+            None,
+            None,
+            Some("/tmp"),
+            None,
+            None,
+            std::path::Path::new("/tmp"),
+            Arc::clone(&pool),
+            capture(),
+            None,
+        )
+        .unwrap();
+    assert_eq!(
+        fake.last_spawn_spec().unwrap().shell_path.as_deref(),
+        Some("/swapped/bin"),
+        "the next spawn must read the swapped login-shell environment",
+    );
+
+    mgr.kill(&default_session.id).unwrap();
+    mgr.kill(&custom_session.id).unwrap();
+    mgr.kill(&swapped_session.id).unwrap();
+}
+
+#[test]
+fn runtime_only_resume_keeps_live_recorded_path_and_reresolves_dead_path() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let pool = pool_with_schema();
+    let recorded_dir = tempfile::tempdir().unwrap();
+    let detected_dir = tempfile::tempdir().unwrap();
+    let make_executable = |path: &Path| {
+        std::fs::write(path, "#!/bin/sh\n").unwrap();
+        let mut permissions = std::fs::metadata(path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(path, permissions).unwrap();
+    };
+    let recorded = recorded_dir.path().join("codex-recorded");
+    let detected = detected_dir.path().join("codex");
+    make_executable(&recorded);
+    make_executable(&detected);
+
+    let now = Utc::now().to_rfc3339();
+    {
+        let conn = pool.get().unwrap();
+        for (id, command) in [
+            ("runtime-live-path", recorded.display().to_string()),
+            ("runtime-dead-path", "/definitely/missing/codex".to_string()),
+        ] {
+            conn.execute(
+                "INSERT INTO sessions
+                    (id, status, started_at, agent_runtime, agent_command)
+                 VALUES (?1, 'stopped', ?2, 'codex', ?3)",
+                params![id, now, command],
+            )
+            .unwrap();
+        }
+    }
+
+    let fake = fake_runtime();
+    let mgr = mgr_with_fake(
+        Some(detected_dir.path().display().to_string()),
+        Arc::clone(&fake),
+    );
+    mgr.resume(
+        "runtime-live-path",
+        None,
+        None,
+        std::path::Path::new("/tmp"),
+        Arc::clone(&pool),
+        capture(),
+    )
+    .unwrap();
+    assert_eq!(
+        fake.last_spawn_spec().unwrap().command,
+        recorded.display().to_string()
+    );
+
+    mgr.resume(
+        "runtime-dead-path",
+        None,
+        None,
+        std::path::Path::new("/tmp"),
+        Arc::clone(&pool),
+        capture(),
+    )
+    .unwrap();
+    assert_eq!(
+        fake.last_spawn_spec().unwrap().command,
+        detected.display().to_string()
+    );
+
+    mgr.kill("runtime-live-path").unwrap();
+    mgr.kill("runtime-dead-path").unwrap();
 }

--- a/src-tauri/src/session/pty_runtime.rs
+++ b/src-tauri/src/session/pty_runtime.rs
@@ -1512,6 +1512,16 @@ mod tests {
             Some("codex"),
             Some("/custom/bin/codex"),
         ));
+        assert!(command_line_matches_recorded_agent(
+            "/Applications/Agent Tools/claude --resume abc",
+            Some("claude-code"),
+            Some("/Applications/Agent Tools/claude"),
+        ));
+        assert!(command_line_matches_recorded_agent(
+            "/opt/homebrew/bin/claude --resume abc",
+            Some("claude-code"),
+            Some("/opt/homebrew/bin/claude"),
+        ));
         assert!(!command_line_matches_recorded_agent(
             "python worker.py",
             Some("claude-code"),

--- a/src-tauri/src/shell_path.rs
+++ b/src-tauri/src/shell_path.rs
@@ -1,35 +1,9 @@
-//! Resolves env vars from the user's login shell so child PTYs spawned by a
-//! GUI-launched app see the same values they would inside Terminal.app.
+//! Login-shell environment discovery for GUI-launched child PTYs.
 //!
-//! On macOS, launchd hands GUI apps a stripped env: a default PATH of
-//! `/usr/bin:/bin:/usr/sbin:/sbin`, no `HTTPS_PROXY` / `HTTP_PROXY` / etc.
-//! The user's shell rc files set those, but they're sourced by the shell —
-//! not by launchd. So a GUI-launched Runner inherits a stripped env and
-//! tools that need either the user's PATH (Homebrew, mise/asdf/fnm,
-//! npm-global) OR the user's HTTP proxy (claude / codex login behind a
-//! corporate VPN or ClashX-style local proxy) fail in ways that don't
-//! reproduce under `pnpm tauri dev` from a terminal.
-//!
-//! Workaround: at startup, spawn `$SHELL -ilc '<probe>'` once and parse
-//! marker-delimited values out of its stdout. We capture a fixed set of
-//! var names (`PATH` + the standard proxy quartet, both upper- and
-//! lower-case) — names that are dot-files-set rather than launchd-set
-//! and that downstream tools universally respect. Values stay whatever
-//! the user's rc files happen to export.
-//!
-//! Capture choices:
-//!   - `printenv NAME` per var, wrapped in per-var `__RUNNER_KV_NAME_…__`
-//!     markers — rc files often print banners or tool noise (`nvm`
-//!     warnings, `direnv` notices, etc.) on interactive startup; the
-//!     markers let us pluck each value out of an arbitrarily noisy
-//!     stdout, and a missing var (`printenv` exits non-zero) just leaves
-//!     an empty marker pair.
-//!   - try_wait poll with deadline + `kill + wait` on timeout — a hung
-//!     rc would otherwise leave a dangling login shell behind every app
-//!     launch.
-//!
-//! On Windows the problem doesn't arise (no launchd) and this returns an
-//! empty `LoginShellEnv`.
+//! Finder/launchd starts Runner with a stripped environment. Discovery
+//! captures the small set of shell-owned values that agent CLIs need,
+//! while callers retain the last successful snapshot when a later probe
+//! fails or times out.
 
 use std::collections::BTreeMap;
 use std::process::{Command, Stdio};
@@ -37,22 +11,12 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::{Duration, Instant};
 
-const RESOLVE_TIMEOUT: Duration = Duration::from_secs(2);
+use serde::{Deserialize, Serialize};
+
+const RESOLVE_TIMEOUT: Duration = Duration::from_secs(5);
 const POLL_INTERVAL: Duration = Duration::from_millis(50);
 const STDOUT_DRAIN_GRACE: Duration = Duration::from_millis(500);
 
-/// Var names captured from the login shell. PATH covers the original
-/// GUI-launch shim-discovery problem (issue #65); the proxy quartet
-/// (both cases) covers the claude / codex login-behind-VPN problem
-/// (issue #152). Lowercase variants are standard across curl /
-/// reqwest / Python requests / Node's undici / Go's `http.ProxyFromEnvironment`
-/// and many users only export the lowercase form.
-///
-/// This list is intentionally narrow: capturing arbitrary login-shell
-/// env would propagate every prompt customization and tool warning a
-/// user has in their rc files. Adding a name here is an explicit
-/// decision that the var (a) is typically rc-file-set, (b) affects
-/// behavior of CLIs the user expects to "just work."
 const CAPTURED_VARS: &[&str] = &[
     "PATH",
     "HTTP_PROXY",
@@ -65,78 +29,126 @@ const CAPTURED_VARS: &[&str] = &[
     "no_proxy",
 ];
 
-/// Snapshot of the login shell's env captured at app start.
-///
-/// `path` is split out because PATH composition (shim_dir →
-/// bundled_bin_dir → login_shell_path → launchd inherited) has its
-/// own precedence rules in `launch::compose_path` and isn't a
-/// straight env-var passthrough. `vars` holds everything else we
-/// capture (today: the proxy quartet, both cases) and is layered
-/// into every child PTY's env under `runner.env`, so a runner row's
-/// explicit override still wins.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LoginShellEnv {
     pub path: Option<String>,
     pub vars: BTreeMap<String, String>,
 }
 
-#[cfg(unix)]
-pub fn resolve_login_shell_env() -> LoginShellEnv {
-    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DiscoveryOutcome {
+    Ok,
+    Timeout,
+    SpawnError,
+    EmptyCapture,
+    NoShell,
+}
 
-    // -i (interactive) sources `.zshrc` / `.bashrc`; -l (login) sources
-    // `.zprofile` / `.bash_profile`. Both are needed: Homebrew
-    // `shellenv` typically lives in `.zprofile` on Apple Silicon while
-    // mise / fnm / asdf inject from `.zshrc`. `printenv` is in
-    // coreutils on every Unix we target and reads the exported env var
-    // straight from the process env (no shell-specific `$var`
-    // expansion).
-    //
-    // For each captured var: print BEGIN marker → printenv (stderr to
-    // /dev/null so a missing var doesn't pollute stdout) → END marker
-    // on its own line. The trailing newline keeps banner text on
-    // subsequent lines from running into the END marker. Missing vars
-    // produce `BEGIN__END__\n` (empty value) which the parser skips.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiscoveryResult {
+    pub shell: Option<String>,
+    pub outcome: DiscoveryOutcome,
+    pub duration_ms: u64,
+    pub env: LoginShellEnv,
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscoveryState {
+    pub checking: bool,
+    pub result: Option<DiscoveryResult>,
+    pub seeded_shell: Option<String>,
+    pub last_known_good_captured_at: Option<String>,
+}
+
+impl DiscoveryState {
+    pub fn startup(
+        seeded_shell: Option<String>,
+        last_known_good_captured_at: Option<String>,
+    ) -> Self {
+        Self {
+            checking: true,
+            result: None,
+            seeded_shell,
+            last_known_good_captured_at,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn pending() -> Self {
+        Self::startup(None, None)
+    }
+}
+
+#[cfg(unix)]
+pub fn resolve_login_shell_env() -> DiscoveryResult {
+    let started = Instant::now();
+    let shell = configured_shell(std::env::var("SHELL").ok());
+    let Some(shell) = shell else {
+        return finish_discovery(
+            None,
+            DiscoveryOutcome::NoShell,
+            started,
+            LoginShellEnv::default(),
+        );
+    };
+    resolve_shell_env(&shell, RESOLVE_TIMEOUT, started)
+}
+
+fn configured_shell(value: Option<String>) -> Option<String> {
+    value
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+#[cfg(unix)]
+fn resolve_shell_env(shell: &str, timeout: Duration, started: Instant) -> DiscoveryResult {
+    let Some(probe_args) = shell_probe_args(shell) else {
+        return finish_discovery(
+            Some(shell.to_string()),
+            DiscoveryOutcome::SpawnError,
+            started,
+            LoginShellEnv::default(),
+        );
+    };
+
     let mut inner = String::new();
-    for v in CAPTURED_VARS {
-        // The shell sees the script as a single -c arg — using
-        // double-quoted markers inside single-quoted printf args
-        // means we don't have to escape anything. var names are
-        // ASCII identifiers (no shell metachars) so direct
-        // interpolation is safe here.
+    for var in CAPTURED_VARS {
         inner.push_str(&format!(
-            "printf '%s' '__RUNNER_KV_{v}_BEGIN__'; printenv {v} 2>/dev/null; printf '%s\\n' '__RUNNER_KV_{v}_END__'; "
+            "printf '%s' '__RUNNER_KV_{var}_BEGIN__'; printenv {var} 2>/dev/null; printf '%s\\n' '__RUNNER_KV_{var}_END__'; "
         ));
     }
 
-    let mut child = match Command::new(&shell)
-        .arg("-ilc")
+    let mut child = match Command::new(shell)
+        .args(probe_args)
         .arg(&inner)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
         .spawn()
     {
-        Ok(c) => c,
-        Err(e) => {
-            log::warn!(
-                "login-shell env resolution via `{shell}` failed to spawn ({e}); \
-                 falling back to launchd env"
+        Ok(child) => child,
+        Err(_) => {
+            return finish_discovery(
+                Some(shell.to_string()),
+                DiscoveryOutcome::SpawnError,
+                started,
+                LoginShellEnv::default(),
             );
-            return LoginShellEnv::default();
         }
     };
 
-    // Drain stdout in a worker so a slow / chatty rc filling the pipe
-    // buffer can't deadlock our timeout poll. We `take()` the handle so
-    // `wait` below doesn't fight the reader for it.
     let mut stdout = match child.stdout.take() {
-        Some(s) => s,
+        Some(stdout) => stdout,
         None => {
             let _ = child.kill();
             let _ = child.wait();
-            log::warn!("login-shell env resolution lost stdout pipe; falling back");
-            return LoginShellEnv::default();
+            return finish_discovery(
+                Some(shell.to_string()),
+                DiscoveryOutcome::SpawnError,
+                started,
+                LoginShellEnv::default(),
+            );
         }
     };
     let (tx, rx) = mpsc::channel();
@@ -147,85 +159,115 @@ pub fn resolve_login_shell_env() -> LoginShellEnv {
         let _ = tx.send(buf);
     });
 
-    // Poll try_wait until the child exits or we hit the deadline. On
-    // timeout, SIGTERM the child and reap it — without this a hung
-    // shell init would leave one stranded login shell per app launch.
-    let deadline = Instant::now() + RESOLVE_TIMEOUT;
+    let deadline = Instant::now() + timeout;
     let status = loop {
         match child.try_wait() {
-            Ok(Some(s)) => break s,
-            Ok(None) => {
-                if Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait();
-                    log::warn!(
-                        "login-shell env resolution via `{shell}` timed out after {}s; \
-                         killed shell; falling back to launchd env",
-                        RESOLVE_TIMEOUT.as_secs()
-                    );
-                    return LoginShellEnv::default();
-                }
-                thread::sleep(POLL_INTERVAL);
-            }
-            Err(e) => {
+            Ok(Some(status)) => break status,
+            Ok(None) if Instant::now() >= deadline => {
                 let _ = child.kill();
                 let _ = child.wait();
-                log::warn!(
-                    "login-shell env resolution via `{shell}` failed waiting ({e}); \
-                     falling back to launchd env"
+                return finish_discovery(
+                    Some(shell.to_string()),
+                    DiscoveryOutcome::Timeout,
+                    started,
+                    LoginShellEnv::default(),
                 );
-                return LoginShellEnv::default();
+            }
+            Ok(None) => thread::sleep(POLL_INTERVAL),
+            Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                return finish_discovery(
+                    Some(shell.to_string()),
+                    DiscoveryOutcome::SpawnError,
+                    started,
+                    LoginShellEnv::default(),
+                );
             }
         }
     };
 
     if !status.success() {
-        log::warn!(
-            "login-shell env resolution via `{shell}` exited non-zero (status={:?}); \
-             falling back to launchd env",
-            status.code()
+        return finish_discovery(
+            Some(shell.to_string()),
+            DiscoveryOutcome::SpawnError,
+            started,
+            LoginShellEnv::default(),
         );
-        return LoginShellEnv::default();
     }
 
     let stdout_bytes = match rx.recv_timeout(STDOUT_DRAIN_GRACE) {
-        Ok(b) => b,
+        Ok(bytes) => bytes,
         Err(_) => {
-            log::warn!(
-                "login-shell env resolution via `{shell}` produced no stdout in time; \
-                 falling back"
+            return finish_discovery(
+                Some(shell.to_string()),
+                DiscoveryOutcome::EmptyCapture,
+                started,
+                LoginShellEnv::default(),
             );
-            return LoginShellEnv::default();
         }
     };
-    let stdout_str = String::from_utf8_lossy(&stdout_bytes);
-    let parsed = parse_login_shell_env(&stdout_str);
-    if parsed.path.is_none() && parsed.vars.is_empty() {
-        log::warn!(
-            "login-shell env resolution via `{shell}` returned no captured vars; \
-             falling back to launchd env"
-        );
+    let env = parse_login_shell_env(&String::from_utf8_lossy(&stdout_bytes));
+    let outcome = capture_outcome(&env);
+    finish_discovery(Some(shell.to_string()), outcome, started, env)
+}
+
+fn capture_outcome(env: &LoginShellEnv) -> DiscoveryOutcome {
+    if env.path.is_none() && env.vars.is_empty() {
+        DiscoveryOutcome::EmptyCapture
+    } else {
+        DiscoveryOutcome::Ok
     }
-    parsed
+}
+
+#[cfg(unix)]
+fn shell_probe_args(shell: &str) -> Option<&'static [&'static str]> {
+    match std::path::Path::new(shell)
+        .file_name()
+        .and_then(|name| name.to_str())
+    {
+        Some("bash" | "zsh" | "sh" | "dash" | "ksh") => Some(&["-ilc"]),
+        Some("fish") => Some(&["-i", "-l", "-c"]),
+        _ => None,
+    }
 }
 
 #[cfg(not(unix))]
-pub fn resolve_login_shell_env() -> LoginShellEnv {
-    LoginShellEnv::default()
+pub fn resolve_login_shell_env() -> DiscoveryResult {
+    finish_discovery(
+        None,
+        DiscoveryOutcome::NoShell,
+        Instant::now(),
+        LoginShellEnv::default(),
+    )
 }
 
-/// Pull each `__RUNNER_KV_<NAME>_BEGIN__…__RUNNER_KV_<NAME>_END__`
-/// block out of arbitrary shell stdout. Tolerates rc-file banners
-/// before / between / after blocks. Uses `rfind` for each begin
-/// marker so a marker mention in a banner can't shadow the real one.
-/// An empty value (missing var) is dropped — distinct from "var set
-/// to empty string", which we'd represent the same way and which has
-/// no useful effect on a child anyway.
+fn finish_discovery(
+    shell: Option<String>,
+    outcome: DiscoveryOutcome,
+    started: Instant,
+    env: LoginShellEnv,
+) -> DiscoveryResult {
+    let duration_ms = started.elapsed().as_millis() as u64;
+    log::info!(
+        "runtime discovery: shell={} duration_ms={} outcome={:?}",
+        shell.as_deref().unwrap_or("<none>"),
+        duration_ms,
+        outcome,
+    );
+    DiscoveryResult {
+        shell,
+        outcome,
+        duration_ms,
+        env,
+    }
+}
+
 fn parse_login_shell_env(stdout: &str) -> LoginShellEnv {
     let mut env = LoginShellEnv::default();
-    for v in CAPTURED_VARS {
-        let begin = format!("__RUNNER_KV_{v}_BEGIN__");
-        let end = format!("__RUNNER_KV_{v}_END__");
+    for var in CAPTURED_VARS {
+        let begin = format!("__RUNNER_KV_{var}_BEGIN__");
+        let end = format!("__RUNNER_KV_{var}_END__");
         let Some(begin_idx) = stdout.rfind(&begin) else {
             continue;
         };
@@ -237,10 +279,10 @@ fn parse_login_shell_env(stdout: &str) -> LoginShellEnv {
         if value.is_empty() {
             continue;
         }
-        if *v == "PATH" {
+        if *var == "PATH" {
             env.path = Some(value.to_string());
         } else {
-            env.vars.insert(v.to_string(), value.to_string());
+            env.vars.insert(var.to_string(), value.to_string());
         }
     }
     env
@@ -255,7 +297,7 @@ mod tests {
     }
 
     #[test]
-    fn parses_path_and_proxy_quartet_ignoring_rc_banner() {
+    fn parses_path_and_proxy_values_ignoring_rc_banner() {
         let mut stdout = String::from("Welcome to zsh!\nnvm: using node v20\n");
         stdout.push_str(&block("PATH", "/opt/homebrew/bin:/usr/bin:/bin"));
         stdout.push_str(&block("HTTPS_PROXY", "http://127.0.0.1:7890"));
@@ -279,40 +321,80 @@ mod tests {
             parsed.vars.get("NO_PROXY").map(String::as_str),
             Some("localhost,127.0.0.1,*.byted.org"),
         );
-        // Empty value (var was unset) is dropped — distinct from a
-        // set-but-empty value, which we'd skip anyway since exporting
-        // an empty proxy var has no useful effect on a child.
         assert!(!parsed.vars.contains_key("HTTP_PROXY"));
     }
 
     #[test]
-    fn banner_mentioning_marker_substring_doesnt_shadow_real_block() {
+    fn banner_marker_does_not_shadow_real_block() {
         let mut stdout = String::from("echo: __RUNNER_KV_PATH_BEGIN__ (banner)\n");
         stdout.push_str(&block("PATH", "/usr/bin:/bin"));
-        let parsed = parse_login_shell_env(&stdout);
-        assert_eq!(parsed.path.as_deref(), Some("/usr/bin:/bin"));
+        assert_eq!(
+            parse_login_shell_env(&stdout).path.as_deref(),
+            Some("/usr/bin:/bin")
+        );
     }
 
     #[test]
-    fn missing_blocks_returns_default() {
-        let parsed = parse_login_shell_env("just a banner");
-        assert!(parsed.path.is_none());
-        assert!(parsed.vars.is_empty());
-
-        let parsed = parse_login_shell_env("__RUNNER_KV_PATH_BEGIN__only");
-        assert!(parsed.path.is_none());
-        assert!(parsed.vars.is_empty());
-
-        let parsed = parse_login_shell_env("");
-        assert!(parsed.path.is_none());
-        assert!(parsed.vars.is_empty());
+    fn missing_or_empty_blocks_return_default() {
+        for stdout in [
+            "just a banner",
+            "__RUNNER_KV_PATH_BEGIN__only",
+            "",
+            &block("PATH", ""),
+        ] {
+            assert_eq!(parse_login_shell_env(stdout), LoginShellEnv::default());
+        }
     }
 
+    #[cfg(unix)]
     #[test]
-    fn empty_value_between_markers_is_dropped() {
-        let stdout = block("PATH", "") + &block("HTTPS_PROXY", "  \n  ");
-        let parsed = parse_login_shell_env(&stdout);
-        assert!(parsed.path.is_none());
-        assert!(parsed.vars.is_empty());
+    fn supported_shells_use_their_startup_semantics() {
+        assert_eq!(shell_probe_args("/bin/zsh"), Some(&["-ilc"][..]));
+        assert_eq!(shell_probe_args("/bin/bash"), Some(&["-ilc"][..]));
+        assert_eq!(
+            shell_probe_args("/opt/homebrew/bin/fish"),
+            Some(&["-i", "-l", "-c"][..])
+        );
+        assert_eq!(shell_probe_args("/bin/tcsh"), None);
+        assert_eq!(configured_shell(None), None);
+        assert_eq!(configured_shell(Some("  ".into())), None);
+        assert_eq!(
+            configured_shell(Some(" /bin/zsh ".into())).as_deref(),
+            Some("/bin/zsh")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn invalid_shell_maps_to_spawn_error() {
+        let result = resolve_shell_env(
+            "/definitely/missing/runner-shell",
+            Duration::from_millis(20),
+            Instant::now(),
+        );
+        assert_eq!(result.outcome, DiscoveryOutcome::SpawnError);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn slow_shell_maps_to_timeout_and_empty_capture_is_typed() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let slow_dir = tempfile::tempdir().unwrap();
+        let slow_shell = slow_dir.path().join("zsh");
+        std::fs::write(&slow_shell, "#!/bin/sh\nwhile :; do :; done\n").unwrap();
+        let mut permissions = std::fs::metadata(&slow_shell).unwrap().permissions();
+        permissions.set_mode(0o755);
+        std::fs::set_permissions(&slow_shell, permissions).unwrap();
+        let result = resolve_shell_env(
+            slow_shell.to_str().unwrap(),
+            Duration::from_millis(20),
+            Instant::now(),
+        );
+        assert_eq!(result.outcome, DiscoveryOutcome::Timeout);
+        assert_eq!(
+            capture_outcome(&LoginShellEnv::default()),
+            DiscoveryOutcome::EmptyCapture
+        );
     }
 }

--- a/src/components/settings/AgentsPane.test.tsx
+++ b/src/components/settings/AgentsPane.test.tsx
@@ -1,0 +1,96 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  setOverride: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: vi.fn(async () => () => {}),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(async () => null),
+}));
+
+vi.mock("../../lib/api", () => ({
+  api: {
+    runtime: {
+      status: vi.fn(async () => ({
+        shell: {
+          shell: "/bin/zsh",
+          outcome: "ok",
+          duration_ms: 25,
+          checking: false,
+          using_last_known_good: false,
+          last_known_good_captured_at: null,
+        },
+        runtimes: [
+          {
+            name: "codex",
+            display_name: "Codex",
+            command: "codex",
+            detected_path: "/usr/local/bin/codex",
+            override_path: "/opt/codex",
+            effective_command: "/opt/codex",
+            effective_source: "override",
+            state: "override",
+            invalid_reason: null,
+          },
+        ],
+      })),
+      setOverride: mocks.setOverride,
+      clearOverride: vi.fn(),
+      refresh: vi.fn(),
+    },
+  },
+}));
+
+import { AgentsPane } from "./AgentsPane";
+
+describe("AgentsPane", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.setOverride.mockClear();
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("discards an edited override on Escape without saving it on blur", async () => {
+    await act(async () => {
+      root.render(<AgentsPane />);
+    });
+    const input = container.querySelector<HTMLInputElement>(
+      '[aria-label="Codex executable override"]',
+    );
+    expect(input).not.toBeNull();
+
+    await act(async () => {
+      input?.focus();
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")
+        ?.set?.call(input, "/tmp/new-codex");
+      input?.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      input?.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(mocks.setOverride).not.toHaveBeenCalled();
+    expect(input?.value).toBe("/opt/codex");
+  });
+});

--- a/src/components/settings/AgentsPane.tsx
+++ b/src/components/settings/AgentsPane.tsx
@@ -1,0 +1,480 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Loader2, RefreshCw } from "lucide-react";
+
+import { listen } from "@tauri-apps/api/event";
+import { open } from "@tauri-apps/plugin-dialog";
+
+import {
+  api,
+  type RuntimeExecutableStatus,
+  type RuntimeDiscoveryOutcome,
+  type RuntimeOverrideError,
+  type RuntimeRowState,
+  type RuntimeShellStatus,
+  type RuntimeStatusResponse,
+} from "../../lib/api";
+import { PaneHeader } from "./shared";
+
+export function AgentsPane() {
+  const [status, setStatus] = useState<RuntimeStatusResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      setStatus(await api.runtime.status());
+      setError(null);
+    } catch (loadError) {
+      setError(errorMessage(loadError));
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    let disposed = false;
+    let stop: (() => void) | undefined;
+    void listen("runtime/changed", () => {
+      if (!disposed) void load();
+    }).then((unlisten) => {
+      if (disposed) unlisten();
+      else stop = unlisten;
+    });
+    return () => {
+      disposed = true;
+      stop?.();
+    };
+  }, [load]);
+
+  const refresh = async () => {
+    if (refreshing || status?.shell.checking) return;
+    setRefreshing(true);
+    try {
+      setStatus(await api.runtime.refresh());
+      setError(null);
+    } catch (refreshError) {
+      setError(errorMessage(refreshError));
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  return (
+    <>
+      <PaneHeader
+        title="Agents"
+        subtitle="Discover and override built-in agent executables."
+      />
+      <ShellEnvironmentCard
+        shell={status?.shell ?? null}
+        refreshing={refreshing}
+        onRefresh={() => void refresh()}
+      />
+      <div className="flex flex-col divide-y divide-line overflow-hidden rounded-xl border border-line bg-panel">
+        {status?.runtimes.map((runtime) => (
+          <RuntimeRow
+            key={runtime.name}
+            runtime={runtime}
+            probeOutcome={status.shell.outcome}
+            onStatus={setStatus}
+          />
+        )) ??
+          [0, 1].map((index) => (
+            <div
+              key={index}
+              className="h-[108px] animate-pulse bg-raised/20 px-5 py-4"
+            />
+          ))}
+      </div>
+      <p className="text-[12px] leading-[1.5] text-fg-3">
+        Overrides apply to new sessions in direct chats, runners, and missions
+        that use the runtime&apos;s default command. Runners with a custom
+        command keep it.
+      </p>
+      {error ? (
+        <div className="flex items-start justify-between gap-3 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3">
+          <p className="min-w-0 text-[12px] text-red-300">{error}</p>
+          <button
+            type="button"
+            onClick={() => void load()}
+            className="shrink-0 cursor-pointer text-[12px] font-medium text-red-200 underline"
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
+    </>
+  );
+}
+
+function ShellEnvironmentCard({
+  shell,
+  refreshing,
+  onRefresh,
+}: {
+  shell: RuntimeShellStatus | null;
+  refreshing: boolean;
+  onRefresh: () => void;
+}) {
+  const checking = refreshing || shell?.checking;
+  const description = shellDescription(shell);
+  return (
+    <div className="rounded-xl border border-line bg-panel px-5 py-4">
+      <div className="flex items-center justify-between gap-8">
+        <div className="min-w-0">
+          <div className="text-[13px] font-semibold text-fg">
+            Shell environment
+          </div>
+          <p className="mt-0.5 text-[12px] leading-[1.45] text-fg-2">
+            {description}
+          </p>
+        </div>
+        <button
+          type="button"
+          disabled={Boolean(checking)}
+          onClick={onRefresh}
+          className="flex shrink-0 cursor-pointer items-center gap-1.5 rounded-md border border-line bg-raised px-3 py-1.5 text-[12px] font-medium text-fg transition-colors hover:border-line-strong disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {checking ? (
+            <Loader2 aria-hidden className="h-3 w-3 animate-spin" />
+          ) : (
+            <RefreshCw aria-hidden className="h-3 w-3" />
+          )}
+          {checking ? "Checking…" : "Refresh"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function RuntimeRow({
+  runtime,
+  probeOutcome,
+  onStatus,
+}: {
+  runtime: RuntimeExecutableStatus;
+  probeOutcome: RuntimeDiscoveryOutcome | null;
+  onStatus: (status: RuntimeStatusResponse) => void;
+}) {
+  const [draft, setDraft] = useState(runtime.override_path ?? "");
+  const [validation, setValidation] = useState<string | null>(
+    runtime.invalid_reason,
+  );
+  const [saving, setSaving] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const cancelBlurRef = useRef(false);
+
+  useEffect(() => {
+    if (focused || saving) return;
+    setDraft(runtime.override_path ?? "");
+    setValidation(runtime.invalid_reason);
+  }, [
+    focused,
+    runtime.invalid_reason,
+    runtime.override_path,
+    saving,
+  ]);
+
+  const commit = async (nextValue: string) => {
+    if (saving) return;
+    const next = nextValue.trim();
+    if (next === (runtime.override_path ?? "")) {
+      setValidation(runtime.invalid_reason);
+      return;
+    }
+    setSaving(true);
+    setValidation(null);
+    try {
+      const nextStatus = next
+        ? await api.runtime.setOverride(runtime.name, next)
+        : await api.runtime.clearOverride(runtime.name);
+      onStatus(nextStatus);
+      setDraft(
+        nextStatus.runtimes.find((row) => row.name === runtime.name)
+          ?.override_path ?? "",
+      );
+    } catch (saveError) {
+      setValidation(errorMessage(saveError));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const browse = async () => {
+    try {
+      const selected = await open({
+        directory: false,
+        multiple: false,
+        title: `Choose ${runtime.display_name} executable`,
+      });
+      const path = Array.isArray(selected) ? selected[0] : selected;
+      if (!path) return;
+      setDraft(path);
+      await commit(path);
+    } catch (browseError) {
+      setValidation(errorMessage(browseError));
+    }
+  };
+
+  const reset = async () => {
+    if (saving) return;
+    setSaving(true);
+    setValidation(null);
+    try {
+      const nextStatus = await api.runtime.clearOverride(runtime.name);
+      onStatus(nextStatus);
+      setDraft("");
+    } catch (clearError) {
+      setValidation(errorMessage(clearError));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const state: RuntimeRowState = validation
+    ? "invalid_override"
+    : runtime.state;
+  const autoPath =
+    runtime.state === "checking"
+      ? "Auto — detecting…"
+      : runtime.detected_path
+        ? `Auto — ${runtime.detected_path}`
+      : `Auto — ${runtime.command} not found on PATH`;
+  const showReset = Boolean(runtime.override_path || draft);
+
+  return (
+    <div className="flex flex-col gap-3 px-5 py-4">
+      <div className="flex items-center gap-2.5">
+        <span className="text-[13px] font-semibold text-fg">
+          {runtime.display_name}
+        </span>
+        <RuntimeBadge
+          state={state}
+          probeOutcome={probeOutcome}
+          saving={saving}
+        />
+        <span className="min-w-0 flex-1" />
+        <span className="font-mono text-[11px] text-fg-3">
+          {runtime.command}
+        </span>
+      </div>
+      <div className="flex items-center gap-2">
+        <input
+          value={draft}
+          disabled={saving}
+          placeholder={autoPath}
+          aria-label={`${runtime.display_name} executable override`}
+          onFocus={() => setFocused(true)}
+          onChange={(event) => {
+            setDraft(event.target.value);
+            setValidation(null);
+          }}
+          onBlur={(event) => {
+            setFocused(false);
+            if (cancelBlurRef.current) {
+              cancelBlurRef.current = false;
+              return;
+            }
+            void commit(event.currentTarget.value);
+          }}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") event.currentTarget.blur();
+            if (event.key === "Escape") {
+              cancelBlurRef.current = true;
+              setDraft(runtime.override_path ?? "");
+              setValidation(runtime.invalid_reason);
+              event.currentTarget.blur();
+            }
+          }}
+          className={`h-8 min-w-0 flex-1 rounded-md border bg-bg px-3 font-mono text-[11px] text-fg outline-none transition-colors placeholder:text-fg-3 disabled:opacity-60 ${
+            validation
+              ? "border-red-500/70 focus:border-red-400"
+              : "border-line focus:border-line-strong"
+          }`}
+        />
+        <button
+          type="button"
+          disabled={saving}
+          onPointerDown={(event) => event.preventDefault()}
+          onClick={() => void browse()}
+          className="h-8 shrink-0 cursor-pointer rounded-md border border-line bg-raised px-3 text-[12px] font-medium text-fg transition-colors hover:border-line-strong disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          Browse…
+        </button>
+        {showReset ? (
+          <button
+            type="button"
+            disabled={saving}
+            onPointerDown={(event) => event.preventDefault()}
+            onClick={() => void reset()}
+            className="h-8 shrink-0 cursor-pointer px-2 text-[12px] font-medium text-fg-2 transition-colors hover:text-fg disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Reset to auto
+          </button>
+        ) : null}
+      </div>
+      <RuntimeCaption
+        runtime={runtime}
+        state={state}
+        probeOutcome={probeOutcome}
+        validation={validation}
+      />
+    </div>
+  );
+}
+
+function RuntimeBadge({
+  state,
+  probeOutcome,
+  saving,
+}: {
+  state: RuntimeRowState;
+  probeOutcome: RuntimeDiscoveryOutcome | null;
+  saving: boolean;
+}) {
+  if (saving) {
+    return <Badge label="Saving…" tone="muted" spinning />;
+  }
+  switch (state) {
+    case "detected":
+      return <Badge label="Detected" tone="accent" />;
+    case "override":
+      return <Badge label="Override" tone="neutral" />;
+    case "not_found":
+      return <Badge label="Not found" tone="danger" />;
+    case "checking":
+      return <Badge label="Checking…" tone="muted" spinning />;
+    case "probe_timed_out":
+      return (
+        <Badge
+          label={
+            probeOutcome === "timeout" ? "Probe timed out" : "Detection failed"
+          }
+          tone="warning"
+        />
+      );
+    case "invalid_override":
+      return <Badge label="Invalid" tone="danger" />;
+  }
+}
+
+function Badge({
+  label,
+  tone,
+  spinning = false,
+}: {
+  label: string;
+  tone: "accent" | "neutral" | "danger" | "warning" | "muted";
+  spinning?: boolean;
+}) {
+  const classes = {
+    accent: "bg-accent/10 text-accent",
+    neutral: "bg-fg/5 text-fg",
+    danger: "bg-red-500/10 text-red-300",
+    warning: "bg-amber-400/10 text-amber-300",
+    muted: "bg-fg-3/10 text-fg-3",
+  }[tone];
+  const dot = {
+    accent: "bg-accent",
+    neutral: "bg-fg",
+    danger: "bg-red-400",
+    warning: "bg-amber-300",
+    muted: "bg-fg-3",
+  }[tone];
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[10px] font-medium ${classes}`}
+    >
+      {spinning ? (
+        <Loader2 aria-hidden className="h-2.5 w-2.5 animate-spin" />
+      ) : (
+        <span className={`h-1.5 w-1.5 rounded-full ${dot}`} />
+      )}
+      {label}
+    </span>
+  );
+}
+
+function RuntimeCaption({
+  runtime,
+  state,
+  probeOutcome,
+  validation,
+}: {
+  runtime: RuntimeExecutableStatus;
+  state: RuntimeRowState;
+  probeOutcome: RuntimeDiscoveryOutcome | null;
+  validation: string | null;
+}) {
+  let text: string | null = null;
+  let danger = false;
+  if (validation) {
+    text = validation;
+    danger = true;
+  } else if (state === "override") {
+    text = runtime.detected_path
+      ? `Detected: ${runtime.detected_path}`
+      : `${runtime.command} was not found automatically.`;
+  } else if (state === "not_found") {
+    text = `Install ${runtime.display_name} or set an explicit executable path.`;
+  } else if (state === "probe_timed_out") {
+    const failure =
+      probeOutcome === "timeout" ? "Login shell timed out" : "Shell detection failed";
+    text = runtime.detected_path
+      ? `${failure} — using the last resolved path: ${runtime.detected_path}`
+      : `${failure}. Refresh or set an explicit executable path.`;
+  } else if (state === "checking" && runtime.detected_path) {
+    text = `Using last detected path: ${runtime.detected_path}`;
+  }
+  return text ? (
+    <p
+      className={`font-mono text-[11px] leading-[1.4] ${
+        danger ? "text-red-300" : "text-fg-3"
+      }`}
+    >
+      {text}
+    </p>
+  ) : null;
+}
+
+function shellDescription(shell: RuntimeShellStatus | null) {
+  if (!shell) return "Loading shell discovery status…";
+  const selected = shell.shell;
+  const duration =
+    shell.duration_ms == null
+      ? ""
+      : ` in ${(shell.duration_ms / 1000).toFixed(1)} s`;
+  if (shell.checking) {
+    if (!selected) return "Checking login shell for PATH and proxy settings…";
+    return shell.using_last_known_good
+      ? `Checking ${selected}; agents keep using the last saved environment.`
+      : `Checking ${selected} for PATH and proxy settings…`;
+  }
+  switch (shell.outcome) {
+    case "ok":
+      return `PATH captured from your login shell (${selected})${duration}. Spawned agents inherit it.`;
+    case "timeout":
+      return `${selected} did not respond${duration}; agents keep using the last saved environment.`;
+    case "spawn_error":
+      return `Could not start ${selected}; refresh after fixing the login shell or set an override below.`;
+    case "empty_capture":
+      return `${selected} returned no usable environment; refresh or set an override below.`;
+    case "no_shell":
+      return "No supported login shell was configured; set an executable override below.";
+    default:
+      return selected
+        ? `Waiting to check ${selected}.`
+        : "Waiting to check the login shell.";
+  }
+}
+
+function errorMessage(error: unknown) {
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as RuntimeOverrideError).message === "string"
+  ) {
+    return (error as RuntimeOverrideError).message;
+  }
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -130,6 +130,52 @@ export interface RuntimeDefinition {
   command: string;
 }
 
+export type RuntimeDiscoveryOutcome =
+  | "ok"
+  | "timeout"
+  | "spawn_error"
+  | "empty_capture"
+  | "no_shell";
+
+export type RuntimeRowState =
+  | "detected"
+  | "override"
+  | "not_found"
+  | "checking"
+  | "probe_timed_out"
+  | "invalid_override";
+
+export interface RuntimeShellStatus {
+  shell: string | null;
+  outcome: RuntimeDiscoveryOutcome | null;
+  duration_ms: number | null;
+  checking: boolean;
+  using_last_known_good: boolean;
+  last_known_good_captured_at: string | null;
+}
+
+export interface RuntimeExecutableStatus {
+  name: string;
+  display_name: string;
+  command: string;
+  detected_path: string | null;
+  override_path: string | null;
+  effective_command: string | null;
+  effective_source: "override" | "detected" | "catalog" | null;
+  state: RuntimeRowState;
+  invalid_reason: string | null;
+}
+
+export interface RuntimeStatusResponse {
+  shell: RuntimeShellStatus;
+  runtimes: RuntimeExecutableStatus[];
+}
+
+export interface RuntimeOverrideError {
+  code: string;
+  message: string;
+}
+
 export const api = {
   project: {
     list: () => invoke<ProjectRow[]>("project_list"),
@@ -207,6 +253,12 @@ export const api = {
   },
   runtime: {
     list: () => invoke<RuntimeDefinition[]>("runtime_list"),
+    status: () => invoke<RuntimeStatusResponse>("runtime_status_list"),
+    setOverride: (runtime: string, path: string) =>
+      invoke<RuntimeStatusResponse>("runtime_set_override", { runtime, path }),
+    clearOverride: (runtime: string) =>
+      invoke<RuntimeStatusResponse>("runtime_clear_override", { runtime }),
+    refresh: () => invoke<RuntimeStatusResponse>("runtime_refresh"),
   },
   mission: {
     list: (crewId?: string) =>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -18,6 +18,7 @@ import { matchPath, useLocation, useNavigate } from "react-router-dom";
 import {
   Archive,
   ArrowLeft,
+  Bot,
   FileText,
   Info,
   Keyboard,
@@ -31,6 +32,7 @@ import {
 } from "lucide-react";
 
 import { AboutPane } from "../components/settings/AboutPane";
+import { AgentsPane } from "../components/settings/AgentsPane";
 import { AppearancePane } from "../components/settings/AppearancePane";
 import { ArchivedPane } from "../components/settings/ArchivedPane";
 import { ChatPane } from "../components/settings/ChatPane";
@@ -56,6 +58,7 @@ type PaneKey =
   | "appearance"
   | "terminal"
   | "shortcuts"
+  | "agents"
   | "mcp"
   | "updates"
   | "diagnostics"
@@ -79,6 +82,7 @@ const PANES: Record<
     icon: Keyboard,
     render: () => <ShortcutsPane />,
   },
+  agents: { label: "Agents", icon: Bot, render: () => <AgentsPane /> },
   mcp: { label: "MCP", icon: Plug, render: () => <McpPane /> },
   updates: { label: "Updates", icon: RefreshCw, render: () => <UpdatesPane /> },
   diagnostics: {
@@ -99,7 +103,7 @@ const NAV_GROUPS: { label: string; panes: PaneKey[] }[] = [
     label: "App",
     panes: ["general", "chat", "appearance", "terminal", "shortcuts"],
   },
-  { label: "Integrations", panes: ["mcp"] },
+  { label: "Integrations", panes: ["agents", "mcp"] },
   { label: "System", panes: ["updates", "diagnostics", "about"] },
   { label: "Archived", panes: ["archived"] },
 ];


### PR DESCRIPTION
## Summary

- discover Claude Code and Codex executables from a background login-shell probe with persisted last-known-good environment
- resolve runtime commands with override, detected-path, and catalog precedence across direct, runner, mission, and resume spawns
- add Settings → Agents status and override controls with backend-owned persistence and actionable pre-PTY errors
- document the runtime discovery architecture and preserve the supplied settings design

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace`
- `cargo test --workspace`
- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm test`

Manual app verification items remain explicitly unchecked in the feature spec and implementation plan.

Closes #279