### PR TITLE
feat(runtime): add TRAE CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@
   ·
   <a href="#features">Features</a>
   ·
+  <a href="#supported-agent-runtimes">Runtimes</a>
+  ·
   <a href="#drive-it-from-your-agents-mcp">MCP</a>
   ·
   <a href="#example-crew">Crew example</a>
@@ -42,6 +44,19 @@ Runner is an **agentic development environment (ADE)**. Where an IDE organizes b
 The coordination model is explicit. A **runner** is a reusable agent configuration — runtime, role, system prompt, working directory. A **crew** composes runners with exactly one lead. Starting a **mission** spawns one real PTY per slot into a tabbed workspace where the crew coordinates over an append-only event log: handoffs and status flow between agents, and when a decision needs a human, `ask_human` surfaces it in the feed. Everything runs and persists locally — sessions are real processes on your machine, and the log is on-disk and replayable.
 
 Runner also runs as an **MCP server**: any MCP client — including the agents themselves — can create crews, start missions, and steer them programmatically. See [Drive it from your agents](#drive-it-from-your-agents-mcp).
+
+## Supported agent runtimes
+
+Runner currently ships first-class adapters for four CLI coding agents:
+
+| Runtime | Default command | Notes |
+| --- | --- | --- |
+| Claude Code | `claude` | Direct chats, crews, conversation resume, permission modes, and MCP registration. |
+| Codex | `codex` | Direct chats, crews, conversation resume, model effort, permission modes, and MCP registration. |
+| Qoder | `qodercli` | Direct chats, crews, conversation resume, permission modes, and MCP registration. |
+| TRAE CLI | `traecli` | Internal-edition runtime; activates when `traecli` is available on `PATH`. Supports chats, crews, resume, model effort, permission modes, and MCP registration. |
+
+Runner does not bundle these agent CLIs. Install and authenticate each runtime separately; Runner detects its default command from `PATH`, and **Settings → Agents** lets you override the executable path.
 
 ## Download
 

--- a/docs/arch/arch.md
+++ b/docs/arch/arch.md
@@ -50,7 +50,7 @@ Runner is a local desktop app. A user configures a **crew** of CLI coding agents
 │   │                                                                      │   │
 │   │  ┌──────────┐   PTY   ┌─────────────────────────────────────┐        │   │
 │   │  │  master  │ ◄─────► │ child: claude-code / codex / qoder  │        │   │
-│   │  └──────────┘         │        / shell                      │        │   │
+│   │  └──────────┘         │        / trae / shell               │        │   │
 │   │                       │   env: RUNNER_CREW_ID,              │        │   │
 │   │                       │        RUNNER_MISSION_ID,           │        │   │
 │   │                       │        RUNNER_HANDLE,               │        │   │
@@ -80,7 +80,7 @@ Runner is a local desktop app. A user configures a **crew** of CLI coding agents
 
 *Runtime (the hot path — the row below MissionManager).*
 
-- **SessionManager** — the per-session PTY runtime. Holds each PTY master, runs the blocking reader thread, keeps the scrollback ring, and serializes writes. Resume is a fresh spawn against the same session row; for claude-code/codex/qoder, `agent_session_key` lets the agent CLI continue its own conversation when supported.
+- **SessionManager** — the per-session PTY runtime. Holds each PTY master, runs the blocking reader thread, keeps the scrollback ring, and serializes writes. Resume is a fresh spawn against the same session row; for claude-code/codex/qoder/trae, `agent_session_key` lets the agent CLI continue its own conversation when supported.
 - **EventBus** — tails the per-mission NDJSON file with `notify`, parses each new line, and republishes it as Tauri events the webview and the router can subscribe to. "Projections" are the in-memory rollups it computes on the fly — inbox, pending HITL cards, status map — all derived from the same event stream.
 
 **The Signal router** sits downstream of the EventBus. When a parsed line is a built-in signal type, the router runs a fixed handler. The "inject_stdin / human_question / status" arrow into SessionManager covers the three things a handler can do: write bytes into a specific session's PTY master (`inject_stdin` — launch prompt to lead on `mission_goal`, human choice on `human_response`, worker question on `ask_lead`), append a new event back to the NDJSON log so the UI renders a HITL card (`human_question`), or update the in-memory status map (`runner_status` events from the forwarder feed this).
@@ -154,7 +154,7 @@ A mission is a container. Everything in the runtime column is either the contain
 
 ### 3.2 Runner — *one configured agent*
 
-A reusable template: handle, display name, runtime (`claude-code | codex | qoder` today), command + args, working dir, system prompt (persona), env. **Top-level, not nested under a crew.** The same runner template can be used by many crews simultaneously, and can also be the subject of standalone direct-chat sessions.
+A reusable template: handle, display name, runtime (`claude-code | codex | qoder | trae` today), command + args, working dir, system prompt (persona), env. **Top-level, not nested under a crew.** The same runner template can be used by many crews simultaneously, and can also be the subject of standalone direct-chat sessions.
 
 A runner has two identifying fields:
 
@@ -365,7 +365,7 @@ The whole system runs many of these side-by-side — one per slot per live missi
 
 ### 5.2 Why PTY (not pipes)
 
-Claude Code and Codex are TUIs. They check `isatty()`; if false, they degrade (no colors, no spinner, sometimes outright refuse). Their output is a stream of escape sequences (`\x1b[2K`, alt-screen toggles) that only a terminal emulator can render.
+Claude Code, Codex, Qoder, and TRAE CLI are TUIs. They check `isatty()`; if false, they degrade (no colors, no spinner, sometimes outright refuse). Their output is a stream of escape sequences (`\x1b[2K`, alt-screen toggles) that only a terminal emulator can render.
 
 A pseudo-terminal gives the child a real terminal on stdin/stdout/ stderr (full TUI mode) and hands us the master end as a byte stream that we forward to **xterm.js** in the webview.
 
@@ -402,7 +402,7 @@ Reader thread (blocking):
   on EOF: wait(child) → emit session:{id}:exit { code } → update sessions row
 ```
 
-System prompt content is delivered through the runtime adapter in `router::runtime`. Claude-code, codex, and qoder receive the composed first-turn body as a positional argument on fresh spawn; resumed conversations suppress it to avoid injecting a duplicate turn.
+System prompt content is delivered through the runtime adapter in `router::runtime`. Claude-code, codex, qoder, and trae receive the composed first-turn body as a positional argument on fresh spawn; resumed conversations suppress it to avoid injecting a duplicate turn.
 
 ### 5.4 Frontend wiring and human takeover
 
@@ -437,7 +437,7 @@ The PTY master writer is shared between the human (via `send_input` command) and
 
 Bounded raw-byte ring per session in SessionManager. It survives tab switches, route changes, and late workspace attachment while the app process is alive. It does not survive app restart, and there is no on-disk scrollback overflow today. The ring sees raw bytes including alt-screen toggles — acceptable because the frontend replays through xterm.js which can absorb them.
 
-Resume preserves the ring for claude-code and qoder (impls 0024, 0032, and 0034): they paint inline into the main screen, so kept scrollback + resume banner + tail repaint is what a physical terminal would show, and a later remount replay keeps the pre-resume conversation. Before the new child forks, Runner appends a synthetic seam chunk through the normal output ingest path to reset SGR, disable bracketed paste and mouse reporting, and start the banner on a fresh line. The ring stays bounded and process-local as before — old and new bytes share the same cap. Codex and other purge runtimes still drop prior bytes because their full-frame resume repaint would stack over retained content; Runner seeds the purged ring with an in-band full-reset chunk so mounted xterm grids and later replay both start clean. Claude-code, codex, and qoder all clear stale scrollback on width changes before their SIGWINCH-driven repaint. Either way `resume` stamps a seq watermark before appending the synthetic chunk; the frontend's starting/resuming pills only honor TUI-ready escapes above it, and the synthetic chunks contain no ready-mode enable, so retained or synthetic bytes cannot clear an overlay waiting on the new PTY.
+Resume preserves the ring for claude-code and qoder (impls 0024, 0032, and 0034): they paint inline into the main screen, so kept scrollback + resume banner + tail repaint is what a physical terminal would show, and a later remount replay keeps the pre-resume conversation. Before the new child forks, Runner appends a synthetic seam chunk through the normal output ingest path to reset SGR, disable bracketed paste and mouse reporting, and start the banner on a fresh line. The ring stays bounded and process-local as before — old and new bytes share the same cap. Codex, trae, and other purge runtimes still drop prior bytes because their full-frame resume repaint would stack over retained content; Runner seeds the purged ring with an in-band full-reset chunk so mounted xterm grids and later replay both start clean. Claude-code, codex, qoder, and trae all clear stale scrollback on width changes before their SIGWINCH-driven repaint. Either way `resume` stamps a seq watermark before appending the synthetic chunk; the frontend's starting/resuming pills only honor TUI-ready escapes above it, and the synthetic chunks contain no ready-mode enable, so retained or synthetic bytes cannot clear an overlay waiting on the new PTY.
 
 Each session row persists the last applied PTY `cols` and `rows`. Spawn and resume resolve their initial size as explicit frontend dimensions, then the persisted dimensions, then 80×24 only for a session with no prior size. This resolution happens in SessionManager before the runtime forks, so relaunch resumes and other temporarily unmeasurable views cannot emit an initial 80-column segment before the frontend settles.
 
@@ -682,7 +682,7 @@ runners (
   id TEXT PRIMARY KEY,
   handle TEXT NOT NULL UNIQUE,        -- globally unique slug; see §3.2
   display_name TEXT NOT NULL,
-  runtime TEXT NOT NULL,              -- first-class runtime key; claude-code | codex | qoder today
+  runtime TEXT NOT NULL,              -- first-class runtime key; claude-code | codex | qoder | trae today
   command TEXT NOT NULL,
   args_json TEXT,
   working_dir TEXT,                   -- direct-chat working dir; missions override via mission.cwd

--- a/docs/impls/0036-trae-runtime.md
+++ b/docs/impls/0036-trae-runtime.md
@@ -1,0 +1,113 @@
+# TRAE CLI as a runtime
+
+## Status
+
+Planned. Tracking issue [#361](https://github.com/yicheng47/runner/issues/361). Capabilities were live-probed against `traecli 0.200.19 (internal edition)` on 2026-07-27: help output for the interactive and `exec` surfaces, a real `exec` run in a scratch git repo, the on-disk rollout envelope, and an add/remove round-trip through `traecli mcp`. Follows [0034](archive/0034-qoder-runtime.md), which added qoder and established that a runtime is mostly a catalog edit.
+
+## Problem
+
+`RUNTIME_DEFINITIONS` (`router/runtime.rs:37`) has three entries. TRAE CLI is a **Codex fork**, so the adapter is codex's, cloned. The evidence is direct rather than inferred: the rollout envelope records `"originator":"codex_exec"`, and the CLI ships codex's `-c key=value` TOML override flag, the `model_reasoning_effort` config key, the `[mcp_servers.<name>]` config shape, `-a/--ask-for-approval`, `-s/--sandbox`, a `resume` subcommand, `apply`, `--oss`, and the `sessions/YYYY/MM/DD/rollout-<ts>-<uuidv7>.jsonl` layout — rooted at `~/.trae/cli/sessions` rather than `~/.codex/sessions`.
+
+What makes this more than a catalog edit is that trae is the **second capture-needing runtime**. Qoder took the claude-code path (caller-supplied `--session-id`), which is why 0034 decision 1 deliberately avoided `codex_capture.rs` and non-goal 3 deferred generalizing it on the grounds that "no third self-assigning runtime is on the table." Trae is not self-assigning, so that module has to be parameterized now.
+
+Five specific traps, all confirmed in the current tree or by probe:
+
+1. **`codex_capture` is hardcoded to codex twice over.** The sessions root is built inline as `$HOME/.codex/sessions` (`codex_capture.rs:91`), and capture is gated on `runner.runtime == "codex"` at three spawn sites (`spawn.rs:489`, `:876`, `:1336`). Trae's root carries an extra segment (`.trae/cli/sessions`), so a naive copy of the codex arm produces a runtime that never captures a key and therefore never resumes.
+2. **`--session-id` looks like self-assignment but is not.** The flag exists on both the interactive and `exec` surfaces, documented as "Legacy compatibility flag for selecting or naming the session." Probed directly: `traecli exec --session-id d0971d26-…` produced rollout `019fa1b9-a133-7841-…` and our supplied id appears in **no** rollout file. Mirroring qoder or claude-code here would persist an `agent_session_key` that can never resume, and the failure is silent until the user restarts a chat.
+3. **Frontend session-key polling is codex-gated.** `MissionWorkspace.tsx:454`, `:482` and `RunnerChat.tsx:530` all test `runtime === "codex"` before polling for the captured key. Backend capture can work perfectly and the key readout still never populates.
+4. **`runtime_purges_on_resume` (`output.rs:828`) is a denylist** — `!matches!(runtime, Some("claude-code") | Some("qoder"))`. For once the inverted default is *correct*: trae repaints its whole frame on resume exactly like codex, so it must be left out of that list. Adding it "for symmetry" with the other three-runtime match arms would garble resumed panes.
+5. **Directory trust gate.** `traecli exec` in an untrusted or non-git directory fails with `Not inside a trusted directory and --skip-git-repo-check was not specified`. Codex has the same posture, so this is not new, but Runner spawns into arbitrary project cwds and the first spawn in a fresh directory may block on trust.
+
+## Key Decisions
+
+1. **Clone codex's adapter, not claude-code's.** `resume_plan("trae", Some(uuid))` → `args: ["resume", uuid]` with `prepend: true` (subcommand prefix, same as codex); fresh spawn → empty args and `assigned_key: None`, with the key arriving post-spawn through capture. Trae also accepts a `--resume <uuid>` flag form, but the subcommand form is what codex's branch already encodes and what the caller's prepend plumbing expects.
+2. **Parameterize `codex_capture`'s sessions root; do not rename the module.** Add the resolved root to `CaptureRequest` (or a `runtime` field plus a `sessions_root_for(runtime)` helper) so `run()` stops building the path inline, and widen the three spawn gates to `matches!(runner.runtime.as_str(), "codex" | "trae")`. Renaming `codex_capture` / `CodexCaptureContext` / `SessionHandle.codex_capture` / `capture_codex_session_key` to something runtime-neutral is a large diff with zero behavior change — leave the names and add a module doc line stating it serves codex-lineage runtimes. Everything else in the module already generalizes: the rollout envelope, the `payload.id` field, the pid-owned-rollout scan, the cwd + start-time fallback, and the `claimed_rollouts` de-dup are all identical for trae.
+3. **Permission modes mirror codex exactly.** `permission_mode_args("trae", Auto)` → `["--ask-for-approval", "on-request", "--sandbox", "workspace-write"]`; `Bypass` → `["--ask-for-approval", "never", "--sandbox", "workspace-write"]`; `AcceptEdits` → empty (no equivalent, reads as Default). `strip_permission_flags("trae")` → `[("--ask-for-approval", true), ("--sandbox", true)]`. Trae *also* declares a qoder-style `--permission-mode default|bypass_permissions|auto`, deliberately unused: two mechanisms for one setting invites drift, and codex's pair is what the semantics table already encodes. Only `--sandbox read-only` was live-probed; the remaining values are help-declared with value sets identical to codex's.
+4. **Model and effort come free; model suggestions do not.** Trae joins codex's arm in `model_effort_args` — `-m/--model` plus `-c model_reasoning_effort=<lowercased>`, and the user's own `~/.trae/traecli.toml` already carries a `model_reasoning_effort` key, confirming the config path. Effort options mirror codex's TOML enum. `MODEL_SUGGESTIONS_BY_RUNTIME` gets **no** trae key (degrades to `[]`): its catalog is internal and differs from codex's `gpt-5-codex` family, and `traecli models` is the source of truth if suggestions are wanted later.
+5. **MCP registration reuses codex's TOML writer.** `~/.trae/traecli.toml` stores servers as `[mcp_servers.<name>]` with `command` / `args` — verified by adding and removing a probe entry. `codex_status_at` / `codex_write_at` work unchanged behind a new path function. This matters more than for codex: the file is mode `600` and also holds auth state and per-hook trust hashes, so the `toml_edit` document-preserving write (which those functions already use) is load-bearing, and only `mcp_servers.runner` may be touched. `traecli mcp add/remove` exists but is not used — direct config editing is how Runner already treats codex.
+6. **Catalog and internal docs yes, public README no.** Trae is an internal-edition binary authed against Trae with plugins sourced from `code.byted.org`; it is not publicly installable. Advertising it in the README tagline and feature copy would be a promise readers can't act on. The runtime simply activates when `traecli` is on `PATH`. `docs/arch/arch.md` and the MCP tool doc comment do get it, since those are engineering references.
+7. **Hook-based session status is out of scope.** Worth recording because it is a genuine find: the probe run emitted `hook: UserPromptSubmit` and `hook: Stop`, and `traecli.toml` carries per-hook trust state for `user_prompt_submit`, `pre_tool_use`, `post_tool_use`, `post_tool_use_failure`, and `stop` — claude-code's event vocabulary, declared in a plugin's `hooks.json`, with `--dangerously-bypass-hook-trust` available for automation. That would make trae a first-class runtime for spec 52. The open question is whether a Runner-owned hook can be injected per-spawn via `-c hooks…=` overrides without writing to the user's config, which spec 52 requires. Not investigated here.
+8. **No `--skip-git-repo-check`, no launch gate.** Keep the same posture as codex: don't pass trust-bypass flags speculatively. If spawns into non-git project cwds fail, that becomes a follow-up with a real reproduction. Likewise no `enter_claude_launch_gate` equivalent — that exists for claude-code's OAuth refresh race, and adding a serialization gate for a hypothetical would slow every multi-slot mission.
+
+## Goals
+
+- Trae is selectable everywhere the other three runtimes are: direct-chat runtime picker, runner form, and crew slot runtime override.
+- Settings → Agents shows a TRAE CLI row with its detected `traecli` path, an override field, and the same states as the other runtimes.
+- Settings → MCP can register or unregister Runner in `~/.trae/traecli.toml` without disturbing auth or hook-trust state.
+- A trae direct chat spawns, takes its first turn via positional argv, captures its rollout id into `agent_session_key`, stops, and resumes into the same conversation.
+- A trae mission slot receives its worker preamble and responds to inbox nudges.
+- A missing or deleted rollout falls back to a fresh spawn instead of an error loop.
+
+## Non-Goals
+
+- Hook-based session status (decision 7) — belongs to spec 52.
+- Renaming `codex_capture` and its types to runtime-neutral names (decision 2).
+- Model suggestions for trae (decision 4).
+- Trae's `--permission-mode` preset flag (decision 3), `--worktree` isolation, `--add-dir`, `--search`, and `--no-alt-screen`.
+- README and public-facing runtime enumerations (decision 6).
+- Generating `src/components/ui/runtimes.ts` from the Rust catalog — still a hand-port, as 0034 left it.
+
+## Implementation Phases
+
+### Phase 1 — Rust catalog and adapter (`src-tauri/src/router/runtime.rs`)
+
+- **Append** to `RUNTIME_DEFINITIONS` (`:37`): `{ name: "trae", display_name: "TRAE CLI", command: "traecli" }`. Append, never prepend — `RUNTIME_OPTIONS[0]` is the Create Runner default and a `runtime_status.rs` test indexes `.runtimes[0]`.
+- `resume_plan` (`:612`): add a `"trae"` arm mirroring codex — `Some(k) if is_uuid(k)` → `args: ["resume", k]`, `prepend: true`, `assigned_key: Some(k)`, `resuming: true`; otherwise the fresh-spawn shape with `assigned_key: None` (decision 1). Note trae's ids are UUIDv7, which `is_uuid` accepts.
+- `first_turn_argv` (`:522`): add `"trae"` to the `"claude-code" | "codex" | "qoder"` arm. Mandatory — without it a trae lead spawns with no persona and no mission goal.
+- `model_effort_args` (`:107`): add `"trae"` to codex's arm (`--model`, `-c model_reasoning_effort=<lowercased>`).
+- `permission_mode_args` (`:198`) and `mode_match_pairs` (`:372`): trae arms mirroring codex per decision 3.
+- `strip_permission_flags` (`:263`): `"trae"` → `&[("--ask-for-approval", true), ("--sandbox", true)]`.
+- `src-tauri/src/commands/mcp.rs`: add Trae to the client enum (`:66`), the snippet and status structs (`:12`, `:22`), a `trae_path()` returning `~/.trae/traecli.toml`, and wire status/write to the existing `codex_status_at` / `codex_write_at` (decision 5) — the same delegation pattern `qoder_status_at` uses for claude-code.
+- Tests: extend the multi-runtime loops (`:1548` and the permission matrix near `:1090`) to include trae; add resume-plan coverage for both the fresh and prior-key arms; assert the strip set round-trips.
+
+### Phase 2 — Capture parameterization, spawn and output policy
+
+- `src-tauri/src/session/codex_capture.rs`: replace the inline `$HOME/.codex/sessions` (`:91`) with the root carried on `CaptureRequest`; add `sessions_root_for(runtime)` mapping `"codex"` → `.codex/sessions` and `"trae"` → `.trae/cli/sessions`; keep the `is_dir()` bail-out. Update the module header (`:6-7`) to name both runtimes.
+- `src-tauri/src/session/manager/spawn.rs:489`, `:876`, `:1336`: widen `runner.runtime == "codex"` to `matches!(runner.runtime.as_str(), "codex" | "trae")` and pass the resolved root into `CodexCaptureContext`.
+- `src-tauri/src/session/manager/spawn.rs:189-200` `codex_capture_prompt_marker`: same widening, so trae gets the prompt-marker disambiguation path that protects sibling chats in one cwd.
+- `src-tauri/src/session/manager/spawn.rs:550`, `:936`, and the third site near `:1421`: add `"trae"` to the first-turn-not-delivered warning gate so the diagnostic stays honest.
+- `src-tauri/src/session/manager/output.rs:812-815` `runtime_clears_on_resize`: add `Some("trae")`.
+- `src-tauri/src/session/manager/output.rs:843` `runtime_purges_on_resume`: **no change** — leaving trae out of the exception list is what gives it codex's purge-on-resume (trap 4). Add a test asserting it, so a later "symmetry" edit fails loudly.
+- `src-tauri/src/session/manager/output.rs:813` full-repaint list and the `Some("claude-code") | Some("codex") | Some("qoder")` arm near `:874`: add trae.
+- Tests in `session/manager/tests.rs`: mirror codex's purge-on-resume coverage for trae, add a trae case to the `resolve_runtime_override` matrix, and cover `sessions_root_for` for both runtimes.
+
+### Phase 3 — Frontend
+
+- `src/components/ui/runtimes.ts`: **append** to `RUNTIME_OPTIONS` (`:18`) — `{ value: "trae", label: "trae", defaultCommand: "traecli", description: "TRAE CLI" }`. Add `"trae"` to `RUNTIMES_CLEARING_ON_RESIZE` (`:39`, in lockstep with Phase 2) and `RUNTIMES_WITH_PERMISSION_MODE` (`:55`). Add `PERMISSION_MODES_BY_RUNTIME` (`:178`), `MODE_MATCH_PAIRS_BY_RUNTIME` (`:245`), `PERMISSION_STRIP_KEYS_BY_RUNTIME`, and `EFFORT_OPTIONS_BY_RUNTIME` (`:85`) entries mirroring codex. Leave `MODEL_SUGGESTIONS_BY_RUNTIME` without a trae key (decision 4).
+- `src/pages/MissionWorkspace.tsx:454`, `:482` and `src/pages/RunnerChat.tsx:530`: widen the `runtime === "codex"` session-key polling guards to include trae (trap 3).
+- `src/components/settings/McpPane.tsx`: add the TRAE CLI registration toggle and manual-config copy action alongside the existing three.
+- `AgentsPane.tsx` needs no change — it renders from `status.runtimes` and `RUNTIME_OPTIONS`, with no hardcoded row count (0034's skeleton fix already landed).
+
+### Phase 4 — Docs and verification
+
+- `docs/arch/arch.md`: update the runtime enumerations and record trae's purge-on-resume / clear-on-resize policy alongside the others.
+- `src-tauri/src/mcp/tools/session.rs:16`: the `runtime` doc comment lists valid names — add trae.
+- `src-tauri/src/commands/slot.rs`: the invalid-runtime error lists valid names; extend the assertion at `:843` to cover trae.
+- Leave `README.md` untouched (decision 6).
+- Full check matrix: `cargo fmt --check`, `cargo clippy --workspace`, `cargo test --workspace`, `pnpm exec tsc --noEmit`, `pnpm run lint`, `pnpm test`.
+
+## Verification
+
+Automated:
+
+- [ ] `resume_plan("trae", None)` yields no args and `assigned_key: None`; with a prior UUID it emits `["resume", uuid]` with `prepend: true`.
+- [ ] `first_turn_argv("trae", body)` returns the positional body; suppressed on resume.
+- [ ] Permission round-trip: Auto → `--ask-for-approval on-request --sandbox workspace-write`; switch to Default → both flags stripped.
+- [ ] `model_effort_args("trae", Some("…"), Some("High"))` emits `--model` plus `-c model_reasoning_effort=high` (lowercased).
+- [ ] `sessions_root_for` returns `.codex/sessions` for codex and `.trae/cli/sessions` for trae.
+- [ ] `runtime_purges_on_resume("trae")` is **true**; `runtime_clears_on_resize("trae")` is true; the TS mirror agrees.
+- [ ] Unknown-runtime slot-override rejection lists trae among valid names.
+- [ ] Trae MCP registration creates `~/.trae/traecli.toml` when absent, preserves unrelated keys — specifically `[hooks.state]` entries and auth values — and removes only `mcp_servers.runner` when disabled.
+
+Manual (the human smoke-tests):
+
+- [ ] Direct chat: spawn, converse, stop, resume — conversation restored via `traecli resume <uuid>`, no blank grid.
+- [ ] `agent_session_key` populates within the capture window; the key readout appears in the chat meta line (confirms trap 3 is fixed).
+- [ ] Two trae chats started seconds apart in the **same** cwd each capture their own rollout id — no fused keys (exercises the prompt-marker and `claimed_rollouts` paths).
+- [ ] First-turn prompt auto-submits in interactive mode.
+- [ ] Mission slot: worker preamble lands; the inbox nudge submit chord (80ms Enter) lands in its input box.
+- [ ] Resize a trae pane mid-conversation — frame repaints cleanly, no shredded box-drawing.
+- [ ] Delete the rollout `.jsonl` and resume — falls back to a fresh spawn without an error loop.
+- [ ] Spawn a trae chat in a cwd that is not a git repo — record whether the trust gate blocks it (decision 8; becomes a follow-up if it does).
+- [ ] Settings → Agents shows a TRAE CLI row with the detected `traecli` path.
+- [ ] Settings → MCP toggles trae registration; a new trae session sees Runner tools.

--- a/src-tauri/migrations/0018_slot_model_override.sql
+++ b/src-tauri/migrations/0018_slot_model_override.sql
@@ -1,0 +1,1 @@
+ALTER TABLE slots ADD COLUMN model_override TEXT;

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -12,6 +14,7 @@ pub struct McpConfigSnippet {
     pub claude_code: String,
     pub codex: String,
     pub qoder: String,
+    pub trae: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -22,6 +25,7 @@ pub struct McpIntegrationStatus {
     pub claude_code: McpClientStatus,
     pub codex: McpClientStatus,
     pub qoder: McpClientStatus,
+    pub trae: McpClientStatus,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -58,6 +62,7 @@ enum Client {
     ClaudeCode,
     Codex,
     Qoder,
+    Trae,
 }
 
 impl Client {
@@ -66,8 +71,9 @@ impl Client {
             "claude_code" => Ok(Self::ClaudeCode),
             "codex" => Ok(Self::Codex),
             "qoder" => Ok(Self::Qoder),
+            "trae" => Ok(Self::Trae),
             other => Err(Error::msg(format!(
-                "unknown MCP client: {other:?} (expected claude_code, codex, or qoder)"
+                "unknown MCP client: {other:?} (expected claude_code, codex, qoder, or trae)"
             ))),
         }
     }
@@ -89,6 +95,10 @@ fn codex_path() -> Result<PathBuf> {
 
 fn qoder_path() -> Result<PathBuf> {
     Ok(home_dir()?.join(".qoder").join("settings.json"))
+}
+
+fn trae_path() -> Result<PathBuf> {
+    Ok(home_dir()?.join(".trae").join("traecli.toml"))
 }
 
 fn mcp_binary_path(state: &AppState) -> String {
@@ -310,7 +320,14 @@ pub(crate) fn codex_write_at(path: &Path, enabled: bool, binary_path: &str) -> R
         servers.remove("runner");
     }
 
-    std::fs::write(path, doc.to_string())
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .mode(0o600)
+        .open(path)
+        .map_err(|e| Error::msg(format!("write {}: {e}", path.display())))?;
+    file.write_all(doc.to_string().as_bytes())
         .map_err(|e| Error::msg(format!("write {}: {e}", path.display())))?;
     Ok(())
 }
@@ -321,12 +338,15 @@ pub async fn mcp_integration_status(state: State<'_, AppState>) -> Result<McpInt
     let claude_code_path = claude_code_path()?;
     let codex_path = codex_path()?;
     let qoder_path = qoder_path()?;
+    let trae_path = trae_path()?;
     let claude_code = claude_code_status_at(&claude_code_path, &binary_path)
         .unwrap_or_else(|e| McpClientStatus::error(&claude_code_path, e.to_string()));
     let codex = codex_status_at(&codex_path, &binary_path)
         .unwrap_or_else(|e| McpClientStatus::error(&codex_path, e.to_string()));
     let qoder = qoder_status_at(&qoder_path, &binary_path)
         .unwrap_or_else(|e| McpClientStatus::error(&qoder_path, e.to_string()));
+    let trae = codex_status_at(&trae_path, &binary_path)
+        .unwrap_or_else(|e| McpClientStatus::error(&trae_path, e.to_string()));
     Ok(McpIntegrationStatus {
         environment: environment_label(),
         socket_path: socket_path(&state),
@@ -334,6 +354,7 @@ pub async fn mcp_integration_status(state: State<'_, AppState>) -> Result<McpInt
         claude_code,
         codex,
         qoder,
+        trae,
     })
 }
 
@@ -348,6 +369,7 @@ pub async fn mcp_set_integration(
         Client::ClaudeCode => claude_code_write_at(&claude_code_path()?, enabled, &binary_path),
         Client::Codex => codex_write_at(&codex_path()?, enabled, &binary_path),
         Client::Qoder => qoder_write_at(&qoder_path()?, enabled, &binary_path),
+        Client::Trae => codex_write_at(&trae_path()?, enabled, &binary_path),
     }
 }
 
@@ -362,6 +384,7 @@ pub async fn mcp_config_snippet(state: State<'_, AppState>) -> Result<McpConfigS
     });
 
     let codex = format!("[mcp_servers.runner]\ncommand = \"{runner_bin}\"\n");
+    let trae = codex.clone();
     let qoder = json!({
         "mcpServers": {
             "runner": json_mcp_entry(&runner_bin)
@@ -372,6 +395,7 @@ pub async fn mcp_config_snippet(state: State<'_, AppState>) -> Result<McpConfigS
         claude_code: serde_json::to_string_pretty(&claude_code).unwrap_or_default(),
         codex,
         qoder: serde_json::to_string_pretty(&qoder).unwrap_or_default(),
+        trae,
     })
 }
 
@@ -579,6 +603,79 @@ mod tests {
             Some("gh-mcp")
         );
         assert_eq!(after_disable["model"].as_str(), Some("gpt-5"));
+    }
+
+    #[test]
+    fn trae_write_creates_dir_and_runner_entry() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join(".trae").join("traecli.toml");
+
+        codex_write_at(&path, true, "/test/runner-mcp").unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o600,
+        );
+        let doc: toml_edit::DocumentMut = std::fs::read_to_string(&path).unwrap().parse().unwrap();
+        assert_eq!(
+            doc["mcp_servers"]["runner"]["command"].as_str(),
+            Some("/test/runner-mcp")
+        );
+        let status = codex_status_at(&path, "/test/runner-mcp").unwrap();
+        assert!(status.registered);
+        assert!(status.matches_current);
+    }
+
+    #[test]
+    fn trae_write_preserves_auth_hooks_and_other_servers() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("traecli.toml");
+        std::fs::write(
+            &path,
+            "auth_token = \"secret\"\n\n[hooks.state]\nstop = \"trusted\"\n\n[mcp_servers.github]\ncommand = \"gh-mcp\"\nargs = []\n",
+        )
+        .unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o640)).unwrap();
+
+        codex_write_at(&path, true, "/test/runner-mcp").unwrap();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o640,
+        );
+        let after: toml_edit::DocumentMut =
+            std::fs::read_to_string(&path).unwrap().parse().unwrap();
+        assert_eq!(after["auth_token"].as_str(), Some("secret"));
+        assert_eq!(after["hooks"]["state"]["stop"].as_str(), Some("trusted"));
+        assert_eq!(
+            after["mcp_servers"]["github"]["command"].as_str(),
+            Some("gh-mcp")
+        );
+        assert_eq!(
+            after["mcp_servers"]["runner"]["command"].as_str(),
+            Some("/test/runner-mcp")
+        );
+
+        codex_write_at(&path, false, "/test/runner-mcp").unwrap();
+        assert_eq!(
+            std::fs::metadata(&path).unwrap().permissions().mode() & 0o777,
+            0o640,
+        );
+        let after_disable: toml_edit::DocumentMut =
+            std::fs::read_to_string(&path).unwrap().parse().unwrap();
+        assert!(after_disable["mcp_servers"].get("runner").is_none());
+        assert_eq!(after_disable["auth_token"].as_str(), Some("secret"));
+        assert_eq!(
+            after_disable["hooks"]["state"]["stop"].as_str(),
+            Some("trusted")
+        );
+        assert_eq!(
+            after_disable["mcp_servers"]["github"]["command"].as_str(),
+            Some("gh-mcp")
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -1929,7 +1929,7 @@ mod tests {
             },
         )
         .unwrap();
-        slot::create(conn, crew_id, &r.id, handle, None)
+        slot::create(conn, crew_id, &r.id, handle, None, None)
             .unwrap()
             .slot
             .id

--- a/src-tauri/src/commands/runner.rs
+++ b/src-tauri/src/commands/runner.rs
@@ -928,6 +928,55 @@ mod tests {
     }
 
     #[test]
+    fn create_and_update_apply_trae_native_permission_mode() {
+        let pool = ctx();
+        let conn = pool.get().unwrap();
+        let r = create(
+            &conn,
+            CreateRunnerInput {
+                handle: "trae-tester".into(),
+                display_name: "TRAE".into(),
+                runtime: "trae".into(),
+                command: "traecli".into(),
+                args: vec!["--debug".into()],
+                working_dir: None,
+                system_prompt: None,
+                env: HashMap::new(),
+                model: None,
+                effort: None,
+                permission_mode: PermissionMode::Auto,
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            r.args,
+            vec![
+                "--debug".to_string(),
+                "--permission-mode".to_string(),
+                "auto".to_string(),
+            ],
+        );
+
+        let r = update(
+            &conn,
+            &r.id,
+            UpdateRunnerInput {
+                permission_mode: Some(PermissionMode::Bypass),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            r.args,
+            vec![
+                "--debug".to_string(),
+                "--permission-mode".to_string(),
+                "bypass_permissions".to_string(),
+            ],
+        );
+    }
+
+    #[test]
     fn create_omits_bypass_flags_when_toggle_off() {
         let pool = ctx();
         let conn = pool.get().unwrap();

--- a/src-tauri/src/commands/slot.rs
+++ b/src-tauri/src/commands/slot.rs
@@ -55,6 +55,11 @@ pub struct UpdateSlotInput {
     /// name to override. Validated against the runtime registry.
     #[serde(default, deserialize_with = "double_option")]
     pub runtime_override: Option<Option<String>>,
+    /// Per-slot model for the selected runtime. Omit to preserve,
+    /// pass `null` or blank to use the runtime default, or pass a
+    /// model name to pin it. Requires a runtime override.
+    #[serde(default, deserialize_with = "double_option")]
+    pub model_override: Option<Option<String>>,
 }
 
 /// Present-vs-missing deserializer for the clear/preserve/set field.
@@ -88,6 +93,13 @@ fn validate_runtime_override(value: Option<&str>) -> Result<Option<String>> {
         )));
     }
     Ok(Some(name.to_string()))
+}
+
+fn normalize_model_override(value: Option<&str>) -> Option<String> {
+    value
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
 }
 
 fn new_id() -> String {
@@ -190,6 +202,7 @@ pub fn create(
     runner_id: &str,
     slot_handle: &str,
     runtime_override: Option<&str>,
+    model_override: Option<&str>,
 ) -> Result<SlotWithRunner> {
     if !crew_exists(conn, crew_id)? {
         return Err(Error::msg(format!("crew not found: {crew_id}")));
@@ -202,6 +215,12 @@ pub fn create(
         return Err(Error::msg("slot_handle must not be empty"));
     }
     let runtime_override = validate_runtime_override(runtime_override)?;
+    let model_override = normalize_model_override(model_override);
+    if runtime_override.is_none() && model_override.is_some() {
+        return Err(Error::msg(
+            "model_override requires a runtime_override on the slot",
+        ));
+    }
 
     let id = new_id();
     let added_at = now();
@@ -229,6 +248,7 @@ pub fn create(
             position: next_position,
             lead: is_first,
             runtime_override,
+            model_override,
             added_at,
         },
     )
@@ -247,10 +267,9 @@ pub fn create(
         .ok_or_else(|| Error::msg("slot_create: inserted row vanished"))
 }
 
-/// Edit a slot's `slot_handle` and/or `runtime_override`. Trims and
-/// rejects empty handles; `runtime_override: Some(None)` clears the
-/// override, `Some(Some(name))` validates against the runtime
-/// registry, `None` preserves. Slot id, crew membership, runner
+/// Edit a slot's handle, runtime override, and/or model override.
+/// Runtime changes clear a stale model unless the caller supplies a
+/// replacement in the same patch. Slot id, crew membership, runner
 /// template ref, position, and lead flag are unchanged.
 pub fn update(
     conn: &mut Connection,
@@ -273,12 +292,36 @@ pub fn update(
         .runtime_override
         .map(|v| validate_runtime_override(v.as_deref()))
         .transpose()?;
+    let model_override = input
+        .model_override
+        .map(|value| normalize_model_override(value.as_deref()));
+    let runtime_changed = runtime_override
+        .as_ref()
+        .is_some_and(|value| *value != existing.runtime_override);
+    let final_runtime_override = runtime_override
+        .clone()
+        .unwrap_or_else(|| existing.runtime_override.clone());
+    let final_model_override = model_override.clone().unwrap_or_else(|| {
+        if runtime_changed {
+            None
+        } else {
+            existing.model_override.clone()
+        }
+    });
+    if final_runtime_override.is_none() && final_model_override.is_some() {
+        return Err(Error::msg(
+            "model_override requires a runtime_override on the slot",
+        ));
+    }
 
     // Both fields commit atomically: a handle collision must not
     // leave a half-applied runtime change behind (or vice versa).
     let tx = conn.transaction_with_behavior(rusqlite::TransactionBehavior::Immediate)?;
     if let Some(runtime_override) = &runtime_override {
         repo::slot::set_runtime_override(&tx, slot_id, runtime_override.as_deref())?;
+    }
+    if model_override.is_some() || runtime_changed {
+        repo::slot::set_model_override(&tx, slot_id, final_model_override.as_deref())?;
     }
     repo::slot::set_slot_handle(&tx, slot_id, &slot_handle).map_err(|e| {
         match e.sqlite_error_code() {
@@ -445,6 +488,10 @@ pub struct CreateSlotInput {
     /// "Runner default" behavior; otherwise a runtime registry name.
     #[serde(default)]
     pub runtime_override: Option<String>,
+    /// Optional model pinned to the selected runtime. Blank or omitted
+    /// uses that runtime's configured default.
+    #[serde(default)]
+    pub model_override: Option<String>,
 }
 
 #[tauri::command]
@@ -459,6 +506,7 @@ pub async fn slot_create(
         &input.runner_id,
         &input.slot_handle,
         input.runtime_override.as_deref(),
+        input.model_override.as_deref(),
     )
 }
 
@@ -543,7 +591,7 @@ mod tests {
         let mut conn = pool.get().unwrap();
         let c = seed_crew(&conn, "Alpha");
         let r = seed_runner(&conn, "lead-template");
-        let added = create(&mut conn, &c, &r, "lead-slot", None).unwrap();
+        let added = create(&mut conn, &c, &r, "lead-slot", None, None).unwrap();
         assert!(added.slot.lead);
         assert_eq!(added.slot.position, 0);
         assert_eq!(added.slot.slot_handle, "lead-slot");
@@ -556,8 +604,8 @@ mod tests {
         let c = seed_crew(&conn, "Alpha");
         let r1 = seed_runner(&conn, "alpha");
         let r2 = seed_runner(&conn, "beta");
-        create(&mut conn, &c, &r1, "alpha", None).unwrap();
-        let second = create(&mut conn, &c, &r2, "beta", None).unwrap();
+        create(&mut conn, &c, &r1, "alpha", None, None).unwrap();
+        let second = create(&mut conn, &c, &r2, "beta", None, None).unwrap();
         assert!(!second.slot.lead);
         assert_eq!(second.slot.position, 1);
     }
@@ -569,8 +617,8 @@ mod tests {
         let mut conn = pool.get().unwrap();
         let c = seed_crew(&conn, "Alpha");
         let r = seed_runner(&conn, "claude");
-        create(&mut conn, &c, &r, "architect", None).unwrap();
-        create(&mut conn, &c, &r, "reviewer", None).unwrap();
+        create(&mut conn, &c, &r, "architect", None, None).unwrap();
+        create(&mut conn, &c, &r, "reviewer", None, None).unwrap();
         let roster = list(&conn, &c).unwrap();
         assert_eq!(roster.len(), 2);
         assert_eq!(roster[0].slot.runner_id, roster[1].slot.runner_id);
@@ -584,8 +632,8 @@ mod tests {
         let c1 = seed_crew(&conn, "A");
         let c2 = seed_crew(&conn, "B");
         let r = seed_runner(&conn, "shared");
-        create(&mut conn, &c1, &r, "shared-a", None).unwrap();
-        create(&mut conn, &c2, &r, "shared-b", None).unwrap();
+        create(&mut conn, &c1, &r, "shared-a", None, None).unwrap();
+        create(&mut conn, &c2, &r, "shared-b", None, None).unwrap();
         let in_c1 = list(&conn, &c1).unwrap();
         let in_c2 = list(&conn, &c2).unwrap();
         assert_eq!(in_c1.len(), 1);
@@ -602,8 +650,8 @@ mod tests {
         let c = seed_crew(&conn, "A");
         let r1 = seed_runner(&conn, "alpha");
         let r2 = seed_runner(&conn, "beta");
-        create(&mut conn, &c, &r1, "shared-handle", None).unwrap();
-        let err = create(&mut conn, &c, &r2, "shared-handle", None).unwrap_err();
+        create(&mut conn, &c, &r1, "shared-handle", None, None).unwrap();
+        let err = create(&mut conn, &c, &r2, "shared-handle", None, None).unwrap_err();
         assert!(err.to_string().contains("already used"));
     }
 
@@ -614,8 +662,8 @@ mod tests {
         let c = seed_crew(&conn, "A");
         let r1 = seed_runner(&conn, "one");
         let r2 = seed_runner(&conn, "two");
-        let s1 = create(&mut conn, &c, &r1, "one", None).unwrap();
-        let s2 = create(&mut conn, &c, &r2, "two", None).unwrap();
+        let s1 = create(&mut conn, &c, &r1, "one", None, None).unwrap();
+        let s2 = create(&mut conn, &c, &r2, "two", None, None).unwrap();
 
         let promoted = set_lead(&mut conn, &s2.slot.id).unwrap();
         assert!(promoted.slot.lead);
@@ -649,9 +697,9 @@ mod tests {
         let r1 = seed_runner(&conn, "alpha");
         let r2 = seed_runner(&conn, "beta");
         let r3 = seed_runner(&conn, "gamma");
-        let s1 = create(&mut conn, &c, &r1, "alpha", None).unwrap();
-        create(&mut conn, &c, &r2, "beta", None).unwrap();
-        let s3 = create(&mut conn, &c, &r3, "gamma", None).unwrap();
+        let s1 = create(&mut conn, &c, &r1, "alpha", None, None).unwrap();
+        create(&mut conn, &c, &r2, "beta", None, None).unwrap();
+        let s3 = create(&mut conn, &c, &r3, "gamma", None, None).unwrap();
         set_lead(&mut conn, &s3.slot.id).unwrap();
 
         delete(&mut conn, &s3.slot.id).unwrap();
@@ -672,7 +720,7 @@ mod tests {
         let mut conn = pool.get().unwrap();
         let c = seed_crew(&conn, "A");
         let r = seed_runner(&conn, "only");
-        let s = create(&mut conn, &c, &r, "only", None).unwrap();
+        let s = create(&mut conn, &c, &r, "only", None, None).unwrap();
         delete(&mut conn, &s.slot.id).unwrap();
         assert!(list(&conn, &c).unwrap().is_empty());
     }
@@ -685,9 +733,9 @@ mod tests {
         let r1 = seed_runner(&conn, "alpha");
         let r2 = seed_runner(&conn, "beta");
         let r3 = seed_runner(&conn, "gamma");
-        let s1 = create(&mut conn, &c, &r1, "alpha", None).unwrap();
-        let s2 = create(&mut conn, &c, &r2, "beta", None).unwrap();
-        let s3 = create(&mut conn, &c, &r3, "gamma", None).unwrap();
+        let s1 = create(&mut conn, &c, &r1, "alpha", None, None).unwrap();
+        let s2 = create(&mut conn, &c, &r2, "beta", None, None).unwrap();
+        let s3 = create(&mut conn, &c, &r3, "gamma", None, None).unwrap();
 
         let roster = reorder(
             &mut conn,
@@ -721,9 +769,9 @@ mod tests {
         let r1 = seed_runner(&conn, "alpha");
         let r2 = seed_runner(&conn, "beta");
         let r3 = seed_runner(&conn, "gamma");
-        create(&mut conn, &c, &r1, "alpha", None).unwrap();
-        let s2 = create(&mut conn, &c, &r2, "beta", None).unwrap();
-        create(&mut conn, &c, &r3, "gamma", None).unwrap();
+        create(&mut conn, &c, &r1, "alpha", None, None).unwrap();
+        let s2 = create(&mut conn, &c, &r2, "beta", None, None).unwrap();
+        create(&mut conn, &c, &r3, "gamma", None, None).unwrap();
 
         delete(&mut conn, &s2.slot.id).unwrap();
 
@@ -736,7 +784,7 @@ mod tests {
         );
 
         let r4 = seed_runner(&conn, "delta");
-        let added = create(&mut conn, &c, &r4, "delta", None).unwrap();
+        let added = create(&mut conn, &c, &r4, "delta", None, None).unwrap();
         assert_eq!(
             added.slot.position, 2,
             "new slot appends at the dense next position"
@@ -753,11 +801,11 @@ mod tests {
         let a2 = seed_runner(&conn, "a2");
         let b1 = seed_runner(&conn, "b1");
         let b2 = seed_runner(&conn, "b2");
-        create(&mut conn, &c1, &a2, "a2", None).unwrap();
-        create(&mut conn, &c1, &shared, "shared-a", None).unwrap();
-        create(&mut conn, &c2, &b1, "b1", None).unwrap();
-        create(&mut conn, &c2, &shared, "shared-b", None).unwrap();
-        create(&mut conn, &c2, &b2, "b2", None).unwrap();
+        create(&mut conn, &c1, &a2, "a2", None, None).unwrap();
+        create(&mut conn, &c1, &shared, "shared-a", None, None).unwrap();
+        create(&mut conn, &c2, &b1, "b1", None, None).unwrap();
+        create(&mut conn, &c2, &shared, "shared-b", None, None).unwrap();
+        create(&mut conn, &c2, &b2, "b2", None, None).unwrap();
 
         runner::delete(&mut conn, &shared).unwrap();
 
@@ -776,7 +824,7 @@ mod tests {
         let mut conn = pool.get().unwrap();
         let c = seed_crew(&conn, "A");
         let r = seed_runner(&conn, "alpha");
-        let s = create(&mut conn, &c, &r, "old", None).unwrap();
+        let s = create(&mut conn, &c, &r, "old", None, None).unwrap();
         let updated = update(
             &mut conn,
             &s.slot.id,
@@ -796,8 +844,8 @@ mod tests {
         let c = seed_crew(&conn, "A");
         let r1 = seed_runner(&conn, "alpha");
         let r2 = seed_runner(&conn, "beta");
-        create(&mut conn, &c, &r1, "alpha", None).unwrap();
-        let s2 = create(&mut conn, &c, &r2, "beta", None).unwrap();
+        create(&mut conn, &c, &r1, "alpha", None, None).unwrap();
+        let s2 = create(&mut conn, &c, &r2, "beta", None, None).unwrap();
         let err = update(
             &mut conn,
             &s2.slot.id,
@@ -818,14 +866,35 @@ mod tests {
         let r1 = seed_runner(&conn, "alpha");
         let r2 = seed_runner(&conn, "beta");
 
-        let with_override = create(&mut conn, &c, &r1, "alpha", Some("claude-code")).unwrap();
+        let with_override = create(
+            &mut conn,
+            &c,
+            &r1,
+            "alpha",
+            Some("claude-code"),
+            Some("  opus  "),
+        )
+        .unwrap();
         assert_eq!(
             with_override.slot.runtime_override.as_deref(),
             Some("claude-code")
         );
+        assert_eq!(with_override.slot.model_override.as_deref(), Some("opus"));
 
-        let blank = create(&mut conn, &c, &r2, "beta", Some("   ")).unwrap();
+        let blank = create(&mut conn, &c, &r2, "beta", Some("   "), None).unwrap();
         assert_eq!(blank.slot.runtime_override, None);
+    }
+
+    #[test]
+    fn create_rejects_model_override_without_runtime_override() {
+        let pool = pool();
+        let mut conn = pool.get().unwrap();
+        let c = seed_crew(&conn, "A");
+        let r = seed_runner(&conn, "alpha");
+        let err = create(&mut conn, &c, &r, "alpha", None, Some("opus")).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("model_override requires a runtime_override"));
     }
 
     #[test]
@@ -834,7 +903,7 @@ mod tests {
         let mut conn = pool.get().unwrap();
         let c = seed_crew(&conn, "A");
         let r = seed_runner(&conn, "alpha");
-        let err = create(&mut conn, &c, &r, "alpha", Some("aider-future")).unwrap_err();
+        let err = create(&mut conn, &c, &r, "alpha", Some("aider-future"), None).unwrap_err();
         assert!(
             err.to_string().contains("unknown runtime 'aider-future'"),
             "got: {err}",
@@ -842,6 +911,10 @@ mod tests {
         assert!(
             err.to_string().contains("qoder"),
             "valid-runtime list must include qoder: {err}",
+        );
+        assert!(
+            err.to_string().contains("trae"),
+            "valid-runtime list must include trae: {err}",
         );
         assert!(list(&conn, &c).unwrap().is_empty(), "no row on rejection");
     }
@@ -852,7 +925,7 @@ mod tests {
         let mut conn = pool.get().unwrap();
         let c = seed_crew(&conn, "A");
         let r = seed_runner(&conn, "alpha");
-        let s = create(&mut conn, &c, &r, "alpha", None).unwrap();
+        let s = create(&mut conn, &c, &r, "alpha", None, None).unwrap();
 
         // Set.
         let set = update(
@@ -866,6 +939,17 @@ mod tests {
         .unwrap();
         assert_eq!(set.slot.runtime_override.as_deref(), Some("codex"));
 
+        let model_set = update(
+            &mut conn,
+            &s.slot.id,
+            UpdateSlotInput {
+                model_override: Some(Some("gpt-slot".into())),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(model_set.slot.model_override.as_deref(), Some("gpt-slot"));
+
         // Omitted field preserves.
         let preserved = update(
             &mut conn,
@@ -877,6 +961,7 @@ mod tests {
         )
         .unwrap();
         assert_eq!(preserved.slot.runtime_override.as_deref(), Some("codex"));
+        assert_eq!(preserved.slot.model_override.as_deref(), Some("gpt-slot"));
         assert_eq!(preserved.slot.slot_handle, "renamed");
 
         // Explicit null clears back to Runner default.
@@ -890,6 +975,10 @@ mod tests {
         )
         .unwrap();
         assert_eq!(cleared.slot.runtime_override, None);
+        assert_eq!(
+            cleared.slot.model_override, None,
+            "clearing the runtime must clear its model override",
+        );
     }
 
     #[test]
@@ -902,6 +991,7 @@ mod tests {
         // green.
         let missing: UpdateSlotInput = serde_json::from_str(r#"{}"#).unwrap();
         assert_eq!(missing.runtime_override, None);
+        assert_eq!(missing.model_override, None);
 
         let null: UpdateSlotInput = serde_json::from_str(r#"{"runtime_override": null}"#).unwrap();
         assert_eq!(null.runtime_override, Some(None));
@@ -909,6 +999,14 @@ mod tests {
         let set: UpdateSlotInput =
             serde_json::from_str(r#"{"runtime_override": "codex"}"#).unwrap();
         assert_eq!(set.runtime_override, Some(Some("codex".into())));
+
+        let model_null: UpdateSlotInput =
+            serde_json::from_str(r#"{"model_override": null}"#).unwrap();
+        assert_eq!(model_null.model_override, Some(None));
+
+        let model_set: UpdateSlotInput =
+            serde_json::from_str(r#"{"model_override": "gpt-slot"}"#).unwrap();
+        assert_eq!(model_set.model_override, Some(Some("gpt-slot".into())),);
     }
 
     #[test]
@@ -920,7 +1018,7 @@ mod tests {
         let mut conn = pool.get().unwrap();
         let c = seed_crew(&conn, "A");
         let r = seed_runner(&conn, "alpha");
-        let s = create(&mut conn, &c, &r, "alpha", Some("codex")).unwrap();
+        let s = create(&mut conn, &c, &r, "alpha", Some("codex"), None).unwrap();
 
         let input: UpdateSlotInput = serde_json::from_str(r#"{"runtime_override": null}"#).unwrap();
         let cleared = update(&mut conn, &s.slot.id, input).unwrap();
@@ -937,8 +1035,8 @@ mod tests {
         let c = seed_crew(&conn, "A");
         let r1 = seed_runner(&conn, "alpha");
         let r2 = seed_runner(&conn, "beta");
-        create(&mut conn, &c, &r1, "alpha", None).unwrap();
-        let b = create(&mut conn, &c, &r2, "beta", None).unwrap();
+        create(&mut conn, &c, &r1, "alpha", None, None).unwrap();
+        let b = create(&mut conn, &c, &r2, "beta", None, None).unwrap();
 
         let err = update(
             &mut conn,
@@ -946,6 +1044,7 @@ mod tests {
             UpdateSlotInput {
                 slot_handle: Some("alpha".into()),
                 runtime_override: Some(Some("codex".into())),
+                model_override: None,
             },
         )
         .unwrap_err();
@@ -966,7 +1065,7 @@ mod tests {
         let mut conn = pool.get().unwrap();
         let c = seed_crew(&conn, "A");
         let r = seed_runner(&conn, "alpha");
-        let s = create(&mut conn, &c, &r, "alpha", Some("codex")).unwrap();
+        let s = create(&mut conn, &c, &r, "alpha", Some("codex"), None).unwrap();
         let err = update(
             &mut conn,
             &s.slot.id,

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -104,6 +104,9 @@ fn init_connection(conn: &mut Connection) -> rusqlite::Result<()> {
 // resume can fork at the prior width before any frontend pane is measurable.
 // 0017: records sessions that were running at graceful quit so the next
 // launch can resume them without treating crash-demoted rows the same way.
+// 0018: adds nullable `slots.model_override` so a slot that selects a
+// different runtime can pin that runtime's model without mutating the
+// reusable runner template.
 const MIGRATIONS: &[(i64, &str)] = &[
     (1, include_str!("../migrations/0001_init.sql")),
     (2, include_str!("../migrations/0002_persona_only_seeds.sql")),
@@ -145,6 +148,10 @@ const MIGRATIONS: &[(i64, &str)] = &[
     (
         17,
         include_str!("../migrations/0017_session_resume_on_launch.sql"),
+    ),
+    (
+        18,
+        include_str!("../migrations/0018_slot_model_override.sql"),
     ),
 ];
 

--- a/src-tauri/src/mcp/tools/session.rs
+++ b/src-tauri/src/mcp/tools/session.rs
@@ -13,7 +13,7 @@ pub struct StartDirectSessionArgs {
     /// Runner template ID.
     pub runner_id: String,
     /// Optional runtime override (registry name, e.g. "codex",
-    /// "claude-code", or "qoder"). Omit to use the runner's own runtime. When it
+    /// "claude-code", "qoder", or "trae"). Omit to use the runner's own runtime. When it
     /// differs, the chat spawns that engine with registry defaults
     /// while the runner's persona (system prompt, working dir, env)
     /// carries over.

--- a/src-tauri/src/mcp/tools/slot.rs
+++ b/src-tauri/src/mcp/tools/slot.rs
@@ -69,6 +69,7 @@ impl RunnerMcpHandler {
             &input.runner_id,
             &input.slot_handle,
             input.runtime_override.as_deref(),
+            input.model_override.as_deref(),
         )
         .map_err(|e| ErrorData::internal_error(e.to_string(), None))?;
         self.state.app_handle.emit("slot/changed", ()).ok();

--- a/src-tauri/src/model.rs
+++ b/src-tauri/src/model.rs
@@ -81,10 +81,15 @@ pub struct Slot {
     /// Per-slot engine choice. NULL = use the runner's own `runtime`.
     /// When set (validated against the runtime registry on write),
     /// mission spawns resolve the effective runtime as
-    /// `runtime_override ?? runner.runtime` and reset runtime-specific
-    /// fields (command, args, model, effort) to registry defaults.
+    /// `runtime_override ?? runner.runtime` and reset the command,
+    /// args, and effort to registry defaults. `model_override` can
+    /// optionally pin a model for that selected runtime.
     #[serde(default)]
     pub runtime_override: Option<String>,
+    /// Optional model pinned to the slot's selected runtime. NULL means
+    /// use the effective runtime's default model.
+    #[serde(default)]
+    pub model_override: Option<String>,
     pub added_at: Timestamp,
 }
 

--- a/src-tauri/src/repo/slot.rs
+++ b/src-tauri/src/repo/slot.rs
@@ -21,6 +21,7 @@ pub struct SlotRow {
     pub position: i64,
     pub lead: bool,
     pub runtime_override: Option<String>,
+    pub model_override: Option<String>,
     #[serde(with = "crate::repo::serde::rfc3339")]
     pub added_at: Timestamp,
 }
@@ -33,6 +34,7 @@ pub const COLUMNS: &[&str] = &[
     "position",
     "lead",
     "runtime_override",
+    "model_override",
     "added_at",
 ];
 
@@ -46,6 +48,7 @@ impl From<SlotRow> for Slot {
             position: r.position,
             lead: r.lead,
             runtime_override: r.runtime_override,
+            model_override: r.model_override,
             added_at: r.added_at,
         }
     }
@@ -61,6 +64,7 @@ impl From<&Slot> for SlotRow {
             position: s.position,
             lead: s.lead,
             runtime_override: s.runtime_override.clone(),
+            model_override: s.model_override.clone(),
             added_at: s.added_at,
         }
     }
@@ -137,6 +141,17 @@ pub fn set_runtime_override(
     )
 }
 
+pub fn set_model_override(
+    conn: &Connection,
+    id: &str,
+    model_override: Option<&str>,
+) -> rusqlite::Result<usize> {
+    conn.execute(
+        "UPDATE slots SET model_override = ?1 WHERE id = ?2",
+        rusqlite::params![model_override, id],
+    )
+}
+
 pub fn set_position(conn: &Connection, id: &str, position: i64) -> rusqlite::Result<usize> {
     conn.execute(
         "UPDATE slots SET position = ?1 WHERE id = ?2",
@@ -203,6 +218,7 @@ mod tests {
             position: 3,
             lead: true,
             runtime_override: Some("claude-code".into()),
+            model_override: Some("opus".into()),
             added_at: Utc::now(),
         }
     }
@@ -216,6 +232,7 @@ mod tests {
             position: 0,
             lead: false,
             runtime_override: None,
+            model_override: None,
             added_at: Utc::now(),
         }
     }

--- a/src-tauri/src/router/runtime.rs
+++ b/src-tauri/src/router/runtime.rs
@@ -50,6 +50,11 @@ const RUNTIME_DEFINITIONS: &[RuntimeDefinition] = &[
         display_name: "Qoder",
         command: "qodercli",
     },
+    RuntimeDefinition {
+        name: "trae",
+        display_name: "TRAE CLI",
+        command: "traecli",
+    },
 ];
 
 pub fn runtime_definitions() -> &'static [RuntimeDefinition] {
@@ -126,7 +131,7 @@ pub fn model_effort_args(runtime: &str, model: Option<&str>, effort: Option<&str
             }
             out
         }
-        "codex" => {
+        "codex" | "trae" => {
             let mut out = Vec::new();
             if let Some(m) = model {
                 out.push("--model".into());
@@ -184,6 +189,11 @@ pub fn model_effort_args(runtime: &str, model: Option<&str>, effort: Option<&str
 /// qoder (2 modes — only the live-probed flag is exposed):
 /// - **Default** — no flag.
 /// - **Auto** — `--permission-mode auto`.
+///
+/// trae (3 modes — native presets declared by `traecli --help`):
+/// - **Default** — no flag; use TRAE CLI's configured default.
+/// - **Auto** — `--permission-mode auto`.
+/// - **Bypass** — `--permission-mode bypass_permissions`.
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, schemars::JsonSchema,
 )]
@@ -223,11 +233,19 @@ pub fn permission_mode_args(runtime: &str, mode: PermissionMode) -> Vec<String> 
         ("qoder", PermissionMode::Auto) => {
             vec!["--permission-mode".into(), "auto".into()]
         }
+        ("trae", PermissionMode::Auto) => {
+            vec!["--permission-mode".into(), "auto".into()]
+        }
+        ("trae", PermissionMode::Bypass) => {
+            vec!["--permission-mode".into(), "bypass_permissions".into()]
+        }
         // codex: `--ask-for-approval <cadence> --sandbox
         // workspace-write` pair for both Auto and Bypass. AcceptEdits
         // returns empty (codex has no equivalent) so a user who
         // somehow lands AcceptEdits on a codex row reads as Default.
-        ("codex", PermissionMode::AcceptEdits) => Vec::new(),
+        ("codex", PermissionMode::AcceptEdits) | ("trae", PermissionMode::AcceptEdits) => {
+            Vec::new()
+        }
         ("codex", PermissionMode::Auto) => vec![
             "--ask-for-approval".into(),
             "on-request".into(),
@@ -259,7 +277,7 @@ pub fn permission_mode_args(runtime: &str, mode: PermissionMode) -> Vec<String> 
 ///     `--dangerously-skip-permissions` (standalone, kept in the
 ///     strip set so legacy rows that still carry the deprecated flag
 ///     get cleaned up the next time the user touches their row).
-///   - qoder: `--permission-mode <value>` (value-bearing).
+///   - qoder/trae: `--permission-mode <value>` (value-bearing).
 pub fn strip_permission_flags(runtime: &str, args: &[String]) -> Vec<String> {
     // (flag_name, takes_value)
     let keys: &[(&str, bool)] = match runtime {
@@ -268,7 +286,7 @@ pub fn strip_permission_flags(runtime: &str, args: &[String]) -> Vec<String> {
             ("--dangerously-skip-permissions", false),
             ("--permission-mode", true),
         ],
-        "qoder" => &[("--permission-mode", true)],
+        "qoder" | "trae" => &[("--permission-mode", true)],
         _ => &[],
     };
     if keys.is_empty() {
@@ -396,6 +414,8 @@ fn mode_match_pairs(
             &[("--permission-mode", Some("bypassPermissions"))]
         }
         ("qoder", PermissionMode::Auto) => &[("--permission-mode", Some("auto"))],
+        ("trae", PermissionMode::Auto) => &[("--permission-mode", Some("auto"))],
+        ("trae", PermissionMode::Bypass) => &[("--permission-mode", Some("bypass_permissions"))],
         ("codex", PermissionMode::Auto) => &[
             ("--ask-for-approval", Some("on-request")),
             ("--sandbox", Some("workspace-write")),
@@ -488,7 +508,7 @@ pub const FIRST_TURN_ARGV_MAX_BYTES: usize = 32 * 1024;
 /// Map a runtime + composed first-turn body to the positional argv
 /// the agent CLI reads as its first user turn at process spawn.
 ///
-/// claude-code, codex, and qoder accept a positional `[PROMPT]` argument.
+/// claude-code, codex, qoder, and trae accept a positional `[PROMPT]` argument.
 /// Delivering
 /// the first turn at spawn-time eliminates the post-spawn paste race
 /// the original `inject_paste_with_verify` machinery was working
@@ -519,7 +539,7 @@ pub fn first_turn_argv(runtime: &str, body: Option<&str>) -> Vec<String> {
         return Vec::new();
     }
     match runtime {
-        "claude-code" | "codex" | "qoder" => vec![body.to_string()],
+        "claude-code" | "codex" | "qoder" | "trae" => vec![body.to_string()],
         _ => Vec::new(),
     }
 }
@@ -528,9 +548,9 @@ pub fn first_turn_argv(runtime: &str, body: Option<&str>) -> Vec<String> {
 /// any `system_prompt` argv + first-turn body positional) in the
 /// order the runtime's CLI expects.
 ///
-/// `system_prompt_args` still returns empty for all three first-class
-/// runtimes (claude-code's `--append-system-prompt` is SDK-only; codex
-/// and qoder have no probed equivalent flag). The first user turn —
+/// `system_prompt_args` still returns empty for all four first-class
+/// runtimes (claude-code's `--append-system-prompt` is SDK-only; codex,
+/// qoder, and trae have no probed equivalent flag). The first user turn —
 /// composed launch prompt for a mission lead, worker preamble for
 /// non-leads, persona for direct chats — rides on `first_turn_argv`
 /// instead and lands as the trailing positional.
@@ -576,18 +596,18 @@ pub fn mission_bus_sandbox_args(runtime: &str, mission_dir: Option<&Path>) -> Ve
 #[derive(Debug, Clone)]
 pub struct ResumePlan {
     /// Args to splice into the spawn command. For claude-code and qoder these
-    /// are trailing flags; for codex `resume <uuid>` is a subcommand prefix
-    /// the caller must place ahead of any user-supplied args. See `prepend`.
+    /// are trailing flags; for codex and trae `resume <uuid>` is a subcommand
+    /// prefix the caller must place ahead of any user-supplied args. See `prepend`.
     pub args: Vec<String>,
     /// `true` when `args` are a subcommand prefix that must precede the
-    /// runner's configured args (codex resume). `false` when they are
+    /// runner's configured args (codex/trae resume). `false` when they are
     /// trailing flags safe to append (claude-code/qoder --session-id / --resume).
     pub prepend: bool,
     /// The native agent session key this spawn is bound to, when known up
     /// front. claude-code/qoder: a freshly-generated UUID we just told the CLI
-    /// to use, or the prior key when resuming. codex: the prior key when
-    /// resuming, otherwise `None` (fresh codex sessions self-assign an id;
-    /// post-spawn capture is a follow-up).
+    /// to use, or the prior key when resuming. codex/trae: the prior key when
+    /// resuming, otherwise `None` (fresh sessions self-assign an id that
+    /// Runner captures post-spawn).
     pub assigned_key: Option<String>,
     /// Whether this plan is a resume of a prior conversation. Callers can
     /// surface a "resuming previous session" hint, and on later detection
@@ -615,10 +635,8 @@ impl ResumePlan {
 ///   - claude-code/qoder with no `prior_key` → fresh spawn but with a
 ///     self-assigned UUID via `--session-id`, so the very next respawn can
 ///     resume.
-///   - codex with no `prior_key` → fresh spawn, no key. Capturing the codex
-///     rollout id post-spawn is tracked as a follow-up; until then, codex
-///     resumes only if the user has previously triggered a captured key by
-///     other means (manual seed, future capture path).
+///   - codex/trae with no `prior_key` → fresh spawn, no key. Runner captures
+///     the rollout id post-spawn.
 ///
 /// `prior_key` should be the value of `sessions.agent_session_key` from the
 /// most recent prior session in the same scope. The caller decides how to
@@ -680,7 +698,7 @@ pub fn resume_plan(runtime: &str, prior_key: Option<&str>) -> ResumePlan {
                 }
             }
         },
-        "codex" => match prior_key {
+        "codex" | "trae" => match prior_key {
             Some(k) if is_uuid(k) => ResumePlan {
                 // `codex resume <uuid>` is a subcommand prefix. The caller
                 // places these args ahead of any user-supplied args.
@@ -934,6 +952,24 @@ mod tests {
     }
 
     #[test]
+    fn trae_fresh_returns_empty_plan() {
+        let plan = resume_plan("trae", None);
+        assert!(plan.args.is_empty());
+        assert!(plan.assigned_key.is_none());
+        assert!(!plan.resuming);
+    }
+
+    #[test]
+    fn trae_resume_uses_subcommand_prefix() {
+        let prior = "019fa1b9-a133-7841-b4dd-730d376ab1d1".to_string();
+        let plan = resume_plan("trae", Some(&prior));
+        assert!(plan.resuming);
+        assert!(plan.prepend, "trae resume is a subcommand, must prepend");
+        assert_eq!(plan.args, vec!["resume", &prior]);
+        assert_eq!(plan.assigned_key.as_deref(), Some(prior.as_str()));
+    }
+
+    #[test]
     fn unknown_runtime_returns_empty_resume_plan() {
         let plan = resume_plan("aider-future", Some("anything"));
         assert!(plan.args.is_empty());
@@ -971,6 +1007,20 @@ mod tests {
             args.windows(2)
                 .any(|w| w[0] == "-c" && w[1] == "model_reasoning_effort=high"),
             "expected `-c model_reasoning_effort=high`, got: {args:?}",
+        );
+    }
+
+    #[test]
+    fn trae_emits_model_and_reasoning_effort_override() {
+        let args = model_effort_args("trae", Some("trae-model"), Some("High"));
+        assert_eq!(
+            args,
+            vec![
+                "--model".to_string(),
+                "trae-model".to_string(),
+                "-c".to_string(),
+                "model_reasoning_effort=high".to_string(),
+            ],
         );
     }
 
@@ -1069,6 +1119,7 @@ mod tests {
         // Default → no flags for any runtime / any mode.
         assert!(permission_mode_args("claude-code", PermissionMode::Default).is_empty());
         assert!(permission_mode_args("codex", PermissionMode::Default).is_empty());
+        assert!(permission_mode_args("trae", PermissionMode::Default).is_empty());
         // claude-code: AcceptEdits / Auto / Bypass each emit
         // `--permission-mode <value>` with a runtime-specific value.
         assert_eq!(
@@ -1112,6 +1163,18 @@ mod tests {
                 "never".to_string(),
                 "--sandbox".to_string(),
                 "workspace-write".to_string(),
+            ],
+        );
+        assert!(permission_mode_args("trae", PermissionMode::AcceptEdits).is_empty());
+        assert_eq!(
+            permission_mode_args("trae", PermissionMode::Auto),
+            vec!["--permission-mode".to_string(), "auto".to_string()],
+        );
+        assert_eq!(
+            permission_mode_args("trae", PermissionMode::Bypass),
+            vec![
+                "--permission-mode".to_string(),
+                "bypass_permissions".to_string(),
             ],
         );
         // Unknown runtime → empty for every mode.
@@ -1217,6 +1280,25 @@ mod tests {
         ];
         let out = apply_permission_mode("codex", &user, PermissionMode::Default);
         assert_eq!(out, vec!["--debug".to_string()]);
+    }
+
+    #[test]
+    fn apply_permission_mode_trae_round_trips_auto_to_default() {
+        let user = vec!["--debug".to_string()];
+        let auto = apply_permission_mode("trae", &user, PermissionMode::Auto);
+        assert_eq!(
+            auto,
+            vec![
+                "--debug".to_string(),
+                "--permission-mode".to_string(),
+                "auto".to_string(),
+            ],
+        );
+        assert_eq!(infer_permission_mode("trae", &auto), PermissionMode::Auto);
+        assert_eq!(
+            apply_permission_mode("trae", &auto, PermissionMode::Default),
+            user,
+        );
     }
 
     #[test]
@@ -1545,7 +1627,7 @@ mod tests {
 
     #[test]
     fn first_turn_rides_trailing_argv_on_fresh_spawn_for_supported_runtimes() {
-        for runtime in ["claude-code", "codex", "qoder"] {
+        for runtime in ["claude-code", "codex", "qoder", "trae"] {
             let body = "You are the architect. Goal: ship 0007.";
             let args = trailing_runtime_args(
                 runtime,
@@ -1568,7 +1650,7 @@ mod tests {
 
     #[test]
     fn first_turn_suppressed_on_resume_for_supported_runtimes() {
-        for runtime in ["claude-code", "codex", "qoder"] {
+        for runtime in ["claude-code", "codex", "qoder", "trae"] {
             let body = "You are the architect. Goal: ship 0007.";
             let args = trailing_runtime_args(
                 runtime,

--- a/src-tauri/src/router/tests.rs
+++ b/src-tauri/src/router/tests.rs
@@ -381,6 +381,7 @@ fn slot_with_runner(handle: &str, lead: bool) -> SlotWithRunner {
             position: 0,
             lead,
             runtime_override: None,
+            model_override: None,
             added_at: Utc::now(),
         },
         runner,

--- a/src-tauri/src/runtime_status.rs
+++ b/src-tauri/src/runtime_status.rs
@@ -460,7 +460,7 @@ mod tests {
     }
 
     #[test]
-    fn status_list_includes_qoder_from_the_catalog() {
+    fn status_list_includes_all_catalog_runtimes() {
         let pool = crate::db::open_in_memory().unwrap();
         let shell_env = Arc::new(RwLock::new(LoginShellEnv::default()));
         let status = status_list(&pool, &shell_env, &completed_discovery()).unwrap();
@@ -478,6 +478,7 @@ mod tests {
                 ("codex", "Codex", "codex"),
                 ("claude-code", "Claude Code", "claude"),
                 ("qoder", "Qoder", "qodercli"),
+                ("trae", "TRAE CLI", "traecli"),
             ],
         );
     }

--- a/src-tauri/src/session/codex_capture.rs
+++ b/src-tauri/src/session/codex_capture.rs
@@ -1,13 +1,12 @@
-// Codex post-spawn session-key capture.
+// Codex-lineage post-spawn session-key capture for Codex and TRAE CLI.
 //
 // Codex's CLI doesn't accept a caller-provided session id at spawn time
 // (claude-code does, via `--session-id <uuid>`), so we can't pre-assign
 // the key the way the runtime adapter does for claude-code. Instead,
-// codex writes a "rollout" file at
-// `$HOME/.codex/sessions/YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl` whose
+// both runtimes write a "rollout" file under their sessions root at
+// `YYYY/MM/DD/rollout-<ts>-<uuid>.jsonl` whose
 // first JSON line is a `session_meta` envelope containing `payload.id`
-// (the session UUID) and `payload.cwd` (the working directory codex
-// started in).
+// (the session UUID) and `payload.cwd` (the runtime's working directory).
 //
 // After every codex spawn that didn't already have an
 // `agent_session_key` on the row, we kick off a short-lived background
@@ -64,13 +63,23 @@ fn claimed_rollouts() -> &'static Mutex<HashSet<PathBuf>> {
     SET.get_or_init(|| Mutex::new(HashSet::new()))
 }
 
-/// Spawn a background thread that captures the codex session id for
+pub fn sessions_root_for(runtime: &str) -> Option<PathBuf> {
+    let home = PathBuf::from(std::env::var_os("HOME")?);
+    match runtime {
+        "codex" => Some(home.join(".codex").join("sessions")),
+        "trae" => Some(home.join(".trae").join("cli").join("sessions")),
+        _ => None,
+    }
+}
+
+/// Spawn a background thread that captures the codex-lineage session id for
 /// `session_id` (a Runner sessions row) and writes it into
-/// `agent_session_key`. Returns immediately; no-op if `$HOME/.codex/`
-/// doesn't exist.
+/// `agent_session_key`. Returns immediately; no-op if the runtime's
+/// sessions root doesn't exist.
 pub struct CaptureRequest {
     pub session_id: String,
     pub mission_id: Option<String>,
+    pub sessions_root: PathBuf,
     pub spawn_cwd: String,
     pub started_at: DateTime<Utc>,
     pub expected_row_started_at: String,
@@ -85,11 +94,7 @@ pub fn spawn_capture(request: CaptureRequest) {
 }
 
 fn run(request: CaptureRequest) {
-    let Some(home) = std::env::var_os("HOME") else {
-        return;
-    };
-    let sessions_root = PathBuf::from(home).join(".codex").join("sessions");
-    if !sessions_root.is_dir() {
+    if !request.sessions_root.is_dir() {
         return;
     }
 
@@ -110,8 +115,8 @@ fn run(request: CaptureRequest) {
     loop {
         let (scan, source) = if let Some(pid) = request.spawn_pid {
             scan_pid_result_or_fallback(
-                open_rollout_paths_for_pid(pid, &sessions_root),
-                &sessions_root,
+                open_rollout_paths_for_pid(pid, &request.sessions_root),
+                &request.sessions_root,
                 &candidates,
                 &request.spawn_cwd,
                 request.started_at,
@@ -120,7 +125,7 @@ fn run(request: CaptureRequest) {
             )
         } else {
             scan_fallback_with_marker(
-                &sessions_root,
+                &request.sessions_root,
                 &candidates,
                 &request.spawn_cwd,
                 request.started_at,
@@ -616,6 +621,20 @@ mod tests {
             })
         )
         .unwrap();
+    }
+
+    #[test]
+    fn sessions_root_for_maps_codex_lineage_layouts() {
+        let home = PathBuf::from(std::env::var_os("HOME").expect("tests require HOME"));
+        assert_eq!(
+            sessions_root_for("codex"),
+            Some(home.join(".codex").join("sessions")),
+        );
+        assert_eq!(
+            sessions_root_for("trae"),
+            Some(home.join(".trae").join("cli").join("sessions")),
+        );
+        assert_eq!(sessions_root_for("shell"), None);
     }
 
     #[test]

--- a/src-tauri/src/session/manager/mod.rs
+++ b/src-tauri/src/session/manager/mod.rs
@@ -479,9 +479,9 @@ struct SessionHandle {
     /// `runtime.resize` / `runtime.stop` for every operation on the
     /// live session.
     runtime_session: RuntimeSession,
-    /// Codex cannot be given a caller-owned session id at launch.
+    /// Codex-lineage runtimes cannot be given a caller-owned session id at launch.
     /// When this is present, user activity can retry native id
-    /// capture after Codex has actually created its rollout file.
+    /// capture after the runtime has actually created its rollout file.
     codex_capture: Option<CodexCaptureContext>,
     /// Forwarder thread that drains the runtime's `OutputStream`
     /// into `session/output` events. `kill` joins on this so callers
@@ -501,6 +501,7 @@ struct SessionHandle {
 #[derive(Clone)]
 struct CodexCaptureContext {
     mission_id: Option<String>,
+    sessions_root: PathBuf,
     spawn_cwd: String,
     started_at: DateTime<Utc>,
     row_started_at: String,
@@ -1011,6 +1012,7 @@ impl SessionManager {
             crate::session::codex_capture::CaptureRequest {
                 session_id: session_id.to_string(),
                 mission_id: ctx.mission_id.clone(),
+                sessions_root: ctx.sessions_root.clone(),
                 spawn_cwd: ctx.spawn_cwd.clone(),
                 started_at: ctx.started_at,
                 expected_row_started_at: ctx.row_started_at.clone(),
@@ -1122,6 +1124,7 @@ pub(crate) struct RuntimeOverrideResolution {
 pub(crate) fn resolve_runtime_override(
     runner: &Runner,
     runtime_override: Option<&str>,
+    model_override: Option<&str>,
 ) -> Result<RuntimeOverrideResolution> {
     let Some(name) = runtime_override.map(str::trim).filter(|s| !s.is_empty()) else {
         return Ok(RuntimeOverrideResolution {
@@ -1129,9 +1132,20 @@ pub(crate) fn resolve_runtime_override(
             pinned: false,
         });
     };
-    if name == runner.runtime {
+    let model_override = model_override
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    if name == runner.runtime && model_override.is_none() {
         return Ok(RuntimeOverrideResolution {
             effective: None,
+            pinned: true,
+        });
+    }
+    if name == runner.runtime {
+        let mut effective = runner.clone();
+        effective.model = model_override.map(ToOwned::to_owned);
+        return Ok(RuntimeOverrideResolution {
+            effective: Some(effective),
             pinned: true,
         });
     }
@@ -1145,7 +1159,7 @@ pub(crate) fn resolve_runtime_override(
         &[],
         crate::commands::runner::default_permission_mode(),
     );
-    effective.model = None;
+    effective.model = model_override.map(ToOwned::to_owned);
     effective.effort = None;
     Ok(RuntimeOverrideResolution {
         effective: Some(effective),

--- a/src-tauri/src/session/manager/output.rs
+++ b/src-tauri/src/session/manager/output.rs
@@ -518,7 +518,7 @@ impl SessionManager {
         // PTY rejects the ioctl. Keep last_pty_cols as the last size actually
         // applied so a failed live resize cannot trigger a ring purge.
         self.runtime.resize(&rt_session, cols, rows)?;
-        // Full-repaint TUI runtimes (claude-code, codex, qoder) redraw the whole
+        // Full-repaint TUI runtimes (claude-code, codex, qoder, trae) redraw the whole
         // frame on SIGWINCH, so bytes buffered before a *width* change
         // describe a stale grid width. Replaying them into the new grid on
         // a later snapshot re-attach wraps their absolute-positioned frames
@@ -562,7 +562,7 @@ impl SessionManager {
         let mut events: Vec<OutputEvent> = state.output_buffer.iter().cloned().collect();
         // For sessions currently inside terminal modes that xterm
         // reset clears, prepend a synthetic chunk restoring them.
-        // Long-running TUI sessions (claude-code, codex, qoder) lose the
+        // Long-running TUI sessions (claude-code, codex, qoder, trae) lose the
         // original enter-alt-screen escape from the bounded
         // 4096-chunk buffer over time, so a re-attach that just
         // replays the remaining chunks lands mid-alt-screen content
@@ -810,20 +810,20 @@ pub(super) fn runtime_clears_on_resize(session_id: &str, pool: &DbPool) -> bool 
         .flatten();
     matches!(
         runtime.as_deref(),
-        Some("claude-code") | Some("codex") | Some("qoder")
+        Some("claude-code") | Some("codex") | Some("qoder") | Some("trae")
     )
 }
 
 /// Whether `resume` should drop the session's output ring before
-/// spawning the new PTY. Codex repaints its whole frame on resume
-/// (and its own resume replay restores a deep conversation tail), so
+/// spawning the new PTY. Codex and trae repaint their whole frame on resume
+/// (and their own resume replays restore a deep conversation tail), so
 /// replaying retained scrollback under the new frame stacks garbled
 /// content — the artifact class from impls 0009/0011/0020. Claude-code
 /// and qoder paint inline into the main screen: kept scrollback, then the
 /// resume banner, then the tail repaint is exactly what a physical
-/// terminal shows, so its ring is kept. Shells and future runtimes
-/// keep today's purge purely
-/// for scope (extending them is a one-line change here). Best-effort:
+/// terminal shows, so their rings are kept. Shells and future runtimes
+/// keep today's purge purely for scope (extending them is a one-line
+/// change here). Best-effort:
 /// a DB miss fails toward the purge, i.e. today's behavior.
 pub(super) fn runtime_purges_on_resume(session_id: &str, pool: &DbPool) -> bool {
     let Ok(conn) = pool.get() else {

--- a/src-tauri/src/session/manager/spawn.rs
+++ b/src-tauri/src/session/manager/spawn.rs
@@ -186,12 +186,12 @@ impl SessionManager {
         delivered_via_argv
     }
 
-    fn codex_capture_prompt_marker(
+    pub(super) fn codex_capture_prompt_marker(
         runtime: &str,
         session_id: &str,
         first_turn: Option<String>,
     ) -> (Option<String>, Option<String>) {
-        if runtime != "codex" {
+        if !matches!(runtime, "codex" | "trae") {
             return (first_turn, None);
         }
         let Some(first_turn) = first_turn else {
@@ -234,10 +234,15 @@ impl SessionManager {
 
         // Slot-level runtime override (feature 41): the effective
         // runtime is `slot.runtime_override ?? runner.runtime`. On a
-        // differing override the spawn uses registry command/default
-        // args and drops model/effort; persona fields carry over. A
+        // differing override the spawn uses the registry command,
+        // default args, and default effort; persona fields carry over. A slot may
+        // independently pin the selected runtime's model. A
         // matching override spawns byte-identically but still pins.
-        let resolution = resolve_runtime_override(runner, slot.runtime_override.as_deref())?;
+        let resolution = resolve_runtime_override(
+            runner,
+            slot.runtime_override.as_deref(),
+            slot.model_override.as_deref(),
+        )?;
         let pinned = resolution.pinned;
         let runner =
             self.resolve_runner_executable(resolution.effective.as_ref().unwrap_or(runner), &pool)?;
@@ -486,20 +491,26 @@ impl SessionManager {
             );
         }
 
-        let codex_capture = if runner.runtime == "codex" && plan.assigned_key.is_none() {
-            capture_cwd(resolved_cwd.clone()).map(|cwd| CodexCaptureContext {
-                mission_id: Some(mission.id.clone()),
-                spawn_cwd: cwd,
-                started_at: spawn_started_at_dt,
-                row_started_at: row_started_at.clone(),
-                spawn_pid,
-                prompt_marker: codex_prompt_marker.clone(),
-                pool: Arc::clone(&pool),
-                events: Arc::clone(&events),
-            })
-        } else {
-            None
-        };
+        let codex_capture =
+            if matches!(runner.runtime.as_str(), "codex" | "trae") && plan.assigned_key.is_none() {
+                crate::session::codex_capture::sessions_root_for(&runner.runtime).and_then(
+                    |sessions_root| {
+                        capture_cwd(resolved_cwd.clone()).map(|cwd| CodexCaptureContext {
+                            mission_id: Some(mission.id.clone()),
+                            sessions_root,
+                            spawn_cwd: cwd,
+                            started_at: spawn_started_at_dt,
+                            row_started_at: row_started_at.clone(),
+                            spawn_pid,
+                            prompt_marker: codex_prompt_marker.clone(),
+                            pool: Arc::clone(&pool),
+                            events: Arc::clone(&events),
+                        })
+                    },
+                )
+            } else {
+                None
+            };
 
         let spawn_emit_ctx = open_mission_event_log(&app_data_dir, &mission.crew_id, &mission.id)
             .map(|event_log| ForwarderEmitCtx {
@@ -547,8 +558,10 @@ impl SessionManager {
         }
 
         emit_runner_activity(&pool, &runner, events.as_ref());
-        if matches!(runner.runtime.as_str(), "claude-code" | "codex" | "qoder")
-            && !plan.resuming
+        if matches!(
+            runner.runtime.as_str(),
+            "claude-code" | "codex" | "qoder" | "trae"
+        ) && !plan.resuming
             && !first_turn_delivered_via_argv
         {
             log::warn!(
@@ -752,7 +765,7 @@ impl SessionManager {
 
         // Chat-level runtime override (feature 41) — same resolution
         // rule as mission spawns.
-        let resolution = resolve_runtime_override(runner, runtime_override)?;
+        let resolution = resolve_runtime_override(runner, runtime_override, None)?;
         let pinned = resolution.pinned;
         let runner =
             self.resolve_runner_executable(resolution.effective.as_ref().unwrap_or(runner), &pool)?;
@@ -873,20 +886,26 @@ impl SessionManager {
             );
         }
 
-        let codex_capture = if runner.runtime == "codex" && plan.assigned_key.is_none() {
-            capture_cwd(resolved_cwd.clone()).map(|cwd| CodexCaptureContext {
-                mission_id: None,
-                spawn_cwd: cwd,
-                started_at: spawn_started_at_dt,
-                row_started_at: started_at.clone(),
-                spawn_pid,
-                prompt_marker: codex_prompt_marker.clone(),
-                pool: Arc::clone(&pool),
-                events: Arc::clone(&events),
-            })
-        } else {
-            None
-        };
+        let codex_capture =
+            if matches!(runner.runtime.as_str(), "codex" | "trae") && plan.assigned_key.is_none() {
+                crate::session::codex_capture::sessions_root_for(&runner.runtime).and_then(
+                    |sessions_root| {
+                        capture_cwd(resolved_cwd.clone()).map(|cwd| CodexCaptureContext {
+                            mission_id: None,
+                            sessions_root,
+                            spawn_cwd: cwd,
+                            started_at: spawn_started_at_dt,
+                            row_started_at: started_at.clone(),
+                            spawn_pid,
+                            prompt_marker: codex_prompt_marker.clone(),
+                            pool: Arc::clone(&pool),
+                            events: Arc::clone(&events),
+                        })
+                    },
+                )
+            } else {
+                None
+            };
 
         self.install_handle(
             &session_id,
@@ -933,8 +952,10 @@ impl SessionManager {
         if emit_activity {
             emit_runner_activity(&pool, &runner, events.as_ref());
         }
-        if matches!(runner.runtime.as_str(), "claude-code" | "codex" | "qoder")
-            && !plan.resuming
+        if matches!(
+            runner.runtime.as_str(),
+            "claude-code" | "codex" | "qoder" | "trae"
+        ) && !plan.resuming
             && !first_turn_delivered_via_argv
         {
             log::warn!(
@@ -1147,7 +1168,9 @@ impl SessionManager {
             let conn = pool.get()?;
             let runner = crate::commands::runner::get(&conn, runner_id)?;
             let runner =
-                match resolve_runtime_override(&runner, snap.agent_runtime.as_deref())?.effective {
+                match resolve_runtime_override(&runner, snap.agent_runtime.as_deref(), None)?
+                    .effective
+                {
                     Some(effective) => effective,
                     None => runner,
                 };
@@ -1333,20 +1356,26 @@ impl SessionManager {
             );
         }
 
-        let codex_capture = if runner.runtime == "codex" && plan.assigned_key.is_none() {
-            capture_cwd(resolved_cwd.clone()).map(|cwd| CodexCaptureContext {
-                mission_id: snap.mission_id.clone(),
-                spawn_cwd: cwd,
-                started_at: spawn_started_at_dt,
-                row_started_at: started_at.clone(),
-                spawn_pid,
-                prompt_marker: None,
-                pool: Arc::clone(&pool),
-                events: Arc::clone(&events),
-            })
-        } else {
-            None
-        };
+        let codex_capture =
+            if matches!(runner.runtime.as_str(), "codex" | "trae") && plan.assigned_key.is_none() {
+                crate::session::codex_capture::sessions_root_for(&runner.runtime).and_then(
+                    |sessions_root| {
+                        capture_cwd(resolved_cwd.clone()).map(|cwd| CodexCaptureContext {
+                            mission_id: snap.mission_id.clone(),
+                            sessions_root,
+                            spawn_cwd: cwd,
+                            started_at: spawn_started_at_dt,
+                            row_started_at: started_at.clone(),
+                            spawn_pid,
+                            prompt_marker: None,
+                            pool: Arc::clone(&pool),
+                            events: Arc::clone(&events),
+                        })
+                    },
+                )
+            } else {
+                None
+            };
 
         let resume_emit_ctx = mission_ctx.as_ref().and_then(|ctx| {
             open_mission_event_log(app_data_dir, &ctx.crew_id, &ctx.mission_id).map(|event_log| {
@@ -1422,7 +1451,11 @@ impl SessionManager {
         // returned SpawnedSession. For direct-chat resume there's no
         // slot/lead concept; if that degrades to fresh and argv
         // delivery was unavailable, we log the skipped injection.
-        if matches!(runner.runtime.as_str(), "claude-code" | "codex" | "qoder") && !plan.resuming {
+        if matches!(
+            runner.runtime.as_str(),
+            "claude-code" | "codex" | "qoder" | "trae"
+        ) && !plan.resuming
+        {
             if mission_ctx.is_some() {
                 log::warn!(
                     "first-turn argv not delivered for {session_id} (runtime {}); skipping post-spawn injection",

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -333,6 +333,7 @@ fn slot_for(runner: &Runner) -> crate::model::Slot {
         position: 0,
         lead: true,
         runtime_override: None,
+        model_override: None,
         added_at: Utc::now(),
     }
 }
@@ -1319,6 +1320,22 @@ fn mission_spawn_worker_preamble_lands_as_trailing_positional_argv_with_brief() 
     );
 
     mgr.kill(&spawned.id).unwrap();
+}
+
+#[test]
+fn trae_first_turn_gets_capture_prompt_marker() {
+    let (first_turn, marker) = SessionManager::codex_capture_prompt_marker(
+        "trae",
+        "session-id",
+        Some("first turn".to_string()),
+    );
+    let marker = marker.expect("trae must use the codex-lineage capture marker");
+    assert_eq!(
+        marker,
+        crate::session::codex_capture::prompt_marker("session-id")
+    );
+    let expected = format!("first turn\n\n{marker}");
+    assert_eq!(first_turn.as_deref(), Some(expected.as_str()));
 }
 
 #[test]
@@ -2981,9 +2998,8 @@ fn resume_keeps_scrollback_for_qoder() {
     assert_resume_keeps_scrollback("qoder");
 }
 
-#[test]
-fn resume_purges_scrollback_for_codex() {
-    // Codex keeps the pre-0024 behavior: its full-frame repaint over
+fn assert_resume_purges_scrollback(runtime: &str) {
+    // Codex-lineage runtimes keep the pre-0024 behavior: their full-frame repaint over
     // retained scrollback is the stacking artifact the purge was
     // added for, so resume still drops the ring — while the watermark
     // is stamped uniformly (equal to the post-purge floor here).
@@ -2997,16 +3013,16 @@ fn resume_purges_scrollback_for_codex() {
                     (id, handle, display_name, runtime, command,
                      args_json, working_dir, system_prompt, env_json,
                      created_at, updated_at)
-                 VALUES (?1, 'purger', 'P', 'codex', '/bin/sh',
-                         NULL, NULL, NULL, NULL, ?2, ?2)",
-            params![runner_id, now],
+                 VALUES (?1, 'purger', 'P', ?2, '/bin/sh',
+                         NULL, NULL, NULL, NULL, ?3, ?3)",
+            params![runner_id, runtime, now],
         )
         .unwrap();
     }
     let mut runner = runner("/bin/sh", &[]);
     runner.id = runner_id;
     runner.handle = "purger".into();
-    runner.runtime = "codex".into();
+    runner.runtime = runtime.into();
 
     let fake = fake_runtime();
     let mgr = mgr_with_fake(None, Arc::clone(&fake));
@@ -3047,7 +3063,7 @@ fn resume_purges_scrollback_for_codex() {
     assert_eq!(
         reset_snapshot.len(),
         1,
-        "codex resume must replace prior output with one reset chunk"
+        "{runtime} resume must replace prior output with one reset chunk"
     );
     assert_eq!(
         BASE64.decode(&reset_snapshot[0].data).unwrap(),
@@ -3074,6 +3090,16 @@ fn resume_purges_scrollback_for_codex() {
     assert_eq!(snapshot[1].data, BASE64.encode(b"fresh repaint"));
 
     mgr.kill(&session_id).unwrap();
+}
+
+#[test]
+fn resume_purges_scrollback_for_codex() {
+    assert_resume_purges_scrollback("codex");
+}
+
+#[test]
+fn resume_purges_scrollback_for_trae() {
+    assert_resume_purges_scrollback("trae");
 }
 
 #[test]
@@ -3966,6 +3992,7 @@ fn runtime_clears_on_resize_resolves_runner_backed_runtimes() {
     for (runner_id, runtime) in [
         ("r-codex", "codex"),
         ("r-qoder", "qoder"),
+        ("r-trae", "trae"),
         ("r-shell", "shell"),
     ] {
         conn.execute(
@@ -3989,6 +4016,12 @@ fn runtime_clears_on_resize_resolves_runner_backed_runtimes() {
     conn.execute(
         "INSERT INTO sessions (id, mission_id, runner_id, cwd, status, started_at)
              VALUES ('s-qoder-runner', NULL, 'r-qoder', '/tmp', 'running', ?1)",
+        params![now],
+    )
+    .unwrap();
+    conn.execute(
+        "INSERT INTO sessions (id, mission_id, runner_id, cwd, status, started_at)
+             VALUES ('s-trae-runner', NULL, 'r-trae', '/tmp', 'running', ?1)",
         params![now],
     )
     .unwrap();
@@ -4018,6 +4051,14 @@ fn runtime_clears_on_resize_resolves_runner_backed_runtimes() {
     ));
     assert!(super::output::runtime_clears_on_resize(
         "s-qoder-runner",
+        &pool
+    ));
+    assert!(super::output::runtime_clears_on_resize(
+        "s-trae-runner",
+        &pool
+    ));
+    assert!(super::output::runtime_purges_on_resume(
+        "s-trae-runner",
         &pool
     ));
     assert!(!super::output::runtime_clears_on_resize(
@@ -4126,7 +4167,7 @@ fn runtime_override_helper_distinguishes_absent_matching_and_differing() {
 
     // Absent / blank: no rebuild, no pin.
     for value in [None, Some("  ")] {
-        let res = resolve_runtime_override(&r, value).unwrap();
+        let res = resolve_runtime_override(&r, value, None).unwrap();
         assert!(res.effective.is_none());
         assert!(!res.pinned, "absent/blank override must not pin");
     }
@@ -4134,13 +4175,13 @@ fn runtime_override_helper_distinguishes_absent_matching_and_differing() {
     // Matching: no rebuild (spawn stays byte-identical), but pinned —
     // the session row must record the engine so a later runner-
     // template edit can't re-engine its resume.
-    let matching = resolve_runtime_override(&r, Some("codex")).unwrap();
+    let matching = resolve_runtime_override(&r, Some("codex"), None).unwrap();
     assert!(matching.effective.is_none());
     assert!(matching.pinned, "explicit matching override must pin");
 
     // Differing: rebuild + pin for every other catalog runtime.
-    for runtime in ["claude-code", "qoder"] {
-        let differing = resolve_runtime_override(&r, Some(runtime)).unwrap();
+    for runtime in ["claude-code", "qoder", "trae"] {
+        let differing = resolve_runtime_override(&r, Some(runtime), None).unwrap();
         assert_eq!(
             differing.effective.as_ref().map(|r| r.runtime.as_str()),
             Some(runtime),
@@ -4159,7 +4200,7 @@ fn runtime_override_helper_resets_engine_fields_and_keeps_persona() {
     r.working_dir = Some("/work".into());
     r.env.insert("FOO".into(), "bar".into());
 
-    let effective = resolve_runtime_override(&r, Some("claude-code"))
+    let effective = resolve_runtime_override(&r, Some("claude-code"), None)
         .unwrap()
         .effective
         .expect("differing runtime must produce an effective runner");
@@ -4187,9 +4228,31 @@ fn runtime_override_helper_resets_engine_fields_and_keeps_persona() {
 }
 
 #[test]
+fn runtime_override_helper_applies_slot_model_to_selected_runtime() {
+    let mut r = runner("codex-custom", &["--custom"]);
+    r.runtime = "codex".into();
+    r.model = Some("runner-model".into());
+
+    let differing = resolve_runtime_override(&r, Some("trae"), Some("trae-slot-model"))
+        .unwrap()
+        .effective
+        .expect("differing runtime must produce an effective runner");
+    assert_eq!(differing.runtime, "trae");
+    assert_eq!(differing.model.as_deref(), Some("trae-slot-model"));
+
+    let matching = resolve_runtime_override(&r, Some("codex"), Some("codex-slot-model"))
+        .unwrap()
+        .effective
+        .expect("a model override must rebuild even for a matching runtime");
+    assert_eq!(matching.runtime, "codex");
+    assert_eq!(matching.model.as_deref(), Some("codex-slot-model"));
+    assert_eq!(matching.args, r.args);
+}
+
+#[test]
 fn runtime_override_helper_rejects_unknown_runtime() {
     let r = runner("/bin/sh", &[]);
-    let err = resolve_runtime_override(&r, Some("aider-future")).unwrap_err();
+    let err = resolve_runtime_override(&r, Some("aider-future"), None).unwrap_err();
     assert!(err.to_string().contains("unknown runtime"), "got: {err}",);
 }
 
@@ -4201,7 +4264,8 @@ fn mission_spawn_with_slot_override_uses_registry_engine_and_records_runtime() {
     let slot_id = insert_crew_runner(&pool, &mission_row.id, &runner_id);
 
     // Runner row is a codex engine with custom flags + pinned
-    // model/effort; the slot overrides to claude-code.
+    // model/effort; the slot overrides to claude-code and selects
+    // its own model.
     let mut runner = runner("codex-custom", &["--custom-flag"]);
     runner.id = runner_id.clone();
     runner.runtime = "codex".into();
@@ -4211,6 +4275,7 @@ fn mission_spawn_with_slot_override_uses_registry_engine_and_records_runtime() {
     let mut slot = slot_for(&runner);
     slot.id = slot_id;
     slot.runtime_override = Some("claude-code".into());
+    slot.model_override = Some("opus".into());
 
     let fake = fake_runtime();
     let mgr = mgr_with_fake(None, Arc::clone(&fake));
@@ -4235,8 +4300,10 @@ fn mission_spawn_with_slot_override_uses_registry_engine_and_records_runtime() {
         spec.args,
     );
     assert!(
-        !spec.args.contains(&"--model".to_string()),
-        "pinned model must be dropped on override: {:?}",
+        spec.args
+            .windows(2)
+            .any(|w| w[0] == "--model" && w[1] == "opus"),
+        "slot model must replace the runner model on override: {:?}",
         spec.args,
     );
     assert!(

--- a/src/components/AddSlotModal.tsx
+++ b/src/components/AddSlotModal.tsx
@@ -12,6 +12,7 @@ import type { RunnerWithActivity } from "../lib/types";
 import { Button } from "./ui/Button";
 import { Modal } from "./ui/Overlay";
 import { Field } from "./ui/Field";
+import { ModelField } from "./ui/ModelField";
 import { StyledSelect } from "./ui/StyledSelect";
 import { RUNTIME_OPTIONS } from "./ui/runtimes";
 
@@ -41,6 +42,7 @@ export function AddSlotModal({
   const [slotHandleEdited, setSlotHandleEdited] = useState(false);
   // "" = the "Runner default" sentinel — no per-slot override.
   const [runtimeOverride, setRuntimeOverride] = useState("");
+  const [modelOverride, setModelOverride] = useState("");
   const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -54,6 +56,7 @@ export function AddSlotModal({
     setSlotHandle("");
     setSlotHandleEdited(false);
     setRuntimeOverride("");
+    setModelOverride("");
     setError(null);
     setSubmitting(false);
     setLoading(true);
@@ -151,6 +154,10 @@ export function AddSlotModal({
         runner_id: selectedRunner.id,
         slot_handle: slotHandle,
         runtime_override: runtimeOverride || null,
+        model_override:
+          runtimeOverride && modelOverride.trim()
+            ? modelOverride.trim()
+            : null,
       });
       await onCreated();
     } catch (e) {
@@ -309,9 +316,27 @@ export function AddSlotModal({
                 description: o.description,
               })),
             ]}
-            onChange={setRuntimeOverride}
+            onChange={(runtime) => {
+              setRuntimeOverride(runtime);
+              setModelOverride("");
+            }}
           />
         </Field>
+
+        {runtimeOverride && selectedRunner ? (
+          <Field
+            id="add-slot-model"
+            label="Model"
+            hint="optional · default uses the selected runtime's own model"
+          >
+            <ModelField
+              id="add-slot-model"
+              runtime={runtimeOverride}
+              model={modelOverride}
+              onModelChange={setModelOverride}
+            />
+          </Field>
+        ) : null}
 
         <section className="flex flex-col gap-2 opacity-70">
           <div className="flex items-center justify-between gap-3">

--- a/src/components/CreateRunnerModal.tsx
+++ b/src/components/CreateRunnerModal.tsx
@@ -179,7 +179,10 @@ export function CreateRunnerModal({
           <RuntimeSelect
             id="new-runner-runtime"
             value={runtime}
-            onChange={(opt) => setRuntime(opt.value)}
+            onChange={(opt) => {
+              setRuntime(opt.value);
+              setModel("");
+            }}
           />
         </Field>
 

--- a/src/components/RunnerEditDrawer.tsx
+++ b/src/components/RunnerEditDrawer.tsx
@@ -33,14 +33,19 @@ import {
 export function RunnerEditDrawer({
   open,
   runner,
+  effectiveRuntime,
+  effectiveModel,
   onClose,
   onSaved,
 }: {
   open: boolean;
   runner: Runner | null;
+  effectiveRuntime?: string;
+  effectiveModel?: string | null;
   onClose: () => void;
   onSaved: () => void | Promise<void>;
 }) {
+  const previewsSlotEngine = effectiveRuntime !== undefined;
   const [displayName, setDisplayName] = useState("");
   const [runtime, setRuntime] = useState<string>(RUNTIME_OPTIONS[0].value);
   // Command is bound to runtime — the field below is read-only — but
@@ -70,27 +75,49 @@ export function RunnerEditDrawer({
   useEffect(() => {
     if (open && runner) {
       setDisplayName(runner.display_name);
-      setRuntime(runner.runtime);
-      setCommand(runner.command);
-      setArgsText(stripPermissionFlags(runner.runtime, runner.args).join(" "));
+      const runtime = effectiveRuntime ?? runner.runtime;
+      const runtimeOption = RUNTIME_OPTIONS.find((option) => option.value === runtime);
+      setRuntime(runtime);
+      setCommand(
+        previewsSlotEngine
+          ? (runtimeOption?.defaultCommand ?? runner.command)
+          : runner.command,
+      );
+      setArgsText(
+        previewsSlotEngine
+          ? ""
+          : stripPermissionFlags(runner.runtime, runner.args).join(" "),
+      );
       setWorkingDir(runner.working_dir ?? "");
       setSystemPrompt(runner.system_prompt ?? "");
-      setModel(runner.model ?? "");
+      setModel(
+        previewsSlotEngine ? (effectiveModel ?? "") : (runner.model ?? ""),
+      );
       // Coerce historically-stored effort values that aren't in this
       // runtime's current enum (e.g. an old codex row with
       // `minimal`, dropped from the picker) to "" so what's saved
       // matches what's shown.
       {
-        const loaded = runner.effort ?? "";
-        const validEfforts = EFFORT_OPTIONS_BY_RUNTIME[runner.runtime] ?? [];
+        const loaded = previewsSlotEngine ? "" : (runner.effort ?? "");
+        const validEfforts = EFFORT_OPTIONS_BY_RUNTIME[runtime] ?? [];
         setEffort(
           validEfforts.some((o) => o.value === loaded) ? loaded : "",
         );
       }
-      setPermissionMode(inferPermissionMode(runner.runtime, runner.args));
+      setPermissionMode(
+        previewsSlotEngine
+          ? "default"
+          : inferPermissionMode(runner.runtime, runner.args),
+      );
       setError(null);
     }
-  }, [open, runner]);
+  }, [
+    effectiveModel,
+    effectiveRuntime,
+    open,
+    previewsSlotEngine,
+    runner,
+  ]);
 
   const canSubmit =
     runner !== null &&
@@ -105,26 +132,20 @@ export function RunnerEditDrawer({
     try {
       const input: UpdateRunnerInput = {
         display_name: displayName.trim(),
-        runtime,
-        command: command.trim(),
-        args: argsText.trim() ? argsText.trim().split(/\s+/) : [],
         working_dir: workingDir.trim() || null,
         system_prompt: systemPrompt.trim() || null,
-        // Send the trimmed string (empty when cleared/“default”), not
-        // null: the backend collapses a blank string to NULL, but an
-        // explicit JSON null deserializes to the outer `None` (= "leave
-        // unchanged"), so null could never clear a previously-pinned
-        // value. See commands::runner::update.
-        model: model.trim(),
-        effort: effort.trim(),
-        // Send the mode only for runtimes that support it —
-        // otherwise the backend's permission-flag helper is a no-op
-        // anyway, but keeping the field undefined for shell/unknown
-        // makes the contract explicit (`None` mode on the Rust side
-        // preserves args verbatim).
-        ...(runtimeSupportsPermissionMode(runtime)
-          ? { permission_mode: permissionMode }
-          : {}),
+        ...(previewsSlotEngine
+          ? {}
+          : {
+              runtime,
+              command: command.trim(),
+              args: argsText.trim() ? argsText.trim().split(/\s+/) : [],
+              model: model.trim(),
+              effort: effort.trim(),
+              ...(runtimeSupportsPermissionMode(runtime)
+                ? { permission_mode: permissionMode }
+                : {}),
+            }),
       };
       await api.runner.update(runner.id, input);
       await onSaved();
@@ -177,62 +198,86 @@ export function RunnerEditDrawer({
           />
         </Field>
 
-        <Field id="edit-runtime" label="Runtime">
-          <RuntimeSelect
-            id="edit-runtime"
-            value={runtime}
-            onChange={(opt) => {
-              setRuntime(opt.value);
-              // Runtime change is the explicit signal to normalize
-              // Command to the new runtime's defaultCommand. Without
-              // a runtime change we keep whatever was saved on the
-              // row so custom commands aren't wiped silently.
-              setCommand(opt.defaultCommand);
-              // Coerce effort to "" if the current value isn't in
-              // the new runtime's enum, so the saved value tracks
-              // what the dropdown displays. claude-code's `max` is
-              // not in codex's enum; codex's `none / minimal` aren't
-              // in claude-code's.
-              const nextEffortOptions =
-                EFFORT_OPTIONS_BY_RUNTIME[opt.value] ?? [];
-              if (!nextEffortOptions.some((o) => o.value === effort)) {
-                setEffort("");
-              }
-            }}
-          />
+        <Field
+          id="edit-runtime"
+          label="Runtime"
+          hint={
+            previewsSlotEngine
+              ? "effective crew-slot override · change it from the crew row"
+              : undefined
+          }
+        >
+          {previewsSlotEngine ? (
+            <Input id="edit-runtime" value={runtime} disabled readOnly />
+          ) : (
+            <RuntimeSelect
+              id="edit-runtime"
+              value={runtime}
+              onChange={(opt) => {
+                setRuntime(opt.value);
+                setModel("");
+                // Runtime change is the explicit signal to normalize
+                // Command to the new runtime's defaultCommand. Without
+                // a runtime change we keep whatever was saved on the
+                // row so custom commands aren't wiped silently.
+                setCommand(opt.defaultCommand);
+                // Coerce effort to "" if the current value isn't in
+                // the new runtime's enum, so the saved value tracks
+                // what the dropdown displays. claude-code's `max` is
+                // not in codex's enum; codex's `none / minimal` aren't
+                // in claude-code's.
+                const nextEffortOptions =
+                  EFFORT_OPTIONS_BY_RUNTIME[opt.value] ?? [];
+                if (!nextEffortOptions.some((o) => o.value === effort)) {
+                  setEffort("");
+                }
+              }}
+            />
+          )}
         </Field>
 
         <Field id="edit-command" label="Command">
           <Input id="edit-command" value={command} disabled readOnly />
         </Field>
 
-        <Field
-          id="edit-args"
-          label="Args"
-          hint="extra flags · whitespace-separated"
-        >
-          <Input
+        {!previewsSlotEngine ? (
+          <Field
             id="edit-args"
-            value={argsText}
-            placeholder="--mcp-debug"
-            onChange={(e) => setArgsText(e.target.value)}
-          />
-        </Field>
+            label="Args"
+            hint="extra flags · whitespace-separated"
+          >
+            <Input
+              id="edit-args"
+              value={argsText}
+              placeholder="--mcp-debug"
+              onChange={(e) => setArgsText(e.target.value)}
+            />
+          </Field>
+        ) : null}
 
         <Field
           id="edit-model"
           label="Model"
           hint="optional · blank uses the runtime's own model · type a name or pick an alias"
         >
-          <ModelField
-            id="edit-model"
-            runtime={runtime}
-            model={model}
-            onModelChange={setModel}
-          />
+          {previewsSlotEngine ? (
+            <Input
+              id="edit-model"
+              value={model || "default"}
+              disabled
+              readOnly
+            />
+          ) : (
+            <ModelField
+              id="edit-model"
+              runtime={runtime}
+              model={model}
+              onModelChange={setModel}
+            />
+          )}
         </Field>
 
-        {runtimeSupportsEffort(runtime) ? (() => {
+        {!previewsSlotEngine && runtimeSupportsEffort(runtime) ? (() => {
           const effortOptions = EFFORT_OPTIONS_BY_RUNTIME[runtime] ?? [];
           // Effort enums differ per runtime — claude-code's `max` is
           // not in codex's enum; codex's `none / minimal` aren't in
@@ -262,7 +307,7 @@ export function RunnerEditDrawer({
           );
         })() : null}
 
-        {runtimeSupportsPermissionMode(runtime) ? (() => {
+        {!previewsSlotEngine && runtimeSupportsPermissionMode(runtime) ? (() => {
           const modeOptions = PERMISSION_MODES_BY_RUNTIME[runtime] ?? [];
           // Mode space is per-runtime: a mode that's valid for the
           // prior runtime might not exist for the new one (e.g.

--- a/src/components/RunnerRuntimeModelReset.test.tsx
+++ b/src/components/RunnerRuntimeModelReset.test.tsx
@@ -1,0 +1,162 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Runner } from "../lib/types";
+
+const mocks = vi.hoisted(() => ({
+  runnerCreate: vi.fn(),
+  runnerUpdate: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(async () => null),
+}));
+
+vi.mock("../lib/api", () => ({
+  api: {
+    runner: {
+      create: mocks.runnerCreate,
+      update: mocks.runnerUpdate,
+    },
+  },
+}));
+
+import { CreateRunnerModal } from "./CreateRunnerModal";
+import { RunnerEditDrawer } from "./RunnerEditDrawer";
+
+async function changeInput(input: HTMLInputElement, value: string) {
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")
+      ?.set?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function selectRuntime(trigger: HTMLButtonElement, runtime: string) {
+  await act(async () => trigger.click());
+  const option = Array.from(
+    document.querySelectorAll<HTMLButtonElement>('[role="option"] button'),
+  ).find((button) => button.textContent?.includes(runtime));
+  expect(option).toBeDefined();
+  await act(async () => option?.click());
+}
+
+const runner: Runner = {
+  id: "runner-1",
+  handle: "coder",
+  display_name: "Coder",
+  runtime: "codex",
+  command: "codex",
+  args: [],
+  working_dir: null,
+  system_prompt: null,
+  env: {},
+  model: "gpt-5",
+  effort: null,
+  created_at: "2026-07-27T00:00:00Z",
+  updated_at: "2026-07-27T00:00:00Z",
+};
+
+describe("runner runtime model reset", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.runnerCreate.mockReset();
+    mocks.runnerUpdate.mockReset();
+    mocks.runnerUpdate.mockResolvedValue(runner);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("resets a new runner's model when its runtime changes", async () => {
+    await act(async () => {
+      root.render(
+        <CreateRunnerModal
+          open
+          onClose={() => {}}
+          onCreated={() => {}}
+        />,
+      );
+    });
+
+    const model = container.querySelector<HTMLInputElement>("#new-runner-model");
+    const runtime =
+      container.querySelector<HTMLButtonElement>("#new-runner-runtime");
+    expect(model).not.toBeNull();
+    expect(runtime).not.toBeNull();
+
+    await changeInput(model!, "gpt-5");
+    await selectRuntime(runtime!, "trae");
+
+    expect(model?.value).toBe("");
+    expect(model?.placeholder).toBe("default");
+  });
+
+  it("resets an existing runner's model when its runtime changes", async () => {
+    await act(async () => {
+      root.render(
+        <RunnerEditDrawer
+          open
+          runner={runner}
+          onClose={() => {}}
+          onSaved={() => {}}
+        />,
+      );
+    });
+
+    const model = container.querySelector<HTMLInputElement>("#edit-model");
+    const runtime =
+      container.querySelector<HTMLButtonElement>("#edit-runtime");
+    expect(model?.value).toBe("gpt-5");
+    expect(runtime).not.toBeNull();
+
+    await selectRuntime(runtime!, "trae");
+
+    expect(model?.value).toBe("");
+    expect(model?.placeholder).toBe("default");
+  });
+
+  it("shows a crew slot's effective engine without overwriting the runner engine", async () => {
+    await act(async () => {
+      root.render(
+        <RunnerEditDrawer
+          open
+          runner={runner}
+          effectiveRuntime="trae"
+          effectiveModel={null}
+          onClose={() => {}}
+          onSaved={() => {}}
+        />,
+      );
+    });
+
+    const runtime = container.querySelector<HTMLInputElement>("#edit-runtime");
+    const model = container.querySelector<HTMLInputElement>("#edit-model");
+    expect(runtime?.value).toBe("trae");
+    expect(model?.value).toBe("default");
+    expect(container.querySelector("#edit-args")).toBeNull();
+
+    const save = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent === "Save");
+    await act(async () => save?.click());
+
+    expect(mocks.runnerUpdate).toHaveBeenCalledWith("runner-1", {
+      display_name: "Coder",
+      working_dir: null,
+      system_prompt: null,
+    });
+  });
+});

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -6,7 +6,7 @@
 //
 // Setup: active-pane WebGL renderer for cell-row alignment, base64 PTY frames
 // to preserve raw bytes, backend snapshot replay for late attach, and SIGWINCH
-// dance on attach so claude-code/codex/qoder repaint onto a fresh grid.
+// dance on attach so claude-code/codex/qoder/trae repaint onto a fresh grid.
 
 import {
   forwardRef,
@@ -106,7 +106,7 @@ function inferPasteImageMime(
 interface RunnerTerminalProps {
   sessionId: string;
   /** Runtime kind of the runner driving this session (e.g.
-   *  `"claude-code"`, `"codex"`, `"qoder"`, `"shell"`). Used to gate the
+   *  `"claude-code"`, `"codex"`, `"qoder"`, `"trae"`, `"shell"`). Used to gate the
    *  scrollback-clear on resize: TUI agents whose `SIGWINCH` repaint
    *  policy fully redraws the screen get a hard-clear before the
    *  resize lands, so the previous frame doesn't stay visible in

--- a/src/components/settings/McpPane.test.tsx
+++ b/src/components/settings/McpPane.test.tsx
@@ -30,6 +30,7 @@ const status = {
   claude_code: clientStatus,
   codex: clientStatus,
   qoder: clientStatus,
+  trae: clientStatus,
 };
 
 describe("McpPane", () => {
@@ -45,7 +46,7 @@ describe("McpPane", () => {
     mocks.invoke.mockImplementation(async (command: string) => {
       if (command === "mcp_integration_status") return status;
       if (command === "mcp_config_snippet") {
-        return { claude_code: "{}", codex: "", qoder: "{}" };
+        return { claude_code: "{}", codex: "", qoder: "{}", trae: "" };
       }
       return undefined;
     });
@@ -57,21 +58,21 @@ describe("McpPane", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders and toggles Qoder registration", async () => {
+  it("renders and toggles TRAE registration", async () => {
     await act(async () => {
       root.render(<McpPane />);
     });
 
-    expect(container.textContent).toContain("Qoder CLI");
+    expect(container.textContent).toContain("TRAE CLI");
     const toggles = container.querySelectorAll<HTMLButtonElement>(
       '[role="switch"]',
     );
-    expect(toggles).toHaveLength(3);
+    expect(toggles).toHaveLength(4);
 
-    await act(async () => toggles[2].click());
+    await act(async () => toggles[3].click());
 
     expect(mocks.invoke).toHaveBeenCalledWith("mcp_set_integration", {
-      client: "qoder",
+      client: "trae",
       enabled: true,
     });
   });

--- a/src/components/settings/McpPane.tsx
+++ b/src/components/settings/McpPane.tsx
@@ -8,7 +8,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { Toggle } from "../ui/Toggle";
 import { PaneHeader } from "./shared";
 
-type McpClientId = "claude_code" | "codex" | "qoder";
+type McpClientId = "claude_code" | "codex" | "qoder" | "trae";
 type McpCopyKey = McpClientId | "binding_dir";
 
 interface McpClientStatus {
@@ -27,12 +27,14 @@ interface McpIntegrationStatus {
   claude_code: McpClientStatus;
   codex: McpClientStatus;
   qoder: McpClientStatus;
+  trae: McpClientStatus;
 }
 
 interface McpConfigSnippet {
   claude_code: string;
   codex: string;
   qoder: string;
+  trae: string;
 }
 
 export function McpPane() {
@@ -129,6 +131,13 @@ export function McpPane() {
         busy={busy === "qoder"}
         onToggle={(enabled) => void setIntegration("qoder", enabled)}
       />
+      <McpClientRow
+        title="TRAE CLI"
+        subtitle="Writes the runner table under ~/.trae/traecli.toml."
+        status={status?.trae ?? null}
+        busy={busy === "trae"}
+        onToggle={(enabled) => void setIntegration("trae", enabled)}
+      />
       <div className="rounded-xl border border-line bg-panel p-4">
         <div className="mb-2 flex items-center justify-between gap-3">
           <span className="text-[13px] font-semibold text-fg">
@@ -149,6 +158,11 @@ export function McpPane() {
               copied={copied === "qoder"}
               label="Qoder"
               onClick={() => void copyMcpText("qoder", snippet?.qoder)}
+            />
+            <CopyButton
+              copied={copied === "trae"}
+              label="TRAE"
+              onClick={() => void copyMcpText("trae", snippet?.trae)}
             />
           </div>
         </div>

--- a/src/components/ui/runtimes.test.ts
+++ b/src/components/ui/runtimes.test.ts
@@ -12,16 +12,17 @@ import {
   stripPermissionFlags,
 } from "./runtimes";
 
-describe("qoder runtime metadata", () => {
-  it("appends qoder without changing the default runtime", () => {
+describe("runtime metadata", () => {
+  it("appends new runtimes without changing the default runtime", () => {
     expect(RUNTIME_OPTIONS.map((runtime) => runtime.value)).toEqual([
       "codex",
       "claude-code",
       "qoder",
+      "trae",
     ]);
     expect(RUNTIME_OPTIONS[RUNTIME_OPTIONS.length - 1]).toMatchObject({
-      value: "qoder",
-      defaultCommand: "qodercli",
+      value: "trae",
+      defaultCommand: "traecli",
     });
   });
 
@@ -41,16 +42,56 @@ describe("qoder runtime metadata", () => {
     ).toEqual(["--debug"]);
   });
 
-  it("does not expose unprobed model or effort options", () => {
+  it("offers only the CLI model default and no effort override for qoder", () => {
     expect(runtimeSupportsEffort("qoder")).toBe(false);
     expect(EFFORT_OPTIONS_BY_RUNTIME.qoder).toBeUndefined();
-    expect(modelSuggestions("qoder")).toEqual([]);
+    expect(modelSuggestions("qoder")).toEqual([
+      expect.objectContaining({ value: "", label: "default" }),
+    ]);
   });
 
   it("keeps the frontend resize policy aligned for full-repaint runtimes", () => {
     expect(runtimeClearsOnResize("claude-code")).toBe(true);
     expect(runtimeClearsOnResize("codex")).toBe(true);
     expect(runtimeClearsOnResize("qoder")).toBe(true);
+    expect(runtimeClearsOnResize("trae")).toBe(true);
     expect(runtimeClearsOnResize("shell")).toBe(false);
+  });
+
+  it("exposes TRAE-native permission modes with only the CLI default model", () => {
+    expect(runtimeSupportsPermissionMode("trae")).toBe(true);
+    expect(PERMISSION_MODES_BY_RUNTIME.trae.map((mode) => mode.value)).toEqual([
+      "default",
+      "auto",
+      "bypass",
+    ]);
+    expect(
+      inferPermissionMode("trae", [
+        "--permission-mode",
+        "auto",
+      ]),
+    ).toBe("auto");
+    expect(
+      stripPermissionFlags("trae", [
+        "--debug",
+        "--permission-mode=bypass_permissions",
+      ]),
+    ).toEqual(["--debug"]);
+    expect(runtimeSupportsEffort("trae")).toBe(true);
+    expect(EFFORT_OPTIONS_BY_RUNTIME.trae).toEqual(
+      EFFORT_OPTIONS_BY_RUNTIME.codex,
+    );
+    expect(modelSuggestions("trae")).toEqual([
+      expect.objectContaining({ value: "", label: "default" }),
+    ]);
+  });
+
+  it("offers the CLI default model first for every agent runtime", () => {
+    for (const runtime of RUNTIME_OPTIONS) {
+      expect(modelSuggestions(runtime.value)[0]).toMatchObject({
+        value: "",
+        label: "default",
+      });
+    }
   });
 });

--- a/src/components/ui/runtimes.ts
+++ b/src/components/ui/runtimes.ts
@@ -34,12 +34,19 @@ export const RUNTIME_OPTIONS: RuntimeOption[] = [
     defaultCommand: "qodercli",
     description: "Qoder CLI",
   },
+  {
+    value: "trae",
+    label: "trae",
+    defaultCommand: "traecli",
+    description: "TRAE CLI",
+  },
 ];
 
 const RUNTIMES_CLEARING_ON_RESIZE = new Set([
   "claude-code",
   "codex",
   "qoder",
+  "trae",
 ]);
 
 export function runtimeClearsOnResize(runtime: string): boolean {
@@ -56,6 +63,7 @@ const RUNTIMES_WITH_PERMISSION_MODE = new Set([
   "claude-code",
   "codex",
   "qoder",
+  "trae",
 ]);
 
 export function runtimeSupportsPermissionMode(runtime: string): boolean {
@@ -109,6 +117,13 @@ export const EFFORT_OPTIONS_BY_RUNTIME: Record<
     { value: "high", label: "High", description: "Greater reasoning depth for complex problems." },
     { value: "xhigh", label: "Extra high", description: "Extra reasoning depth for complex problems." },
   ],
+  trae: [
+    EFFORT_INHERIT,
+    { value: "low", label: "Low", description: "Fast responses with lighter reasoning." },
+    { value: "medium", label: "Medium", description: "Balances speed and reasoning depth." },
+    { value: "high", label: "High", description: "Greater reasoning depth for complex problems." },
+    { value: "xhigh", label: "Extra high", description: "Extra reasoning depth for complex problems." },
+  ],
 };
 
 export function runtimeSupportsEffort(runtime: string): boolean {
@@ -138,8 +153,9 @@ const MODEL_DEFAULT: ModelOption = {
 // claude-code's `--model` accepts version-stable aliases (`opus` always
 // resolves to the latest Opus), so suggesting them never goes stale.
 // codex has no alias scheme — it takes full names like `gpt-5-codex`
-// that rot every release — so it offers only `default` and lets the
-// user type any full name.
+// that rot every release — and qoder/trae expose runtime-specific
+// catalogs. Those runtimes offer only `default` here and let the user
+// type any full name.
 export const MODEL_SUGGESTIONS_BY_RUNTIME: Record<
   string,
   ReadonlyArray<ModelOption>
@@ -151,6 +167,8 @@ export const MODEL_SUGGESTIONS_BY_RUNTIME: Record<
     { value: "haiku", label: "haiku", description: "Latest Claude Haiku." },
   ],
   codex: [MODEL_DEFAULT],
+  qoder: [MODEL_DEFAULT],
+  trae: [MODEL_DEFAULT],
 };
 
 export function modelSuggestions(runtime: string): ReadonlyArray<ModelOption> {
@@ -215,12 +233,13 @@ export const PERMISSION_MODES_BY_RUNTIME: Record<
       value: "auto",
       label: "Auto",
       description:
-        "Auto-runs in the workspace; the model decides when to ask the user for approval (`--ask-for-approval on-request`).",
+        "Auto-run in the workspace and ask only when the model decides approval is needed (`--ask-for-approval on-request`).",
     },
     {
       value: "bypass",
       label: "Bypass",
-      description: "Never ask. Auto-runs everything in the workspace.",
+      description:
+        "Never ask while keeping Codex's workspace-write sandbox (`--ask-for-approval never`).",
       danger: true,
     },
   ],
@@ -234,6 +253,26 @@ export const PERMISSION_MODES_BY_RUNTIME: Record<
       value: "auto",
       label: "Auto",
       description: "Run with Qoder's verified `--permission-mode auto` mode.",
+    },
+  ],
+  trae: [
+    {
+      value: "default",
+      label: "Default",
+      description: "TRAE CLI's built-in approval cadence.",
+    },
+    {
+      value: "auto",
+      label: "Auto",
+      description:
+        "Use TRAE CLI's native auto-reviewer (`--permission-mode auto`).",
+    },
+    {
+      value: "bypass",
+      label: "Bypass",
+      description:
+        "Bypass TRAE CLI permission prompts (`--permission-mode bypass_permissions`).",
+      danger: true,
     },
   ],
 };
@@ -263,6 +302,10 @@ const MODE_MATCH_PAIRS_BY_RUNTIME: Record<
   },
   qoder: {
     auto: [["--permission-mode", "auto"]],
+  },
+  trae: {
+    auto: [["--permission-mode", "auto"]],
+    bypass: [["--permission-mode", "bypass_permissions"]],
   },
 };
 
@@ -336,7 +379,7 @@ export function inferPermissionMode(
 //   - claude-code: `--permission-mode <value>` (value-bearing) plus
 //     the legacy standalone `--dangerously-skip-permissions` flag,
 //     so old rows get cleaned up on the next save.
-//   - qoder: `--permission-mode <value>` (value-bearing).
+//   - qoder/trae: `--permission-mode <value>` (value-bearing).
 // Mirror of `router::runtime::strip_permission_flags`.
 const PERMISSION_STRIP_KEYS_BY_RUNTIME: Record<
   string,
@@ -351,6 +394,7 @@ const PERMISSION_STRIP_KEYS_BY_RUNTIME: Record<
     ["--sandbox", true],
   ],
   qoder: [["--permission-mode", true]],
+  trae: [["--permission-mode", true]],
 };
 
 /// Strip every permission-mode flag from `args`. Used by the runner

--- a/src/contexts/UpdateContext.test.tsx
+++ b/src/contexts/UpdateContext.test.tsx
@@ -68,7 +68,15 @@ describe("UpdateProvider trigger policy", () => {
   }
 
   beforeEach(() => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({
+      toFake: [
+        "Date",
+        "setTimeout",
+        "clearTimeout",
+        "setInterval",
+        "clearInterval",
+      ],
+    });
     vi.setSystemTime(new Date("2026-07-22T00:00:00Z"));
     storage = new Map();
     vi.stubGlobal("localStorage", {

--- a/src/hooks/useCurrentWindowFullscreen.test.tsx
+++ b/src/hooks/useCurrentWindowFullscreen.test.tsx
@@ -38,7 +38,7 @@ describe("useCurrentWindowFullscreen", () => {
   let root: Root;
 
   beforeEach(() => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     mocks.fullscreen = false;
     mocks.resize = null;
     mocks.unlisten.mockReset();

--- a/src/lib/paneLayout.test.ts
+++ b/src/lib/paneLayout.test.ts
@@ -425,7 +425,7 @@ describe("hydrateLayoutSet (cross-window sync)", () => {
   });
 
   it("marks hydrated members fresh so the vanished-session sweep spares them", () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(1_000);
     applyPreset("single", "A", ["A"]);
 
@@ -463,7 +463,7 @@ describe("fresh assignments", () => {
   });
 
   it("marks a session fresh immediately after assignment", () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(1_000);
 
     assignSessionToPane("p1", "fresh-session");
@@ -476,7 +476,7 @@ describe("fresh assignments", () => {
   });
 
   it("expires freshness after the assignment TTL", () => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["Date"] });
     vi.setSystemTime(2_000);
 
     assignSessionToPane("p1", "expired-session");

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -55,8 +55,12 @@ export interface Slot {
   lead: boolean;
   /** Per-slot engine choice (feature 41). NULL = the runner's own
    *  runtime. When set, mission spawns run this runtime with registry
-   *  defaults while the runner's persona carries over. */
+   *  defaults, plus an optional model override, while the runner's
+   *  persona carries over. */
   runtime_override: string | null;
+  /** Model pinned to the selected slot runtime. NULL = that runtime's
+   *  configured default. */
+  model_override: string | null;
   added_at: Timestamp;
 }
 
@@ -307,6 +311,8 @@ export interface CreateSlotInput {
   /** Omit / null for "Runner default"; a runtime registry name to
    *  override the engine for this slot. */
   runtime_override?: string | null;
+  /** Omit / null / blank for the selected runtime's default model. */
+  model_override?: string | null;
 }
 
 export interface UpdateSlotInput {
@@ -314,6 +320,8 @@ export interface UpdateSlotInput {
   /** Omit to preserve; null to clear back to "Runner default"; a
    *  runtime registry name to override. */
   runtime_override?: string | null;
+  /** Omit to preserve; null to clear to the selected runtime's default. */
+  model_override?: string | null;
 }
 
 export interface StartMissionInput {

--- a/src/lib/windowFocus.test.ts
+++ b/src/lib/windowFocus.test.ts
@@ -29,7 +29,7 @@ const direct = (value: string): Subject => ({ type: "DirectChat", value });
 
 describe("reportSubjectsNow", () => {
   beforeEach(() => {
-    vi.useFakeTimers();
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
     mocks.reportSubjects.mockClear();
   });
 

--- a/src/pages/CrewEditor.test.tsx
+++ b/src/pages/CrewEditor.test.tsx
@@ -1,0 +1,147 @@
+/** @vitest-environment jsdom */
+
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Crew, SlotWithRunner } from "../lib/types";
+
+const mocks = vi.hoisted(() => ({
+  crewGet: vi.fn(),
+  slotList: vi.fn(),
+  slotUpdate: vi.fn(),
+  listen: vi.fn(async () => () => {}),
+}));
+
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: mocks.listen,
+}));
+
+vi.mock("../lib/api", () => ({
+  api: {
+    crew: {
+      get: mocks.crewGet,
+      update: vi.fn(),
+    },
+    slot: {
+      list: mocks.slotList,
+      update: mocks.slotUpdate,
+      setLead: vi.fn(),
+      delete: vi.fn(),
+      reorder: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../components/AddSlotModal", () => ({
+  AddSlotModal: () => null,
+}));
+
+vi.mock("../components/RunnerEditDrawer", () => ({
+  RunnerEditDrawer: () => null,
+}));
+
+vi.mock("../components/StartMissionModal", () => ({
+  StartMissionModal: () => null,
+}));
+
+import CrewEditor from "./CrewEditor";
+
+const crew: Crew = {
+  id: "crew-1",
+  name: "Crew",
+  purpose: null,
+  goal: null,
+  system_prompt_addendum: null,
+  created_at: "2026-07-27T00:00:00Z",
+  updated_at: "2026-07-27T00:00:00Z",
+};
+
+const slot: SlotWithRunner = {
+  id: "slot-1",
+  crew_id: crew.id,
+  runner_id: "runner-1",
+  slot_handle: "coder",
+  position: 0,
+  lead: true,
+  runtime_override: "trae",
+  model_override: null,
+  added_at: "2026-07-27T00:00:00Z",
+  runner: {
+    id: "runner-1",
+    handle: "coder",
+    display_name: "Coder",
+    runtime: "codex",
+    command: "codex",
+    args: [],
+    working_dir: null,
+    system_prompt: null,
+    env: {},
+    model: null,
+    effort: null,
+    created_at: "2026-07-27T00:00:00Z",
+    updated_at: "2026-07-27T00:00:00Z",
+  },
+};
+
+describe("CrewEditor slot model override", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    mocks.crewGet.mockReset();
+    mocks.slotList.mockReset();
+    mocks.slotUpdate.mockReset();
+    mocks.listen.mockClear();
+    mocks.crewGet.mockResolvedValue(crew);
+    mocks.slotList.mockResolvedValue([slot]);
+    mocks.slotUpdate.mockResolvedValue(slot);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("selects and saves a model for an overridden runtime", async () => {
+    await act(async () => {
+      root.render(
+        <MemoryRouter initialEntries={[`/crews/${crew.id}`]}>
+          <Routes>
+            <Route path="/crews/:crewId" element={<CrewEditor />} />
+          </Routes>
+        </MemoryRouter>,
+      );
+    });
+
+    const trigger = Array.from(
+      container.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent?.includes("model: default"));
+    expect(trigger).toBeDefined();
+
+    await act(async () => trigger?.click());
+
+    const input = document.querySelector<HTMLInputElement>("#slot-model-slot-1");
+    expect(input).not.toBeNull();
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")
+        ?.set?.call(input, "trae-model");
+      input?.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const save = Array.from(
+      document.querySelectorAll<HTMLButtonElement>("button"),
+    ).find((button) => button.textContent === "Save");
+    await act(async () => save?.click());
+
+    expect(mocks.slotUpdate).toHaveBeenCalledWith("slot-1", {
+      model_override: "trae-model",
+    });
+  });
+});

--- a/src/pages/CrewEditor.tsx
+++ b/src/pages/CrewEditor.tsx
@@ -18,11 +18,12 @@ import { listen } from "@tauri-apps/api/event";
 import { MoreHorizontal, SquarePen, Star, Trash2 } from "lucide-react";
 
 import { api } from "../lib/api";
-import type { Crew, Runner, SlotWithRunner } from "../lib/types";
+import type { Crew, SlotWithRunner } from "../lib/types";
 import { AddSlotModal } from "../components/AddSlotModal";
 import { RunnerEditDrawer } from "../components/RunnerEditDrawer";
 import { StartMissionModal } from "../components/StartMissionModal";
 import { Button } from "../components/ui/Button";
+import { ModelField } from "../components/ui/ModelField";
 import { PopoverMenu } from "../components/ui/PopoverMenu";
 import { RUNTIME_OPTIONS } from "../components/ui/runtimes";
 
@@ -35,7 +36,7 @@ export default function CrewEditor() {
   const [error, setError] = useState<string | null>(null);
   const [adding, setAdding] = useState(false);
   const [starting, setStarting] = useState(false);
-  const [editing, setEditing] = useState<Runner | null>(null);
+  const [editing, setEditing] = useState<SlotWithRunner | null>(null);
   const [nameDraft, setNameDraft] = useState("");
   const [savingName, setSavingName] = useState(false);
   const [addendumEditing, setAddendumEditing] = useState(false);
@@ -202,7 +203,22 @@ export default function CrewEditor() {
     runtimeOverride: string | null,
   ) => {
     try {
-      await api.slot.update(slotId, { runtime_override: runtimeOverride });
+      await api.slot.update(slotId, {
+        runtime_override: runtimeOverride,
+        model_override: null,
+      });
+      await refresh();
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const onSetModelOverride = async (
+    slotId: string,
+    modelOverride: string | null,
+  ) => {
+    try {
+      await api.slot.update(slotId, { model_override: modelOverride });
       await refresh();
     } catch (e) {
       setError(String(e));
@@ -496,7 +512,8 @@ export default function CrewEditor() {
                 reordering={reordering}
                 onSetLead={onSetLead}
                 onSetRuntimeOverride={onSetRuntimeOverride}
-                onEdit={(s) => setEditing(s.runner)}
+                onSetModelOverride={onSetModelOverride}
+                onEdit={setEditing}
                 onRemove={onRemoveSlot}
                 onReorder={onCommitReorder}
               />
@@ -519,7 +536,9 @@ export default function CrewEditor() {
 
       <RunnerEditDrawer
         open={editing !== null}
-        runner={editing}
+        runner={editing?.runner ?? null}
+        effectiveRuntime={editing?.runtime_override ?? undefined}
+        effectiveModel={editing?.model_override}
         onClose={() => setEditing(null)}
         onSaved={async () => {
           setEditing(null);
@@ -545,6 +564,7 @@ function SlotList({
   reordering,
   onSetLead,
   onSetRuntimeOverride,
+  onSetModelOverride,
   onEdit,
   onRemove,
   onReorder,
@@ -553,6 +573,7 @@ function SlotList({
   reordering: boolean;
   onSetLead: (slotId: string) => void;
   onSetRuntimeOverride: (slotId: string, runtimeOverride: string | null) => void;
+  onSetModelOverride: (slotId: string, modelOverride: string | null) => void;
   onEdit: (s: SlotWithRunner) => void;
   onRemove: (s: SlotWithRunner) => void;
   onReorder: (newOrder: SlotWithRunner[]) => void;
@@ -579,6 +600,7 @@ function SlotList({
           dragDisabled={reordering}
           onSetLead={() => onSetLead(s.id)}
           onSetRuntimeOverride={(runtime) => onSetRuntimeOverride(s.id, runtime)}
+          onSetModelOverride={(model) => onSetModelOverride(s.id, model)}
           onEdit={() => onEdit(s)}
           onRemove={() => onRemove(s)}
           onReorderDrop={(fromIndex) => {
@@ -606,6 +628,7 @@ function SlotRow({
   dragDisabled,
   onSetLead,
   onSetRuntimeOverride,
+  onSetModelOverride,
   onEdit,
   onRemove,
   onReorderDrop,
@@ -616,6 +639,7 @@ function SlotRow({
   dragDisabled: boolean;
   onSetLead: () => void;
   onSetRuntimeOverride: (runtimeOverride: string | null) => void;
+  onSetModelOverride: (modelOverride: string | null) => void;
   onEdit: () => void;
   onRemove: () => void;
   onReorderDrop: (fromIndex: number) => void;
@@ -652,11 +676,22 @@ function SlotRow({
       const cmd =
         RUNTIME_OPTIONS.find((o) => o.value === override)?.defaultCommand ??
         override;
-      return `${cmd} (runtime defaults)`;
+      return slot.model_override
+        ? `${cmd} (runtime defaults · model ${slot.model_override})`
+        : `${cmd} (runtime defaults)`;
     }
     const parts = [runner.command, ...runner.args];
-    return parts.filter(Boolean).join(" ");
-  }, [slot.runtime_override, runner.runtime, runner.command, runner.args]);
+    const command = parts.filter(Boolean).join(" ");
+    return slot.model_override
+      ? `${command} (model ${slot.model_override})`
+      : command;
+  }, [
+    slot.runtime_override,
+    slot.model_override,
+    runner.runtime,
+    runner.command,
+    runner.args,
+  ]);
 
   return (
     <li
@@ -691,6 +726,12 @@ function SlotRow({
             </span>
           ) : null}
           <SlotRuntimeSelect slot={slot} onChange={onSetRuntimeOverride} />
+          {slot.runtime_override ? (
+            <SlotModelOverrideEditor
+              slot={slot}
+              onChange={onSetModelOverride}
+            />
+          ) : null}
           <span className="font-mono text-[11px] text-fg-3">
             from @{runner.handle}
           </span>
@@ -804,6 +845,88 @@ function SlotRuntimeSelect({
             );
           })}
         </ul>
+      </PopoverMenu>
+    </div>
+  );
+}
+
+function SlotModelOverrideEditor({
+  slot,
+  onChange,
+}: {
+  slot: SlotWithRunner;
+  onChange: (modelOverride: string | null) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState(slot.model_override ?? "");
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const runtime = slot.runtime_override ?? slot.runner.runtime;
+
+  useEffect(() => {
+    if (!open) setDraft(slot.model_override ?? "");
+  }, [open, slot.model_override]);
+
+  const save = () => {
+    const model = draft.trim();
+    setOpen(false);
+    if (model !== (slot.model_override ?? "")) onChange(model || null);
+  };
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        onClick={() => setOpen((value) => !value)}
+        onMouseDown={(e) => e.stopPropagation()}
+        className="inline-flex cursor-pointer items-center gap-1 rounded bg-raised px-1.5 py-0.5 font-mono text-[10px] text-fg-2 transition-colors hover:text-fg"
+        title="Model override"
+      >
+        model: {slot.model_override ?? "default"}
+        <span aria-hidden className={open ? "rotate-180" : ""}>
+          ▾
+        </span>
+      </button>
+      <PopoverMenu
+        open={open}
+        anchorRef={rootRef}
+        onClose={() => setOpen(false)}
+        minWidth={280}
+      >
+        <form
+          className="flex w-full flex-col gap-3 rounded border border-line-strong bg-panel p-3 shadow-xl"
+          onSubmit={(e) => {
+            e.preventDefault();
+            save();
+          }}
+        >
+          <div className="flex flex-col gap-1.5">
+            <label
+              htmlFor={`slot-model-${slot.id}`}
+              className="text-xs font-semibold text-fg"
+            >
+              Model override
+            </label>
+            <ModelField
+              id={`slot-model-${slot.id}`}
+              runtime={runtime}
+              model={draft}
+              onModelChange={setDraft}
+            />
+            <p className="text-[11px] text-fg-3">
+              Blank uses {runtime}&apos;s CLI default.
+            </p>
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button type="button" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" variant="primary">
+              Save
+            </Button>
+          </div>
+        </form>
       </PopoverMenu>
     </div>
   );

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -451,7 +451,7 @@ export default function MissionWorkspace({
         .filter(
           (s) =>
             s.status === "running" &&
-            s.runtime === "codex" &&
+            (s.runtime === "codex" || s.runtime === "trae") &&
             !s.agent_session_key,
         )
         .map((s) => s.id)
@@ -479,7 +479,7 @@ export default function MissionWorkspace({
           const stillPending = rows.some(
             (s) =>
               s.status === "running" &&
-              s.runtime === "codex" &&
+              (s.runtime === "codex" || s.runtime === "trae") &&
               !s.agent_session_key,
           );
           if (!stillPending || attempts >= MAX_ATTEMPTS) {

--- a/src/pages/RunnerChat.tsx
+++ b/src/pages/RunnerChat.tsx
@@ -527,7 +527,8 @@ export default function RunnerChat({
   useEffect(() => {
     if (!sessionId || !metaLoaded || isArchived) return;
     if (
-      chatMeta?.agent_runtime !== "codex" ||
+      (chatMeta?.agent_runtime !== "codex" &&
+        chatMeta?.agent_runtime !== "trae") ||
       chatMeta.agent_session_key ||
       chatMeta.status !== "running"
     ) {


### PR DESCRIPTION
## Summary
- add TRAE CLI as the fourth first-class runtime, including session capture, resume behavior, permissions, MCP registration, settings, and docs
- add crew-slot model overrides with default-model behavior and effective-runtime display
- scope Vitest fake timers to the affected tests and cover runtime/model switching regressions

## Checks
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets
- cargo test --workspace
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm test

Closes #361