### PR TITLE
fix(ui): paste copied file paths into terminals

### DIFF
--- a/docs/features/55-paste-file-paths.md
+++ b/docs/features/55-paste-file-paths.md
@@ -1,0 +1,60 @@
+# 55 — Paste file paths into the terminal
+
+Tracking: [#368](https://github.com/yicheng47/runner/issues/368)
+
+History: first landed in PR [#369](https://github.com/yicheng47/runner/pull/369) and reverted when main was rebuilt around the #372 spawn-width fix. This spec re-lands the feature with one correction: the original decision 3 let a file reference beat image bytes, which changed the paste behavior of Finder-copied image *files*. The redo inverts that — the image flow is untouchable, and the path branch runs only where today's handler does nothing.
+
+## Motivation
+
+Copying a file in GoLand (or Finder) and pressing ⌘V over a Runner terminal inserts nothing. Every native terminal — Terminal.app, iTerm2, Ghostty — inserts the file's POSIX path instead, which is how you hand an agent a file to look at without typing the path out.
+
+The cause is that a file copy puts no text on the clipboard. It writes `public.file-url` / `NSFilenamesPboardType` flavors to NSPasteboard, and native terminals read those flavors explicitly and insert the path. Over the WKWebView boundary the paste arrives as a `File` in `DataTransfer` with an empty (or unusable) `text/plain`, so xterm.js's default paste has nothing to insert.
+
+Runner already intercepts paste for exactly this class of problem. `onPaste` in `RunnerTerminal.tsx` handles image paste — it walks `clipboardData.items` for `kind === "file"`, and for images ships the bytes to Rust to restore the NSPasteboard flavor (#79). A non-image file falls straight through: `inferPasteImageMime` returns null, the loop `continue`s, the handler returns **without** `preventDefault`, and xterm's default paste inserts the empty text. So the extension point exists and the gap is one branch wide.
+
+The web layer cannot close it alone. `DataTransfer` deliberately withholds filesystem paths — `File.name` is only the basename, and WKWebView exposes no `file.path`. The path has to come from the native pasteboard, which is what the existing image path already reaches into.
+
+## Scope
+
+- ⌘V over a terminal pane, when the clipboard holds file references and neither an image the current flow would attach nor usable text, inserts the file's absolute path at the cursor, shell-quoted when needed.
+- Multiple copied files insert as multiple quoted paths separated by single spaces.
+- Text pastes and image pastes — **including Finder-copied image files** — keep their current behavior exactly.
+- Out of scope: drag-and-drop of files onto a pane (same underlying need, but Tauri's drag-drop event supplies paths through an entirely different path — its own spec); pasting directory contents; translating paths to be relative to the session cwd; any change to the image-paste flow.
+
+## Key Decisions
+
+1. **The image flow is untouchable; the path branch runs only in today's dead zone.** (Inverts the reverted spec's decision 3.) The handler keeps main's exact ordering: the image scan runs first, and anything it catches — pasted screenshot bytes, browser image copies, *and* Finder-copied `shot.png`, which `inferPasteImageMime`'s extension fallback classifies as an image — takes the #79 attach flow unchanged. Then non-empty `text/plain` falls through to xterm unchanged. Only when both yield nothing — the case where today's handler inserts nothing at all — does the path branch consult the native pasteboard. Consequence accepted: an image *file* pastes as an attachment, not a path; users who want an image's path can get it from Finder's Copy-as-Pathname. The re-land constraint from the revert is exactly this: #368 must not change any behavior the image paste (#79 / #234) has today.
+
+2. **Read the paths in Rust, not in the webview.** A command returns the current pasteboard's file URLs as POSIX paths. The frontend never sees a path it could have fabricated from `File.name`. This is a direct `objc2` NSPasteboard binding, not another `osascript` shell-out like the image write: the read happens on every candidate paste, and a process spawn per paste isn't worth the symmetry. `objc2-app-kit` is declared `default-features = false`, so the `NSPasteboard` feature must be added in `src-tauri/Cargo.toml`.
+
+3. **Decide synchronously, act asynchronously.** `preventDefault()` after an `await` does nothing — the browser has already run the default action by the time an IPC round-trip resolves. So the handler cannot "call the command, then decide". It reads the event synchronously (image scan, text check), commits (`preventDefault` + `stopImmediatePropagation`) once both come up empty, and only then goes async to the pasteboard command. An empty result then swallows a paste that had nothing to insert anyway — a no-op.
+
+4. **Prefer the native read over `text/uri-list`.** WKWebView sometimes exposes a `text/uri-list` flavor with `file://` URLs, which would avoid an IPC round-trip, but its presence is inconsistent across source applications. One authoritative path (the pasteboard) beats two code paths that disagree.
+
+5. **Quote only when the path needs it.** iTerm2 quotes unconditionally because its panes are shell prompts. Runner's panes are usually *agent* prompts, where `'/Users/jason/foo.go'` is noise and defeats `@`-style file completion. Quote when the path contains whitespace or shell metacharacters, using single quotes with embedded quotes escaped (`'` → `'\''`); otherwise insert it bare.
+
+6. **Insert as text, never submit.** Write through the existing raw-stdin injection (`api.session.injectStdin`). Do **not** route through `inject_paste`, which appends Enter — a pasted path is the middle of a sentence the user is still composing. The draft-gate state (spec 54) sees it as ordinary local input, which is correct: the user now has a pending draft.
+
+7. **No cwd-relative rewriting.** Absolute paths always resolve regardless of where the agent has `cd`'d, and the agent can shorten them itself. Relativizing would need the session's live cwd, which Runner only knows at spawn time.
+
+## Verification
+
+- [ ] Copy a `.go` file in GoLand, ⌘V over a terminal pane — the absolute path appears at the cursor, unquoted, not submitted.
+- [ ] Copy a file whose path contains a space — the pasted text is quoted and the agent resolves it.
+- [ ] Copy two files at once — both paths appear, space-separated.
+- [ ] Copy a file in Finder — same result as GoLand.
+- [ ] Take a screenshot to the clipboard (⌘⇧4), paste — the existing `[Image #N]` attach flow is unchanged (#79).
+- [ ] Copy an image *file* in Finder, paste — it **attaches as an image**, exactly as today (decision 1; this inverts the reverted spec).
+- [ ] Copy ordinary text — pastes exactly as before, with no IPC round-trip.
+- [ ] Paste with an empty clipboard — nothing happens, no error.
+- [ ] Paste with the session stopped or the pane disabled — no injection, no error.
+- [ ] The pasted path leaves the pane in a pending-draft state (spec 54), not a submitted one.
+
+## Relevant Code
+
+- `src/components/RunnerTerminal.tsx` — `onPaste` (~`:808`), the interception point whose image-first ordering decision 1 preserves; `inferPasteImageMime` (~`:97`), whose filename fallback is what keeps Finder-copied image files on the attach flow.
+- `src-tauri/src/commands/session.rs` — `session_paste_image` and its MIME→OSType table, the plumbing neighborhood for the new read command.
+- `src-tauri/Cargo.toml` — `objc2-app-kit` with `default-features = false`; `NSPasteboard` must be added to its feature list.
+- `src/lib/api.ts` — `session.injectStdin`; `session.pasteImage`, the call shape to mirror.
+- `docs/features/54-draft-aware-delivery-gate.md` — the draft model a pasted path feeds into (decision 6).
+- Reverted implementation for reference: PR #369, commit `61cafd2` (local branch `fix/367-368-spawn-width-and-paste-paths`) — `src/lib/terminalPaste.ts`, `src/lib/terminalPaste.test.ts`, and `session_clipboard_file_paths` are all reusable; only the orchestration's precedence order changes.

--- a/docs/impls/0040-paste-file-paths.md
+++ b/docs/impls/0040-paste-file-paths.md
@@ -1,0 +1,56 @@
+# Paste file paths: re-land #368 without touching the image flow
+
+## Status
+
+Planned. Tracking issue [#368](https://github.com/yicheng47/runner/issues/368), spec [55](../features/55-paste-file-paths.md). This is a **redo**: the feature first landed in PR [#369](https://github.com/yicheng47/runner/pull/369) (commit `61cafd2`) and was reverted when main was rebuilt around the #372 spawn-width fix. The reverted code survives on the local branch `fix/367-368-spawn-width-and-paste-paths` and is the reference implementation — most of it re-lands verbatim; the one behavioral correction is decision 1.
+
+## Problem
+
+Copying a file (Finder, GoLand) puts only `public.file-url` flavors on NSPasteboard — no text — so ⌘V over a Runner terminal inserts nothing. Native terminals insert the POSIX path. The webview cannot recover the path (`DataTransfer` withholds it by design), so it must be read from NSPasteboard in Rust.
+
+The reverted implementation solved this but changed an existing behavior along the way: its precedence rule ("a file reference beats image bytes") made a Finder-copied `shot.png` paste its *path*, where today it attaches as an image via `inferPasteImageMime`'s extension fallback. The re-land constraint is explicit: **the current image paste behavior (#79 / #234) must not change in any case.**
+
+## Key Decisions
+
+1. **Image scan first, text second, path branch only in the dead zone.** (Inverts the reverted feature-55 decision 3.) `onPaste` keeps main's exact ordering: the synchronous image scan runs first and anything it catches — screenshot bytes, browser image copies, and Finder-copied image *files* — takes the existing attach flow untouched. Non-empty `text/plain` still falls through to xterm's default paste. Only when both come up empty (today: the handler returns and nothing is inserted) does the new branch commit the event and consult the pasteboard. Structurally this guarantees the constraint: every clipboard shape that does something today is dispatched before the new code runs.
+
+2. **Reuse the reverted orchestration module, reordered.** `src/lib/terminalPaste.ts` from `61cafd2` re-lands as the testable orchestration (`handleTerminalPaste` + effects interface), with its internal order changed from text→file→image to image→text→file per decision 1. Its helpers re-land unchanged: `clipboardHasUsableText`, `shellQuotePath` (quote only when whitespace/metacharacters require it, `'` → `'\''`), `formatPastedPaths` (space-joined), and the `normalizePasteImageMime` / `inferPasteImageMime` pair moves out of `RunnerTerminal.tsx` with it. `RunnerTerminal.tsx`'s `onPaste` shrinks to reading refs and delegating.
+
+3. **Reuse the reverted Rust command as-is.** `session_clipboard_file_paths` (`commands/session.rs` on the reference branch): direct `objc2` NSPasteboard binding reading `NSPasteboardTypeFileURL` per item, decoding through `NSURL` (never hand-parsing the percent-encoded URL), filtering non-file URLs, returning `Vec<String>` of POSIX paths; empty when the flavor is absent; `#[cfg(not(target_os = "macos"))]` returns empty. Requires adding `NSPasteboard` (and the `NSPasteboardItem`/`NSURL` support it compiles against) to the `objc2-app-kit` feature list in `src-tauri/Cargo.toml` and registering the command in `lib.rs`. Its doc comment must be updated: the flavor no longer decides path-vs-attach (that was old decision 3); it only feeds the dead-zone branch.
+
+4. **Commit synchronously, act asynchronously.** `preventDefault` after an `await` is a no-op, so the handler reads the event synchronously (image scan + text check), commits with `preventDefault` + `stopImmediatePropagation`, then goes async to the pasteboard command. An empty result swallows a paste that had nothing to insert anyway.
+
+5. **Insert via `injectStdin`, never `inject_paste`.** A pasted path is mid-sentence; `inject_paste` appends Enter. The draft gate (spec 54) sees ordinary local input.
+
+6. **Frontend API surface**: one `api.ts` addition, `session.clipboardFilePaths(): Promise<string[]>`, mirroring the `session.pasteImage` call shape from the reference branch.
+
+## Goals
+
+- Copying a non-image file and pasting into a pane inserts its absolute path (quoted only when needed); multiple files insert space-separated.
+- Every clipboard shape that does something today — text, screenshot bytes, browser image copy, Finder-copied image file — behaves byte-for-byte as before, with no added IPC on those paths.
+- The orchestration is unit-tested without mounting xterm, including regression tests pinning the image-file-still-attaches behavior.
+
+## Non-Goals
+
+- Drag-and-drop of files onto a pane (different Tauri mechanism, its own spec).
+- Directory contents, cwd-relative rewriting, `text/uri-list` parsing.
+- Any change to the image-paste flow, the #367/#372 spawn-width machinery, or `inject_paste` semantics.
+
+## Implementation Notes
+
+- `src-tauri/Cargo.toml` — add `NSPasteboard` feature(s) to `objc2-app-kit`; `objc2-foundation` may need `NSURL` if not already enabled.
+- `src-tauri/src/commands/session.rs` — `session_clipboard_file_paths` (from `61cafd2`, doc comment corrected per decision 3).
+- `src-tauri/src/lib.rs` — register the command.
+- `src/lib/api.ts` — `session.clipboardFilePaths`.
+- `src/lib/terminalPaste.ts` — orchestration from `61cafd2`, reordered per decision 1; mime helpers move here from `RunnerTerminal.tsx`.
+- `src/lib/terminalPaste.test.ts` — re-land the reverted suite, updated for the new precedence; add the two pinning tests: image *bytes* attach, image *file* attaches (not a path), even with file-urls on the pasteboard.
+- `src/components/RunnerTerminal.tsx` — `onPaste` delegates to `handleTerminalPaste` with effects wired to `api.session.*` and `onErrorRef`; keep the `!sid || disabledRef.current` early return ahead of everything.
+
+Reference diff: `git show 61cafd2` (or diff the local branch `fix/367-368-spawn-width-and-paste-paths`) — take only the paste-path files; the spawn-width/db changes there are superseded by #372 and must not be re-landed.
+
+## Validation
+
+- Frontend (vitest, `terminalPaste.test.ts`): text paste → null return, no IPC; image bytes → attach flow + Ctrl-V; **image file with file-urls present → attach flow, never a path** (the redo's pin); non-image file → committed, quoted path injected; multiple files → space-separated; empty pasteboard → committed no-op; quoting table (bare, spaces, embedded `'`, metacharacters).
+- Rust: quoting lives frontend-side, so backend needs no new logic tests beyond compile; `cargo test --workspace` for regressions.
+- Checks: `cargo fmt --check`, `cargo clippy`, `cargo test --workspace`, `pnpm exec tsc --noEmit`, `pnpm run lint`, `pnpm test`.
+- Manual: the spec's Verification list, run by Jason in the app — most importantly ⌘⇧4 screenshot paste and Finder image-file paste behaving exactly as v0.4.7.

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -64,13 +64,13 @@ libc = "0.2"
 portable-pty = "0.9"
 
 [target.'cfg(target_os = "macos")'.dependencies]
-objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSButton", "NSControl", "NSResponder", "NSView", "NSWindow", "NSWorkspace"] }
+objc2-app-kit = { version = "0.3", default-features = false, features = ["std", "NSButton", "NSControl", "NSPasteboard", "NSPasteboardItem", "NSResponder", "NSView", "NSWindow", "NSWorkspace"] }
 # System-wake observer (impl 0037). `NSWorkspace`'s notification center is
 # the only precise sleep/wake signal available to the app — tao never emits
 # `Event::Resumed` on macOS. `block2` + `NSOperation` are what the
 # `addObserverForName:object:queue:usingBlock:` binding is gated on; both
 # crates are already in the lock via tao/wry.
-objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSNotification", "NSOperation", "NSString", "block2"] }
+objc2-foundation = { version = "0.3", default-features = false, features = ["std", "NSNotification", "NSOperation", "NSString", "NSURL", "block2"] }
 block2 = "0.6"
 
 [dev-dependencies]

--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -239,6 +239,44 @@ pub async fn session_paste_image(bytes: Vec<u8>, mime_type: String) -> Result<()
     }
 }
 
+/// POSIX paths of files referenced by the general pasteboard, in
+/// pasteboard order.
+///
+/// The frontend calls this only after its current image scan and
+/// `text/plain` check both come up empty. File URLs therefore fill the
+/// existing no-op paste case without changing image or text precedence.
+#[tauri::command]
+pub fn session_clipboard_file_paths() -> Vec<String> {
+    #[cfg(not(target_os = "macos"))]
+    {
+        Vec::new()
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        use objc2_app_kit::{NSPasteboard, NSPasteboardTypeFileURL};
+        use objc2_foundation::NSURL;
+
+        // SAFETY: AppKit's own flavor constant, read-only.
+        let file_url_type = unsafe { NSPasteboardTypeFileURL };
+        let Some(items) = NSPasteboard::generalPasteboard().pasteboardItems() else {
+            return Vec::new();
+        };
+        items
+            .to_vec()
+            .into_iter()
+            .filter_map(|item| {
+                let url_string = item.stringForType(file_url_type)?;
+                let url = NSURL::URLWithString(&url_string)?;
+                if !url.isFileURL() {
+                    return None;
+                }
+                Some(url.path()?.to_string())
+            })
+            .collect()
+    }
+}
+
 /// One row per direct-chat *session* in the sidebar SESSION tray. Each
 /// runner can host multiple parallel chats — see
 /// docs/impls/archive/0003-direct-chats.md — so the tray is flat (not collapsed per

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -447,6 +447,7 @@ pub fn run() {
             commands::session::session_output_snapshot,
             commands::session::session_replay_watermark,
             commands::session::session_paste_image,
+            commands::session::session_clipboard_file_paths,
             commands::session::session_start_direct,
             commands::session::session_start_runtime,
             commands::mcp::mcp_integration_status,

--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -26,7 +26,7 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
 import "@xterm/xterm/css/xterm.css";
 
-import { api, type PasteImageMimeType } from "../lib/api";
+import { api } from "../lib/api";
 import { logLaunchDims, logResizeGate } from "../lib/frontendLog";
 import { takeLaunchResumed } from "../lib/launchResumeTrace";
 import {
@@ -58,6 +58,7 @@ import {
   type TerminalGridSize,
 } from "../lib/terminalResize";
 import { TERMINAL_SCROLLBAR_WIDTH_PX } from "../lib/terminalSizing";
+import { handleTerminalPaste } from "../lib/terminalPaste";
 import { observeBackingScale, stalesTextureAtlas } from "../lib/textureAtlas";
 import { eventMatchesShortcut } from "../lib/keymap";
 import { runtimeClearsOnResize } from "./ui/runtimes";
@@ -81,32 +82,6 @@ const SIDEBAR_TOGGLE_EVENT = "runner:toggle-sidebar";
 const SIDEBAR_NAVIGATE_EVENT = "runner:navigate-sidebar-page";
 const RUNNER_TERMINAL_CYCLE_EVENT = "runner:cycle-terminal";
 const OPEN_SETTINGS_EVENT = "runner:open-settings";
-
-function normalizePasteImageMime(type: string): PasteImageMimeType | null {
-  switch (type.trim().toLowerCase()) {
-    case "image/png":
-      return "image/png";
-    case "image/jpeg":
-    case "image/jpg":
-      return "image/jpeg";
-    default:
-      return null;
-  }
-}
-
-function inferPasteImageMime(
-  itemType: string,
-  file: File,
-): PasteImageMimeType | null {
-  const fromType =
-    normalizePasteImageMime(itemType) ?? normalizePasteImageMime(file.type);
-  if (fromType) return fromType;
-
-  const name = file.name.toLowerCase();
-  if (name.endsWith(".png")) return "image/png";
-  if (name.endsWith(".jpg") || name.endsWith(".jpeg")) return "image/jpeg";
-  return null;
-}
 
 interface RunnerTerminalProps {
   sessionId: string;
@@ -805,38 +780,19 @@ export const RunnerTerminal = forwardRef<
     // they would in a host terminal, attach the image with their
     // native `[Image x]` placeholder. Pure-text pastes fall through
     // to xterm.js's default behavior unchanged.
+    //
+    // When neither an image nor usable text is present, the clipboard
+    // may hold native file references. Read their paths from
+    // NSPasteboard and inject them without submitting the prompt.
     const onPaste = (e: ClipboardEvent) => {
       const sid = sessionIdRef.current;
       if (!sid || disabledRef.current) return;
-      const items = e.clipboardData?.items;
-      if (!items) return;
-      let imageFile: File | null = null;
-      let imageMimeType: PasteImageMimeType | null = null;
-      for (let i = 0; i < items.length; i += 1) {
-        const it = items[i];
-        if (it.kind !== "file") continue;
-        const file = it.getAsFile();
-        if (!file) continue;
-        const mimeType = inferPasteImageMime(it.type, file);
-        if (!mimeType) continue;
-        imageFile = file;
-        imageMimeType = mimeType;
-        break;
-      }
-      if (!imageFile || !imageMimeType) return;
-      const file = imageFile;
-      const mimeType = imageMimeType;
-      e.preventDefault();
-      e.stopImmediatePropagation();
-      void (async () => {
-        try {
-          const buf = await file.arrayBuffer();
-          await api.session.pasteImage(new Uint8Array(buf), mimeType);
-          await api.session.injectStdin(sid, "\x16");
-        } catch (err) {
-          onErrorRef.current?.(String(err));
-        }
-      })();
+      void handleTerminalPaste(e, {
+        clipboardFilePaths: () => api.session.clipboardFilePaths(),
+        injectStdin: (text) => api.session.injectStdin(sid, text),
+        pasteImage: (bytes, mimeType) => api.session.pasteImage(bytes, mimeType),
+        onError: (message) => onErrorRef.current?.(message),
+      });
     };
     const textarea = term.textarea;
     textarea?.addEventListener("paste", onPaste, { capture: true });

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -423,6 +423,8 @@ export const api = {
         bytes: Array.from(bytes),
         mimeType,
       }),
+    clipboardFilePaths: () =>
+      invoke<string[]>("session_clipboard_file_paths"),
     startDirect: (
       runnerId: string,
       cwd: string | null,

--- a/src/lib/terminalPaste.test.ts
+++ b/src/lib/terminalPaste.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { PasteImageMimeType } from "./api";
+import {
+  clipboardHasUsableText,
+  formatPastedPaths,
+  handleTerminalPaste,
+  shellQuotePath,
+} from "./terminalPaste";
+
+function clipboard(text: string | null): DataTransfer {
+  return {
+    getData: (type: string) => (type === "text/plain" ? (text ?? "") : ""),
+  } as unknown as DataTransfer;
+}
+
+describe("clipboardHasUsableText", () => {
+  it("is true for an ordinary text paste", () => {
+    expect(clipboardHasUsableText(clipboard("/tmp/note.txt"))).toBe(true);
+  });
+
+  it("treats whitespace-only text as usable", () => {
+    expect(clipboardHasUsableText(clipboard("  "))).toBe(true);
+  });
+
+  it("is false for a file copy with no text", () => {
+    expect(clipboardHasUsableText(clipboard(""))).toBe(false);
+  });
+
+  it("is false when clipboardData is unavailable", () => {
+    expect(clipboardHasUsableText(null)).toBe(false);
+  });
+
+  it("is false when reading text/plain throws", () => {
+    const hostile = {
+      getData: () => {
+        throw new Error("no access");
+      },
+    } as unknown as DataTransfer;
+
+    expect(clipboardHasUsableText(hostile)).toBe(false);
+  });
+});
+
+describe("shellQuotePath", () => {
+  it("leaves an ordinary path bare", () => {
+    expect(shellQuotePath("/Users/jason/go/src/runner/main.go")).toBe(
+      "/Users/jason/go/src/runner/main.go",
+    );
+  });
+
+  it("leaves routine path punctuation bare", () => {
+    expect(shellQuotePath("/tmp/a-b_c.d+e=f%g@h:i,j")).toBe(
+      "/tmp/a-b_c.d+e=f%g@h:i,j",
+    );
+  });
+
+  it("leaves non-ASCII paths bare", () => {
+    expect(shellQuotePath("/Users/jason/文档/笔记.md")).toBe(
+      "/Users/jason/文档/笔记.md",
+    );
+  });
+
+  it("quotes whitespace and shell metacharacters", () => {
+    expect(shellQuotePath("/Users/jason/My Documents/a.txt")).toBe(
+      "'/Users/jason/My Documents/a.txt'",
+    );
+    expect(shellQuotePath("/tmp/a$b.txt")).toBe("'/tmp/a$b.txt'");
+    expect(shellQuotePath("/tmp/a;b.txt")).toBe("'/tmp/a;b.txt'");
+    expect(shellQuotePath("/tmp/a&b.txt")).toBe("'/tmp/a&b.txt'");
+    expect(shellQuotePath("/tmp/a*b.txt")).toBe("'/tmp/a*b.txt'");
+    expect(shellQuotePath("/tmp/a(b).txt")).toBe("'/tmp/a(b).txt'");
+    expect(shellQuotePath("/tmp/a`b`.txt")).toBe("'/tmp/a`b`.txt'");
+    expect(shellQuotePath("/tmp/a|b.txt")).toBe("'/tmp/a|b.txt'");
+  });
+
+  it("escapes an embedded single quote", () => {
+    expect(shellQuotePath("/tmp/jason's file.txt")).toBe(
+      "'/tmp/jason'\\''s file.txt'",
+    );
+    expect(shellQuotePath("/tmp/it's.txt")).toBe("'/tmp/it'\\''s.txt'");
+  });
+});
+
+describe("formatPastedPaths", () => {
+  it("joins paths with single spaces and quotes only as needed", () => {
+    expect(formatPastedPaths(["/tmp/a.go", "/tmp/b c.go"])).toBe(
+      "/tmp/a.go '/tmp/b c.go'",
+    );
+  });
+
+  it("is empty for an empty pasteboard", () => {
+    expect(formatPastedPaths([])).toBe("");
+  });
+});
+
+function clipboardFile(name: string, type: string, bytes = [1, 2, 3]): File {
+  const buffer = new Uint8Array(bytes).buffer;
+  return {
+    name,
+    type,
+    arrayBuffer: () => Promise.resolve(buffer),
+  } as unknown as File;
+}
+
+function pasteEvent(
+  text: string,
+  files: { file: File; type: string }[] = [],
+): ClipboardEvent & {
+  preventDefault: ReturnType<typeof vi.fn>;
+  stopImmediatePropagation: ReturnType<typeof vi.fn>;
+} {
+  const items = files.map(({ file, type }) => ({
+    kind: "file" as const,
+    type,
+    getAsFile: () => file,
+  }));
+  return {
+    clipboardData: {
+      getData: (type: string) => (type === "text/plain" ? text : ""),
+      items: Object.assign(items, { length: items.length }),
+    },
+    preventDefault: vi.fn(),
+    stopImmediatePropagation: vi.fn(),
+  } as unknown as ClipboardEvent & {
+    preventDefault: ReturnType<typeof vi.fn>;
+    stopImmediatePropagation: ReturnType<typeof vi.fn>;
+  };
+}
+
+function effects(paths: string[]) {
+  return {
+    clipboardFilePaths: vi.fn(() => Promise.resolve(paths)),
+    injectStdin: vi.fn(() => Promise.resolve()),
+    pasteImage:
+      vi.fn<(bytes: Uint8Array, mimeType: PasteImageMimeType) => Promise<void>>(
+        () => Promise.resolve(),
+      ),
+    onError: vi.fn(),
+  };
+}
+
+describe("handleTerminalPaste", () => {
+  it("leaves ordinary text to xterm without IPC", () => {
+    const event = pasteEvent("some copied text");
+    const fx = effects(["/tmp/should-not-be-read.go"]);
+
+    expect(handleTerminalPaste(event, fx)).toBeNull();
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(event.stopImmediatePropagation).not.toHaveBeenCalled();
+    expect(fx.clipboardFilePaths).not.toHaveBeenCalled();
+    expect(fx.injectStdin).not.toHaveBeenCalled();
+  });
+
+  it("attaches image bytes without consulting file paths", async () => {
+    const event = pasteEvent("", [
+      {
+        file: clipboardFile("image.png", "image/png", [9, 8, 7]),
+        type: "image/png",
+      },
+    ]);
+    const fx = effects([]);
+
+    await handleTerminalPaste(event, fx);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    expect(fx.clipboardFilePaths).not.toHaveBeenCalled();
+    expect(fx.pasteImage).toHaveBeenCalledTimes(1);
+    const [bytes, mimeType] = fx.pasteImage.mock.calls[0];
+    expect(Array.from(bytes)).toEqual([9, 8, 7]);
+    expect(mimeType).toBe("image/png");
+    expect(fx.injectStdin).toHaveBeenCalledWith("\x16");
+  });
+
+  it("attaches a Finder-copied image file even when file URLs are present", async () => {
+    const event = pasteEvent("", [
+      {
+        file: clipboardFile("shot.png", "image/png"),
+        type: "image/png",
+      },
+    ]);
+    const fx = effects(["/Users/jason/Desktop/shot.png"]);
+
+    await handleTerminalPaste(event, fx);
+
+    expect(fx.clipboardFilePaths).not.toHaveBeenCalled();
+    expect(fx.pasteImage).toHaveBeenCalledTimes(1);
+    expect(fx.injectStdin).toHaveBeenCalledTimes(1);
+    expect(fx.injectStdin).toHaveBeenCalledWith("\x16");
+  });
+
+  it("keeps image-first precedence when the event also exposes text", async () => {
+    const event = pasteEvent("file:///Users/jason/Desktop/shot.png", [
+      {
+        file: clipboardFile("shot.png", "", [4, 5, 6]),
+        type: "application/octet-stream",
+      },
+    ]);
+    const fx = effects(["/Users/jason/Desktop/shot.png"]);
+
+    await handleTerminalPaste(event, fx);
+
+    expect(fx.clipboardFilePaths).not.toHaveBeenCalled();
+    expect(fx.pasteImage).toHaveBeenCalledTimes(1);
+    expect(fx.pasteImage.mock.calls[0][1]).toBe("image/png");
+    expect(fx.injectStdin).toHaveBeenCalledWith("\x16");
+  });
+
+  it("commits before the pasteboard round-trip starts", async () => {
+    const event = pasteEvent("");
+    const fx = effects(["/tmp/a.go"]);
+    let committedBeforeRoundTrip = false;
+    fx.clipboardFilePaths.mockImplementation(() => {
+      committedBeforeRoundTrip = event.preventDefault.mock.calls.length > 0;
+      return Promise.resolve(["/tmp/a.go"]);
+    });
+
+    const pending = handleTerminalPaste(event, fx);
+
+    expect(pending).not.toBeNull();
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(event.stopImmediatePropagation).toHaveBeenCalledTimes(1);
+    await pending;
+    expect(committedBeforeRoundTrip).toBe(true);
+  });
+
+  it("injects non-image file paths through raw stdin without Enter", async () => {
+    const event = pasteEvent("", [
+      {
+        file: clipboardFile("main.go", "application/octet-stream"),
+        type: "application/octet-stream",
+      },
+    ]);
+    const fx = effects(["/tmp/a.go", "/tmp/b c.go"]);
+
+    await handleTerminalPaste(event, fx);
+
+    expect(fx.injectStdin).toHaveBeenCalledTimes(1);
+    expect(fx.injectStdin).toHaveBeenCalledWith("/tmp/a.go '/tmp/b c.go'");
+    expect(fx.pasteImage).not.toHaveBeenCalled();
+  });
+
+  it("is a committed no-op for an empty pasteboard", async () => {
+    const event = pasteEvent("");
+    const fx = effects([]);
+
+    await handleTerminalPaste(event, fx);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(fx.clipboardFilePaths).toHaveBeenCalledTimes(1);
+    expect(fx.injectStdin).not.toHaveBeenCalled();
+    expect(fx.pasteImage).not.toHaveBeenCalled();
+    expect(fx.onError).not.toHaveBeenCalled();
+  });
+
+  it("reports pasteboard and injection failures without throwing", async () => {
+    const pasteboardEvent = pasteEvent("");
+    const pasteboardFx = effects([]);
+    pasteboardFx.clipboardFilePaths.mockRejectedValueOnce(
+      new Error("pasteboard gone"),
+    );
+
+    await handleTerminalPaste(pasteboardEvent, pasteboardFx);
+
+    expect(pasteboardFx.onError).toHaveBeenCalledWith(
+      expect.stringContaining("pasteboard gone"),
+    );
+
+    const injectionEvent = pasteEvent("");
+    const injectionFx = effects(["/tmp/a.go"]);
+    injectionFx.injectStdin.mockRejectedValueOnce(
+      new Error("session not found"),
+    );
+
+    await handleTerminalPaste(injectionEvent, injectionFx);
+
+    expect(injectionFx.onError).toHaveBeenCalledWith(
+      expect.stringContaining("session not found"),
+    );
+  });
+});

--- a/src/lib/terminalPaste.ts
+++ b/src/lib/terminalPaste.ts
@@ -1,0 +1,107 @@
+import type { PasteImageMimeType } from "./api";
+
+export function clipboardHasUsableText(data: DataTransfer | null): boolean {
+  if (!data) return false;
+  try {
+    return data.getData("text/plain").length > 0;
+  } catch {
+    return false;
+  }
+}
+
+const NEEDS_QUOTING = /[\s!"#$&'()*;<>?[\\\]^`{|}~]/;
+
+export function shellQuotePath(path: string): string {
+  if (!NEEDS_QUOTING.test(path)) return path;
+  return `'${path.split("'").join("'\\''")}'`;
+}
+
+export function formatPastedPaths(paths: string[]): string {
+  return paths.map(shellQuotePath).join(" ");
+}
+
+export function normalizePasteImageMime(
+  type: string,
+): PasteImageMimeType | null {
+  switch (type.trim().toLowerCase()) {
+    case "image/png":
+      return "image/png";
+    case "image/jpeg":
+    case "image/jpg":
+      return "image/jpeg";
+    default:
+      return null;
+  }
+}
+
+export function inferPasteImageMime(
+  itemType: string,
+  file: File,
+): PasteImageMimeType | null {
+  const fromType =
+    normalizePasteImageMime(itemType) ?? normalizePasteImageMime(file.type);
+  if (fromType) return fromType;
+
+  const name = file.name.toLowerCase();
+  if (name.endsWith(".png")) return "image/png";
+  if (name.endsWith(".jpg") || name.endsWith(".jpeg")) return "image/jpeg";
+  return null;
+}
+
+function findPasteImage(
+  data: DataTransfer | null,
+): { file: File; mimeType: PasteImageMimeType } | null {
+  const items = data?.items;
+  if (!items) return null;
+  for (let i = 0; i < items.length; i += 1) {
+    const item = items[i];
+    if (item.kind !== "file") continue;
+    const file = item.getAsFile();
+    if (!file) continue;
+    const mimeType = inferPasteImageMime(item.type, file);
+    if (mimeType) return { file, mimeType };
+  }
+  return null;
+}
+
+export interface TerminalPasteEffects {
+  clipboardFilePaths: () => Promise<string[]>;
+  injectStdin: (text: string) => Promise<void>;
+  pasteImage: (bytes: Uint8Array, mimeType: PasteImageMimeType) => Promise<void>;
+  onError: (message: string) => void;
+}
+
+export function handleTerminalPaste(
+  event: ClipboardEvent,
+  effects: TerminalPasteEffects,
+): Promise<void> | null {
+  const image = findPasteImage(event.clipboardData);
+  if (image) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    return (async () => {
+      try {
+        const buffer = await image.file.arrayBuffer();
+        await effects.pasteImage(new Uint8Array(buffer), image.mimeType);
+        await effects.injectStdin("\x16");
+      } catch (error) {
+        effects.onError(String(error));
+      }
+    })();
+  }
+
+  if (clipboardHasUsableText(event.clipboardData)) return null;
+
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  return (async () => {
+    try {
+      const paths = await effects.clipboardFilePaths();
+      if (paths.length > 0) {
+        await effects.injectStdin(formatPastedPaths(paths));
+      }
+    } catch (error) {
+      effects.onError(String(error));
+    }
+  })();
+}


### PR DESCRIPTION
## Summary

- re-land copied-file path paste support from #369 without the superseded spawn-width changes
- preserve current image-first behavior, including Finder-copied image files attaching as images
- insert quoted NSPasteboard file paths only when both image and text handling come up empty

## Validation

- cargo fmt --check
- cargo clippy
- cargo test --workspace
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm test
- reviewer found no must-fix issues on the working-tree diff
- Jason passed the spec 55 smoke test

Closes #368