### PR TITLE
fix(session): correct auto-resume width and make it opt-in

### DIFF
--- a/docs/features/45-auto-resume-on-launch.md
+++ b/docs/features/45-auto-resume-on-launch.md
@@ -16,7 +16,7 @@ The gap is memory plus initiative: nothing records *which* sessions were live at
 - **Auto-resume at launch.** After the webview is ready, resume every marked session that is still resumable (`agent_session_key` present, not archived), clearing the flag as each is consumed. Missions need no extra start step: their status is still `running` and buses re-mount as today — resuming their marked slot sessions brings the workspace back to life.
 - **Staggered spawns.** Resume sequentially with a short gap, not as one burst — N simultaneous PTY spawns + login-shell env snapshots is a stampede for no benefit.
 - **Failure tolerance.** The existing resume-failure heuristic (fast death → `crashed` + warning toast, next launch starts fresh) already covers rejected `--resume` keys; auto-resume inherits it. A failed auto-resume must not block the rest of the queue.
-- **Setting to disable.** One toggle in Settings ("Resume running agents on launch", default on). No per-chat granularity in v1.
+- **Opt-in setting.** One toggle in Settings ("Resume running agents on launch", default off). Spawning agents unprompted at launch must be an explicit choice; there is no per-chat granularity in v1.
 
 ### Out of scope
 
@@ -37,7 +37,7 @@ The gap is memory plus initiative: nothing records *which* sessions were live at
 
 - Stagger resume spawns by 300ms.
 - Resume silently in v1; do not add a "Resuming N agents…" indicator.
-- Put "Resume running agents on launch" in Settings → General under a new Startup section. It defaults on and persists in `localStorage` through the `src/lib/settings.ts` `STORAGE_*` pattern.
+- Put "Resume running agents on launch" in Settings → General under a new Startup section. It defaults off and persists in `localStorage` through the `src/lib/settings.ts` `STORAGE_*` pattern. The default flip also applies to existing users who never stored an explicit choice; there is no migration key.
 
 ## Implementation phases
 
@@ -47,9 +47,9 @@ The gap is memory plus initiative: nothing records *which* sessions were live at
 
 ## Verification
 
-- [ ] Quit with two running chats and a running mission → relaunch → all three come back live without interaction; scrollback intact for claude-code.
+- [ ] Turn the toggle on, quit with two running chats and a running mission → relaunch → all three come back live without interaction; scrollback intact for claude-code.
 - [ ] A chat stopped manually before quit stays stopped after relaunch.
 - [ ] Kill the app process (simulated crash) → nothing auto-resumes.
 - [ ] A session with a rejected resume key surfaces the existing crash warning and doesn't block other resumes.
-- [ ] Toggle off → relaunch restores nothing; rows keep their normal Resume buttons; turning the toggle back on does not resume the old quit's set.
+- [ ] Toggle absent or off → relaunch restores nothing and clears pending stamps; rows keep their normal Resume buttons; turning the toggle back on does not resume the old quit's set.
 - [ ] `cargo fmt --check`, `cargo clippy --workspace`, `cargo test --workspace`, `pnpm exec tsc --noEmit`, `pnpm run lint` clean.

--- a/docs/impls/0035-auto-resume-width-and-opt-in.md
+++ b/docs/impls/0035-auto-resume-width-and-opt-in.md
@@ -1,0 +1,93 @@
+# Auto-resume: correct fork width, and make it opt-in
+
+## Status
+
+Implemented. Follows [0032](archive/0032-in-place-resume-seam-and-width-hardening.md) (which introduced the persisted-dims fallback this bug lives in) and the auto-resume feature shipped in 0.4.2 ([#320](https://github.com/yicheng47/runner/issues/320), spec `docs/features/45-auto-resume-on-launch.md`). Two changes: fix the fork width, and flip the setting to opt-in.
+
+## Release note
+
+Auto-resume is now opt-in, including for existing users who previously received it through the default. Turn on **Settings → General → Resume running agents on launch** to restore the prior launch behavior.
+
+## Problem
+
+Sessions restored by auto-resume-on-launch come back at the wrong terminal width. Manual resume does not have this bug. The asymmetry is the tell, and it traces to a five-step mechanism where two independent holes line up:
+
+1. **Auto-resume asks for no particular size.** `api.session.resumeOnLaunch` invokes `session_resume` with `cols: null, rows: null` (`src/lib/api.ts:371`), unlike manual resume which measures the live pane first — `const dims = terminals.get(targetId)?.measure() ?? null` (`src/pages/RunnerChat.tsx:1185`, whose own comment at `:1182` already notes "measure() can be null right after a restart").
+2. **So the backend falls back to persisted dims.** `resume()` resolves `cols.zip(rows).or(snap.last_cols.zip(snap.last_rows)).unwrap_or(DEFAULT_PTY_SIZE)` (`src-tauri/src/session/manager/spawn.rs:1056-1059`) — exactly the 0032 decision-5 chain. Correct by design; the inputs are what's wrong.
+3. **Hole one — `last_cols`/`last_rows` can't be updated while a session is stopped.** The only writer outside spawn is `SessionManager::resize` (`output.rs:488`), and its first line is `let rt_session = self.live_runtime_session(session_id)?` (`:489`), which returns `Err("session not found")` whenever the session has no live handle (`manager/mod.rs:1029-1035`). The `update_last_size` call sits *after* that early return (`:492`). A pane that mounts and measures while its session is still stopped therefore records nothing.
+4. **Hole two — the frontend believes it already pushed.** `RunnerTerminal`'s mount effect fits, sets `lastPushedColsRef.current = term.cols`, then fires `api.session.resize(...).catch(() => {})` (`RunnerTerminal.tsx:531-543`). The ref is updated unconditionally and the rejection from step 3 is swallowed. Since `pushSize` dedupes against that ref, the frontend will **never re-send** that size unless the pane's geometry genuinely changes.
+5. **Result.** At launch the pane mounts and pushes `W_real` → dropped, because the session hasn't been resumed yet. Auto-resume then forks the PTY at the stale persisted `W_old`. The agent's resume banner and first repaint are emitted hard-wrapped at `W_old`. Nothing corrects it: the frontend thinks `W_real` is already in flight, and the backend never heard it. For claude-code — which *keeps* its ring on resume (`runtime_purges_on_resume`, `output.rs`) — those miswrapped lines stay in scrollback permanently, since no reflow can undo wrapping the agent performed itself.
+
+Manual resume escapes all of this because step 1 supplies real dims from an already-laid-out pane.
+
+Note this is a genuine race, not a fixed ordering: `consumeResumeOnLaunch` fires from `App.tsx:51-61` immediately after `app_ready`, concurrently with route/pane mounting. Whether the mount push or the resume wins is timing-dependent — which is why the fix must not be a timing fix.
+
+## Key Decisions
+
+1. **Persist pane geometry independently of PTY liveness.** Split `SessionManager::resize` so recording `last_cols`/`last_rows` happens before the missing-live-handle early return, and applying the resize to the PTY happens only when a handle exists. Rationale: the dims are a fact about the *pane that will display this session*, not about the process — a stopped session's row should learn its geometry so the next spawn or resume forks correctly. This closes hole one and makes the persisted fallback trustworthy on its own. A resize for a nonexistent session still returns a genuine not-found error and does not create manager state.
+2. **Re-assert size when a session goes live, instead of trusting a dedupe ref that may describe a dropped call.** A dedicated disabled-state effect detects the stopped→running transition, clears `lastPushedColsRef`/`lastPushedRowsRef`, and invokes `reassertSizeRef` to fit and issue one plain deduped push. This closes hole two and, unlike decision 1, also repairs any *other* path where a resize was rejected in flight (session exiting, crash-and-resume, window handoff).
+
+   Stopped and transitional panes deliberately differ: stopped panes keep pushing every laid-out geometry measurement so later zoom, sidebar, split-layout, and window changes can correct the persisted size, while transitional panes suppress resize until the fork completes. Stopped pushes are plain RPCs that skip both the local TUI clear and the forced resize dance, and they preserve `replayJustDrainedRef` so a geometry-only push cannot consume the next clear-capable push's replay protection.
+3. **Do not fix this with ordering.** The obvious alternative — defer `consumeResumeOnLaunch` until layout settles, or have it await a "surfaces ready" signal — makes correctness depend on a race we'd have to keep winning as the boot sequence evolves. Decisions 1 and 2 make the outcome correct whichever side wins: if the mount push lands first, the fork is already right; if the resume lands first, the correction fires the moment the pane is live and measurable. No new timing dependency.
+4. **Accept that background sessions still fork at their last known width.** Most auto-resumed sessions have no mounted pane at all — only the active tab and the persistent surfaces are mounted. There is no correct width to give them, and the persisted one (now trustworthy per decision 1) is the best available guess. When the user later opens such a tab, activation pushes real dims and the agent repaints. Explicitly not solved here: history a background agent hard-wrapped before you ever looked at it. That's the same irreducible limit 0032 recorded.
+5. **Auto-resume becomes opt-in, default off.** Export one `DEFAULT_RESUME_ON_LAUNCH = false` constant and use it in both the `App.tsx` consumer and the `GeneralPane.tsx` toggle. Sharing the constant structurally prevents the two defaults from drifting and rendering a toggle state the consumer does not act on.
+6. **No migration for existing users, but the behavior change is real and must be stated.** The setting is stored under `settings.resumeOnLaunch` and read with a default; anyone who never touched the toggle has no stored key, so flipping the default silently turns auto-resume off for them too. That is the intent — spawning agents unprompted at launch should be something you choose, not something you discover. It shipped only two releases ago (0.4.2), so the blast radius is small, and writing a one-time "preserve previous default" key would leave a permanent wart to explain. Call it out in the release notes instead.
+7. **The quit-side stamp stays unconditional.** The backend continues to mark sessions at graceful quit regardless of the toggle, and a launch with the toggle off still *clears* pending stamps without resuming (the edge case #320 built deliberately). This keeps enabling the setting a forward-looking act rather than something that resurrects a session set from an old quit.
+
+## Goals
+
+- A session restored by auto-resume forks its PTY at the width of the pane that will display it, and its resume banner is not hard-wrapped at a stale width.
+- A resize issued against a stopped session updates the row, so the next spawn or resume uses it.
+- A session that goes live re-asserts its pane geometry rather than assuming an earlier push landed.
+- Auto-resume is off unless the user turns it on; the toggle and the consumer agree on that default.
+
+## Non-Goals
+
+- Repairing scrollback already hard-wrapped at a previous width — impossible once the agent wrapped it (0032 non-goal, restated).
+- Giving background, never-displayed sessions a "correct" width (decision 4).
+- Reordering or gating the boot sequence (decision 3).
+- Any change to the quit-side stamping, the 300ms stagger, resume-never-fresh-spawn, or the crash-never-stamps rule from #320.
+
+## Implementation Phases
+
+### Phase 1 — backend: record dims regardless of liveness
+
+- `src-tauri/src/session/manager/output.rs`: restructure `resize` so the `update_last_size` write runs before the missing-live-handle early return, and the runtime resize plus the `cols_changed`/`runtime_clears_on_resize` purge run only when a live handle exists. Preserve current behavior exactly for live sessions — the ring-purge rules and the rows-only-keeps-ring reasoning are unchanged.
+- A resize on a nonexistent session returns a genuine not-found error and does not create manager state. Persisting geometry for an unknown id must not silently create state.
+- Tests in `session/manager/tests.rs`: resizing a stopped session updates `last_cols`/`last_rows` and does not error; a subsequent resume with `None` dims forks at those dims; resizing a live session still purges the ring on a cols change and still keeps it on a rows-only change.
+
+### Phase 2 — frontend: re-assert geometry on going live
+
+- `src/components/RunnerTerminal.tsx`: use a dedicated disabled-state effect to reset `lastPushedColsRef`/`lastPushedRowsRef` on the transition into a running session, then fit and issue a plain deduped push through `reassertSizeRef`. Keep geometry enabled for stopped panes but disabled for transitional panes; do not disturb the transitional latch's dance-suppression behavior, which #352 depends on.
+- Verify the interaction with #352's activation change: the re-push must be a plain deduped push, **not** a forced resize dance — the goal is to inform the backend of a size it never received, not to make the agent repaint.
+- Helper tests in `src/lib/terminalResize.test.ts`: a push that the backend rejects must not leave the frontend believing it succeeded; the stopped→running transition resets the dedupe state so the current dims need one push and are deduped afterward. The xterm effect wiring remains a manual check because the repository has no component harness for `RunnerTerminal`.
+
+### Phase 3 — opt-in default
+
+- `src/App.tsx` and `src/components/settings/GeneralPane.tsx`: use the shared false default at both sites.
+- Check the GeneralPane row's sub-copy still reads correctly for an off-by-default control.
+- Test that the consumer does not resume when the key is absent, and still clears pending stamps in that case (decision 7).
+
+### Phase 4 — docs
+
+- `docs/features/45-auto-resume-on-launch.md`: the spec says "One toggle in Settings … default on." Update it and record why.
+- The GitHub release notes must manually include this document's release note stating that auto-resume is now opt-in, including for users who had it working by default (decision 6); the repository has no changelog that publishes it automatically.
+
+## Verification
+
+Automated:
+
+- [x] Resize a stopped session → `last_cols`/`last_rows` updated, no error.
+- [x] Resume with `None` dims after such a resize → forks at those dims, not `DEFAULT_PTY_SIZE` and not the pre-quit value.
+- [x] Live-session resize behavior unchanged: cols change purges the ring for full-repaint runtimes, rows-only keeps it.
+- [x] Push-state helpers clear the pushed-dims refs on going live and dedupe the next size after one push; the xterm effect wiring has no component harness and remains part of manual verification.
+- [x] Toggle absent → no resume, stamps cleared.
+
+Manual (Jason smoke-tests):
+
+- [ ] With the toggle **on**, run two chats and a mission, quit, relaunch → restored panes are wrapped at the current window width, with no short-wrapped resume banner and no shredded box-drawing above it.
+- [ ] Same, but resize the window materially before relaunching → restored panes still match the new width.
+- [ ] Switch to a background auto-resumed tab → it repaints at the correct width on activation.
+- [ ] Fresh profile (or cleared `settings.resumeOnLaunch`) → nothing auto-resumes; the General toggle reads off.
+- [ ] Turn the toggle on, quit, relaunch → auto-resume works as before.
+- [ ] Resume a visible stopped pane and confirm the log records one plain size push, without a forced resize dance.

--- a/src-tauri/src/session/manager/output.rs
+++ b/src-tauri/src/session/manager/output.rs
@@ -486,11 +486,38 @@ impl SessionManager {
     /// the spawn-time grid regardless of how big the visible grid
     /// is.
     pub fn resize(&self, session_id: &str, cols: u16, rows: u16, pool: &DbPool) -> Result<()> {
-        let rt_session = self.live_runtime_session(session_id)?;
-        self.runtime.resize(&rt_session, cols, rows)?;
-        if let Ok(conn) = pool.get() {
-            let _ = crate::repo::session::update_last_size(&conn, session_id, cols, rows);
+        let state = self.session_state(session_id);
+        let rt_session = state.as_ref().and_then(|state| {
+            state
+                .lock()
+                .unwrap()
+                .handle
+                .as_ref()
+                .map(|handle| handle.runtime_session.clone())
+        });
+        match pool.get() {
+            Ok(conn) => match crate::repo::session::update_last_size(&conn, session_id, cols, rows)
+            {
+                Ok(0) if rt_session.is_none() => {
+                    return Err(Error::msg(format!("session not found: {session_id}")));
+                }
+                Ok(_) => {}
+                Err(error) if rt_session.is_none() => return Err(error.into()),
+                Err(_) => {}
+            },
+            Err(error) if rt_session.is_none() => return Err(error.into()),
+            Err(_) => {}
         }
+        let Some(rt_session) = rt_session else {
+            return Ok(());
+        };
+        let Some(state) = state else {
+            return Ok(());
+        };
+        // Pane geometry is the next fork's desired size even if the current
+        // PTY rejects the ioctl. Keep last_pty_cols as the last size actually
+        // applied so a failed live resize cannot trigger a ring purge.
+        self.runtime.resize(&rt_session, cols, rows)?;
         // Full-repaint TUI runtimes (claude-code, codex, qoder) redraw the whole
         // frame on SIGWINCH, so bytes buffered before a *width* change
         // describe a stale grid width. Replaying them into the new grid on
@@ -509,7 +536,6 @@ impl SessionManager {
         // frame). Shells keep their buffer unconditionally — no repaint
         // would arrive, and their history is meaningful.
         let cols_changed = {
-            let state = self.session_state_or_insert(session_id);
             let mut state = state.lock().unwrap();
             let changed = state.last_pty_cols != Some(cols);
             state.last_pty_cols = Some(cols);

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -3167,9 +3167,27 @@ fn resume_size_resolution_prefers_explicit_then_persisted_after_manager_restart(
             None,
         )
         .unwrap();
-    first_mgr.resize(&spawned.id, 132, 41, &pool).unwrap();
     first_fake.close_spawn(0);
     wait_for_db_stop(&pool, &spawned.id);
+    first_mgr.resize(&spawned.id, 132, 41, &pool).unwrap();
+    let persisted: (u16, u16) = pool
+        .get()
+        .unwrap()
+        .query_row(
+            "SELECT last_cols, last_rows FROM sessions WHERE id = ?1",
+            params![spawned.id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        persisted,
+        (132, 41),
+        "a stopped pane must persist its measured dimensions"
+    );
+    assert!(
+        first_fake.resizes.lock().unwrap().is_empty(),
+        "a stopped pane must not call the runtime resize path"
+    );
     drop(first_mgr);
     drop(first_fake);
 
@@ -3210,6 +3228,20 @@ fn resume_size_resolution_prefers_explicit_then_persisted_after_manager_restart(
         "explicit resume size must win over the persisted size"
     );
     resumed_mgr.kill(&spawned.id).unwrap();
+}
+
+#[test]
+fn resize_rejects_unknown_session_without_creating_state() {
+    let pool = pool_with_schema();
+    let mgr = mgr_with_runtime(crate::shell_path::LoginShellEnv::default(), inert_runtime());
+
+    let err = mgr.resize("missing-session", 120, 30, &pool).unwrap_err();
+
+    assert_eq!(format!("{err}"), "session not found: missing-session");
+    assert!(
+        mgr.session_state("missing-session").is_none(),
+        "resize must not create manager state for an unknown row"
+    );
 }
 
 #[test]
@@ -4064,6 +4096,20 @@ fn resize_purges_ring_only_on_cols_change() {
     assert!(
         mgr.output_snapshot(&spawned.id).is_empty(),
         "cols change must purge the replay ring"
+    );
+    let persisted: (u16, u16) = pool
+        .get()
+        .unwrap()
+        .query_row(
+            "SELECT last_cols, last_rows FROM sessions WHERE id = ?1",
+            params![spawned.id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(
+        persisted,
+        (100, 30),
+        "a live resize must still persist the applied dimensions"
     );
 
     mgr.kill(&spawned.id).unwrap();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ import { api } from "./lib/api";
 import { nudgeAppZoom, syncTitlebarZoom } from "./lib/appZoom";
 import { eventMatchesShortcut } from "./lib/keymap";
 import {
+  DEFAULT_RESUME_ON_LAUNCH,
   readAppZoom,
   readStoredBool,
   STORAGE_RESUME_ON_LAUNCH,
@@ -53,7 +54,10 @@ export default function App() {
         .then(async () => {
           if (cancelled || getCurrentWebview().label !== "main") return;
           await consumeResumeOnLaunch(
-            readStoredBool(STORAGE_RESUME_ON_LAUNCH, true),
+            readStoredBool(
+              STORAGE_RESUME_ON_LAUNCH,
+              DEFAULT_RESUME_ON_LAUNCH,
+            ),
             api.session,
           );
         })

--- a/src/components/ChatPaneGroup.tsx
+++ b/src/components/ChatPaneGroup.tsx
@@ -359,6 +359,7 @@ export function ChatPaneGroup({
             hiddenByDisplayNone={!visible}
             autoFocus={visible && paneLeaf.id === layout.focusedPaneId}
             disabled={dead || transitional}
+            resizeDisabled={transitional}
             onExit={onTerminalExit}
             onError={onTerminalError}
           />

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -48,6 +48,9 @@ import {
 import {
   activationResizeRequest,
   shouldDelayTerminalResize,
+  shouldPushTerminalSize,
+  terminalSizeAfterDisabledChange,
+  terminalSizeAfterRejectedPush,
   type TerminalGridSize,
 } from "../lib/terminalResize";
 import { TERMINAL_SCROLLBAR_WIDTH_PX } from "../lib/terminalSizing";
@@ -128,13 +131,15 @@ interface RunnerTerminalProps {
    *  passes false for every pane except the focused one, so mounting a
    *  sibling pane can't yank keystrokes away from the focused chat. */
   autoFocus?: boolean;
-  /** Stop forwarding keystrokes / resize events to the backend.
+  /** Stop forwarding keystrokes to the backend.
    *  Set by the parent when the bound session has exited so stray
    *  input on the dimmed pane doesn't surface a "session not found"
-   *  error from the now-empty live map. The xterm buffer stays
-   *  visible (and scrollable) — only the input/resize pipes shut
-   *  off. */
+   *  error from the now-empty live map. */
   disabled?: boolean;
+  /** Suppress geometry pushes while a spawn/resume is transitional.
+   *  Stopped panes keep this false so their measured size is persisted
+   *  for the next resume even though keyboard input stays disabled. */
+  resizeDisabled?: boolean;
 }
 
 /**
@@ -178,6 +183,7 @@ export const RunnerTerminal = forwardRef<
     hiddenByDisplayNone,
     autoFocus,
     disabled,
+    resizeDisabled,
   },
   ref,
 ) {
@@ -201,6 +207,7 @@ export const RunnerTerminal = forwardRef<
   // closures don't capture a stale value across the long-lived
   // terminal effect.
   const disabledRef = useRef<boolean>(disabled ?? false);
+  const resizeDisabledRef = useRef<boolean>(resizeDisabled ?? false);
   // Mirrors `autoFocus` for the activation effect below.
   const autoFocusRef = useRef<boolean>(autoFocus ?? true);
   // Last (cols, rows) pushed to the backend. Shared between `pushSize`
@@ -212,6 +219,7 @@ export const RunnerTerminal = forwardRef<
   // lengthen the redraw window the user perceives.
   const lastPushedColsRef = useRef(0);
   const lastPushedRowsRef = useRef(0);
+  const reassertSizeRef = useRef<(() => void) | null>(null);
   // Snapshot replay is deferred until the pane is both active and
   // measurable. Mission workspaces mount every slot's RunnerTerminal
   // at once with `activeTab="feed"` by default — every slot pane is
@@ -267,7 +275,24 @@ export const RunnerTerminal = forwardRef<
   }, [sessionId]);
 
   useEffect(() => {
-    disabledRef.current = disabled ?? false;
+    resizeDisabledRef.current = resizeDisabled ?? false;
+  }, [resizeDisabled]);
+
+  useEffect(() => {
+    const nextDisabled = disabled ?? false;
+    const wentLive = disabledRef.current && !nextDisabled;
+    const lastPushed = terminalSizeAfterDisabledChange(
+      {
+        cols: lastPushedColsRef.current,
+        rows: lastPushedRowsRef.current,
+      },
+      disabledRef.current,
+      nextDisabled,
+    );
+    disabledRef.current = nextDisabled;
+    lastPushedColsRef.current = lastPushed.cols;
+    lastPushedRowsRef.current = lastPushed.rows;
+    if (wentLive) reassertSizeRef.current?.();
   }, [disabled]);
 
   useEffect(() => {
@@ -317,6 +342,18 @@ export const RunnerTerminal = forwardRef<
     }
   }, []);
 
+  const rejectSizePush = useCallback((cols: number, rows: number) => {
+    const lastPushed = terminalSizeAfterRejectedPush(
+      {
+        cols: lastPushedColsRef.current,
+        rows: lastPushedRowsRef.current,
+      },
+      { cols, rows },
+    );
+    lastPushedColsRef.current = lastPushed.cols;
+    lastPushedRowsRef.current = lastPushed.rows;
+  }, []);
+
   const refreshActiveTerminal = useCallback(
     ({
       focus = false,
@@ -363,8 +400,11 @@ export const RunnerTerminal = forwardRef<
         }
         t.refresh(0, t.rows - 1);
         if (focus && !disabledRef.current) t.focus();
-        if ((!forceResizeDance && !pushBackendSize) || disabledRef.current) {
-          if ((forceResizeDance || pushBackendSize) && disabledRef.current) {
+        if (
+          (!forceResizeDance && !pushBackendSize) ||
+          resizeDisabledRef.current
+        ) {
+          if ((forceResizeDance || pushBackendSize) && resizeDisabledRef.current) {
             console.info(
               `[terminal] push-suppressed session=${sessionIdRef.current} ` +
                 `cols=${t.cols} rows=${t.rows} ` +
@@ -378,6 +418,24 @@ export const RunnerTerminal = forwardRef<
         if (!sid) return true;
         const cols = t.cols;
         const rows = t.rows;
+        if (disabledRef.current) {
+          if (
+            cols === lastPushedColsRef.current &&
+            rows === lastPushedRowsRef.current
+          ) {
+            return true;
+          }
+          console.info(
+            `[terminal] refresh-push-stopped session=${sid} cols=${cols} rows=${rows} ` +
+              `prev=${lastPushedColsRef.current}x${lastPushedRowsRef.current}`,
+          );
+          lastPushedColsRef.current = cols;
+          lastPushedRowsRef.current = rows;
+          void api.session.resize(sid, cols, rows).catch(() => {
+            rejectSizePush(cols, rows);
+          });
+          return true;
+        }
         // Blank grid must dance (#312). A running session behind an
         // empty grid has nothing to lose to a forced repaint and no
         // other way to gain content: the plain push below dedupes
@@ -427,7 +485,7 @@ export const RunnerTerminal = forwardRef<
           lastPushedColsRef.current = cols;
           lastPushedRowsRef.current = rows;
           void api.session.resize(sid, cols, rows).catch(() => {
-            // session may have exited
+            rejectSizePush(cols, rows);
           });
           return true;
         }
@@ -463,7 +521,7 @@ export const RunnerTerminal = forwardRef<
           .resize(sid, cols, nudgedRows)
           .then(() => api.session.resize(sid, cols, rows))
           .catch(() => {
-            // session may have exited between the two ioctls
+            rejectSizePush(cols, rows);
           });
         return true;
       } catch {
@@ -471,7 +529,7 @@ export const RunnerTerminal = forwardRef<
         return false;
       }
     },
-    [ensureWebglRenderer, blankGate],
+    [ensureWebglRenderer, rejectSizePush, blankGate],
   );
 
   useEffect(() => {
@@ -516,6 +574,33 @@ export const RunnerTerminal = forwardRef<
     });
     term.loadAddon(webLinks);
     term.open(containerRef.current);
+    function sendBackendResize(current: TerminalGridSize) {
+      const sid = sessionIdRef.current;
+      if (!sid) return;
+      console.info(
+        `[terminal] push-size session=${sid} cols=${current.cols} rows=${current.rows} ` +
+          `prev=${lastPushedColsRef.current}x${lastPushedRowsRef.current}`,
+      );
+      lastPushedColsRef.current = current.cols;
+      lastPushedRowsRef.current = current.rows;
+      void api.session.resize(sid, current.cols, current.rows).catch(() => {
+        rejectSizePush(current.cols, current.rows);
+      });
+    }
+    function pushBackendResize() {
+      if (resizeDisabledRef.current) return false;
+      const current = { cols: term.cols, rows: term.rows };
+      if (
+        !shouldPushTerminalSize(current, {
+          cols: lastPushedColsRef.current,
+          rows: lastPushedRowsRef.current,
+        })
+      ) {
+        return false;
+      }
+      sendBackendResize(current);
+      return true;
+    }
     const initialRect = containerRef.current.getBoundingClientRect();
     if (initialRect.width > 0 && initialRect.height > 0) {
       fit.fit();
@@ -533,17 +618,11 @@ export const RunnerTerminal = forwardRef<
       //
       // Hidden panes (rect 0) skip this — the activation effect picks
       // up the push when they come to the front, same as before.
-      lastPushedColsRef.current = term.cols;
-      lastPushedRowsRef.current = term.rows;
       // sessionIdRef is initialized with the prop value (line ~124),
       // so this reads the right id on initial mount without forcing
       // sessionId into the mount-effect's deps (which is intentionally
       // `[]` to avoid tearing down the whole xterm on session swap).
-      void api.session
-        .resize(sessionIdRef.current, term.cols, term.rows)
-        .catch(() => {
-          // session may have exited before mount; nothing to do
-        });
+      pushBackendResize();
     }
     // Don't auto-focus on mount: in the workspace, multiple
     // RunnerTerminals mount at once before any tab is selected, and the
@@ -706,19 +785,25 @@ export const RunnerTerminal = forwardRef<
     const pushSize = () => {
       const t = termRef.current;
       const sid = sessionIdRef.current;
-      if (!t || !sid || disabledRef.current) return;
       if (
-        t.cols === lastPushedColsRef.current &&
-        t.rows === lastPushedRowsRef.current
+        !t ||
+        !sid ||
+        resizeDisabledRef.current
       ) {
         return;
       }
-      console.info(
-        `[terminal] push-size session=${sid} cols=${t.cols} rows=${t.rows} ` +
-          `prev=${lastPushedColsRef.current}x${lastPushedRowsRef.current}`,
-      );
-      lastPushedColsRef.current = t.cols;
-      lastPushedRowsRef.current = t.rows;
+      const current = { cols: t.cols, rows: t.rows };
+      if (
+        !shouldPushTerminalSize(
+          current,
+          {
+            cols: lastPushedColsRef.current,
+            rows: lastPushedRowsRef.current,
+          },
+        )
+      ) {
+        return;
+      }
       // Clear the visible region before the SIGWINCH-driven redraw
       // lands for full-screen TUI agents. Without this, claude-code /
       // codex repaint at the new dims and the prior frame's visible
@@ -732,16 +817,27 @@ export const RunnerTerminal = forwardRef<
       // intact. Plain shells skip the wipe entirely and keep their
       // history. See docs/impls/archive/0011-pty-host-terminal-runtime.md
       // §"Per-runtime clear-on-resize".
-      const skipLocalClear = replayJustDrainedRef.current;
+      const skipLocalClear =
+        replayJustDrainedRef.current || disabledRef.current;
       if (runtimeClearsOnResize(runnerRuntimeRef.current) && !skipLocalClear) {
         // ESC[2J — erase visible region
         // ESC[H  — cursor home
         t.write("\x1b[2J\x1b[H");
       }
-      replayJustDrainedRef.current = false;
-      void api.session.resize(sid, t.cols, t.rows).catch(() => {
-        // session may have exited
-      });
+      if (!disabledRef.current) replayJustDrainedRef.current = false;
+      sendBackendResize(current);
+    };
+    reassertSizeRef.current = () => {
+      const node = containerRef.current;
+      if (!node) return;
+      const rect = node.getBoundingClientRect();
+      if (rect.width <= 0 || rect.height <= 0) return;
+      try {
+        fit.fit();
+        pushBackendResize();
+      } catch {
+        // layout not ready; the next measurable refit will push
+      }
     };
     let stableResizeTimer: number | null = null;
     let stableResizeRaf: number | null = null;
@@ -995,11 +1091,12 @@ export const RunnerTerminal = forwardRef<
       textarea?.removeEventListener("paste", onPaste, { capture: true });
       onDataDisposable.dispose();
       webglRef.current = null;
+      reassertSizeRef.current = null;
       term.dispose();
       termRef.current = null;
       fitRef.current = null;
     };
-  }, [refreshActiveTerminal]);
+  }, [refreshActiveTerminal, rejectSizePush]);
 
   // A mounted hidden terminal still owns its CPU-side xterm buffer, but it
   // must not hold a WebGL context: RunnerChat deliberately keeps every

--- a/src/components/settings/GeneralPane.tsx
+++ b/src/components/settings/GeneralPane.tsx
@@ -11,6 +11,7 @@ import { useEffect, useState } from "react";
 import { api } from "../../lib/api";
 import { applyAppZoom } from "../../lib/appZoom";
 import {
+  DEFAULT_RESUME_ON_LAUNCH,
   readAppZoom,
   readDefaultWorkingDir,
   STORAGE_APP_ZOOM,
@@ -79,7 +80,7 @@ export function GeneralPane() {
   const [appZoom, setAppZoomState] = useState<number>(() => readAppZoom());
   const [resumeOnLaunch, setResumeOnLaunch] = useStoredBool(
     STORAGE_RESUME_ON_LAUNCH,
-    true,
+    DEFAULT_RESUME_ON_LAUNCH,
   );
   const setAppZoom = (next: number) => {
     setAppZoomState(next);

--- a/src/lib/autoResume.test.ts
+++ b/src/lib/autoResume.test.ts
@@ -1,9 +1,18 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   AUTO_RESUME_STAGGER_MS,
   consumeResumeOnLaunch,
 } from "./autoResume";
+import {
+  DEFAULT_RESUME_ON_LAUNCH,
+  readStoredBool,
+  STORAGE_RESUME_ON_LAUNCH,
+} from "./settings";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("consumeResumeOnLaunch", () => {
   it("resumes sequentially, staggers attempts, and continues after failure", async () => {
@@ -50,6 +59,32 @@ describe("consumeResumeOnLaunch", () => {
       resumeOnLaunch,
     });
 
+    expect(clearResumeOnLaunch).toHaveBeenCalledOnce();
+    expect(takeResumeOnLaunch).not.toHaveBeenCalled();
+    expect(resumeOnLaunch).not.toHaveBeenCalled();
+  });
+
+  it("clears pending stamps without resuming when the setting is absent", async () => {
+    vi.stubGlobal("localStorage", {
+      getItem: vi.fn<(key: string) => string | null>().mockReturnValue(null),
+    });
+    const takeResumeOnLaunch = vi.fn<() => Promise<string | null>>();
+    const resumeOnLaunch = vi.fn<(sessionId: string) => Promise<void>>();
+    const clearResumeOnLaunch = vi
+      .fn<() => Promise<void>>()
+      .mockResolvedValue();
+
+    await consumeResumeOnLaunch(
+      readStoredBool(
+        STORAGE_RESUME_ON_LAUNCH,
+        DEFAULT_RESUME_ON_LAUNCH,
+      ),
+      { takeResumeOnLaunch, clearResumeOnLaunch, resumeOnLaunch },
+    );
+
+    expect(localStorage.getItem).toHaveBeenCalledWith(
+      STORAGE_RESUME_ON_LAUNCH,
+    );
     expect(clearResumeOnLaunch).toHaveBeenCalledOnce();
     expect(takeResumeOnLaunch).not.toHaveBeenCalled();
     expect(resumeOnLaunch).not.toHaveBeenCalled();

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -8,6 +8,7 @@ import type { ITheme } from "@xterm/xterm";
 
 export const STORAGE_AUTO_INSTALL_UPDATES = "settings.autoInstallUpdates";
 export const STORAGE_RESUME_ON_LAUNCH = "settings.resumeOnLaunch";
+export const DEFAULT_RESUME_ON_LAUNCH = false;
 export const STORAGE_SIDEBAR_COLLAPSED = "runner.sidebar.collapsed";
 export const STORAGE_APP_ZOOM = "settings.appZoom";
 export const STORAGE_TERMINAL_FONT_SIZE = "settings.terminalFontSize";

--- a/src/lib/terminalResize.test.ts
+++ b/src/lib/terminalResize.test.ts
@@ -4,7 +4,51 @@ import {
   activationResizeRequest,
   isLargeTerminalRowDrop,
   shouldDelayTerminalResize,
+  shouldPushTerminalSize,
+  terminalSizeAfterDisabledChange,
+  terminalSizeAfterRejectedPush,
 } from "./terminalResize";
+
+describe("terminal size push state", () => {
+  it("retries a rejected push without erasing a newer measurement", () => {
+    expect(
+      terminalSizeAfterRejectedPush(
+        { cols: 120, rows: 30 },
+        { cols: 120, rows: 30 },
+      ),
+    ).toEqual({ cols: 0, rows: 0 });
+    expect(
+      terminalSizeAfterRejectedPush(
+        { cols: 132, rows: 41 },
+        { cols: 120, rows: 30 },
+      ),
+    ).toEqual({ cols: 132, rows: 41 });
+  });
+
+  it("pushes current dimensions exactly once after going live", () => {
+    const current = { cols: 132, rows: 41 };
+    const cleared = terminalSizeAfterDisabledChange(
+      current,
+      true,
+      false,
+    );
+
+    expect(cleared).toEqual({ cols: 0, rows: 0 });
+    expect(shouldPushTerminalSize(current, cleared)).toBe(true);
+    expect(shouldPushTerminalSize(current, current)).toBe(false);
+  });
+
+  it("keeps the dedupe state across non-live disabled changes", () => {
+    const current = { cols: 132, rows: 41 };
+
+    expect(terminalSizeAfterDisabledChange(current, false, false)).toEqual(
+      current,
+    );
+    expect(terminalSizeAfterDisabledChange(current, false, true)).toEqual(
+      current,
+    );
+  });
+});
 
 describe("activationResizeRequest", () => {
   it("uses a deduped size push after a live hidden-surface return", () => {

--- a/src/lib/terminalResize.ts
+++ b/src/lib/terminalResize.ts
@@ -3,6 +3,33 @@ export interface TerminalGridSize {
   rows: number;
 }
 
+export function shouldPushTerminalSize(
+  current: TerminalGridSize,
+  lastPushed: TerminalGridSize,
+): boolean {
+  return (
+    current.cols !== lastPushed.cols || current.rows !== lastPushed.rows
+  );
+}
+
+export function terminalSizeAfterRejectedPush(
+  lastPushed: TerminalGridSize,
+  rejected: TerminalGridSize,
+): TerminalGridSize {
+  if (!shouldPushTerminalSize(lastPushed, rejected)) {
+    return { cols: 0, rows: 0 };
+  }
+  return lastPushed;
+}
+
+export function terminalSizeAfterDisabledChange(
+  lastPushed: TerminalGridSize,
+  wasDisabled: boolean,
+  disabled: boolean,
+): TerminalGridSize {
+  return wasDisabled && !disabled ? { cols: 0, rows: 0 } : lastPushed;
+}
+
 export function activationResizeRequest({
   canvasWasDisplayNone,
   wasTransitional,

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -1548,6 +1548,7 @@ function SlotPtyPane({
           active={active && !resuming && !starting}
           hiddenByDisplayNone={hiddenByDisplayNone}
           disabled={dead || resuming || starting}
+          resizeDisabled={resuming || starting}
         />
       </div>
       {!dead && deliveryBlockedUnreadCount !== null ? (


### PR DESCRIPTION
## Summary

- Persist laid-out pane geometry for stopped sessions while preserving live resize and ring-purge behavior.
- Reassert geometry with one plain deduped push when a session goes live; stopped panes keep recording later refits while transitional panes remain suppressed.
- Make auto-resume opt-in through one shared false default, with no migration for users who never stored a choice.
- Document the implementation and update the feature specification.

Implementation record: [docs/impls/0035-auto-resume-width-and-opt-in.md](https://github.com/yicheng47/runner/blob/fix/auto-resume-width-opt-in/docs/impls/0035-auto-resume-width-and-opt-in.md)

## Geometry risk assessment

Native window geometry is restored before the webview renders, non-laid-out terminal rects remain rejected, and stopped panes now persist every later laid-out ResizeObserver, window, sidebar, and split-layout refit. This includes the correction after page zoom settles, so a transient early measurement cannot remain the persisted launch width.

## Release note

Auto-resume is now opt-in, including for existing users who previously received it through the default. Turn on Settings → General → Resume running agents on launch to restore the prior launch behavior.

## Verification

- cargo fmt --all --check
- cargo clippy --workspace
- cargo test --workspace
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm test (196 tests)

The six manual smoke tests in the implementation record are left for human validation.