### PR TITLE
feat(session): resume agents on launch

### DIFF
--- a/docs/features/45-auto-resume-on-launch.md
+++ b/docs/features/45-auto-resume-on-launch.md
@@ -30,11 +30,14 @@ The gap is memory plus initiative: nothing records *which* sessions were live at
 1. **Explicit flag, not timestamp inference.** Inferring "was running at quit" from `stopped_at` proximity to shutdown confuses deliberately-stopped chats with quit-killed ones. The quit hook knows exactly which rows it's killing; it should say so.
 2. **Crash = no auto-resume.** The stamp lives in the graceful-quit path only. After a crash, sessions demote via startup cleanup as today and stay stopped — auto-respawning agents after a crash risks looping into whatever caused it. (If crash-restore is ever wanted, it's a separate, deliberate decision.)
 3. **Resume, never fresh-spawn.** A marked session that lost its `agent_session_key` (or whose resume fails) stays stopped with the existing Resume affordance — auto-starting a *fresh* conversation the user didn't ask for is worse than doing nothing.
+4. **Quit stamping is unconditional.** The backend does not read the frontend setting. Every graceful quit records the live set; the launch consumer decides whether to resume it.
+5. **Toggle-off consumes without resuming.** A launch with auto-resume disabled clears every pending `resume_on_launch` stamp so turning the setting on later cannot resurrect work from an older quit.
 
-### To be decided
+### Resolved product decisions
 
-- Stagger interval (likely 250–500ms between spawns).
-- Whether a launch with many marked sessions (say >6) should resume silently or show a one-line "Resuming N agents…" indicator.
+- Stagger resume spawns by 300ms.
+- Resume silently in v1; do not add a "Resuming N agents…" indicator.
+- Put "Resume running agents on launch" in Settings → General under a new Startup section. It defaults on and persists in `localStorage` through the `src/lib/settings.ts` `STORAGE_*` pattern.
 
 ## Implementation phases
 
@@ -48,5 +51,5 @@ The gap is memory plus initiative: nothing records *which* sessions were live at
 - [ ] A chat stopped manually before quit stays stopped after relaunch.
 - [ ] Kill the app process (simulated crash) → nothing auto-resumes.
 - [ ] A session with a rejected resume key surfaces the existing crash warning and doesn't block other resumes.
-- [ ] Toggle off → relaunch restores nothing; rows keep their normal Resume buttons.
-- [ ] `cargo test --workspace`, `pnpm exec tsc --noEmit`, `pnpm run lint` clean.
+- [ ] Toggle off → relaunch restores nothing; rows keep their normal Resume buttons; turning the toggle back on does not resume the old quit's set.
+- [ ] `cargo fmt --check`, `cargo clippy --workspace`, `cargo test --workspace`, `pnpm exec tsc --noEmit`, `pnpm run lint` clean.

--- a/src-tauri/migrations/0017_session_resume_on_launch.sql
+++ b/src-tauri/migrations/0017_session_resume_on_launch.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sessions ADD COLUMN resume_on_launch INTEGER NOT NULL DEFAULT 0;

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -32,7 +32,11 @@ use crate::{
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 pub struct StartMissionInput {
     pub crew_id: String,
-    /// Optional project membership. Its cwd is used when cwd is omitted.
+    /// Pass this whenever the mission belongs to a project. Use
+    /// `project_list` to discover the project bound to the cwd. Callers must
+    /// not treat `cwd` alone as an association: with no unique canonical
+    /// match it does NOT associate the mission and leaves it un-nested in
+    /// the sidebar.
     #[serde(default)]
     pub project_id: Option<String>,
     pub title: String,
@@ -182,6 +186,9 @@ pub fn start(
     }
     if let Some(g) = input.goal_override.as_deref() {
         validate_mission_goal(g)?;
+    }
+    if input.project_id.is_none() {
+        input.project_id = project::infer_id_from_cwd(conn, input.cwd.as_deref())?;
     }
     input.cwd = project::resolve_cwd(conn, input.project_id.as_deref(), input.cwd)?;
 
@@ -2132,6 +2139,128 @@ mod tests {
         .unwrap();
 
         assert_eq!(out.mission.cwd.as_deref(), Some("/override"));
+    }
+
+    #[test]
+    fn start_infers_project_from_one_exact_canonical_cwd_match() {
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "Alpha", None);
+        add_runner(&mut conn, &crew_id, "lead");
+        let tmp = tempfile::tempdir().unwrap();
+        let bound = tmp.path().join("bound");
+        std::fs::create_dir(&bound).unwrap();
+        let project = repo::project::create(&conn, "Bound", bound.to_str().unwrap()).unwrap();
+
+        let out = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                project_id: None,
+                crew_id,
+                title: "inferred".into(),
+                goal_override: None,
+                cwd: Some(bound.join(".").to_string_lossy().into_owned()),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(out.mission.project_id.as_deref(), Some(project.id.as_str()));
+    }
+
+    #[test]
+    fn start_leaves_project_null_when_cwd_does_not_match() {
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "Alpha", None);
+        add_runner(&mut conn, &crew_id, "lead");
+        let tmp = tempfile::tempdir().unwrap();
+        let bound = tmp.path().join("bound");
+        let other = tmp.path().join("other");
+        std::fs::create_dir(&bound).unwrap();
+        std::fs::create_dir(&other).unwrap();
+        repo::project::create(&conn, "Bound", bound.to_str().unwrap()).unwrap();
+
+        let out = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                project_id: None,
+                crew_id,
+                title: "unmatched".into(),
+                goal_override: None,
+                cwd: Some(other.to_string_lossy().into_owned()),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(out.mission.project_id, None);
+    }
+
+    #[test]
+    fn start_leaves_project_null_when_multiple_projects_match_cwd() {
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "Alpha", None);
+        add_runner(&mut conn, &crew_id, "lead");
+        let tmp = tempfile::tempdir().unwrap();
+        let bound = tmp.path().join("bound");
+        std::fs::create_dir(&bound).unwrap();
+        let bound = bound.to_str().unwrap();
+        repo::project::create(&conn, "First", bound).unwrap();
+        repo::project::create(&conn, "Second", bound).unwrap();
+
+        let out = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                project_id: None,
+                crew_id,
+                title: "ambiguous".into(),
+                goal_override: None,
+                cwd: Some(bound.into()),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(out.mission.project_id, None);
+    }
+
+    #[test]
+    fn start_explicit_project_wins_over_cwd_inference() {
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let crew_id = seed_crew(&conn, "Alpha", None);
+        add_runner(&mut conn, &crew_id, "lead");
+        let tmp = tempfile::tempdir().unwrap();
+        let first = tmp.path().join("first");
+        let second = tmp.path().join("second");
+        std::fs::create_dir(&first).unwrap();
+        std::fs::create_dir(&second).unwrap();
+        let explicit = repo::project::create(&conn, "Explicit", first.to_str().unwrap()).unwrap();
+        repo::project::create(&conn, "Inferred", second.to_str().unwrap()).unwrap();
+
+        let out = start(
+            &mut conn,
+            tmp.path(),
+            StartMissionInput {
+                project_id: Some(explicit.id.clone()),
+                crew_id,
+                title: "explicit".into(),
+                goal_override: None,
+                cwd: Some(second.to_string_lossy().into_owned()),
+            },
+        )
+        .unwrap();
+
+        assert_eq!(
+            out.mission.project_id.as_deref(),
+            Some(explicit.id.as_str())
+        );
+        assert_eq!(
+            out.mission.cwd.as_deref(),
+            Some(second.to_string_lossy().as_ref())
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/project.rs
+++ b/src-tauri/src/commands/project.rs
@@ -37,6 +37,29 @@ pub(crate) fn resolve_cwd(
     Ok(cwd.or(Some(project.cwd)))
 }
 
+pub(crate) fn infer_id_from_cwd(
+    conn: &rusqlite::Connection,
+    cwd: Option<&str>,
+) -> Result<Option<String>> {
+    let Some(cwd) = cwd else {
+        return Ok(None);
+    };
+    let Ok(canonical_cwd) = std::fs::canonicalize(cwd) else {
+        return Ok(None);
+    };
+    let mut matched_id = None;
+    for project in repo::project::list(conn)? {
+        if std::fs::canonicalize(&project.cwd).ok().as_ref() != Some(&canonical_cwd) {
+            continue;
+        }
+        if matched_id.is_some() {
+            return Ok(None);
+        }
+        matched_id = Some(project.id);
+    }
+    Ok(matched_id)
+}
+
 #[tauri::command]
 pub fn project_list(state: State<'_, AppState>) -> Result<Vec<ProjectRow>> {
     let conn = state.db.get()?;

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -598,12 +598,24 @@ pub async fn session_pin(
     Ok(())
 }
 
+#[tauri::command]
+pub fn session_take_resume_on_launch(state: State<'_, AppState>) -> Result<Option<String>> {
+    let mut conn = state.db.get()?;
+    Ok(repo::session::take_resume_on_launch(&mut conn)?)
+}
+
+#[tauri::command]
+pub fn session_clear_resume_on_launch(state: State<'_, AppState>) -> Result<()> {
+    let conn = state.db.get()?;
+    repo::session::clear_resume_on_launch(&conn)?;
+    Ok(())
+}
+
 /// Respawn an existing direct-chat session row. Reuses the row's id and
 /// `agent_session_key` so the agent CLI continues the prior conversation
 /// (claude-code: `--resume <uuid>`; codex: `codex resume <uuid>` once the
 /// key-capture path lands). See `SessionManager::resume` for the detailed
-/// contract — refused for running rows, mission-scoped rows, and archived
-/// rows.
+/// contract — refused for running and archived rows.
 #[tauri::command]
 pub async fn session_resume(
     state: State<'_, AppState>,
@@ -611,15 +623,18 @@ pub async fn session_resume(
     session_id: String,
     cols: Option<u16>,
     rows: Option<u16>,
+    automatic: Option<bool>,
 ) -> Result<SpawnedSession> {
     // Dims decide the PTY fork size; None forks at the 80×24 default and
     // a TUI's instant banner then renders garbled at pane width. Logged
     // so a garbled-pane report can be traced back to its resume geometry.
-    log::info!("session_resume: session={session_id} cols={cols:?} rows={rows:?}");
+    let automatic = automatic.unwrap_or(false);
+    log::info!(
+        "session_resume: session={session_id} cols={cols:?} rows={rows:?} automatic={automatic}"
+    );
     let emitter: Arc<dyn SessionEvents> = Arc::new(TauriSessionEvents(app.clone()));
-    let spawned = state
-        .sessions
-        .resume(
+    let spawned = if automatic {
+        state.sessions.resume_on_launch(
             &session_id,
             cols,
             rows,
@@ -627,7 +642,17 @@ pub async fn session_resume(
             state.db.clone(),
             emitter,
         )
-        .map_err(|e| Error::msg(format!("session_resume: {e}")))?;
+    } else {
+        state.sessions.resume(
+            &session_id,
+            cols,
+            rows,
+            &state.app_data_dir,
+            state.db.clone(),
+            emitter,
+        )
+    }
+    .map_err(|e| Error::msg(format!("session_resume: {e}")))?;
     // Fresh-fallback for a lead slot: the prior claude-code conversation
     // file was missing, so the resume degraded to a `--session-id` fresh
     // spawn. The bus's mission_goal handler is suppressed on resume by

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -102,6 +102,8 @@ fn init_connection(conn: &mut Connection) -> rusqlite::Result<()> {
 // dropped in the same transaction.
 // 0016: persists the last applied PTY size per session so an unsized
 // resume can fork at the prior width before any frontend pane is measurable.
+// 0017: records sessions that were running at graceful quit so the next
+// launch can resume them without treating crash-demoted rows the same way.
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, include_str!("../migrations/0001_init.sql")),
     (2, include_str!("../migrations/0002_persona_only_seeds.sql")),
@@ -140,6 +142,10 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (14, include_str!("../migrations/0014_nodes.sql")),
     (15, include_str!("../migrations/0015_retire_folders.sql")),
     (16, include_str!("../migrations/0016_session_last_size.sql")),
+    (
+        17,
+        include_str!("../migrations/0017_session_resume_on_launch.sql"),
+    ),
 ];
 
 // Default-data seed: ships the Build squad starter crew on first launch.
@@ -1633,7 +1639,7 @@ Talking to the human:
     }
 
     #[test]
-    fn sessions_has_runtime_and_size_columns_after_migration() {
+    fn sessions_has_runtime_size_and_resume_columns_after_migration() {
         // Defensive: keep the legacy runtime columns present for
         // existing databases. New PTY-runtime writes use only
         // `runtime` + `runtime_session`; socket/window/pane are
@@ -1659,6 +1665,7 @@ Talking to the human:
             "runtime_cursor",
             "last_cols",
             "last_rows",
+            "resume_on_launch",
         ] {
             assert!(
                 columns.iter().any(|c| c == required),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -416,6 +416,8 @@ pub fn run() {
             commands::session::session_rename,
             commands::session::session_pin,
             commands::session::session_set_project,
+            commands::session::session_take_resume_on_launch,
+            commands::session::session_clear_resume_on_launch,
             commands::session::session_resume,
             commands::session::session_inject_stdin,
             commands::session::session_kill,
@@ -571,38 +573,32 @@ fn hide_main_window_on_close(app_handle: &AppHandle) {
     }
 }
 
-/// On-quit hook body. Walks the DB for `running` direct-chat
-/// sessions and asks `SessionManager` to kill each one. Mission-
-/// scoped rows are left alone — their lifecycle is owned by
-/// `mission_stop` flows and v1 keeps router/event-bus migration
-/// out of scope (impl 0011 §"Mission sessions").
+/// On-quit hook body. Durably records the sessions that were live at
+/// graceful quit, then asks `SessionManager` to stop each one. The set
+/// includes direct chats and live slots of running missions; startup
+/// cleanup demotes any rows whose process exits with the app.
 fn stop_running_sessions_on_quit(app_handle: &AppHandle) {
     let state = match app_handle.try_state::<AppState>() {
         Some(s) => s,
         None => return,
     };
-    let ids: Vec<String> = match state.db.get().ok().and_then(|conn| {
-        conn.prepare(
-            "SELECT id FROM sessions
-                WHERE status = 'running' AND mission_id IS NULL",
-        )
-        .ok()
-        .and_then(|mut stmt| {
-            stmt.query_map([], |r| r.get::<_, String>(0))
-                .ok()
-                .map(|rows| rows.filter_map(Result::ok).collect())
-        })
-    }) {
-        Some(v) => v,
-        None => return,
+    let ids = match state.db.get() {
+        Ok(mut conn) => match repo::session::mark_running_for_resume_on_launch(&mut conn) {
+            Ok(ids) => ids,
+            Err(error) => {
+                log::warn!("on-quit resume stamp failed: {error}");
+                return;
+            }
+        },
+        Err(error) => {
+            log::warn!("on-quit resume stamp failed: {error}");
+            return;
+        }
     };
     if ids.is_empty() {
         return;
     }
-    log::info!(
-        "on-quit: stopping {} running direct-chat session(s)",
-        ids.len()
-    );
+    log::info!("on-quit: stamped and stopping {} session(s)", ids.len());
     for id in &ids {
         if let Err(e) = state.sessions.kill(id) {
             log::warn!("on-quit kill {id}: {e}");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -106,6 +106,7 @@ pub fn run() {
         log_builder = log_builder.level_for(target, level);
     }
 
+    let mut quit_prepared = false;
     tauri::Builder::default()
         .plugin(log_builder.build())
         .plugin(tauri_plugin_opener::init())
@@ -439,7 +440,7 @@ pub fn run() {
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
-        .run(|app_handle, event| {
+        .run(move |app_handle, event| {
             // On graceful quit, stop any `running` direct-chat
             // sessions before the runtime drops. Under the pty
             // runtime, this fires SIGTERM-via-ChildKiller so
@@ -518,14 +519,23 @@ pub fn run() {
                     broadcast_focus_map(app_handle);
                 }
                 tauri::RunEvent::ExitRequested { .. } => {
-                    stop_running_sessions_on_quit(app_handle);
+                    if !quit_prepared {
+                        quit_prepared = true;
+                        stop_running_sessions_on_quit(app_handle);
+                    }
                     if let Some(state) = app_handle.try_state::<AppState>() {
                         state.mcp.stop();
                     }
                 }
-                // Final geometry write. The window may already be gone
-                // here; `save` falls back to the Moved/Resized cache.
                 tauri::RunEvent::Exit => {
+                    // macOS's native Quit menu item can terminate the event
+                    // loop without emitting ExitRequested.
+                    if !quit_prepared {
+                        quit_prepared = true;
+                        stop_running_sessions_on_quit(app_handle);
+                    }
+                    // Final geometry write. The window may already be gone
+                    // here; `save` falls back to the Moved/Resized cache.
                     if let Some(state) = app_handle.try_state::<AppState>() {
                         window_state::save(app_handle, &state.app_data_dir);
                     }

--- a/src-tauri/src/mcp/tools/mission.rs
+++ b/src-tauri/src/mcp/tools/mission.rs
@@ -426,7 +426,7 @@ impl RunnerMcpHandler {
     }
 
     #[tool(
-        description = "Start a mission for a crew. A project's cwd is used unless cwd is explicitly provided."
+        description = "Start a mission for a crew. Pass project_id whenever the mission belongs to a project; use project_list to discover the project bound to the cwd. Do not treat cwd alone as an association: with no unique canonical match it does NOT associate the mission with a project and leaves it un-nested in the sidebar. A project's cwd is used unless cwd is explicitly provided."
     )]
     pub async fn mission_start(
         &self,

--- a/src-tauri/src/repo/session.rs
+++ b/src-tauri/src/repo/session.rs
@@ -49,6 +49,7 @@ pub struct SessionRowDb {
     pub agent_command: Option<String>,
     pub last_cols: Option<u16>,
     pub last_rows: Option<u16>,
+    pub resume_on_launch: bool,
 }
 
 impl SessionRowDb {
@@ -80,6 +81,7 @@ impl SessionRowDb {
             agent_command: None,
             last_cols: None,
             last_rows: None,
+            resume_on_launch: false,
         }
     }
 }
@@ -109,6 +111,7 @@ pub const COLUMNS: &[&str] = &[
     "agent_command",
     "last_cols",
     "last_rows",
+    "resume_on_launch",
 ];
 
 pub fn insert(conn: &Connection, row: &SessionRowDb) -> rusqlite::Result<()> {
@@ -290,6 +293,99 @@ pub fn cleanup_stale_running(conn: &Connection, now: Timestamp) -> rusqlite::Res
                 stopped_at = COALESCE(stopped_at, ?1)
             WHERE status = 'running'",
         rusqlite::params![now.to_rfc3339()],
+    )
+}
+
+/// Replace any prior launch-resume set with the sessions live at this
+/// graceful quit: direct chats plus slots belonging to running missions.
+/// The caller kills the returned ids only after this transaction commits.
+pub fn mark_running_for_resume_on_launch(conn: &mut Connection) -> rusqlite::Result<Vec<String>> {
+    let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    tx.execute(
+        "UPDATE sessions SET resume_on_launch = 0 WHERE resume_on_launch != 0",
+        [],
+    )?;
+    tx.execute(
+        "UPDATE sessions
+            SET resume_on_launch = 1
+          WHERE status = 'running'
+            AND archived_at IS NULL
+            AND (
+                mission_id IS NULL
+                OR (
+                    slot_id IS NOT NULL
+                    AND EXISTS (
+                        SELECT 1
+                          FROM missions
+                         WHERE missions.id = sessions.mission_id
+                           AND missions.status = 'running'
+                    )
+                )
+            )",
+        [],
+    )?;
+    let ids = {
+        let mut stmt = tx.prepare(
+            "SELECT id
+               FROM sessions
+              WHERE resume_on_launch = 1
+              ORDER BY started_at, id",
+        )?;
+        let rows = stmt
+            .query_map([], |row| row.get(0))?
+            .collect::<rusqlite::Result<Vec<_>>>()?;
+        rows
+    };
+    tx.commit()?;
+    Ok(ids)
+}
+
+/// Atomically consume the next quit-time stamp. Rows that can no longer
+/// resume are cleared and skipped so they cannot become stale launch work.
+pub fn take_resume_on_launch(conn: &mut Connection) -> rusqlite::Result<Option<String>> {
+    let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
+    let next = loop {
+        let row = tx
+            .query_row(
+                "SELECT id,
+                        status IN ('stopped', 'crashed'),
+                        agent_session_key IS NOT NULL
+                            AND TRIM(agent_session_key) != '',
+                        archived_at IS NULL
+                   FROM sessions
+                  WHERE resume_on_launch = 1
+                  ORDER BY started_at, id
+                  LIMIT 1",
+                [],
+                |row| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, bool>(1)?,
+                        row.get::<_, bool>(2)?,
+                        row.get::<_, bool>(3)?,
+                    ))
+                },
+            )
+            .optional()?;
+        let Some((id, stopped, has_key, active)) = row else {
+            break None;
+        };
+        tx.execute(
+            "UPDATE sessions SET resume_on_launch = 0 WHERE id = ?1",
+            [&id],
+        )?;
+        if stopped && has_key && active {
+            break Some(id);
+        }
+    };
+    tx.commit()?;
+    Ok(next)
+}
+
+pub fn clear_resume_on_launch(conn: &Connection) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE sessions SET resume_on_launch = 0 WHERE resume_on_launch != 0",
+        [],
     )
 }
 
@@ -578,6 +674,7 @@ mod tests {
             agent_command: Some("codex".into()),
             last_cols: Some(132),
             last_rows: Some(41),
+            resume_on_launch: true,
         }
     }
 
@@ -726,6 +823,103 @@ mod tests {
             )
             .unwrap();
         assert_eq!(stored, "key-a");
+    }
+
+    #[test]
+    fn graceful_quit_marks_only_live_direct_and_running_mission_slots() {
+        let pool = db::open_in_memory().unwrap();
+        let mut conn = pool.get().unwrap();
+        seed_runner(&conn, "r1", "alpha");
+        let now = "2026-07-25T00:00:00Z";
+        conn.execute(
+            "INSERT INTO crews (id, name, created_at, updated_at)
+             VALUES ('c1', 'Crew', ?1, ?1)",
+            [now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO missions (id, crew_id, title, status, started_at)
+             VALUES ('mission-running', 'c1', 'Running', 'running', ?1),
+                    ('mission-stopped', 'c1', 'Stopped', 'stopped', ?1)",
+            [now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions
+                (id, mission_id, runner_id, slot_id, status, started_at,
+                 archived_at, resume_on_launch)
+             VALUES
+                ('direct-running', NULL, 'r1', NULL, 'running', ?1, NULL, 0),
+                ('direct-stopped', NULL, 'r1', NULL, 'stopped', ?1, NULL, 1),
+                ('mission-running-slot', 'mission-running', 'r1', 'slot-a',
+                 'running', ?1, NULL, 0),
+                ('mission-stopped-slot', 'mission-stopped', 'r1', 'slot-b',
+                 'running', ?1, NULL, 0),
+                ('mission-no-slot', 'mission-running', 'r1', NULL,
+                 'running', ?1, NULL, 0),
+                ('mission-archived-slot', 'mission-running', 'r1', 'slot-c',
+                 'running', ?1, ?1, 0)",
+            [now],
+        )
+        .unwrap();
+
+        let ids = mark_running_for_resume_on_launch(&mut conn).unwrap();
+        assert_eq!(ids, ["direct-running", "mission-running-slot"]);
+
+        let marked: Vec<String> = conn
+            .prepare(
+                "SELECT id FROM sessions
+                  WHERE resume_on_launch = 1
+                  ORDER BY id",
+            )
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<rusqlite::Result<_>>()
+            .unwrap();
+        assert_eq!(marked, ["direct-running", "mission-running-slot"]);
+    }
+
+    #[test]
+    fn launch_consumer_skips_unresumable_rows_and_clears_every_stamp() {
+        let pool = db::open_in_memory().unwrap();
+        let mut conn = pool.get().unwrap();
+        seed_runner(&conn, "r1", "alpha");
+        let now = "2026-07-25T00:00:00Z";
+        conn.execute(
+            "INSERT INTO sessions
+                (id, runner_id, status, started_at, agent_session_key,
+                 archived_at, resume_on_launch)
+             VALUES
+                ('a-missing-key', 'r1', 'stopped', ?1, NULL, NULL, 1),
+                ('b-archived', 'r1', 'stopped', ?1, 'key-b', ?1, 1),
+                ('c-running', 'r1', 'running', ?1, 'key-c', NULL, 1),
+                ('d-resumable', 'r1', 'stopped', ?1, 'key-d', NULL, 1)",
+            [now],
+        )
+        .unwrap();
+
+        assert_eq!(
+            take_resume_on_launch(&mut conn).unwrap().as_deref(),
+            Some("d-resumable")
+        );
+        assert_eq!(take_resume_on_launch(&mut conn).unwrap(), None);
+        let marked: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM sessions WHERE resume_on_launch = 1",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(marked, 0);
+
+        conn.execute(
+            "UPDATE sessions SET resume_on_launch = 1 WHERE id IN ('a-missing-key', 'd-resumable')",
+            [],
+        )
+        .unwrap();
+        assert_eq!(clear_resume_on_launch(&conn).unwrap(), 2);
+        assert_eq!(take_resume_on_launch(&mut conn).unwrap(), None);
     }
 
     #[test]

--- a/src-tauri/src/session/manager/spawn.rs
+++ b/src-tauri/src/session/manager/spawn.rs
@@ -983,6 +983,36 @@ impl SessionManager {
         pool: Arc<DbPool>,
         events: Arc<dyn SessionEvents>,
     ) -> Result<SpawnedSession> {
+        self.resume_with_fresh_fallback(session_id, cols, rows, app_data_dir, pool, events, true)
+    }
+
+    /// Launch-time resume shares the normal resume path but refuses the
+    /// manual flow's claude-code fresh fallback when the prior conversation
+    /// file is gone.
+    #[allow(clippy::too_many_arguments)]
+    pub fn resume_on_launch(
+        self: &Arc<Self>,
+        session_id: &str,
+        cols: Option<u16>,
+        rows: Option<u16>,
+        app_data_dir: &Path,
+        pool: Arc<DbPool>,
+        events: Arc<dyn SessionEvents>,
+    ) -> Result<SpawnedSession> {
+        self.resume_with_fresh_fallback(session_id, cols, rows, app_data_dir, pool, events, false)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn resume_with_fresh_fallback(
+        self: &Arc<Self>,
+        session_id: &str,
+        cols: Option<u16>,
+        rows: Option<u16>,
+        app_data_dir: &Path,
+        pool: Arc<DbPool>,
+        events: Arc<dyn SessionEvents>,
+        allow_fresh_fallback: bool,
+    ) -> Result<SpawnedSession> {
         // Atomically claim this session id for the resume. If another
         // resume is already in flight (e.g. two fast clicks, two
         // windows), refuse rather than racing two PTY spawns against
@@ -1154,6 +1184,11 @@ impl SessionManager {
                     key,
                 )
         );
+        if conversation_missing && !allow_fresh_fallback {
+            return Err(Error::msg(format!(
+                "session {session_id} conversation is unavailable; resume it manually to start fresh"
+            )));
+        }
         let fresh_fallback_lead = conversation_missing && is_lead_slot;
         let effective_prior_key = match (runner.runtime.as_str(), snap.agent_session_key.as_deref())
         {
@@ -1161,6 +1196,11 @@ impl SessionManager {
             (_, k) => k,
         };
         let plan = router::runtime::resume_plan(&runner.runtime, effective_prior_key);
+        if !allow_fresh_fallback && !plan.resuming {
+            return Err(Error::msg(format!(
+                "session {session_id} cannot resume its prior conversation; resume it manually to start fresh"
+            )));
+        }
 
         // Working directory: same precedence as `spawn_direct` — the
         // row's stored cwd wins; otherwise fall back to the runner's

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -3262,6 +3262,55 @@ fn resume_refuses_running_and_archived_rows() {
 }
 
 #[test]
+fn launch_resume_never_falls_back_to_a_fresh_spawn() {
+    let pool = pool_with_schema();
+    let now = Utc::now().to_rfc3339();
+    let runner_id = ulid::Ulid::new().to_string();
+    {
+        let conn = pool.get().unwrap();
+        conn.execute(
+            "INSERT INTO runners
+                    (id, handle, display_name, runtime, command,
+                     created_at, updated_at)
+                 VALUES (?1, 'shell-runner', 'Shell', 'shell', '/bin/sh', ?2, ?2)",
+            params![runner_id, now],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sessions
+                    (id, runner_id, status, started_at, agent_session_key)
+                 VALUES ('launch-sid', ?1, 'stopped', ?2, 'not-resumable')",
+            params![runner_id, now],
+        )
+        .unwrap();
+    }
+    let mgr = mgr_with_runtime(crate::shell_path::LoginShellEnv::default(), inert_runtime());
+
+    let error = mgr
+        .resume_on_launch(
+            "launch-sid",
+            None,
+            None,
+            std::path::Path::new("/tmp"),
+            Arc::clone(&pool),
+            capture(),
+        )
+        .unwrap_err();
+
+    assert!(error.to_string().contains("cannot resume"));
+    let status: String = pool
+        .get()
+        .unwrap()
+        .query_row(
+            "SELECT status FROM sessions WHERE id = 'launch-sid'",
+            [],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(status, "stopped");
+}
+
+#[test]
 fn resume_mission_session_stamps_slot_handle_env() {
     // Mission resume must look up the slot for the session and
     // use slot.slot_handle as RUNNER_HANDLE, not runner.handle.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,9 +13,15 @@ import { getCurrentWebview } from "@tauri-apps/api/webview";
 import { AppShell } from "./components/AppShell";
 import { ToastProvider } from "./contexts/ToastContext";
 import { UpdateProvider, useUpdate } from "./contexts/UpdateContext";
+import { consumeResumeOnLaunch } from "./lib/autoResume";
+import { api } from "./lib/api";
 import { nudgeAppZoom, syncTitlebarZoom } from "./lib/appZoom";
 import { eventMatchesShortcut } from "./lib/keymap";
-import { readAppZoom } from "./lib/settings";
+import {
+  readAppZoom,
+  readStoredBool,
+  STORAGE_RESUME_ON_LAUNCH,
+} from "./lib/settings";
 import Crews from "./pages/Crews";
 import CrewEditor from "./pages/CrewEditor";
 import Runners from "./pages/Runners";
@@ -27,6 +33,7 @@ export default function App() {
   // hidden windows, so the callback would never fire. Every window runs this
   // effect, and both commands resolve the invoking window.
   useEffect(() => {
+    let cancelled = false;
     const zoom = readAppZoom();
     let webviewZoom = Promise.resolve();
     if (zoom !== 1.0) {
@@ -42,8 +49,19 @@ export default function App() {
     }
 
     void Promise.all([syncTitlebarZoom(zoom), webviewZoom]).finally(() => {
-      invoke("app_ready").catch(console.error);
+      void invoke("app_ready")
+        .then(async () => {
+          if (cancelled || getCurrentWebview().label !== "main") return;
+          await consumeResumeOnLaunch(
+            readStoredBool(STORAGE_RESUME_ON_LAUNCH, true),
+            api.session,
+          );
+        })
+        .catch(console.error);
     });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   // Zoom shortcuts (keymap: zoom-in / zoom-out / zoom-reset). Capture

--- a/src/components/settings/GeneralPane.tsx
+++ b/src/components/settings/GeneralPane.tsx
@@ -14,10 +14,13 @@ import {
   readAppZoom,
   readDefaultWorkingDir,
   STORAGE_APP_ZOOM,
+  STORAGE_RESUME_ON_LAUNCH,
   writeDefaultWorkingDir,
   ZOOM_STEPS,
 } from "../../lib/settings";
+import { useStoredBool } from "../../lib/useStoredBool";
 import { StyledSelect } from "../ui/StyledSelect";
+import { Toggle } from "../ui/Toggle";
 import { WorkingDirField } from "../ui/WorkingDirField";
 import { PaneHeader, SettingsCard, SettingsRow, Stepper } from "./shared";
 
@@ -74,6 +77,10 @@ export function GeneralPane() {
   // the shared `applyAppZoom` so the stepper and the global Cmd+/- path
   // can't drift.
   const [appZoom, setAppZoomState] = useState<number>(() => readAppZoom());
+  const [resumeOnLaunch, setResumeOnLaunch] = useStoredBool(
+    STORAGE_RESUME_ON_LAUNCH,
+    true,
+  );
   const setAppZoom = (next: number) => {
     setAppZoomState(next);
     applyAppZoom(next);
@@ -124,6 +131,19 @@ export function GeneralPane() {
           <ZoomStepper value={appZoom} onChange={setAppZoom} />
         </SettingsRow>
       </SettingsCard>
+      <section className="flex flex-col gap-2">
+        <h3 className="px-1 text-[11px] font-semibold uppercase tracking-[0.08em] text-fg-3">
+          Startup
+        </h3>
+        <SettingsCard>
+          <SettingsRow
+            label="Resume running agents on launch"
+            sub="Reopen chats and mission agents that were live when Runner quit."
+          >
+            <Toggle on={resumeOnLaunch} onChange={setResumeOnLaunch} />
+          </SettingsRow>
+        </SettingsCard>
+      </section>
     </>
   );
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -364,6 +364,17 @@ export const api = {
       invoke<void>("session_pin", { sessionId, pinned }),
     setProject: (sessionIds: string[], projectId: string | null) =>
       invoke<void>("session_set_project", { sessionIds, projectId }),
+    takeResumeOnLaunch: () =>
+      invoke<string | null>("session_take_resume_on_launch"),
+    clearResumeOnLaunch: () =>
+      invoke<void>("session_clear_resume_on_launch"),
+    resumeOnLaunch: (sessionId: string) =>
+      invoke<SpawnedSession>("session_resume", {
+        sessionId,
+        cols: null,
+        rows: null,
+        automatic: true,
+      }),
     resume: (
       sessionId: string,
       cols: number | null,
@@ -373,6 +384,7 @@ export const api = {
         sessionId,
         cols,
         rows,
+        automatic: false,
       }),
     injectStdin: (sessionId: string, text: string) =>
       invoke<void>("session_inject_stdin", { sessionId, text }),

--- a/src/lib/autoResume.test.ts
+++ b/src/lib/autoResume.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  AUTO_RESUME_STAGGER_MS,
+  consumeResumeOnLaunch,
+} from "./autoResume";
+
+describe("consumeResumeOnLaunch", () => {
+  it("resumes sequentially, staggers attempts, and continues after failure", async () => {
+    const takeResumeOnLaunch = vi
+      .fn<() => Promise<string | null>>()
+      .mockResolvedValueOnce("session-a")
+      .mockResolvedValueOnce("session-b")
+      .mockResolvedValueOnce(null);
+    const resumeOnLaunch = vi
+      .fn<(sessionId: string) => Promise<void>>()
+      .mockRejectedValueOnce(new Error("rejected key"))
+      .mockResolvedValueOnce();
+    const clearResumeOnLaunch = vi.fn<() => Promise<void>>();
+    const wait = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue();
+    const onError = vi.fn();
+
+    await consumeResumeOnLaunch(
+      true,
+      { takeResumeOnLaunch, clearResumeOnLaunch, resumeOnLaunch },
+      wait,
+      onError,
+    );
+
+    expect(resumeOnLaunch.mock.calls).toEqual([
+      ["session-a"],
+      ["session-b"],
+    ]);
+    expect(wait).toHaveBeenCalledOnce();
+    expect(wait).toHaveBeenCalledWith(AUTO_RESUME_STAGGER_MS);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(clearResumeOnLaunch).not.toHaveBeenCalled();
+  });
+
+  it("clears pending stamps without resuming when disabled", async () => {
+    const takeResumeOnLaunch = vi.fn<() => Promise<string | null>>();
+    const resumeOnLaunch = vi.fn<(sessionId: string) => Promise<void>>();
+    const clearResumeOnLaunch = vi
+      .fn<() => Promise<void>>()
+      .mockResolvedValue();
+
+    await consumeResumeOnLaunch(false, {
+      takeResumeOnLaunch,
+      clearResumeOnLaunch,
+      resumeOnLaunch,
+    });
+
+    expect(clearResumeOnLaunch).toHaveBeenCalledOnce();
+    expect(takeResumeOnLaunch).not.toHaveBeenCalled();
+    expect(resumeOnLaunch).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/autoResume.ts
+++ b/src/lib/autoResume.ts
@@ -1,0 +1,33 @@
+export const AUTO_RESUME_STAGGER_MS = 300;
+
+interface AutoResumeApi {
+  takeResumeOnLaunch: () => Promise<string | null>;
+  clearResumeOnLaunch: () => Promise<void>;
+  resumeOnLaunch: (sessionId: string) => Promise<unknown>;
+}
+
+export async function consumeResumeOnLaunch(
+  enabled: boolean,
+  sessionApi: AutoResumeApi,
+  wait: (ms: number) => Promise<void> = (ms) =>
+    new Promise((resolve) => window.setTimeout(resolve, ms)),
+  onError: (error: unknown) => void = console.error,
+): Promise<void> {
+  if (!enabled) {
+    await sessionApi.clearResumeOnLaunch();
+    return;
+  }
+
+  let attemptedResume = false;
+  for (;;) {
+    const sessionId = await sessionApi.takeResumeOnLaunch();
+    if (sessionId === null) return;
+    if (attemptedResume) await wait(AUTO_RESUME_STAGGER_MS);
+    attemptedResume = true;
+    try {
+      await sessionApi.resumeOnLaunch(sessionId);
+    } catch (error) {
+      onError(error);
+    }
+  }
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -7,6 +7,7 @@
 import type { ITheme } from "@xterm/xterm";
 
 export const STORAGE_AUTO_INSTALL_UPDATES = "settings.autoInstallUpdates";
+export const STORAGE_RESUME_ON_LAUNCH = "settings.resumeOnLaunch";
 export const STORAGE_SIDEBAR_COLLAPSED = "runner.sidebar.collapsed";
 export const STORAGE_APP_ZOOM = "settings.appZoom";
 export const STORAGE_TERMINAL_FONT_SIZE = "settings.terminalFontSize";


### PR DESCRIPTION
## Summary

- resume gracefully stopped chats and running-mission slots on launch with durable stamps, sequential spawning, and a default-on setting
- prevent launch restore from falling back to fresh conversations and clear stale stamps when disabled
- steer mission_start callers toward project_id and infer a unique canonical cwd match
- record the resolved product decisions in feature spec 45

## Validation

- cargo fmt --all --check
- cargo clippy --workspace
- cargo test --workspace
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm test

Closes #320
Closes #350