### PR TITLE
fix(ui): invalidate the WebGL texture atlas on zoom, backing scale, and system wake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3842,12 +3842,14 @@ name = "runner"
 version = "0.4.5"
 dependencies = [
  "base64 0.22.1",
+ "block2",
  "chrono",
  "fs2",
  "libc",
  "log",
  "notify",
  "objc2-app-kit",
+ "objc2-foundation",
  "portable-pty",
  "r2d2",
  "r2d2_sqlite",

--- a/docs/impls/0037-webgl-atlas-invalidation.md
+++ b/docs/impls/0037-webgl-atlas-invalidation.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented. Tracking issue [#360](https://github.com/yicheng47/runner/issues/360). Phase 1's findings and the answered open questions are recorded below.
+Shipped. Tracking issue [#360](https://github.com/yicheng47/runner/issues/360). Wake behavior confirmed by smoke test on 2026-07-27. Phase 1's findings and the answered open questions are recorded below.
 
 ## Problem
 
@@ -116,6 +116,6 @@ Automated:
 Manual (Jason smoke-tests):
 
 - [x] Change app zoom with visible output on screen → glyphs stay correctly spaced. Done 2026-07-27: they do, and they did before this change too — zoom never broke them.
-- [ ] Sleep the Mac with an active pane, wake, focus Runner → glyphs correct without touching anything.
-- [ ] Move the window between displays of different scale → glyphs correct.
-- [ ] Alt-tab repeatedly → no visible re-rasterization stutter.
+- [x] Sleep the Mac with an active pane, wake, focus Runner → glyphs correct without touching anything. **Confirmed 2026-07-27** — the fix works. This is the one that mattered: with no deterministic repro available, it is the only end-to-end evidence that clearing on `app/woke` repairs the symptom #360 reported.
+- [ ] Move the window between displays of different scale → glyphs correct. Not run — decision 3's watcher is unvalidated in the field, and xterm's upstream `ScreenDprMonitor` may be doing the real work here regardless.
+- [ ] Alt-tab repeatedly → no visible re-rasterization stutter. Not run — the no-clear-on-focus constraint is held by construction (no call site on the focus path), not by observation.

--- a/docs/impls/0037-webgl-atlas-invalidation.md
+++ b/docs/impls/0037-webgl-atlas-invalidation.md
@@ -22,6 +22,8 @@ And a DPR watcher would not catch it. `windowSettle.ts:13-14`, written during #3
 
 This matters out of proportion to its size: **app zoom is a deterministic, on-demand reproduction of a bug that otherwise requires sleeping the machine.** Confirm it reproduces first, then develop against it.
 
+> **Corrected after testing (2026-07-27).** It does not reproduce. Jason smoke-tested it: app zoom leaves glyphs correctly spaced. The paragraph above is wrong about the mechanism — page zoom moves nothing the atlas config keys on, so `configEquals` returns true and the same atlas is reused rather than going stale. Zoom was never a repro, and this plan had no deterministic one; the rest of the work was verified at the source and by unit tests instead. Decision 4 still ships, downgraded from "most certain part of the fix" to cheap insurance — see the open questions.
+
 ### Why the wake signal is the hard part
 
 `RunEvent::Resumed` → `app/resumed` (`lib.rs:554`) is the only trigger that forces the strong refresh, and it is an app-lifecycle event, not a system sleep/wake one. There is no `NSWorkspace.didWakeNotification` observer. A real system wake typically surfaces only as a window focus change, which routes to the non-forcing `scheduleWakeRefit()`.
@@ -33,7 +35,7 @@ Hanging the atlas clear on focus is the obvious shortcut and the wrong answer: f
 1. **Clear the atlas on the events that actually invalidate it, not on a proxy for them.** Three distinct invalidators, each wired to its own real signal: system wake, backing-scale change, and app zoom. Focus is not one of them — it correlates with wake but fires constantly otherwise, and this codebase has already paid twice (#352, #363) for hanging behavior on a correlated proxy instead of the true signal.
 2. **System wake becomes a first-class signal via `NSWorkspace.didWakeNotification`.** Runner is macOS-only (AGENTS.md), so a native observer costs no portability, and `objc2-app-kit` is already a dependency — this needs an added feature, not a new crate. Emit it on the existing `<domain>/<verb>` event convention (e.g. `app/woke`) so the frontend consumes it like any other backend event. This is the precise signal; everything else is inference.
 3. **Watch backing scale directly.** A `matchMedia("(resolution: Xdppx)")` listener, re-registered on each change, catches lid-open-on-a-different-monitor and display re-initialization — cases where wake and scale change are independent. Note this is *complementary* to decision 2, not redundant: a GPU texture reset with unchanged scale fires no resolution change, and a monitor move fires no wake.
-4. **App zoom joins the existing font-change path.** Add `STORAGE_APP_ZOOM` to the storage-event handler beside font size and family, with the same `clearTextureAtlas()` + `refitAndPush()` treatment. This is the smallest and most certain part of the fix, and the only one with a deterministic repro.
+4. **App zoom joins the existing font-change path.** Add `STORAGE_APP_ZOOM` to the storage-event handler beside font size and family, with the same `clearTextureAtlas()` + `refitAndPush()` treatment. ~~This is the smallest and most certain part of the fix, and the only one with a deterministic repro.~~ **Corrected: it was the *least* certain part.** Zoom does not reproduce the symptom (see above), so this clear is probably inert. Kept regardless — it is one predicate entry on an explicit Cmd +/- press, and "probably inert" is read off the addon source, not measured. Delete it on evidence, not on that reasoning.
 5. **Clearing is the whole remedy; do not add a forced repaint.** `clearTextureAtlas()` drops the cache and glyphs re-rasterize lazily on the next draw, which the existing `t.refresh()` on the wake path already triggers. Do **not** reach for the forced resize dance — it fixes geometry, not rasters, and #352 exists precisely because that dance was over-applied.
 6. **Do not clear on ordinary activation.** Tab switches and pane activation must stay atlas-preserving. If a case emerges where activation genuinely needs it, that is a separate finding with its own evidence, not an extension of this one.
 
@@ -47,7 +49,13 @@ Hanging the atlas clear on focus is the obvious shortcut and the wrong answer: f
 
 Independently, tao's own `Event::Resumed` is emitted only from the iOS (`platform_impl/ios/view.rs:615`) and Android backends — `platform_impl/macos/` contains zero occurrences. So decision 2 does **not** collapse; the native observer is required. The existing `app/resumed` handler is left in place untouched as a #352/#363-owned geometry path.
 
-**Does app zoom actually reproduce the symptom?** Not confirmed — this one needs the running app, which is a smoke test, not an automated one. The `STORAGE_APP_ZOOM` branch ships regardless: the atlas is keyed on device-pixel glyph dimensions (`CharAtlasUtils.ts:34-53`), page zoom changes those, and no other signal reports it (WebKit keeps page zoom out of `devicePixelRatio`, webkit#124862). If the repro turns out negative, the branch is defensive rather than load-bearing — it costs one predicate.
+**Does app zoom actually reproduce the symptom?** **No.** Smoke-tested by Jason on 2026-07-27: changing app zoom leaves glyphs correctly spaced. So this plan never had the deterministic repro it was counting on, and phase 1 delivered one empirical answer instead of two.
+
+The addon source agrees, which is worth recording because it explains *why* the plan's reasoning failed. The atlas config is keyed on `devicePixelRatio` plus the CSS-derived char metrics (`CharAtlasUtils.ts:34-53`, `configEquals` at `:55-76`). Page zoom moves neither: WebKit holds `devicePixelRatio` at the display scale (webkit#124862) and CSS char metrics are unchanged, so `configEquals` returns true and the same atlas is reused rather than going stale. The canvas device-pixel box *does* grow — `DevicePixelObserver` sees it and `_setCanvasDevicePixelDimensions` resizes the canvas — but the glyph shader normalizes against the deliberately-retained older `device.canvas` dimensions (`WebglRenderer.ts:680-690`, `GlyphRenderer.ts:324`), so the whole grid scales uniformly. Bigger, not misaligned.
+
+The plan's error was treating "changes the on-screen size of a glyph" as equivalent to "changes what the atlas keys on." They are different questions, and only the second one stales a cache.
+
+Decision 4 ships anyway, on Jason's call, downgraded to insurance: one predicate entry on an explicit Cmd +/- press, against a mechanism argument that is read off dependency source rather than measured. If WebKit rounds a CSS char metric differently at some zoom step the config genuinely differs, and this is the only thing that would notice. Delete it on evidence, not on the reasoning above.
 
 **Is a full atlas clear the right granularity?** Yes — it is the only granularity the addon exposes. `clearTextureAtlas()` is the sole invalidation entry point on the public surface (`typings/addon-webgl.d.ts`), implemented as `_charAtlas?.clearTexture(); _clearModel(true); _requestRedrawViewport()` (`WebglRenderer.ts:332-336`). Something narrower does exist internally — `acquireTextureAtlas` re-keys on a config that includes `devicePixelRatio` and char metrics (`CharAtlasUtils.ts:55-76`) — but it is reachable only from `handleResize` / `handleDevicePixelRatioChange`, not from the addon's API.
 
@@ -80,7 +88,7 @@ A plain backing-scale change is therefore already handled upstream. Decision 3's
 
 ### Phase 1 — reproduce deterministically
 
-- Confirm app zoom reproduces the overlapped-glyph symptom. If it does, it is the development repro for the rest of the work. → Open; needs the running app. See the open questions.
+- Confirm app zoom reproduces the overlapped-glyph symptom. If it does, it is the development repro for the rest of the work. → **It does not.** There is no deterministic repro; the rest of the work was verified at the source and by unit tests. See the open questions.
 - Verify whether `RunEvent::Resumed` fires on real system wake; record the answer, since it decides Phase 2's size. → It does not fire on macOS at all. See the open questions.
 
 ### Phase 2 — wire the three invalidators
@@ -100,14 +108,14 @@ All three landed. The invalidation rules moved out of the event handler into `sr
 
 Automated:
 
-- [x] An app-zoom storage event clears the atlas and refits — `stalesTextureAtlas` is asserted true for `STORAGE_APP_ZOOM`, and it is the sole gate on the handler's `clearTextureAtlas()` + `refitAndPush()`.
+- [x] An app-zoom storage event clears the atlas and refits — `stalesTextureAtlas` is asserted true for `STORAGE_APP_ZOOM`, and it is the sole gate on the handler's `clearTextureAtlas()` + `refitAndPush()`. Note this verifies the wiring, not a fix: zoom does not reproduce the symptom, so there is nothing here for the clear to repair.
 - [x] A resolution-change event clears the atlas — the watcher is asserted to fire on change and, crucially, to re-register at the new scale so the *second* display move is caught too.
 - [x] Ordinary activation / tab switch does **not** clear the atlas — held by construction rather than by a test: `clearTextureAtlas()` has exactly three call sites (storage handler, wake listener, backing-scale listener) and none is on the activation path. `stalesTextureAtlas` is asserted false for cursor style, scrollback, theme, unrelated keys, and `null`.
 - [x] The wake event reaches the terminal and clears — `wake.rs`'s test posts `NSWorkspaceDidWakeNotification` to the workspace notification center and asserts the observer runs, which pins the registration and the notification name without sleeping the machine. The `app/woke` → `clearTextureAtlas()` hop is a one-liner in the component, outside the unit seam.
 
 Manual (Jason smoke-tests):
 
-- [ ] Change app zoom with visible output on screen → glyphs stay correctly spaced.
+- [x] Change app zoom with visible output on screen → glyphs stay correctly spaced. Done 2026-07-27: they do, and they did before this change too — zoom never broke them.
 - [ ] Sleep the Mac with an active pane, wake, focus Runner → glyphs correct without touching anything.
 - [ ] Move the window between displays of different scale → glyphs correct.
 - [ ] Alt-tab repeatedly → no visible re-rasterization stutter.

--- a/docs/impls/0037-webgl-atlas-invalidation.md
+++ b/docs/impls/0037-webgl-atlas-invalidation.md
@@ -1,0 +1,113 @@
+# WebGL texture atlas invalidation
+
+## Status
+
+Implemented. Tracking issue [#360](https://github.com/yicheng47/runner/issues/360). Phase 1's findings and the answered open questions are recorded below.
+
+## Problem
+
+After the Mac wakes from sleep, terminal panes repaint with glyphs jammed together — characters drawn at the wrong advance width, so `$ pnpm tauri dev` renders closer to `$pnpmtauridev`. Wrapping is correct; only the glyph raster is wrong. The WebGL renderer's texture atlas holds glyphs rasterized under conditions that no longer hold, and nothing tells it so.
+
+Three facts, all verified in the current tree:
+
+1. **`clearTextureAtlas()` has exactly two call sites** — `RunnerTerminal.tsx:1053` and `:1059`, both inside the storage-event handler for terminal font size and font family. Their comment already names this exact symptom: *"a stale cache after a font change can leave a band of pre-change glyphs at the new size until something else evicts them."*
+2. **The wake path never calls it.** Every wake trigger funnels into `refreshActiveTerminal`, which does `ensureWebglRenderer()` → `fit.fit()` → `t.refresh(0, t.rows - 1)`. `t.refresh()` only marks lines dirty; the renderer faithfully redraws them from the same stale atlas.
+3. **No backing-scale change is detected anywhere.** There is no `devicePixelRatio` listener in `src/` — the only DPR mentions are inside `windowSettle.ts`, which reads it but does not watch it.
+
+### A fourth trigger the issue doesn't cover
+
+`STORAGE_APP_ZOOM` is **absent** from the storage-event handler that clears the atlas on font changes (`RunnerTerminal.tsx:1042-1073` handles font size, font family, cursor style, scrollback, and theme — not zoom). App zoom changes the device-pixel size of every rendered glyph, so it stales the atlas exactly like a font-size change does.
+
+And a DPR watcher would not catch it. `windowSettle.ts:13-14`, written during #363, records the reason: **WebKit does not fold page zoom into `devicePixelRatio`** (webkit#124862). So under app zoom the atlas goes stale while every signal a naive watcher would monitor stays constant.
+
+This matters out of proportion to its size: **app zoom is a deterministic, on-demand reproduction of a bug that otherwise requires sleeping the machine.** Confirm it reproduces first, then develop against it.
+
+### Why the wake signal is the hard part
+
+`RunEvent::Resumed` → `app/resumed` (`lib.rs:554`) is the only trigger that forces the strong refresh, and it is an app-lifecycle event, not a system sleep/wake one. There is no `NSWorkspace.didWakeNotification` observer. A real system wake typically surfaces only as a window focus change, which routes to the non-forcing `scheduleWakeRefit()`.
+
+Hanging the atlas clear on focus is the obvious shortcut and the wrong answer: focus fires on every alt-tab, and clearing forces every glyph to re-rasterize on the next draw. Cheap once after a wake, wasteful dozens of times an hour.
+
+## Key Decisions
+
+1. **Clear the atlas on the events that actually invalidate it, not on a proxy for them.** Three distinct invalidators, each wired to its own real signal: system wake, backing-scale change, and app zoom. Focus is not one of them — it correlates with wake but fires constantly otherwise, and this codebase has already paid twice (#352, #363) for hanging behavior on a correlated proxy instead of the true signal.
+2. **System wake becomes a first-class signal via `NSWorkspace.didWakeNotification`.** Runner is macOS-only (AGENTS.md), so a native observer costs no portability, and `objc2-app-kit` is already a dependency — this needs an added feature, not a new crate. Emit it on the existing `<domain>/<verb>` event convention (e.g. `app/woke`) so the frontend consumes it like any other backend event. This is the precise signal; everything else is inference.
+3. **Watch backing scale directly.** A `matchMedia("(resolution: Xdppx)")` listener, re-registered on each change, catches lid-open-on-a-different-monitor and display re-initialization — cases where wake and scale change are independent. Note this is *complementary* to decision 2, not redundant: a GPU texture reset with unchanged scale fires no resolution change, and a monitor move fires no wake.
+4. **App zoom joins the existing font-change path.** Add `STORAGE_APP_ZOOM` to the storage-event handler beside font size and family, with the same `clearTextureAtlas()` + `refitAndPush()` treatment. This is the smallest and most certain part of the fix, and the only one with a deterministic repro.
+5. **Clearing is the whole remedy; do not add a forced repaint.** `clearTextureAtlas()` drops the cache and glyphs re-rasterize lazily on the next draw, which the existing `t.refresh()` on the wake path already triggers. Do **not** reach for the forced resize dance — it fixes geometry, not rasters, and #352 exists precisely because that dance was over-applied.
+6. **Do not clear on ordinary activation.** Tab switches and pane activation must stay atlas-preserving. If a case emerges where activation genuinely needs it, that is a separate finding with its own evidence, not an extension of this one.
+
+## Open questions — answered
+
+**Does `RunEvent::Resumed` fire on macOS system wake at all?** No, and worse than the issue assumed: it does not fire on macOS *at all*, wake or otherwise. Three links in the locked dependency tree:
+
+1. `tauri-runtime-wry` 2.10.1 `src/lib.rs:4038-4040` maps `RunEvent::Resumed` from `Event::NewEvents(StartCause::Poll)` — not from tao's `Event::Resumed`.
+2. The same function, `src/lib.rs:4029-4031`, forces `*control_flow = ControlFlow::Wait` on every iteration that is not `Exit`.
+3. `tao` 0.34.8 `src/platform_impl/macos/app_state.rs:329-347` produces `StartCause::Poll` only under `ControlFlow::Poll`; `ControlFlow::Wait` yields `WaitCancelled` or `ResumeTimeReached` instead.
+
+Independently, tao's own `Event::Resumed` is emitted only from the iOS (`platform_impl/ios/view.rs:615`) and Android backends — `platform_impl/macos/` contains zero occurrences. So decision 2 does **not** collapse; the native observer is required. The existing `app/resumed` handler is left in place untouched as a #352/#363-owned geometry path.
+
+**Does app zoom actually reproduce the symptom?** Not confirmed — this one needs the running app, which is a smoke test, not an automated one. The `STORAGE_APP_ZOOM` branch ships regardless: the atlas is keyed on device-pixel glyph dimensions (`CharAtlasUtils.ts:34-53`), page zoom changes those, and no other signal reports it (WebKit keeps page zoom out of `devicePixelRatio`, webkit#124862). If the repro turns out negative, the branch is defensive rather than load-bearing — it costs one predicate.
+
+**Is a full atlas clear the right granularity?** Yes — it is the only granularity the addon exposes. `clearTextureAtlas()` is the sole invalidation entry point on the public surface (`typings/addon-webgl.d.ts`), implemented as `_charAtlas?.clearTexture(); _clearModel(true); _requestRedrawViewport()` (`WebglRenderer.ts:332-336`). Something narrower does exist internally — `acquireTextureAtlas` re-keys on a config that includes `devicePixelRatio` and char metrics (`CharAtlasUtils.ts:55-76`) — but it is reachable only from `handleResize` / `handleDevicePixelRatioChange`, not from the addon's API.
+
+**Multi-pane cost.** Acceptable; no staggering. Cheaper than the question assumed, for two independent reasons:
+
+- Mounted is not the same as holding an atlas. `RunnerTerminal` disposes the WebGL addon whenever a pane leaves the foreground (the `[active]` effect, `RunnerTerminal.tsx:1146-1152`), so only the handful of foreground panes have anything to clear. A pane that was its atlas's sole owner drops the cache entry outright on dispose (`CharAtlasCache.ts:85-100`).
+- The atlas is shared, not per-pane. `charAtlasCache` is module-level and keyed by config, so panes at the same font and scale hold one `TextureAtlas` between them — the re-rasterization is paid once, not once per pane.
+
+### A fifth finding: xterm already watches backing scale
+
+Fact 3 in the problem statement ("no `devicePixelRatio` listener in `src/`") is true of Runner's own code and false of the bundled dependency. xterm core ships `ScreenDprMonitor` (`CoreBrowserService.ts:65-135`) — the same `(resolution: Xdppx)` query, with the same re-registration-per-change — wired through `RenderService.ts:83` to `WebglRenderer.handleDevicePixelRatioChange()` (`WebglRenderer.ts:180-187`), which re-acquires an atlas keyed on the new ratio.
+
+A plain backing-scale change is therefore already handled upstream. Decision 3's listener still ships, as defense-in-depth for the case upstream misses: a display re-initialization that drops GPU texture contents while landing on a scale the config cache has already seen, where `configEquals` returns true and the stale entry is reused. It does not change the shape of the fix, and the cost is one clear on an event that fires when a monitor changes.
+
+## Goals
+
+- After system wake, panes repaint with correctly spaced glyphs, needing no window resize or font-size toggle.
+- Moving the window to a display with a different backing scale repaints correctly.
+- Changing app zoom repaints correctly.
+- Ordinary tab switching and focus changes do not clear the atlas.
+
+## Non-Goals
+
+- The forced resize dance, geometry, or PTY sizing — this is a raster-only defect (#352, #363 own the geometry paths).
+- Reverting the `@xterm/*` beta pin, which fixed a different upstream glyph-corruption bug and stays.
+- A DOM-renderer fallback or any change to `onContextLoss` handling for full context loss.
+- Cross-platform wake detection.
+
+## Implementation Phases
+
+### Phase 1 — reproduce deterministically
+
+- Confirm app zoom reproduces the overlapped-glyph symptom. If it does, it is the development repro for the rest of the work. → Open; needs the running app. See the open questions.
+- Verify whether `RunEvent::Resumed` fires on real system wake; record the answer, since it decides Phase 2's size. → It does not fire on macOS at all. See the open questions.
+
+### Phase 2 — wire the three invalidators
+
+All three landed. The invalidation rules moved out of the event handler into `src/lib/textureAtlas.ts`, since #360's shape was an invalidator missing from a list that lived inline in one `if`/`else` chain.
+
+- App zoom → `stalesTextureAtlas()` now owns the storage-key list (font size, font family, app zoom) and the handler consults it, so the list and its use cannot drift apart.
+- Backing scale → `observeBackingScale()`, a `(resolution: Xdppx)` listener re-registered on each change.
+- System wake → `src-tauri/src/wake.rs`: an `NSWorkspace.didWakeNotification` observer emitting `app/woke`, consumed in `RunnerTerminal`. `app/resumed` is untouched.
+
+### Phase 3 — verification
+
+- Tests where the seam allows: `src/lib/textureAtlas.test.ts` and `wake.rs`'s module test.
+- Full check matrix: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace`, `pnpm exec tsc --noEmit`, `pnpm run lint`, `pnpm test`.
+
+## Verification
+
+Automated:
+
+- [x] An app-zoom storage event clears the atlas and refits — `stalesTextureAtlas` is asserted true for `STORAGE_APP_ZOOM`, and it is the sole gate on the handler's `clearTextureAtlas()` + `refitAndPush()`.
+- [x] A resolution-change event clears the atlas — the watcher is asserted to fire on change and, crucially, to re-register at the new scale so the *second* display move is caught too.
+- [x] Ordinary activation / tab switch does **not** clear the atlas — held by construction rather than by a test: `clearTextureAtlas()` has exactly three call sites (storage handler, wake listener, backing-scale listener) and none is on the activation path. `stalesTextureAtlas` is asserted false for cursor style, scrollback, theme, unrelated keys, and `null`.
+- [x] The wake event reaches the terminal and clears — `wake.rs`'s test posts `NSWorkspaceDidWakeNotification` to the workspace notification center and asserts the observer runs, which pins the registration and the notification name without sleeping the machine. The `app/woke` → `clearTextureAtlas()` hop is a one-liner in the component, outside the unit seam.
+
+Manual (Jason smoke-tests):
+
+- [ ] Change app zoom with visible output on screen → glyphs stay correctly spaced.
+- [ ] Sleep the Mac with an active pane, wake, focus Runner → glyphs correct without touching anything.
+- [ ] Move the window between displays of different scale → glyphs correct.
+- [ ] Alt-tab repeatedly → no visible re-rasterization stutter.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,7 +64,14 @@ libc = "0.2"
 portable-pty = "0.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSButton", "NSControl", "NSResponder", "NSView", "NSWindow"] }
+objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSButton", "NSControl", "NSResponder", "NSView", "NSWindow", "NSWorkspace"] }
+# System-wake observer (impl 0037). `NSWorkspace`'s notification center is
+# the only precise sleep/wake signal available to the app — tao never emits
+# `Event::Resumed` on macOS. `block2` + `NSOperation` are what the
+# `addObserverForName:object:queue:usingBlock:` binding is gated on; both
+# crates are already in the lock via tao/wry.
+objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSNotification", "NSOperation", "NSString", "block2"] }
+block2 = "0.6"
 
 [dev-dependencies]
 tauri = { version = "2", features = ["test"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,8 @@ mod router;
 mod runtime_status;
 mod session;
 mod shell_path;
+#[cfg(target_os = "macos")]
+mod wake;
 mod window_state;
 mod windows;
 
@@ -145,6 +147,11 @@ pub fn run() {
 
             // First line of every app start. Triage-from-log starts here.
             log_startup_banner(app.handle(), &app_data_dir);
+
+            // System wake → `app/woke` (impl 0037). See wake.rs for why
+            // `RunEvent::Resumed` is not this signal on macOS.
+            #[cfg(target_os = "macos")]
+            wake::install(app.handle());
 
             let db_path = app_data_dir.join("runner.db");
             let pool = Arc::new(db::open_pool(&db_path)?);

--- a/src-tauri/src/wake.rs
+++ b/src-tauri/src/wake.rs
@@ -1,0 +1,106 @@
+//! macOS system-wake bridge (impl 0037).
+//!
+//! The app has no sleep/wake signal of its own. `RunEvent::Resumed` looks
+//! like one and is not: tauri-runtime-wry maps it from
+//! `Event::NewEvents(StartCause::Poll)`, and tao's macOS event loop only
+//! produces `StartCause::Poll` under `ControlFlow::Poll` — which
+//! tauri-runtime-wry overwrites with `ControlFlow::Wait` on every
+//! iteration. So `app/resumed` never fires on macOS at all, let alone on
+//! wake. tao's own `Event::Resumed` is emitted from the iOS and Android
+//! backends only.
+//!
+//! `NSWorkspace.didWakeNotification` is the real thing: posted by the
+//! window server when the machine comes back from sleep. The frontend
+//! consumes the resulting `app/woke` event to invalidate WebGL texture
+//! atlases, whose glyphs were rasterized against a display/GPU state that
+//! no longer holds (#360).
+
+use std::ptr::NonNull;
+
+use block2::RcBlock;
+use objc2_app_kit::{NSWorkspace, NSWorkspaceDidWakeNotification};
+use objc2_foundation::NSNotification;
+use tauri::{AppHandle, Emitter, Runtime};
+
+/// Frontend event name. Follows the `<domain>/<verb>` convention used by
+/// the rest of the backend's emits.
+pub const WOKE_EVENT: &str = "app/woke";
+
+/// Broadcast `app/woke` to every webview each time the machine wakes.
+pub fn install<R: Runtime>(app: &AppHandle<R>) {
+    let app = app.clone();
+    observe_wake(move || {
+        if let Err(e) = app.emit(WOKE_EVENT, ()) {
+            log::error!("emit {WOKE_EVENT} failed: {e}");
+        }
+    });
+}
+
+/// Register `on_wake` against `NSWorkspaceDidWakeNotification` for the
+/// remaining life of the process.
+///
+/// `Send + Sync` is the binding's price of admission, not decoration:
+/// Foundation declares the block `NS_SWIFT_SENDABLE` and the objc2 method
+/// is `unsafe` on exactly that condition. A `nil` queue means it runs
+/// synchronously on whichever thread posts — the main thread for a real
+/// wake, but nothing in the API promises that.
+///
+/// Nothing is kept from the call. The center strongly holds both the
+/// copied block and the returned observer token until an explicit
+/// `removeObserver:`, so dropping the local handles here deregisters
+/// nothing — which is what a process-lifetime observer wants. The test
+/// below is what keeps that claim honest: it registers, lets both handles
+/// drop, and only then posts.
+fn observe_wake<F: Fn() + Send + Sync + 'static>(on_wake: F) {
+    let block = RcBlock::new(move |_notification: NonNull<NSNotification>| {
+        on_wake();
+    });
+    let center = NSWorkspace::sharedWorkspace().notificationCenter();
+    // SAFETY: the name is AppKit's own constant, the object filter is nil,
+    // and `F: Send + Sync` makes the block sendable as the method requires.
+    let _observer = unsafe {
+        center.addObserverForName_object_queue_usingBlock(
+            Some(NSWorkspaceDidWakeNotification),
+            None,
+            None,
+            &block,
+        )
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    use super::*;
+
+    /// Stand in for the window server's post. The observer registration
+    /// and the notification name are the parts worth pinning; a real
+    /// sleep/wake cycle exercises the same delivery path.
+    ///
+    /// Every post here happens after `observe_wake` has returned and
+    /// dropped its block and observer handles, so a passing test is also
+    /// the evidence that the center's own strong references are what keep
+    /// the registration alive.
+    fn post_wake_notification() {
+        let center = NSWorkspace::sharedWorkspace().notificationCenter();
+        // SAFETY: nil object is valid for a notification with no sender.
+        unsafe { center.postNotificationName_object(NSWorkspaceDidWakeNotification, None) };
+    }
+
+    #[test]
+    fn wake_notification_reaches_the_observer() {
+        let hits = Arc::new(AtomicUsize::new(0));
+        let counter = Arc::clone(&hits);
+        observe_wake(move || {
+            counter.fetch_add(1, Ordering::SeqCst);
+        });
+
+        post_wake_notification();
+        assert_eq!(hits.load(Ordering::SeqCst), 1);
+
+        post_wake_notification();
+        assert_eq!(hits.load(Ordering::SeqCst), 2);
+    }
+}

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -54,6 +54,7 @@ import {
   type TerminalGridSize,
 } from "../lib/terminalResize";
 import { TERMINAL_SCROLLBAR_WIDTH_PX } from "../lib/terminalSizing";
+import { observeBackingScale, stalesTextureAtlas } from "../lib/textureAtlas";
 import { eventMatchesShortcut } from "../lib/keymap";
 import { runtimeClearsOnResize } from "./ui/runtimes";
 
@@ -1012,6 +1013,32 @@ export const RunnerTerminal = forwardRef<
       }
       unlistenAppResumed = fn;
     });
+    // Real system wake, from the NSWorkspace observer in wake.rs (#360).
+    // Sleep can re-initialize the display or reset the GPU underneath a
+    // live atlas, leaving every cached glyph rasterized for conditions
+    // that no longer hold; `t.refresh()` on the focus path only marks
+    // lines dirty, so the stale rasters get redrawn faithfully. Dropping
+    // the cache is the entire remedy — the addon re-rasterizes lazily on
+    // the redraw it requests itself, and geometry is #352/#363's problem,
+    // not this one. Deliberately not hung on focus or visibilitychange:
+    // those correlate with wake but fire on every alt-tab.
+    let unlistenAppWoke: (() => void) | null = null;
+    let appWokeCancelled = false;
+    void listen("app/woke", () => {
+      webglRef.current?.clearTextureAtlas();
+    }).then((fn) => {
+      if (appWokeCancelled) {
+        fn();
+        return;
+      }
+      unlistenAppWoke = fn;
+    });
+    // Lid opened on a different monitor, or a display that came back at
+    // another scale. Independent of wake in both directions: a monitor
+    // move fires no wake, and a GPU reset fires no resolution change.
+    const disposeBackingScale = observeBackingScale(() => {
+      webglRef.current?.clearTextureAtlas();
+    });
     let unlistenFocus: (() => void) | null = null;
     let focusCancelled = false;
     try {
@@ -1045,25 +1072,29 @@ export const RunnerTerminal = forwardRef<
       try {
         if (e.key === STORAGE_TERMINAL_FONT_SIZE) {
           t.options.fontSize = readTerminalFontSize();
-          // Cell metrics changed — refit, push the new PTY geometry,
-          // and drop the atlas. The atlas indexes cells by their
-          // rendered pixel dimensions; a stale cache after a font
-          // change can leave a band of pre-change glyphs at the new
-          // size until something else evicts them.
-          webglRef.current?.clearTextureAtlas();
-          refitAndPush();
         } else if (e.key === STORAGE_TERMINAL_FONT_FAMILY) {
           t.options.fontFamily = resolveTerminalFontStack(
             readTerminalFontFamily(),
           );
-          webglRef.current?.clearTextureAtlas();
-          refitAndPush();
         } else if (e.key === STORAGE_TERMINAL_CURSOR_STYLE) {
           t.options.cursorStyle = readTerminalCursorStyle();
         } else if (e.key === STORAGE_TERMINAL_SCROLLBACK) {
           t.options.scrollback = readTerminalScrollback();
         } else if (e.key === STORAGE_TERMINAL_THEME) {
           t.options.theme = resolveTerminalTheme(readTerminalTheme());
+        }
+        // Cell metrics changed — refit, push the new PTY geometry, and
+        // drop the atlas. The atlas indexes cells by their rendered
+        // pixel dimensions; a stale cache after a font change can leave
+        // a band of pre-change glyphs at the new size until something
+        // else evicts them. App zoom does the same damage from the other
+        // direction — it rescales every glyph's device-pixel footprint
+        // with no font option changing, and nothing else signals it,
+        // since WebKit keeps page zoom out of `devicePixelRatio`
+        // (webkit#124862) and the backing-scale watcher stays silent.
+        if (stalesTextureAtlas(e.key)) {
+          webglRef.current?.clearTextureAtlas();
+          refitAndPush();
         }
       } catch {
         // xterm may reject runtime mutation of some options; the next
@@ -1083,6 +1114,9 @@ export const RunnerTerminal = forwardRef<
       window.removeEventListener("storage", onStorage);
       appResumedCancelled = true;
       unlistenAppResumed?.();
+      appWokeCancelled = true;
+      unlistenAppWoke?.();
+      disposeBackingScale();
       focusCancelled = true;
       unlistenFocus?.();
       wakeRafs.forEach((id) => window.cancelAnimationFrame(id));

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -1087,11 +1087,9 @@ export const RunnerTerminal = forwardRef<
         // drop the atlas. The atlas indexes cells by their rendered
         // pixel dimensions; a stale cache after a font change can leave
         // a band of pre-change glyphs at the new size until something
-        // else evicts them. App zoom does the same damage from the other
-        // direction — it rescales every glyph's device-pixel footprint
-        // with no font option changing, and nothing else signals it,
-        // since WebKit keeps page zoom out of `devicePixelRatio`
-        // (webkit#124862) and the backing-scale watcher stays silent.
+        // else evicts them. App zoom rides along on weaker evidence —
+        // see `stalesTextureAtlas` for why it is kept despite not
+        // reproducing the symptom.
         if (stalesTextureAtlas(e.key)) {
           webglRef.current?.clearTextureAtlas();
           refitAndPush();

--- a/src/lib/textureAtlas.test.ts
+++ b/src/lib/textureAtlas.test.ts
@@ -1,8 +1,10 @@
 // Two contracts (impl 0037, phase 2).
 //
-// The storage-key list: exactly the settings that change a glyph's
-// rendered dimensions stale the atlas, and nothing else does. #360's whole
-// shape was an invalidator missing from this list.
+// The storage-key list: the settings that can change a glyph's rendered
+// dimensions stale the atlas, and nothing else does. #360's whole shape
+// was an invalidator missing from this list. App zoom is the one entry
+// held on suspicion rather than a reproduced symptom — see
+// `stalesTextureAtlas`.
 //
 // The backing-scale watcher: it re-registers at the new scale on every
 // change so the second display move is caught as reliably as the first, it
@@ -68,7 +70,7 @@ function fakeWindow(initialDpr: number) {
 }
 
 describe("stalesTextureAtlas", () => {
-  it("stales on app zoom — the invalidator #360 was missing", () => {
+  it("stales on app zoom, kept as insurance rather than a known repro", () => {
     expect(stalesTextureAtlas(STORAGE_APP_ZOOM)).toBe(true);
   });
 

--- a/src/lib/textureAtlas.test.ts
+++ b/src/lib/textureAtlas.test.ts
@@ -1,0 +1,145 @@
+// Two contracts (impl 0037, phase 2).
+//
+// The storage-key list: exactly the settings that change a glyph's
+// rendered dimensions stale the atlas, and nothing else does. #360's whole
+// shape was an invalidator missing from this list.
+//
+// The backing-scale watcher: it re-registers at the new scale on every
+// change so the second display move is caught as reliably as the first, it
+// reports the new ratio, and it goes quiet after disposal.
+
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  STORAGE_APP_ZOOM,
+  STORAGE_TERMINAL_CURSOR_STYLE,
+  STORAGE_TERMINAL_FONT_FAMILY,
+  STORAGE_TERMINAL_FONT_SIZE,
+  STORAGE_TERMINAL_SCROLLBACK,
+  STORAGE_TERMINAL_THEME,
+} from "./settings";
+import {
+  observeBackingScale,
+  resolutionQuery,
+  stalesTextureAtlas,
+  type BackingScaleWindow,
+  type ResolutionQuery,
+} from "./textureAtlas";
+
+/** A `window` whose scale is settable, tracking every query it hands out. */
+function fakeWindow(initialDpr: number) {
+  const queries: { query: string; listeners: Set<() => void> }[] = [];
+  let dpr = initialDpr;
+
+  const win: BackingScaleWindow = {
+    get devicePixelRatio() {
+      return dpr;
+    },
+    matchMedia(query: string): ResolutionQuery {
+      const listeners = new Set<() => void>();
+      queries.push({ query, listeners });
+      return {
+        addEventListener: (_type, listener) => {
+          listeners.add(listener);
+        },
+        removeEventListener: (_type, listener) => {
+          listeners.delete(listener);
+        },
+      };
+    },
+  };
+
+  return {
+    win,
+    queries,
+    /** Move the display scale and fire the outgoing query's change event. */
+    setDpr(next: number) {
+      const active = queries[queries.length - 1];
+      dpr = next;
+      for (const listener of [...active.listeners]) listener();
+    },
+    liveListenerCount() {
+      return queries.reduce((n, q) => n + q.listeners.size, 0);
+    },
+    latestQuery() {
+      return queries[queries.length - 1].query;
+    },
+  };
+}
+
+describe("stalesTextureAtlas", () => {
+  it("stales on app zoom — the invalidator #360 was missing", () => {
+    expect(stalesTextureAtlas(STORAGE_APP_ZOOM)).toBe(true);
+  });
+
+  it("stales on the font settings that change cell metrics", () => {
+    expect(stalesTextureAtlas(STORAGE_TERMINAL_FONT_SIZE)).toBe(true);
+    expect(stalesTextureAtlas(STORAGE_TERMINAL_FONT_FAMILY)).toBe(true);
+  });
+
+  it("leaves the atlas alone for settings that don't resize a glyph", () => {
+    expect(stalesTextureAtlas(STORAGE_TERMINAL_CURSOR_STYLE)).toBe(false);
+    expect(stalesTextureAtlas(STORAGE_TERMINAL_SCROLLBACK)).toBe(false);
+    expect(stalesTextureAtlas(STORAGE_TERMINAL_THEME)).toBe(false);
+  });
+
+  it("ignores unrelated and null storage keys", () => {
+    expect(stalesTextureAtlas("settings.somethingElse")).toBe(false);
+    expect(stalesTextureAtlas(null)).toBe(false);
+  });
+});
+
+describe("observeBackingScale", () => {
+  it("registers a resolution query at the current scale", () => {
+    const env = fakeWindow(2);
+    observeBackingScale(vi.fn(), env.win);
+
+    expect(env.queries).toHaveLength(1);
+    expect(env.queries[0].query).toBe(resolutionQuery(2));
+  });
+
+  it("re-registers at the new scale so consecutive changes both fire", () => {
+    const env = fakeWindow(2);
+    const onChange = vi.fn();
+    observeBackingScale(onChange, env.win);
+
+    env.setDpr(1);
+    expect(onChange).toHaveBeenCalledWith(1);
+    expect(env.latestQuery()).toBe(resolutionQuery(1));
+
+    env.setDpr(2);
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange).toHaveBeenLastCalledWith(2);
+    expect(env.latestQuery()).toBe(resolutionQuery(2));
+  });
+
+  it("leaves exactly one live listener behind after re-registering", () => {
+    const env = fakeWindow(2);
+    observeBackingScale(vi.fn(), env.win);
+
+    env.setDpr(1);
+    env.setDpr(3);
+
+    expect(env.liveListenerCount()).toBe(1);
+  });
+
+  it("does not fire on registration", () => {
+    const env = fakeWindow(2);
+    const onChange = vi.fn();
+    observeBackingScale(onChange, env.win);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("stops reporting and unregisters once disposed", () => {
+    const env = fakeWindow(2);
+    const onChange = vi.fn();
+    const dispose = observeBackingScale(onChange, env.win);
+
+    dispose();
+    expect(env.liveListenerCount()).toBe(0);
+
+    env.setDpr(1);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/textureAtlas.ts
+++ b/src/lib/textureAtlas.ts
@@ -42,8 +42,23 @@ import {
 
 /**
  * Settings whose change restales every cached glyph. Font size and family
- * change the rasterized cell outright; app zoom changes how many device
- * pixels that cell occupies, which the atlas keys on just as hard.
+ * change the rasterized cell outright.
+ *
+ * App zoom is here on weaker evidence, deliberately. It was 0037's
+ * candidate for a deterministic repro of #360 and it did **not**
+ * reproduce: page zoom moves nothing the atlas config keys on — WebKit
+ * holds `devicePixelRatio` at the display scale (webkit#124862) and the
+ * CSS char metrics are unchanged, so `configEquals` returns true and the
+ * same atlas is reused. The canvas device-pixel box does grow, but the
+ * glyph shader normalizes against the retained older canvas dimensions,
+ * so the grid scales uniformly — bigger, not misaligned.
+ *
+ * So this clear is probably inert, and kept anyway: it is one predicate
+ * entry on an explicit Cmd +/- press, and the reasoning above is read off
+ * the addon source rather than measured. If WebKit rounds a CSS char
+ * metric differently at some zoom step, the config genuinely differs and
+ * this is the only thing that would notice. Delete it on evidence, not on
+ * the reasoning here.
  *
  * Cursor style, scrollback, and theme are not here on purpose: none of
  * them changes a glyph's rendered dimensions.

--- a/src/lib/textureAtlas.ts
+++ b/src/lib/textureAtlas.ts
@@ -1,0 +1,105 @@
+// What invalidates the WebGL texture atlas (impl 0037, #360).
+//
+// The atlas caches glyphs rasterized at specific device-pixel dimensions.
+// Anything that changes those dimensions leaves every cached glyph wrong,
+// and the renderer has no way to know — `Terminal.refresh()` only marks
+// lines dirty, so stale rasters get redrawn faithfully. #360 exists
+// because the list of invalidators lived inline in one event handler and
+// was missing entries; it lives here now so it is one list, in one place,
+// with one test.
+//
+// The invalidators are independent, not a hierarchy: page zoom moves no
+// resolution and no wake, a monitor move fires no wake, and a GPU reset
+// on wake moves no resolution. Focus is NOT one of them — it correlates
+// with wake but fires on every alt-tab, and each clear costs a full
+// re-rasterization on the next draw.
+//
+// ## Backing scale
+//
+// A `(resolution: Xdppx)` media query matches only while the display scale
+// is exactly X, so the change event fires as the query STOPS matching and
+// the listener has to be re-registered at the new scale to catch the next
+// one. That is the whole reason this is not a one-shot `addEventListener`.
+//
+// Note the overlap, which is deliberate: xterm's own `ScreenDprMonitor`
+// runs the same query shape and re-keys the char atlas by
+// `devicePixelRatio`, so a plain scale change is already handled upstream.
+// What it does not cover is a display re-initialization that drops GPU
+// texture contents on the way to a scale it has already cached — the atlas
+// config compares equal and the stale entry is reused. Clearing here is
+// cheap at these frequencies and closes that case.
+//
+// Deliberately NOT a proxy for wake: page zoom never moves
+// `devicePixelRatio` under WebKit (webkit#124862, see windowSettle.ts), and
+// a GPU reset at an unchanged scale fires no resolution change at all.
+// Those are separate invalidators with separate signals.
+
+import {
+  STORAGE_APP_ZOOM,
+  STORAGE_TERMINAL_FONT_FAMILY,
+  STORAGE_TERMINAL_FONT_SIZE,
+} from "./settings";
+
+/**
+ * Settings whose change restales every cached glyph. Font size and family
+ * change the rasterized cell outright; app zoom changes how many device
+ * pixels that cell occupies, which the atlas keys on just as hard.
+ *
+ * Cursor style, scrollback, and theme are not here on purpose: none of
+ * them changes a glyph's rendered dimensions.
+ */
+export function stalesTextureAtlas(key: string | null): boolean {
+  return (
+    key === STORAGE_TERMINAL_FONT_SIZE ||
+    key === STORAGE_TERMINAL_FONT_FAMILY ||
+    key === STORAGE_APP_ZOOM
+  );
+}
+
+/** The `MediaQueryList` surface this uses, narrowed so tests can fake it. */
+export interface ResolutionQuery {
+  addEventListener(type: "change", listener: () => void): void;
+  removeEventListener(type: "change", listener: () => void): void;
+}
+
+/** The `window` surface this uses, narrowed so tests can fake it. */
+export interface BackingScaleWindow {
+  readonly devicePixelRatio: number;
+  matchMedia(query: string): ResolutionQuery;
+}
+
+export function resolutionQuery(dpr: number): string {
+  return `(resolution: ${dpr}dppx)`;
+}
+
+/**
+ * Call `onChange` with the new device pixel ratio each time the backing
+ * scale changes. Returns a disposer.
+ */
+export function observeBackingScale(
+  onChange: (dpr: number) => void,
+  win: BackingScaleWindow = window,
+): () => void {
+  let query: ResolutionQuery | null = null;
+  let disposed = false;
+
+  const listener = () => {
+    if (disposed) return;
+    register();
+    onChange(win.devicePixelRatio);
+  };
+
+  function register() {
+    query?.removeEventListener("change", listener);
+    query = win.matchMedia(resolutionQuery(win.devicePixelRatio));
+    query.addEventListener("change", listener);
+  }
+
+  register();
+
+  return () => {
+    disposed = true;
+    query?.removeEventListener("change", listener);
+    query = null;
+  };
+}


### PR DESCRIPTION
After the Mac wakes, terminal panes repaint with glyphs jammed together — wrapping correct, advance width wrong, so `$ pnpm tauri dev` renders closer to `$pnpmtauridev`. The WebGL renderer's texture atlas caches glyphs rasterized at specific device-pixel dimensions, and nothing on the wake path told it those dimensions no longer hold. Every wake trigger funnels into `refreshActiveTerminal`, whose `t.refresh()` only marks lines dirty — so the renderer faithfully redraws them from the same stale atlas.

`clearTextureAtlas()` had exactly two call sites, both inside the font-size / font-family storage branches, whose own comment already named this exact symptom. Three things invalidate the atlas; none was detected.

Implements [docs/impls/0037](docs/impls/0037-webgl-atlas-invalidation.md).

## The fix

Each invalidator wired to its own real signal:

| Invalidator | Signal |
|---|---|
| App zoom | `STORAGE_APP_ZOOM` in the storage handler |
| Backing scale | `(resolution: Xdppx)` listener, re-registered per change |
| System wake | `app/woke`, from a new `NSWorkspace.didWakeNotification` observer |

**Not focus, and not `visibilitychange`.** Both correlate with wake and fire on every alt-tab, and each clear costs a full re-rasterization on the next draw. #352 and #363 are both what hanging behavior on a correlated proxy costs. Clearing is also the entire remedy — the addon re-rasterizes lazily on the redraw it requests itself. No resize dance: that fixes geometry, not rasters, and #352 exists because it was over-applied.

The three are independent, not a hierarchy: page zoom moves no resolution and no wake, a monitor move fires no wake, and a GPU reset on wake moves no resolution.

## Two findings worth reading

**`RunEvent::Resumed` never fires on macOS at all** — not merely "not on wake". `tauri-runtime-wry` maps it from `Event::NewEvents(StartCause::Poll)` (`lib.rs:4038`), and the same function forces `ControlFlow::Wait` on every non-`Exit` iteration (`:4029`); tao produces `StartCause::Poll` only under `ControlFlow::Poll` (`macos/app_state.rs:329-347`). tao's own `Event::Resumed` is emitted from the iOS and Android backends only. So the native observer was required rather than optional. `app/resumed` is left exactly as it was — it is a #352/#363 geometry path.

**xterm already watches backing scale.** 0037's premise "no `devicePixelRatio` listener anywhere" is true of `src/` and false of the dependency: xterm core ships `ScreenDprMonitor` (same query shape, same re-registration) re-keying the atlas by DPR. A plain scale change was already handled upstream. The Runner-level listener still ships as defense-in-depth for the case upstream misses — a display re-init landing on a scale the config cache has already seen, where `configEquals` returns true and the stale entry is reused — and the overlap is now documented so the next reader doesn't rediscover it the hard way.

## Notes

The storage-key list moved into `src/lib/textureAtlas.ts` and the handler consults it, so the list and its use can't drift apart — #360's shape was an invalidator missing from a list that lived inline in one `if`/`else` chain.

`Send + Sync` on the wake callback is load-bearing: Foundation declares the block `NS_SWIFT_SENDABLE` and the objc2 method is `unsafe` on exactly that condition. Nothing is retained from the registration — the center strongly holds both the copied block and the observer token until an explicit `removeObserver:`. The test posts after both local handles have dropped, so a passing run is also the evidence for that lifetime claim.

## Verification

Automated, all green locally: `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `cargo test --workspace` (550), `pnpm exec tsc --noEmit`, `pnpm run lint`, `pnpm test` (244).

- An app-zoom storage event clears the atlas and refits.
- A resolution change clears it — and the watcher re-registers, so the *second* display move is caught too.
- Ordinary activation / tab switch does **not** clear: `clearTextureAtlas()` has exactly three call sites and none is on the activation path.
- The wake notification reaches the observer (`wake.rs` test posts `NSWorkspaceDidWakeNotification`, no sleep cycle needed).

**Manual smoke tests are open and are Jason's** — including the one that matters most: whether app zoom reproduces the jammed-glyph symptom is still unconfirmed. 0037 records it as open rather than assumed; if it comes back negative, the zoom branch is defensive rather than load-bearing. The sleep/wake, display-move, and alt-tab-no-stutter checks are also unrun.

Closes #360.