### PR TITLE
fix(session): replay output at produced width

### DIFF
--- a/docs/impls/0038-predictive-pane-sizing.md
+++ b/docs/impls/0038-predictive-pane-sizing.md
@@ -1,95 +1,84 @@
-# Predictive pane sizing for launch resume
+# Launch estimate: the fallback returns the wrong box
 
 ## Status
 
-Planned. Tracking issue [#366](https://github.com/yicheng47/runner/issues/366). **Corrects [0036](0036-launch-resume-fork-width.md)**, whose precedence chain is sound but whose estimated rung was wired to the wrong helpers — see Problem.
+Planned, and **substantially narrowed**. Tracking issue [#366](https://github.com/yicheng47/runner/issues/366).
 
-## Problem
+## Correction — the original premise was wrong
 
-0036 shipped and the symptom survived in packaged builds. The root cause is a category error:
+The first draft of this document (committed as `20979b8`, never implemented) claimed that `chatPaneAreaBox()` composes a `<main>` measurement taken on the `/runners` boot route with chrome subtractions that only apply to the chat surface — "a measurement of one surface, plus chrome corrections for another, describes neither." That is false, and [#366's comment](https://github.com/yicheng47/runner/issues/366#issuecomment-5101422726) is correct to reject it.
 
-**The estimate answers a question about a layout that is not rendered by measuring the layout that is.**
+There is exactly one shell `<main>` — `AppShell.tsx:120` — a flex sibling of `<Sidebar>` with `flex-1`, with `PersistentSurfaces` mounted inside it. Its width is `window − sidebar` and it is **route-independent**: same element, same box, on `/runners` and on a chat route. What is currently rendered inside it does not change its width. `terminalSizing.ts:142-144` says this outright — *"Mounted from boot, so this reads true even with no chat or mission surface on screen"* — and the original draft failed to weigh it.
 
-At cold launch the main window boots on `/runners` (`App.tsx:117`), so no chat surface exists and the *measured* rung is unreachable — `launchDims.ts:8-9` documents this. Every auto-resumed session therefore falls to the *estimated* rung, which does:
+So subtracting the stored chat-panel width from that box is not a mis-applied measurement. It is a deliberate prediction of the destination pane area, which is exactly what a launch estimate must be.
 
+The localStorage-per-origin argument fails on its own terms too. `storedSideWidth` and `RunnerChat.tsx:272` read the **same key** with the **same** absent-means-open default, so within one origin the estimate and the surface the session returns into agree. Dev and packaged profiles do have separate stores, but both halves of the computation live in the same origin, so that divergence cannot produce an asymmetry between them.
+
+### The original fix would have made things worse
+
+The draft proposed replacing the `<main>` read with a DOM-free reconstruction from `window.innerWidth` minus stored chrome. That would discard information the measurement gets for free:
+
+`Sidebar.tsx:2004-2010` sets `width: sidebarVisible ? width : 0` on a `shrink-0` flex item, and the collapsed hover-peek switches it to an absolute overlay. Measuring `<main>` therefore already accounts for collapsed (0), expanded (the dragged width), mid-animation (the interpolated width), and peek-overlay (0) — correctly, and without knowing any of those rules. A reconstruction would have to re-derive all of it from localStorage and would get the overlay and animation cases wrong.
+
+Reading the live layout is the right call here. The draft's own principle — prefer a value that described a real box over a computed one — argued against its own conclusion.
+
+## What actually survives
+
+One defect, in `shellContentBox` (`terminalSizing.ts:145-152`):
+
+```js
+return {
+  width: rect && rect.width > 0 ? rect.width : window.innerWidth,
+  height: rect && rect.height > 0 ? rect.height : window.innerHeight,
+};
 ```
-chatPaneAreaBox()                  // terminalSizing.ts:210
-  → shellContentBox()              // :145 — document.querySelector("main")
-  → width − storedSideWidth("runner.chat.panel.open", …, default 320)
-```
 
-`<main>` on `/runners` holds the runners list and no chat side panel, but the panel width is subtracted anyway. A measurement of one surface, plus chrome corrections for another, describes neither. With the panel open — which is the default, since `RunnerChat.tsx:272` treats a missing key as open — the estimate is `CHAT_PANEL_DEFAULT_WIDTH_PX` (320) too narrow, roughly 30–35 columns.
+`window.innerWidth` is the full window **including** the sidebar, so the fallback silently substitutes a box roughly a sidebar-width too wide. It is a fallback that answers a different question rather than declining to answer.
 
-`shellContentBox()` carries the same error one level down: when `<main>` is missing or zero-width it falls back to `window.innerWidth`, the full window *including* the sidebar. Opposite sign, identical mistake — substituting a different box rather than declining to answer.
+A concrete reachable path: `SettingsPage.tsx:233` renders a **second** `<main>` while AppShell's is `display:none` under the Settings takeover (`AppShell.tsx:102-105`). `document.querySelector("main")` returns the first in document order — AppShell's hidden one — whose rect is zero, so the fallback fires and over-estimates.
 
-Structurally: these helpers were written for the **live** case, where the chat surface is mounted and measure-then-subtract is exactly right. 0036's decision 2 named them for the **predictive** case without noticing that their correctness depends on the surface being on screen. They are correct where they came from and wrong where they were reused. That instruction was in the impl doc, not an implementation slip.
+Note the sign: this makes the estimate too **wide**, the opposite of #366's reported symptom. It is a real defect and worth fixing, but it does not explain the report.
 
-### Why dev looked fixed
+## The reported symptom is #367
 
-Two stores diverge between builds, which is why this reproduced only in production:
+The screenshot behind "0.4.6 still didn't fix the restart width problem" shows a correctly-wrapped full-width frame with **no scrollback above it**. That is not a width bug — it is [#367](https://github.com/yicheng47/runner/issues/367): MCP-started missions fork slots at 80×24, and the first slot visit trips the cols-gate purge and discards the ring. See [impl 0039](0039-backend-initiated-spawn-width.md).
 
-1. **localStorage is per-origin.** Dev serves from `http://localhost:1420`; a packaged build uses the Tauri asset protocol. `runner.chat.panel.open` / `.width` are not shared. A dev profile with the panel closed subtracts 0 and looks correct.
-2. **Database and window state are separate** — `lib.rs:126-134` gives debug builds a sibling `<identifier>-dev` data dir. Different sessions, tab layouts, and split shapes.
+Absent a reproduction that survives the analysis above, there is no confirmed launch-estimate width bug in the shipped tree.
 
 ## Key Decisions
 
-1. **Predictive sizing is its own computation, with no DOM input.** Add a distinct path for "how wide will this pane be once its surface exists," derived from window geometry plus stored chrome. It must not call `document.querySelector` — reading the current DOM is precisely what makes the answer describe the wrong surface. The live helpers stay as they are for the mounted case; this is a sibling, not a replacement.
-2. **Inputs are all available without rendering anything.** `window.innerWidth` / `innerHeight`; sidebar from `runner.sidebar.collapsed` and `runner.sidebar.width` (`Sidebar.tsx:155` — it is draggable, so the width is stored, and collapsed renders as an overlay costing no layout width — confirm); chat side panel from `runner.chat.panel.open` / `.width`; `CHAT_HEADER_HEIGHT_PX`; and the pane's share of its tab from the persisted layout via `paneBoxForSession`. Mission sessions take the mission chrome constants the same way.
-3. **Fail null, never approximate.** When any input is missing or implausible, return null and let the backend's persisted rung take over. A persisted `last_cols` described a real pane once; a confidently wrong estimate never did. This is the principle that would have prevented both defects in this family, and it applies especially to the `window.innerWidth` fallback — delete it rather than repair it.
-4. **Keep the measured rung.** It is dead at cold launch today, but it is correct whenever it does resolve, costs nothing, and becomes live if the boot route changes or a second window ever resumes. Document its reachability where it is defined so the next reader does not mistake it for the working path.
-5. **Verify against a packaged build.** `pnpm tauri dev` cannot reproduce this class — separate origin, separate database. Any check that only passes under `tauri dev` proves nothing here. Unit tests should drive the computation directly with injected geometry and stored values rather than through a rendered tree.
-
-## Open questions
-
-- **Collapsed sidebar width.** Confirm the collapsed sidebar is an overlay contributing 0 to layout width rather than a persistent thin strip; the peek overlay behavior suggests overlay, but the predictive path needs the exact number.
-- **Zoom.** `window.innerWidth` is in CSS pixels and app zoom scales them, so the stored chrome constants and the window measurement should already be in the same space — worth confirming rather than assuming, given #360's WebKit zoom surprise.
-- **Whether the live helpers should also stop falling back.** `shellContentBox`'s `window.innerWidth` fallback is wrong in the live case too, just less visibly. Fixing it there is in scope if it does not disturb mounted-pane behavior; if it does, that is a separate finding.
-
-## Goals
-
-- A session auto-resumed at launch in a **packaged** build forks at the width it will actually be displayed at, with the chat side panel open and several tabs present.
-- The width estimate never silently substitutes a different box; unknown inputs produce null and defer to the persisted value.
-- Live, mounted-pane sizing is unchanged.
+1. **Keep the `<main>` measurement.** It is route-independent, and it captures sidebar collapse, drag width, animation, and peek-overlay state for free. Do not replace it with a reconstruction from stored values.
+2. **Fail null instead of substituting a different box.** When `<main>` is missing or zero-width, return null and let the precedence chain fall to the persisted rung. A persisted `last_cols` described a real pane once; `window.innerWidth` describes a box that includes chrome the terminal never gets.
+3. **Fix the multiple-`<main>` selector while here.** `querySelector("main")` picking a hidden element is a latent trap independent of the fallback. Scope the lookup to the shell's own element rather than relying on document order.
+4. **No change to the precedence chain.** 0036's measured → estimated → persisted → default ordering stands, and its decision 2 was right after all — no correction note is owed to it.
 
 ## Non-Goals
 
-- Changing 0036's precedence order — measured → estimated → persisted → default is right; only the estimated rung's implementation is wrong.
-- Changing the window-settle gate, the 300ms stagger, or anything in #320's auto-resume semantics.
-- Repairing scrollback already mis-wrapped by earlier versions.
-- Reworking live terminal sizing for mounted panes beyond the fallback noted in open questions.
+- Replacing, rewriting, or DOM-freeing the estimate. That was the original draft's proposal and it is withdrawn.
+- Anything in #367 / impl 0039.
+- Changing the window-settle gate, the 300ms stagger, or #320's auto-resume semantics.
 
 ## Implementation Phases
 
-### Phase 1 — predictive sizing path
+### Phase 1 — fallback and selector
 
-- Add the DOM-free computation described in decisions 1–2, for both chat and mission destinations.
-- Point `launchDims.ts`'s estimate rung at it; leave the measured rung intact with a reachability comment.
-- Remove the `window.innerWidth` fallback from the predictive path entirely (decision 3).
+- `shellContentBox` returns null when it cannot measure the shell's `<main>`; callers propagate null rather than substituting.
+- Scope the element lookup so a Settings-route `<main>` cannot shadow the shell's.
 
-### Phase 2 — tests
+### Phase 2 — tests and validation
 
-- Drive the computation directly with injected window dimensions and stored chrome: panel open vs closed, sidebar expanded vs collapsed, single pane vs 2- and 3-pane splits, missing keys, implausible values.
-- Assert the null-not-approximate contract: any missing input yields null rather than a number.
-
-### Phase 3 — verification and record
-
-- Full check matrix: `cargo fmt --check`, `cargo clippy --workspace`, `cargo test --workspace`, `pnpm exec tsc --noEmit`, `pnpm run lint`, `pnpm test`.
-- Append a correction note to 0036 decision 2 pointing at 0038 and #366.
+- Unit-test: absent `<main>` → null; zero-rect `<main>` → null; two `<main>`s with the first hidden → the shell's box, not the other one.
+- `pnpm exec tsc --noEmit`, `pnpm run lint`, `pnpm test`.
 
 ## Verification
 
 Automated:
 
-- [ ] Predictive width with the panel open matches panel-closed width minus the stored panel width — and neither reads the DOM.
-- [ ] Collapsed vs expanded sidebar changes the result by the stored sidebar width.
-- [ ] A session in a 2-pane split gets roughly half the pane area; a 3-pane `cols-3` and a `main-2` with the same pane count give different boxes.
-- [ ] Any missing or implausible input yields null.
-- [ ] Mounted-pane (live) sizing is unchanged.
+- [ ] No measurable `<main>` yields null, and the launch path defers to the persisted rung rather than forking on `window.innerWidth`.
+- [ ] A hidden first `<main>` does not shadow the shell's.
+- [ ] Estimates with a normally-laid-out `<main>` are unchanged, panel open and closed.
 
-Manual (Jason smoke-tests, **packaged build only**):
+Manual (Jason smoke-tests, **packaged build**):
 
-- [ ] Panel open, auto-resume on, quit and relaunch → restored pane wraps at the correct width.
-- [ ] Same with the panel closed.
-- [ ] Same with the sidebar collapsed, and with a widened sidebar.
-- [ ] Same for a session in a 2-pane split tab.
-- [ ] Resize the window between quit and relaunch → still correct (the #363 case stays fixed).
+- [ ] Auto-resume with the Settings surface open at quit → restored panes wrap correctly.
+- [ ] Ordinary quit/relaunch with the panel open → unchanged from today.

--- a/docs/impls/0040-width-tagged-replay.md
+++ b/docs/impls/0040-width-tagged-replay.md
@@ -1,0 +1,110 @@
+# Width-tagged replay — retire the ring purge
+
+## Status
+
+Implemented. Root-cause fix for the recurring launch/spawn width family: [#306](https://github.com/yicheng47/runner/issues/306), [#352](https://github.com/yicheng47/runner/issues/352), [#363](https://github.com/yicheng47/runner/issues/363), [#366](https://github.com/yicheng47/runner/issues/366), [#367](https://github.com/yicheng47/runner/issues/367), impls 0035/0036/0038/0039.
+
+### The confirmed mechanism
+
+Reproduced on a build carrying #367's merge: after restart, most tabs render garbled — two frames interleaved character-by-character in the same cells, not narrow wrapping. Clicking a tab *before* it renders leaves that tab correct. Resizing the window repairs any tab.
+
+The drain is where it happens. `tryDrainReplay` (`RunnerTerminal.tsx:1198`) runs on activation:
+
+```js
+fit.fit();       // :1243 — resize the terminal to the PANE width
+t.reset();
+queued.forEach(ev => write(decodeBase64Chunk(ev.data)));   // bytes produced at the FORK width
+```
+
+The snapshot was fetched at **mount** (`:1339`) — while the pane was hidden — and parked in `pendingSnapshotRef`. So the drain fits to the pane width and then writes bytes laid out for a different width. The backend purge cannot prevent this: it fires asynchronously after the resize IPC, long after the frontend already holds the bytes client-side.
+
+That accounts for all three observations. A hidden pane never pushes its size, so the fork width persists for as long as the agent is producing output. Activating early fits and pushes the real size before the agent paints. A window resize forces a full repaint at the correct width.
+
+It also explains why every fork-width fix missed: each was correct but only sufficient when the fork width happened to equal the eventual pane width.
+
+### Correction to an earlier deferral
+
+This document was briefly marked deferred on the reasoning that the ring is empty at restart. That was wrong — the ring is empty at *process start*, but fills between resume and first tab activation, which is exactly the window the bug lives in. Same shape as the MCP-mission case, triggered by restart rather than by MCP.
+
+### Note on scope
+
+Decision 4 (deleting the backend purge) is severable. The rendering fix is decisions 1-3 and 6 — replay at the produced width, then reflow. The purge can be removed in the same change or left as dead weight for a follow-up; deleting it is not required to fix the symptom.
+
+## Problem
+
+The ring stores raw PTY bytes with no record of the width they were produced at (`session/manager/mod.rs:401-409`). Those bytes are width-coupled — absolute cursor positioning and hard wraps baked in — so replaying them into a different-width grid shreds them. Runner's answer was to detect the mismatch and destroy the history instead (`output.rs:538-546`, impl 0020).
+
+That turned "what width should we fork at?" into a data-integrity invariant: the width chosen *before the pane exists* must exactly equal the width the pane will have, or the transcript is deleted. No component owns that invariant. It is re-decided at three `unwrap_or(DEFAULT_PTY_SIZE)` sites (`spawn.rs:233`, `:789`, `:1077`) across ~7 call paths, and it **defaults to wrong** — any caller that doesn't thread a measurement silently gets 80×24.
+
+Hence the recurrence. Each fix taught one more caller to guess right; none removed the need to guess.
+
+## The mechanism, already proven
+
+`src/lib/xtermReflow.test.ts` (9 tests, green on the pinned `@xterm/xterm 6.1.0-beta.220`) establishes:
+
+- A completed wrapped line reflows correctly when widened **and** when narrowed.
+- **Deep scrollback reflows**, not just the viewport — 30 lines past the viewport all rejoin.
+- Multi-run replay works: write@80 → resize 200 → write → resize 150 → write → resize 120 leaves all three runs intact.
+- Resizing without awaiting `write()`'s callback matches the awaited result.
+- Alt-screen excursions leave the primary scrollback beneath them untouched.
+- **The unterminated line the cursor sits on does not reflow.** Deliberate and fine to rely on: that is the live frame the agent repaints on SIGWINCH.
+
+So replaying each width-run at the width it was produced at, then resizing to the pane, reconstructs history correctly. No server-side terminal state, no VT crate, no new process.
+
+## Key Decisions
+
+1. **Tag ring chunks with the cols they were produced at.** `OutputEvent` gains a width. `last_pty_cols` stops being a purge gate and becomes the current-width bookkeeping that feeds the tag.
+2. **Replay in width-runs.** Group consecutive same-width chunks; for each run `resize(runCols, rows)` → `write(bytes)` → await the callback → next run. Finish with a resize to the pane's real grid.
+3. **Replay resizes must never reach the PTY.** Suppress the backend push for the duration of the drain — `resizeDisabledRef` (`RunnerTerminal.tsx:196`) already gates `pushSize` (`:789`) and is the mechanism to reuse. A replay resize that propagates would SIGWINCH the child to 80 and defeat the entire change.
+4. **Delete the backend purge and its cols-gate**, `output.rs:538-546`. `runtime_clears_on_resize` (`:796`) goes with it if nothing else reads it.
+5. **Leave the frontend's live-resize clear alone.** `runtimeClearsOnResize` in `RunnerTerminal.tsx` gates a viewport clear on *live* resize to stop reflow stacking — a different concern from replay. Do not touch it here; note whether it became redundant and leave that as a follow-up.
+6. **Untagged chunks fall back to the session's fork width.** Sessions already running across the upgrade, and any chunk missing a tag, replay at the fork width rather than being dropped.
+7. **0039's cached grid stays.** It becomes an optimization (fork close to the destination, fewer reflows) rather than a correctness requirement. Do not rip it out in this change.
+
+## Goals
+
+- A session that forks at any width and is displayed at any other keeps its full scrollback, correctly wrapped.
+- Spawn width stops being load-bearing: 80×24 is acceptable everywhere.
+
+## Non-Goals
+
+- Server-side terminal state, a VT parser crate, or a PTY-owning process. Explicitly rejected — the emulator we already ship does the work.
+- Changing spawn sites, MCP tool schemas, or 0039's cache.
+- Reflowing alt-screen content.
+- Touching the blank gate, the #108 wake dance, or the transitional latch beyond what decision 3 requires.
+
+## Implementation Phases
+
+### Phase 1 — backend tagging
+
+- `OutputEvent` carries the width its bytes were produced at; the ring and live fanout both populate it.
+- Delete the cols-gate purge (decision 4).
+- Tests: chunks written across a resize carry distinct widths; a resize no longer empties the ring.
+
+### Phase 2 — segmented replay
+
+- Group the snapshot into width-runs and drain per decision 2, inside the existing `pendingSnapshotRef` / `tryDrainReplay` path.
+- Gate backend resize pushes for the drain's duration (decision 3).
+- Tests: a snapshot spanning three widths replays to the same buffer the spike's multi-run test produces; no `session_resize` is issued during a drain.
+
+### Phase 3 — validation
+
+- `cargo fmt --check`, `cargo clippy --workspace`, `cargo test --workspace`, `pnpm exec tsc --noEmit`, `pnpm run lint`, `pnpm test`.
+- `src/lib/xtermReflow.test.ts` must stay green — it is the contract this design rests on.
+
+## Verification
+
+Automated:
+
+- [ ] A session forked at 80 and replayed into a 200-col pane yields unwrapped, intact scrollback.
+- [ ] A resize no longer purges the ring, for every runtime.
+- [ ] No PTY resize is issued during replay drain.
+- [ ] Untagged chunks replay at the fork width.
+- [ ] The spike's reflow tests still pass.
+
+Manual (Jason smoke-tests, packaged build):
+
+- [ ] Start an MCP mission, leave the slot closed for several minutes, open it — full transcript, correctly wrapped.
+- [ ] Quit and relaunch with auto-resume, into a window resized since quit — scrollback intact and correctly wrapped.
+- [ ] Resize the window while a claude-code pane is live — no scrollback loss, no shredded box-drawing (#306 must not return).
+- [ ] Switch tabs repeatedly on a mission with several slots — no flicker through intermediate widths, no history loss (#352 must not return).

--- a/src-tauri/src/commands/mission.rs
+++ b/src-tauri/src/commands/mission.rs
@@ -490,12 +490,10 @@ pub async fn mission_post_human_signal(
 /// `mission_start_impl_with_size` with the dims it measured.
 ///
 /// An MCP caller is an agent with no view of the window, so instead of
-/// forking at `DEFAULT_PTY_SIZE` (which seeds `last_pty_cols = 80` and
-/// makes the first real resize purge the whole transcript) we reuse the
-/// last grid a mission pane actually measured. An empty cache still
-/// means 80×24: guessing would not avoid the purge, and the cache
-/// self-heals as soon as any mission pane has rendered once. See impl
-/// 0039.
+/// forking at `DEFAULT_PTY_SIZE` we reuse the last grid a mission pane
+/// actually measured. An empty cache still means 80×24; width-tagged
+/// replay preserves the transcript either way, while the cache improves
+/// first paint and reduces reflow. See impls 0039 and 0040.
 pub(crate) async fn mission_start_impl(
     state: &AppState,
     app: &tauri::AppHandle,
@@ -1423,12 +1421,9 @@ pub(crate) async fn mission_reset_impl(
     // see the analogous block in `mission_start`. See issue #171.
     for (idx, member) in roster.iter().enumerate() {
         let first_turn = first_turns.get(idx).cloned().flatten();
-        // `initial_size` matters beyond first paint: an unsized respawn
-        // forks at 80×24 and seeds the resize purge gate at 80 cols, so
-        // the agent's launch frames land in the ring at 80 cols and the
-        // first slot-tab activation's real-cols push purges them all
-        // (`SessionManager::resize` cols-gate). Sized respawns make that
-        // push a same-width no-op and the opening history survives.
+        // A measured `initial_size` gives the respawn a closer first paint
+        // and avoids replay reflow when the pane returns. Width-tagged
+        // replay preserves the opening history even when this is absent.
         let register_res = state.sessions.register_mission_session(
             &mission_for_spawn,
             &member.runner,

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -120,9 +120,9 @@ pub async fn session_resize(
 ///
 /// The frontend calls this with the same dims it pushes to
 /// `session_resize`, from the same place — this adds no measuring pass
-/// of its own. Rust never derives a grid from window geometry: the
-/// purge gate is exact equality on cols, so an estimate that lands one
-/// column off purges exactly as hard as no estimate. See impl 0039.
+/// of its own. Rust never derives a grid from window geometry; a measured
+/// grid improves the next backend-initiated fork without becoming a
+/// replay-correctness requirement. See impls 0039 and 0040.
 ///
 /// Async so the SQLite write stays off the main thread — this fires on
 /// every deduped size change, including each column crossed during a

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -209,11 +209,10 @@ impl PaneSurface {
 
 /// A terminal grid the frontend actually measured, not one computed from
 /// window geometry. Backend-initiated spawns (MCP `mission_start`,
-/// `session_start_direct`) have no pane to measure, and forking at
-/// `DEFAULT_PTY_SIZE` seeds `last_pty_cols = 80`; the first real-cols
-/// resize then trips the purge gate and discards the transcript. The
-/// cols-gate is exact equality, so only a real measurement helps — see
-/// impl 0039.
+/// `session_start_direct`) have no pane to measure. Reusing a real grid
+/// gives them a closer first paint and avoids unnecessary replay reflow;
+/// width-tagged replay still preserves history when the cache is absent
+/// or stale. See impls 0039 and 0040.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PaneGrid {
     pub cols: u16,

--- a/src-tauri/src/mcp/tools/session.rs
+++ b/src-tauri/src/mcp/tools/session.rs
@@ -45,9 +45,9 @@ impl RunnerMcpHandler {
     ) -> Result<CallToolResult, ErrorData> {
         let app_state = self.state.app_state();
         // An MCP caller has no view of the window, so reuse the last
-        // grid a chat pane measured rather than forking at 80×24 and
-        // letting the first real resize purge the transcript. Empty
-        // cache keeps today's behavior. See impl 0039.
+        // grid a chat pane measured rather than forking at 80×24.
+        // Empty cache keeps today's behavior; width-tagged replay makes
+        // either path safe. See impls 0039 and 0040.
         let cached =
             crate::db::pane_grid(&app_state.db, crate::db::PaneSurface::Chat).unwrap_or_default();
         let output = session::session_start_direct_impl(

--- a/src-tauri/src/session/manager/mod.rs
+++ b/src-tauri/src/session/manager/mod.rs
@@ -404,6 +404,8 @@ pub struct OutputEvent {
     /// Monotonic per-session sequence number. Frontend attach uses this to
     /// merge a replay snapshot with live events without duplicating chunks.
     pub seq: u64,
+    /// PTY columns in effect when this chunk was read.
+    pub width: u16,
     /// Base64-encoded raw bytes read from the PTY.
     pub data: String,
 }
@@ -554,10 +556,8 @@ struct SessionState {
     mouse_1003_on: bool,
     mouse_1006_on: bool,
     /// Cols of the last PTY winsize applied (seeded at spawn, updated by
-    /// `resize`). Gates the resize ring purge: rows-only changes — the
-    /// frontend's SIGWINCH nudge dance on every tab return — can't garble
-    /// replay reflow (wrap depends on cols alone), so the ring survives
-    /// them; only a real width change still purges.
+    /// `resize`). Output chunks copy this value so the frontend can replay
+    /// each width-run into xterm before reflowing to the pane.
     last_pty_cols: Option<u16>,
     resuming: bool,
     killed: bool,
@@ -887,9 +887,7 @@ impl SessionManager {
             state.handle = Some(handle);
             state.mission_status_sink = mission_status_sink;
             state.killed = false;
-            // Seed the resize purge gate with the cols the PTY actually
-            // opened at, so the first same-width resize after spawn/resume
-            // doesn't purge the ring.
+            // Seed output tagging with the cols the PTY actually opened at.
             state.last_pty_cols = Some(
                 initial_size
                     .expect("spawn size must be resolved before handle install")

--- a/src-tauri/src/session/manager/output.rs
+++ b/src-tauri/src/session/manager/output.rs
@@ -516,34 +516,10 @@ impl SessionManager {
         };
         // Pane geometry is the next fork's desired size even if the current
         // PTY rejects the ioctl. Keep last_pty_cols as the last size actually
-        // applied so a failed live resize cannot trigger a ring purge.
+        // applied so output is never tagged with a rejected width.
+        let mut state = state.lock().unwrap();
         self.runtime.resize(&rt_session, cols, rows)?;
-        // Full-repaint TUI runtimes (claude-code, codex, qoder, trae) redraw the whole
-        // frame on SIGWINCH, so bytes buffered before a *width* change
-        // describe a stale grid width. Replaying them into the new grid on
-        // a later snapshot re-attach wraps their absolute-positioned frames
-        // wrong — box-drawing borders shredded into scrollback garbage
-        // (seen dogfooding split view, impl 0020). Drop them: the incoming
-        // repaint rebuilds the buffer at the new width, and the frontend
-        // already hard-clears its local viewport for these runtimes on
-        // width changes.
-        //
-        // Rows-only resizes keep the ring: reflow depends on cols alone,
-        // and the frontend's activation dance nudges rows (rows-1 → rows)
-        // with width held constant on every tab return — purging there
-        // threw away claude-code history that snapshot replay could have
-        // restored (the #306 symptom: remount shows only the latest
-        // frame). Shells keep their buffer unconditionally — no repaint
-        // would arrive, and their history is meaningful.
-        let cols_changed = {
-            let mut state = state.lock().unwrap();
-            let changed = state.last_pty_cols != Some(cols);
-            state.last_pty_cols = Some(cols);
-            changed
-        };
-        if cols_changed && runtime_clears_on_resize(session_id, pool) {
-            self.purge_output_buffer_keep_modes(session_id);
-        }
+        state.last_pty_cols = Some(cols);
         Ok(())
     }
 
@@ -600,6 +576,7 @@ impl SessionManager {
                     session_id: session_id.into(),
                     mission_id: None,
                     seq: 0,
+                    width: state.last_pty_cols.unwrap_or(DEFAULT_PTY_SIZE.0),
                     data: BASE64.encode(synthetic_prefix),
                 },
             );
@@ -673,18 +650,6 @@ impl SessionManager {
             state.mouse_1006_on = false;
         }
         self.prune_empty_session_state(session_id);
-    }
-
-    /// Buffer-only purge for `resize`: the child process survives, so its
-    /// terminal modes persist — a SIGWINCH repaint does not re-emit the
-    /// enter-alt-screen / bracketed-paste escapes, and clearing the flags
-    /// here would strip the synthetic prefix a later snapshot needs. The
-    /// seq counter is likewise untouched.
-    fn purge_output_buffer_keep_modes(&self, session_id: &str) {
-        if let Some(state) = self.session_state(session_id) {
-            let mut state = state.lock().unwrap();
-            state.output_buffer.clear();
-        }
     }
 
     /// Update per-session terminal mode flags from a raw runtime
@@ -776,6 +741,7 @@ impl SessionManager {
             session_id: session_id.into(),
             mission_id: mission_id.map(str::to_string),
             seq,
+            width: state.last_pty_cols.unwrap_or(DEFAULT_PTY_SIZE.0),
             data,
         };
 
@@ -785,33 +751,6 @@ impl SessionManager {
         }
         ev
     }
-}
-
-/// Whether the session's agent runtime fully repaints on SIGWINCH — the
-/// same set the frontend's `runtimeClearsOnResize` gates its local
-/// viewport clear on. Runner-backed sessions leave
-/// `sessions.agent_runtime` NULL and carry their runtime on the runner
-/// row, hence the COALESCE join (same pattern as the direct-chat
-/// queries). Best-effort: a DB miss keeps the buffer.
-pub(super) fn runtime_clears_on_resize(session_id: &str, pool: &DbPool) -> bool {
-    let Ok(conn) = pool.get() else {
-        return false;
-    };
-    let runtime = conn
-        .query_row(
-            "SELECT COALESCE(s.agent_runtime, r.runtime)
-               FROM sessions s
-               LEFT JOIN runners r ON r.id = s.runner_id
-              WHERE s.id = ?1",
-            params![session_id],
-            |r| r.get::<_, Option<String>>(0),
-        )
-        .ok()
-        .flatten();
-    matches!(
-        runtime.as_deref(),
-        Some("claude-code") | Some("codex") | Some("qoder") | Some("trae")
-    )
 }
 
 /// Whether `resume` should drop the session's output ring before

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -3979,13 +3979,11 @@ fn enter_claude_launch_gate_first_claude_does_not_sleep() {
     );
 }
 
-// Regression for the resize buffer purge (impl 0020 dogfooding): the
-// runtime lookup must resolve runner-backed sessions too, where
+// The resume-purge lookup must resolve runner-backed sessions too, where
 // `sessions.agent_runtime` is NULL and the runtime lives on the runner
-// row — the common "Chat now" / mission path. A shell runner must NOT
-// purge (no SIGWINCH repaint would rebuild its history).
+// row — the common "Chat now" / mission path.
 #[test]
-fn runtime_clears_on_resize_resolves_runner_backed_runtimes() {
+fn runtime_purges_on_resume_resolves_runner_backed_runtimes() {
     let pool = db::open_in_memory().unwrap();
     let now = chrono::Utc::now().to_rfc3339();
     let conn = pool.get().unwrap();
@@ -4041,42 +4039,31 @@ fn runtime_clears_on_resize_resolves_runner_backed_runtimes() {
     .unwrap();
     drop(conn);
 
-    assert!(super::output::runtime_clears_on_resize(
+    assert!(super::output::runtime_purges_on_resume(
         "s-codex-runner",
-        &pool
-    ));
-    assert!(super::output::runtime_clears_on_resize(
-        "s-claude-runtime",
-        &pool
-    ));
-    assert!(super::output::runtime_clears_on_resize(
-        "s-qoder-runner",
-        &pool
-    ));
-    assert!(super::output::runtime_clears_on_resize(
-        "s-trae-runner",
         &pool
     ));
     assert!(super::output::runtime_purges_on_resume(
         "s-trae-runner",
         &pool
     ));
-    assert!(!super::output::runtime_clears_on_resize(
+    assert!(super::output::runtime_purges_on_resume(
         "s-shell-runner",
         &pool
     ));
-    assert!(!super::output::runtime_clears_on_resize("s-missing", &pool));
+    assert!(super::output::runtime_purges_on_resume("s-missing", &pool));
+    assert!(!super::output::runtime_purges_on_resume(
+        "s-claude-runtime",
+        &pool
+    ));
+    assert!(!super::output::runtime_purges_on_resume(
+        "s-qoder-runner",
+        &pool
+    ));
 }
 
-// The resize ring purge must gate on a *width* change. The frontend's
-// activation dance resizes rows-1 → rows with cols held constant on
-// every tab return; purging there wiped claude-code's replayable
-// history even though rows-only SIGWINCHes can't garble reflow (wrap
-// depends on cols alone) — the #306 "remount shows only the latest
-// frame" symptom. Spawn seeds the gate, so even the first same-width
-// resize keeps the ring.
 #[test]
-fn resize_purges_ring_only_on_cols_change() {
+fn output_chunks_keep_the_ring_and_carry_the_applied_width_across_resize() {
     let pool = pool_with_schema();
     let now = Utc::now().to_rfc3339();
     let runner_id = ulid::Ulid::new().to_string();
@@ -4115,29 +4102,20 @@ fn resize_purges_ring_only_on_cols_change() {
         )
         .unwrap();
 
-    fake.push_output(0, b"history to keep");
-    let deadline = Instant::now() + Duration::from_secs(2);
-    while mgr.output_snapshot(&spawned.id).is_empty() {
-        if Instant::now() > deadline {
-            panic!("output never reached the ring");
-        }
-        std::thread::sleep(Duration::from_millis(20));
-    }
+    fake.push_output(0, b"first width");
+    let first = wait_for_snapshot(&mgr, &spawned.id, 1);
+    assert_eq!(first[0].width, 120);
 
-    // Rows-only nudge (the activation dance): ring must survive both legs.
     mgr.resize(&spawned.id, 120, 29, &pool).unwrap();
     mgr.resize(&spawned.id, 120, 30, &pool).unwrap();
-    assert!(
-        !mgr.output_snapshot(&spawned.id).is_empty(),
-        "rows-only resize must keep the replay ring"
+    mgr.resize(&spawned.id, 100, 30, &pool).unwrap();
+    fake.push_output(0, b"second width");
+    let snapshot = wait_for_snapshot(&mgr, &spawned.id, 2);
+    assert_eq!(
+        snapshot.iter().map(|event| event.width).collect::<Vec<_>>(),
+        vec![120, 100]
     );
 
-    // Width change: stale-width bytes must still purge.
-    mgr.resize(&spawned.id, 100, 30, &pool).unwrap();
-    assert!(
-        mgr.output_snapshot(&spawned.id).is_empty(),
-        "cols change must purge the replay ring"
-    );
     let persisted: (u16, u16) = pool
         .get()
         .unwrap()

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -53,6 +53,7 @@ import {
   terminalSizeAfterRejectedPush,
   type TerminalGridSize,
 } from "../lib/terminalResize";
+import { replayOutputAtWidths } from "../lib/terminalReplay";
 import { TERMINAL_SCROLLBAR_WIDTH_PX } from "../lib/terminalSizing";
 import { observeBackingScale, stalesTextureAtlas } from "../lib/textureAtlas";
 import { eventMatchesShortcut } from "../lib/keymap";
@@ -63,6 +64,7 @@ interface OutputEvent {
   session_id: string;
   mission_id: string | null;
   seq: number;
+  width?: number;
   data: string;
 }
 
@@ -193,7 +195,9 @@ export const RunnerTerminal = forwardRef<
   // closures don't capture a stale value across the long-lived
   // terminal effect.
   const disabledRef = useRef<boolean>(disabled ?? false);
+  const resizeDisabledPropRef = useRef<boolean>(resizeDisabled ?? false);
   const resizeDisabledRef = useRef<boolean>(resizeDisabled ?? false);
+  const replayResizeSuppressionCountRef = useRef(0);
   // Mirrors `autoFocus` for the activation effect below.
   const autoFocusRef = useRef<boolean>(autoFocus ?? true);
   // Last (cols, rows) pushed to the backend. Shared between `pushSize`
@@ -261,8 +265,21 @@ export const RunnerTerminal = forwardRef<
   }, [sessionId]);
 
   useEffect(() => {
-    resizeDisabledRef.current = resizeDisabled ?? false;
+    resizeDisabledPropRef.current = resizeDisabled ?? false;
+    resizeDisabledRef.current =
+      resizeDisabledPropRef.current ||
+      replayResizeSuppressionCountRef.current > 0;
   }, [resizeDisabled]);
+
+  const setReplayResizeSuppressed = useCallback((suppressed: boolean) => {
+    replayResizeSuppressionCountRef.current = Math.max(
+      0,
+      replayResizeSuppressionCountRef.current + (suppressed ? 1 : -1),
+    );
+    resizeDisabledRef.current =
+      resizeDisabledPropRef.current ||
+      replayResizeSuppressionCountRef.current > 0;
+  }, []);
 
   useEffect(() => {
     const nextDisabled = disabled ?? false;
@@ -379,10 +396,27 @@ export const RunnerTerminal = forwardRef<
       if (!t || !fit || !node) return false;
       const rect = node.getBoundingClientRect();
       if (rect.width <= 0 || rect.height <= 0) return false;
+      const deferUntilReplayFlushed = () => {
+        if (!replayFlushPendingRef.current) return false;
+        if (focus && !disabledRef.current) t.focus();
+        replayAfterFlushRef.current.push(() => {
+          window.requestAnimationFrame(() => {
+            refreshActiveTerminal({
+              focus,
+              forceResizeDance,
+              pushBackendSize,
+            });
+          });
+        });
+        return true;
+      };
+      if (deferUntilReplayFlushed()) return true;
       try {
         const beforeCols = t.cols;
         const beforeRows = t.rows;
         ensureWebglRenderer();
+        tryDrainReplayRef.current?.();
+        if (deferUntilReplayFlushed()) return true;
         fit.fit();
         if (t.cols !== beforeCols || t.rows !== beforeRows) {
           console.info(
@@ -391,20 +425,6 @@ export const RunnerTerminal = forwardRef<
               `disabled=${disabledRef.current} forceDance=${forceResizeDance} ` +
               `pushBackend=${pushBackendSize}`,
           );
-        }
-        tryDrainReplayRef.current?.();
-        if (replayFlushPendingRef.current) {
-          if (focus && !disabledRef.current) t.focus();
-          replayAfterFlushRef.current.push(() => {
-            window.requestAnimationFrame(() => {
-              refreshActiveTerminal({
-                focus,
-                forceResizeDance,
-                pushBackendSize,
-              });
-            });
-          });
-          return true;
         }
         t.refresh(0, t.rows - 1);
         if (focus && !disabledRef.current) t.focus();
@@ -826,6 +846,12 @@ export const RunnerTerminal = forwardRef<
       sendBackendResize(current);
     };
     reassertSizeRef.current = () => {
+      if (replayFlushPendingRef.current) {
+        replayAfterFlushRef.current.push(() => {
+          reassertSizeRef.current?.();
+        });
+        return;
+      }
       const node = containerRef.current;
       if (!node) return;
       const rect = node.getBoundingClientRect();
@@ -870,6 +896,12 @@ export const RunnerTerminal = forwardRef<
       if (!containerRef.current) return;
       const rect = containerRef.current.getBoundingClientRect();
       if (rect.width <= 0 || rect.height <= 0) return;
+      if (replayFlushPendingRef.current) {
+        replayAfterFlushRef.current.push(() => {
+          refitAndPush({ allowPendingLargeDrop });
+        });
+        return;
+      }
       try {
         const beforeCols = term.cols;
         const beforeRows = term.rows;
@@ -1240,12 +1272,14 @@ export const RunnerTerminal = forwardRef<
         return false;
       }
 
+      const fallbackWidth = t.cols;
       try {
         fit.fit();
       } catch {
         // teardown in progress
         return false;
       }
+      const target = { cols: t.cols, rows: t.rows };
 
       t.reset();
       const queued: OutputEvent[] = [];
@@ -1263,9 +1297,9 @@ export const RunnerTerminal = forwardRef<
         lastWrittenSeqRef.current = ev.seq;
       }
       pendingLiveRef.current = [];
-      replayDoneRef.current = true;
 
       if (queued.length === 0) {
+        replayDoneRef.current = true;
         return true;
       }
 
@@ -1277,13 +1311,67 @@ export const RunnerTerminal = forwardRef<
         for (const cb of callbacks) cb();
       };
 
-      queued.forEach((ev, index) => {
-        const isLast = index === queued.length - 1;
-        termRef.current?.write(
-          decodeBase64Chunk(ev.data),
-          isLast ? onReplayFlushed : undefined,
-        );
-      });
+      const takePendingChunks = () => {
+        if (pendingLiveOverflowRef.current) return [];
+        const pending = pendingLiveRef.current;
+        pendingLiveRef.current = [];
+        const next: Array<{ data: Uint8Array; width?: number }> = [];
+        for (const ev of pending) {
+          if (ev.seq <= lastWrittenSeqRef.current) continue;
+          lastWrittenSeqRef.current = ev.seq;
+          next.push({
+            data: decodeBase64Chunk(ev.data),
+            width: ev.width,
+          });
+        }
+        return next;
+      };
+
+      void replayOutputAtWidths({
+        terminal: t,
+        initialChunks: queued.map((ev) => ({
+          data: decodeBase64Chunk(ev.data),
+          width: ev.width,
+        })),
+        takePendingChunks,
+        fallbackWidth,
+        target,
+        setResizeSuppressed: setReplayResizeSuppressed,
+        shouldContinue: () =>
+          !cancelled &&
+          termRef.current === t &&
+          sessionIdRef.current === sessionId,
+      })
+        .then((completed) => {
+          if (
+            !completed ||
+            cancelled ||
+            termRef.current !== t ||
+            sessionIdRef.current !== sessionId
+          ) {
+            return;
+          }
+          if (pendingLiveOverflowRef.current) {
+            replayFlushPendingRef.current = false;
+            pendingSnapshotRef.current = [];
+            tryDrainReplayRef.current?.();
+            return;
+          }
+          replayDoneRef.current = true;
+          onReplayFlushed();
+        })
+        .catch((error) => {
+          if (
+            cancelled ||
+            termRef.current !== t ||
+            sessionIdRef.current !== sessionId
+          ) {
+            return;
+          }
+          replayDoneRef.current = true;
+          onReplayFlushed();
+          onErrorRef.current?.(String(error));
+        });
       return true;
     };
     tryDrainReplayRef.current = tryDrainReplay;
@@ -1348,7 +1436,12 @@ export const RunnerTerminal = forwardRef<
       unlistenOutput?.();
       unlistenExit?.();
     };
-  }, [sessionId, refreshActiveTerminal, blankGate]);
+  }, [
+    sessionId,
+    refreshActiveTerminal,
+    blankGate,
+    setReplayResizeSuppressed,
+  ]);
 
   // Latch WHY this terminal is inactive. `active=false` with
   // `disabled=true` is the transitional resume/start window — the canvas
@@ -1434,6 +1527,12 @@ export const RunnerTerminal = forwardRef<
           return { cols: t.cols, rows: t.rows };
         }
         try {
+          if (replayFlushPendingRef.current) {
+            const proposed = fit.proposeDimensions();
+            return proposed
+              ? { cols: proposed.cols, rows: proposed.rows }
+              : null;
+          }
           // Force a fit before reading dims so a stopped pane reflects
           // its latest measurable container when the user clicks Resume.
           const beforeCols = t.cols;

--- a/src/lib/terminalReplay.test.ts
+++ b/src/lib/terminalReplay.test.ts
@@ -1,0 +1,122 @@
+/** @vitest-environment jsdom */
+
+import type { Terminal as TerminalType } from "@xterm/xterm";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { replayOutputAtWidths } from "./terminalReplay";
+
+let Terminal: new (opts: object) => TerminalType;
+
+function lines(term: TerminalType): string[] {
+  const buffer = term.buffer.active;
+  const output: string[] = [];
+  for (let index = 0; index < buffer.length; index += 1) {
+    const text = buffer.getLine(index)?.translateToString(true) ?? "";
+    if (text.length > 0) output.push(text);
+  }
+  return output;
+}
+
+beforeAll(async () => {
+  HTMLCanvasElement.prototype.getContext = (() => ({
+    measureText: () => ({ width: 8 }),
+    fillRect: () => {},
+    getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+  })) as never;
+  if (!window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: () => ({
+        matches: false,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }),
+    });
+  }
+  Terminal = (await import("@xterm/xterm")).Terminal as never;
+});
+
+describe("width-tagged terminal replay", () => {
+  it("replays snapshot and pending live width-runs before final reflow", async () => {
+    const term = new Terminal({
+      cols: 80,
+      rows: 24,
+      scrollback: 1000,
+      allowProposedApi: true,
+    });
+    const encode = (text: string) => new TextEncoder().encode(text);
+    let takePendingCount = 0;
+
+    await replayOutputAtWidths({
+      terminal: term,
+      initialChunks: [
+        { width: 80, data: encode("a".repeat(120) + "\r\n") },
+        { width: 80, data: encode("first-tail\r\n") },
+      ],
+      takePendingChunks: () => {
+        takePendingCount += 1;
+        return takePendingCount === 1
+          ? [
+              { width: 200, data: encode("second-run\r\n") },
+              { width: 150, data: encode("third-run\r\n") },
+            ]
+          : [];
+      },
+      fallbackWidth: 80,
+      target: { cols: 120, rows: 24 },
+      setResizeSuppressed: () => {},
+      shouldContinue: () => true,
+    });
+
+    expect(lines(term)).toEqual([
+      "a".repeat(120),
+      "first-tail",
+      "second-run",
+      "third-run",
+    ]);
+  });
+
+  it("uses the fallback width for legacy chunks and suppresses replay resizes", async () => {
+    const term = new Terminal({
+      cols: 80,
+      rows: 24,
+      scrollback: 1000,
+      allowProposedApi: true,
+    });
+    let resizeSuppressed = false;
+    let sessionResizeCalls = 0;
+    const replayWidths: number[] = [];
+    const terminal = {
+      resize(cols: number, rows: number) {
+        replayWidths.push(cols);
+        term.resize(cols, rows);
+        if (!resizeSuppressed) sessionResizeCalls += 1;
+      },
+      write(data: Uint8Array, callback: () => void) {
+        term.write(data, callback);
+      },
+    };
+
+    await replayOutputAtWidths({
+      terminal,
+      initialChunks: [
+        {
+          data: new TextEncoder().encode("legacy".repeat(20) + "\r\n"),
+        },
+      ],
+      takePendingChunks: () => [],
+      fallbackWidth: 80,
+      target: { cols: 120, rows: 24 },
+      setResizeSuppressed: (suppressed) => {
+        resizeSuppressed = suppressed;
+      },
+      shouldContinue: () => true,
+    });
+
+    expect(lines(term)).toEqual(["legacy".repeat(20)]);
+    expect(replayWidths).toEqual([80, 120]);
+    expect(sessionResizeCalls).toBe(0);
+    terminal.resize(100, 24);
+    expect(sessionResizeCalls).toBe(1);
+  });
+});

--- a/src/lib/terminalReplay.ts
+++ b/src/lib/terminalReplay.ts
@@ -1,0 +1,89 @@
+export interface TerminalReplayChunk {
+  data: Uint8Array;
+  width?: number | null;
+}
+
+interface ReplayTerminal {
+  resize(cols: number, rows: number): void;
+  write(data: Uint8Array, callback: () => void): void;
+}
+
+interface ReplayOptions {
+  terminal: ReplayTerminal;
+  initialChunks: TerminalReplayChunk[];
+  takePendingChunks: () => TerminalReplayChunk[];
+  fallbackWidth: number;
+  target: { cols: number; rows: number };
+  setResizeSuppressed: (suppressed: boolean) => void;
+  shouldContinue: () => boolean;
+}
+
+function chunkWidth(chunk: TerminalReplayChunk, fallbackWidth: number): number {
+  return Number.isInteger(chunk.width) && (chunk.width ?? 0) > 0
+    ? (chunk.width as number)
+    : fallbackWidth;
+}
+
+function joinChunks(
+  chunks: TerminalReplayChunk[],
+  start: number,
+  end: number,
+): Uint8Array {
+  if (end - start === 1) return chunks[start].data;
+  let length = 0;
+  for (let index = start; index < end; index += 1) {
+    length += chunks[index].data.length;
+  }
+  const joined = new Uint8Array(length);
+  let offset = 0;
+  for (let index = start; index < end; index += 1) {
+    joined.set(chunks[index].data, offset);
+    offset += chunks[index].data.length;
+  }
+  return joined;
+}
+
+function write(
+  terminal: ReplayTerminal,
+  data: Uint8Array,
+): Promise<void> {
+  return new Promise((resolve) => terminal.write(data, resolve));
+}
+
+export async function replayOutputAtWidths({
+  terminal,
+  initialChunks,
+  takePendingChunks,
+  fallbackWidth,
+  target,
+  setResizeSuppressed,
+  shouldContinue,
+}: ReplayOptions): Promise<boolean> {
+  setResizeSuppressed(true);
+  try {
+    let chunks = initialChunks;
+    while (chunks.length > 0) {
+      let start = 0;
+      while (start < chunks.length) {
+        if (!shouldContinue()) return false;
+        const width = chunkWidth(chunks[start], fallbackWidth);
+        let end = start + 1;
+        while (
+          end < chunks.length &&
+          chunkWidth(chunks[end], fallbackWidth) === width
+        ) {
+          end += 1;
+        }
+        terminal.resize(width, target.rows);
+        await write(terminal, joinChunks(chunks, start, end));
+        start = end;
+      }
+      chunks = takePendingChunks();
+    }
+    if (!shouldContinue()) return false;
+    terminal.resize(target.cols, target.rows);
+    return true;
+  } finally {
+    setResizeSuppressed(false);
+  }
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -142,6 +142,7 @@ export interface SessionOutputEvent {
   session_id: string;
   mission_id: string | null;
   seq: number;
+  width?: number;
   data: string;
 }
 

--- a/src/lib/xtermReflow.test.ts
+++ b/src/lib/xtermReflow.test.ts
@@ -1,0 +1,180 @@
+/** @vitest-environment jsdom */
+
+// Guards xterm's reflow behavior, which the replay design depends on.
+//
+// Today a session that forks at one width and is displayed at another has
+// its entire output ring destroyed (SessionManager::resize's cols-gate),
+// because replaying width-coupled bytes into a different-width grid shreds
+// them (#306 / impl 0020). The alternative is to replay each width-run at
+// the width it was produced at and let xterm reflow the result into the
+// pane's grid — no server-side terminal state, no purge.
+//
+// That rests on xterm reflowing completed lines in both directions,
+// including deep scrollback, on the beta we pin (@xterm/xterm
+// 6.1.0-beta.220, held for the WebGL atlas fix). If these fail after an
+// xterm bump, the replay design is no longer safe — do not just delete
+// them.
+
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Terminal as TerminalType } from "@xterm/xterm";
+
+// Imported in beforeAll, after the canvas stub below: xterm probes a canvas
+// for color metrics while its modules initialize, and a static import would
+// hoist above the stub and dump a jsdom stack trace on every run.
+let Terminal: new (opts: object) => TerminalType;
+
+/** Resolve once xterm has parsed everything written so far. */
+function write(term: TerminalType, data: string): Promise<void> {
+  return new Promise((resolve) => term.write(data, () => resolve()));
+}
+
+/** Every non-empty line of the active buffer, scrollback included. */
+function lines(term: TerminalType): string[] {
+  const buf = term.buffer.active;
+  const out: string[] = [];
+  for (let i = 0; i < buf.length; i += 1) {
+    const text = buf.getLine(i)?.translateToString(true) ?? "";
+    if (text.length > 0) out.push(text);
+  }
+  return out;
+}
+
+function makeTerm(cols: number, rows = 24): TerminalType {
+  return new Terminal({ cols, rows, scrollback: 1000, allowProposedApi: true });
+}
+
+beforeAll(async () => {
+  // Neither affects buffer semantics — stubbed only to keep output clean.
+  HTMLCanvasElement.prototype.getContext = (() => ({
+    measureText: () => ({ width: 8 }),
+    fillRect: () => {},
+    getImageData: () => ({ data: new Uint8ClampedArray(4) }),
+  })) as never;
+  if (!window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: () => ({
+        matches: false,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }),
+    });
+  }
+  Terminal = (await import("@xterm/xterm")).Terminal as never;
+});
+
+describe("xterm reflow", () => {
+  it("constructs and writes headlessly (no open())", async () => {
+    const term = makeTerm(80);
+    await write(term, "hello");
+    expect(lines(term)).toEqual(["hello"]);
+  });
+
+  // THE LOAD-BEARING ONE. 200 chars at 80 cols hard-wraps into 3 rows;
+  // widening to 200 must rejoin them. Without this, replay cannot
+  // reconstruct history at a width other than the one it was produced at.
+  it("reflows a completed wrapped line when widened", async () => {
+    const term = makeTerm(80);
+    const text = "a".repeat(200);
+    await write(term, text + "\r\n");
+    expect(lines(term)).toEqual([
+      "a".repeat(80),
+      "a".repeat(80),
+      "a".repeat(40),
+    ]);
+
+    term.resize(200, 24);
+    expect(lines(term)).toEqual([text]);
+  });
+
+  it("reflows back when narrowed again", async () => {
+    const term = makeTerm(80);
+    await write(term, "b".repeat(200) + "\r\n");
+    term.resize(200, 24);
+    term.resize(100, 24);
+    expect(lines(term)).toEqual(["b".repeat(100), "b".repeat(100)]);
+  });
+
+  // The real-world shape: enough output to reach true scrollback, not just
+  // the viewport. Every historical line must reflow, not only recent ones.
+  it("reflows deep scrollback, not just the viewport", async () => {
+    const term = makeTerm(80);
+    for (let i = 0; i < 30; i += 1) {
+      await write(term, `line${i}-` + "z".repeat(100) + "\r\n");
+    }
+    term.resize(200, 24);
+
+    const out = lines(term);
+    expect(out).toHaveLength(30);
+    expect(out[0]).toBe("line0-" + "z".repeat(100));
+    expect(out[29]).toBe("line29-" + "z".repeat(100));
+  });
+
+  // The in-progress line the cursor sits on does NOT reflow. That is fine
+  // and deliberate to rely on: it is the frame the agent repaints on
+  // SIGWINCH anyway. Pinned so a future xterm change here is visible
+  // rather than silently altering replay output.
+  it("does not reflow the unterminated cursor line", async () => {
+    const term = makeTerm(80);
+    await write(term, "a".repeat(200)); // no newline — cursor is on it
+    term.resize(200, 24);
+    expect(lines(term)).toEqual([
+      "a".repeat(80),
+      "a".repeat(80),
+      "a".repeat(40),
+    ]);
+  });
+
+  // The actual replay shape: several width-runs written in sequence, each
+  // at the width it was produced at, then one final resize to the pane.
+  // Early runs must survive later resizes, not just the most recent one.
+  it("preserves earlier runs across later resizes", async () => {
+    const term = makeTerm(80);
+    await write(term, "first-run\r\n");
+    term.resize(200, 24);
+    await write(term, "second-run\r\n");
+    term.resize(150, 24);
+    await write(term, "third-run\r\n");
+    term.resize(120, 24);
+
+    expect(lines(term)).toEqual(["first-run", "second-run", "third-run"]);
+  });
+
+  it("reflows a long line written in an early run", async () => {
+    const term = makeTerm(80);
+    await write(term, "x".repeat(120) + "\r\n");
+    await write(term, "tail\r\n");
+    term.resize(200, 24);
+    expect(lines(term)).toEqual(["x".repeat(120), "tail"]);
+  });
+
+  // write() is async. Replay that resizes without awaiting the callback is
+  // the obvious way to write this wrong, so pin down whether it corrupts.
+  it("resizing without awaiting write() matches the awaited result", async () => {
+    const awaited = makeTerm(80);
+    await write(awaited, "c".repeat(200) + "\r\n");
+    awaited.resize(200, 24);
+
+    const eager = makeTerm(80);
+    eager.write("c".repeat(200) + "\r\n");
+    eager.resize(200, 24);
+    await new Promise((r) => eager.write("", () => r(undefined)));
+
+    expect(lines(eager)).toEqual(lines(awaited));
+    expect(lines(eager)).toEqual(["c".repeat(200)]);
+  });
+
+  // Alt-screen content is not reflowed by design — the agent repaints on
+  // SIGWINCH. What must survive is the primary-buffer scrollback beneath
+  // it, which is exactly what the purge destroys today.
+  it("keeps primary scrollback across an alt-screen excursion", async () => {
+    const term = makeTerm(80);
+    await write(term, "scrollback-line\r\n");
+    await write(term, "\x1b[?1049h"); // enter alt screen
+    await write(term, "TUI frame at 80 cols");
+    term.resize(200, 24);
+    await write(term, "\x1b[?1049l"); // leave alt screen
+
+    expect(lines(term)).toEqual(["scrollback-line"]);
+  });
+});


### PR DESCRIPTION
## Summary

- tag PTY output chunks with the width at which they were produced
- replay consecutive width-runs into xterm before reflowing to the pane grid
- suppress local and backend geometry changes during replay, then apply the latest pane size
- remove the backend resize ring purge while keeping pane-grid caching as an optimization
- correct the predictive pane sizing analysis in impl 0038

## Validation

- cargo fmt --check
- cargo clippy --workspace
- cargo test --workspace
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm test
- working-tree review clean

## Manual

- restart behavior smoke-tested by Jason