### PR TITLE
feat(ui): add start project modal

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -49,8 +49,6 @@ import {
   useNavigate,
 } from "react-router-dom";
 import { listen } from "@tauri-apps/api/event";
-import { basename } from "@tauri-apps/api/path";
-import { open as openDialog } from "@tauri-apps/plugin-dialog";
 import {
   AppWindow,
   Archive,
@@ -143,6 +141,7 @@ import type {
   MissionSummary,
   SessionActivityState,
 } from "../lib/types";
+import { StartProjectModal } from "./StartProjectModal";
 import { StartMissionModal } from "./StartMissionModal";
 import { StartChatModal } from "./StartChatModal";
 import { CommandPalette } from "./CommandPalette";
@@ -349,6 +348,7 @@ export function Sidebar({
     getStoredFlag(STORAGE_SESSION_OPEN, true),
   );
 
+  const [creatingProject, setCreatingProject] = useState(false);
   const [creatingMission, setCreatingMission] = useState(false);
   const [newMissionProjectId, setNewMissionProjectId] = useState<
     string | null
@@ -1327,23 +1327,7 @@ export function Sidebar({
     setCreatingMission(true);
   }, []);
 
-  const addProject = useCallback(async () => {
-    try {
-      const picked = await openDialog({
-        directory: true,
-        multiple: false,
-        title: "Add a project",
-      });
-      if (typeof picked !== "string") return;
-      const project = await api.project.create(await basename(picked), picked);
-      setProjectsOpen(true);
-      setStoredFlag(STORAGE_PROJECTS_OPEN, true);
-      setActiveProjectId(project.id);
-      await refreshProjects();
-    } catch (e) {
-      console.error("sidebar: project_create failed", e);
-    }
-  }, [refreshProjects]);
+  const addProject = useCallback(() => setCreatingProject(true), []);
 
   const clearRowDrag = useCallback(() => {
     setDraggedNodeId(null);
@@ -2126,7 +2110,7 @@ export function Sidebar({
                   open={projectsOpen}
                   attention={projectsOpen ? null : projectAttention}
                   onToggle={toggleProjects}
-                  onPlus={() => void addProject()}
+                  onPlus={addProject}
                   plusTitle="Add project"
                 />
                 {projectsOpen ? (
@@ -2427,6 +2411,18 @@ export function Sidebar({
       <CommandPalette
         open={paletteOpen}
         onClose={() => setPaletteOpen(false)}
+      />
+
+      <StartProjectModal
+        open={creatingProject}
+        onClose={() => setCreatingProject(false)}
+        onCreated={async (project) => {
+          setCreatingProject(false);
+          setProjectsOpen(true);
+          setStoredFlag(STORAGE_PROJECTS_OPEN, true);
+          await refreshProjects();
+          setActiveProjectId(project.id);
+        }}
       />
 
       <StartMissionModal

--- a/src/components/StartProjectModal.test.tsx
+++ b/src/components/StartProjectModal.test.tsx
@@ -7,87 +7,61 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProjectRow } from "../lib/api";
 
 const mocks = vi.hoisted(() => ({
-  crewList: vi.fn(async () => [
-    { id: "crew-1", name: "Crew", runner_count: 1 },
-  ]),
-  runnerList: vi.fn(async () => [
-    {
-      id: "runner-1",
-      handle: "coder",
-      display_name: "Coder",
-      runtime: "codex",
-      command: "codex",
-      args: [],
-      env: {},
-      working_dir: null,
-    },
-  ]),
+  basename: vi.fn(async (path: string) => {
+    if (path === "/") throw new Error("path has no basename");
+    const trimmed = path.replace(/\/+$/, "");
+    return trimmed.slice(trimmed.lastIndexOf("/") + 1);
+  }),
+  defaultWorkingDir: "",
+  openDialog: vi.fn(async () => null as string | null),
+  projectCreate: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/path", () => ({
+  basename: mocks.basename,
 }));
 
 vi.mock("@tauri-apps/plugin-dialog", () => ({
-  open: vi.fn(async () => null),
+  open: mocks.openDialog,
 }));
 
 vi.mock("../lib/api", () => ({
   api: {
-    crew: { listAll: mocks.crewList },
-    slot: { list: vi.fn(async () => []) },
-    mission: { start: vi.fn() },
-    runner: { list: mocks.runnerList },
-    runtime: {
-      list: vi.fn(async () => [
-        { name: "codex", display_name: "Codex", command: "codex" },
-        { name: "qoder", display_name: "Qoder", command: "qodercli" },
-      ]),
-    },
-    session: {
-      startDirect: vi.fn(),
-      startRuntime: vi.fn(),
-      rename: vi.fn(),
-    },
+    project: { create: mocks.projectCreate },
   },
 }));
 
 vi.mock("../lib/settings", () => ({
-  readDefaultRuntime: () =>
-    localStorage.getItem("settings.defaultChatRuntime") ?? "",
-  readDefaultWorkingDir: () => "/default",
+  readDefaultWorkingDir: () => mocks.defaultWorkingDir,
 }));
 
-vi.mock("../lib/terminalSizing", () => ({
-  estimateMissionTerminalGrid: () => ({ cols: 80, rows: 24 }),
-}));
-
-import { StartChatModal } from "./StartChatModal";
-import { StartMissionModal } from "./StartMissionModal";
+import { StartProjectModal } from "./StartProjectModal";
 
 const project: ProjectRow = {
   id: "project-1",
   name: "Runner",
   cwd: "/projects/runner",
   position: 0,
-  created_at: "2026-07-14T00:00:00Z",
+  created_at: "2026-08-01T00:00:00Z",
 };
 
-function field<T extends HTMLInputElement | HTMLTextAreaElement>(
-  container: HTMLElement,
-  suffix: string,
-): T {
-  const element = container.querySelector<T>(`[id$="-${suffix}"]`);
+function field(container: HTMLElement, suffix: string): HTMLInputElement {
+  const element = container.querySelector<HTMLInputElement>(`[id$="-${suffix}"]`);
   if (!element) throw new Error(`missing ${suffix} field`);
   return element;
 }
 
-async function changeField(
-  element: HTMLInputElement | HTMLTextAreaElement,
-  value: string,
-) {
+function button(container: HTMLElement, label: string): HTMLButtonElement {
+  const element = [...container.querySelectorAll<HTMLButtonElement>("button")].find(
+    (candidate) => candidate.textContent === label,
+  );
+  if (!element) throw new Error(`missing ${label} button`);
+  return element;
+}
+
+async function changeField(element: HTMLInputElement, value: string) {
   await act(async () => {
-    const prototype =
-      element instanceof HTMLTextAreaElement
-        ? HTMLTextAreaElement.prototype
-        : HTMLInputElement.prototype;
-    Object.getOwnPropertyDescriptor(prototype, "value")?.set?.call(
+    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value")?.set?.call(
       element,
       value,
     );
@@ -95,17 +69,14 @@ async function changeField(
   });
 }
 
-describe("project-scoped start modals", () => {
+describe("StartProjectModal", () => {
   let container: HTMLDivElement;
   let root: Root;
 
   beforeEach(() => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
-    const storage = new Map<string, string>();
-    vi.stubGlobal("localStorage", {
-      getItem: (key: string) => storage.get(key) ?? null,
-      setItem: (key: string, value: string) => storage.set(key, value),
-    });
+    mocks.defaultWorkingDir = "";
+    mocks.projectCreate.mockResolvedValue(project);
     container = document.createElement("div");
     document.body.appendChild(container);
     root = createRoot(container);
@@ -114,74 +85,109 @@ describe("project-scoped start modals", () => {
   afterEach(async () => {
     await act(async () => root.unmount());
     container.remove();
+    vi.clearAllMocks();
     vi.unstubAllGlobals();
   });
 
-  it("preserves an edited mission form when the project row refreshes", async () => {
-    const render = (row: ProjectRow) =>
-      createElement(StartMissionModal, {
-        open: true,
-        project: row,
-        onClose: () => {},
-        onStarted: () => {},
-      });
-    await act(async () => {
-      root.render(render(project));
-    });
-    await changeField(field(container, "title"), "Keep this title");
-    await changeField(field(container, "goal"), "Keep this goal");
-    await changeField(field(container, "cwd"), "/custom/mission");
-
-    await act(async () => {
-      root.render(render({ ...project, name: "Runner renamed" }));
-    });
-
-    expect(field(container, "title").value).toBe("Keep this title");
-    expect(field(container, "goal").value).toBe("Keep this goal");
-    expect(field(container, "cwd").value).toBe("/custom/mission");
-  });
-
-  it("preserves edited chat fields when the project row refreshes", async () => {
-    const render = (row: ProjectRow) =>
-      createElement(StartChatModal, {
-        open: true,
-        project: row,
-        onClose: () => {},
-        onStarted: () => {},
-      });
-    await act(async () => {
-      root.render(render(project));
-    });
-    await changeField(field(container, "title"), "Keep this chat");
-    await changeField(field(container, "cwd"), "/custom/chat");
-
-    await act(async () => {
-      root.render(render({ ...project, name: "Runner renamed" }));
-    });
-
-    expect(field(container, "title").value).toBe("Keep this chat");
-    expect(field(container, "cwd").value).toBe("/custom/chat");
-  });
-
-  it("uses the default runtime selected in Agents settings", async () => {
-    localStorage.setItem("runner.startChat.mode", "runtime");
-    localStorage.setItem("settings.defaultChatRuntime", "qoder");
-
+  async function render(onCreated = vi.fn()) {
     await act(async () => {
       root.render(
-        createElement(StartChatModal, {
+        createElement(StartProjectModal, {
           open: true,
-          project,
           onClose: () => {},
-          onStarted: () => {},
+          onCreated,
         }),
       );
     });
+  }
 
-    const runtimePicker = container.querySelector<HTMLButtonElement>(
-      '[id$="-runtime"]',
-    );
-    expect(runtimePicker?.textContent).toContain("Qoder");
-    expect(field(container, "title").value).toBe("Qoder");
+  it("updates the name with the directory until the name is edited", async () => {
+    await render();
+
+    await changeField(field(container, "cwd"), "/projects/alpha");
+    await vi.waitFor(() => expect(field(container, "name").value).toBe("alpha"));
+
+    await changeField(field(container, "cwd"), "/projects/beta");
+    await vi.waitFor(() => expect(field(container, "name").value).toBe("beta"));
+
+    await changeField(field(container, "name"), "Custom name");
+    await changeField(field(container, "cwd"), "/projects/gamma");
+
+    expect(field(container, "name").value).toBe("Custom name");
+  });
+
+  it("ignores transient basename failures while the directory is typed", async () => {
+    await render();
+
+    await changeField(field(container, "cwd"), "/");
+    await vi.waitFor(() => expect(mocks.basename).toHaveBeenLastCalledWith("/"));
+    expect(field(container, "name").value).toBe("");
+    expect(container.textContent).not.toContain("path has no basename");
+
+    await changeField(field(container, "cwd"), "/projects/runner");
+    await vi.waitFor(() => expect(field(container, "name").value).toBe("runner"));
+    expect(container.textContent).not.toContain("path has no basename");
+  });
+
+  it("prefills the directory and name from the default working directory", async () => {
+    mocks.defaultWorkingDir = "/workspace/runner";
+
+    await render();
+
+    expect(field(container, "cwd").value).toBe("/workspace/runner");
+    await vi.waitFor(() => expect(field(container, "name").value).toBe("runner"));
+  });
+
+  it("disables create while either field is empty", async () => {
+    await render();
+    const createButton = button(container, "Create project");
+
+    expect(createButton.disabled).toBe(true);
+
+    await changeField(field(container, "cwd"), "/projects/runner");
+    await vi.waitFor(() => expect(field(container, "name").value).toBe("runner"));
+    expect(createButton.disabled).toBe(false);
+
+    await changeField(field(container, "name"), "");
+    expect(createButton.disabled).toBe(true);
+
+    await changeField(field(container, "name"), "Runner");
+    await changeField(field(container, "cwd"), "");
+    expect(createButton.disabled).toBe(true);
+  });
+
+  it("creates the project and notifies the caller", async () => {
+    mocks.defaultWorkingDir = "/projects/runner";
+    const onCreated = vi.fn();
+    await render(onCreated);
+    await vi.waitFor(() => expect(button(container, "Create project").disabled).toBe(false));
+
+    await act(async () => {
+      container.querySelector("form")?.dispatchEvent(
+        new Event("submit", { bubbles: true, cancelable: true }),
+      );
+    });
+
+    expect(mocks.projectCreate).toHaveBeenCalledWith("runner", "/projects/runner");
+    expect(onCreated).toHaveBeenCalledWith(project);
+  });
+
+  it("browses from the field value and falls back to the default", async () => {
+    mocks.defaultWorkingDir = "/workspace/default";
+    await render();
+
+    await changeField(field(container, "cwd"), "");
+    await act(async () => button(container, "Browse…").click());
+    expect(mocks.openDialog).toHaveBeenLastCalledWith({
+      directory: true,
+      defaultPath: "/workspace/default",
+    });
+
+    await changeField(field(container, "cwd"), "/workspace/current");
+    await act(async () => button(container, "Browse…").click());
+    expect(mocks.openDialog).toHaveBeenLastCalledWith({
+      directory: true,
+      defaultPath: "/workspace/current",
+    });
   });
 });

--- a/src/components/StartProjectModal.tsx
+++ b/src/components/StartProjectModal.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useId, useState } from "react";
+
+import { basename } from "@tauri-apps/api/path";
+import { open as openDialog } from "@tauri-apps/plugin-dialog";
+import { X } from "lucide-react";
+
+import { api, type ProjectRow } from "../lib/api";
+import { readDefaultWorkingDir } from "../lib/settings";
+import { Button } from "./ui/Button";
+import { Modal } from "./ui/Overlay";
+
+interface StartProjectModalProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: (project: ProjectRow) => void | Promise<void>;
+}
+
+export function StartProjectModal({
+  open,
+  onClose,
+  onCreated,
+}: StartProjectModalProps) {
+  const formId = useId();
+  const cwdInputId = `${formId}-cwd`;
+  const nameInputId = `${formId}-name`;
+  const [cwd, setCwd] = useState("");
+  const [name, setName] = useState("");
+  const [nameEdited, setNameEdited] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setCwd(readDefaultWorkingDir());
+    setName("");
+    setNameEdited(false);
+    setSubmitting(false);
+    setError(null);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open || nameEdited) return;
+    const trimmedCwd = cwd.trim();
+    if (!trimmedCwd) {
+      setName("");
+      return;
+    }
+
+    let cancelled = false;
+    void basename(trimmedCwd)
+      .then((value) => {
+        if (!cancelled) setName(value);
+      })
+      .catch(() => {
+        if (!cancelled) setName("");
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [cwd, nameEdited, open]);
+
+  const browse = async () => {
+    try {
+      const defaultPath = cwd.trim() || readDefaultWorkingDir() || undefined;
+      const picked = await openDialog({ directory: true, defaultPath });
+      if (typeof picked === "string") setCwd(picked);
+    } catch (e) {
+      setError(String(e));
+    }
+  };
+
+  const canCreate = Boolean(cwd.trim() && name.trim()) && !submitting;
+
+  const create = async () => {
+    if (!canCreate) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const project = await api.project.create(name.trim(), cwd.trim());
+      await onCreated(project);
+    } catch (e) {
+      setError(String(e));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={submitting ? () => {} : onClose}
+      title={
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-base font-semibold text-fg">
+              Start project
+            </span>
+            <span className="text-xs font-normal text-fg-2">
+              Add a named working directory to the sidebar.
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={submitting}
+            className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded text-fg-3 transition-colors hover:bg-raised hover:text-fg disabled:pointer-events-none disabled:opacity-50"
+            aria-label="Close start project"
+          >
+            <X aria-hidden className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      }
+      widthClass="w-full max-w-[560px]"
+      footer={
+        <>
+          <Button onClick={onClose} disabled={submitting}>
+            Cancel
+          </Button>
+          <Button
+            type="submit"
+            form={formId}
+            variant="primary"
+            disabled={!canCreate}
+          >
+            {submitting ? "Creating…" : "Create project"}
+          </Button>
+        </>
+      }
+    >
+      <form
+        id={formId}
+        className="flex flex-col gap-5"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void create();
+        }}
+      >
+        {error ? (
+          <div className="rounded border border-danger/40 bg-danger/10 px-3 py-2 text-xs text-danger">
+            {error}
+          </div>
+        ) : null}
+
+        <Field label="Directory" htmlFor={cwdInputId}>
+          <div className="flex items-center gap-2">
+            <input
+              id={cwdInputId}
+              autoFocus
+              value={cwd}
+              onChange={(e) => setCwd(e.target.value)}
+              placeholder="/Users/you/projects/runner"
+              disabled={submitting}
+              className="min-w-0 flex-1 rounded-md border border-line bg-bg px-3 py-2 font-mono text-xs text-fg placeholder:text-fg-3 focus:border-fg-3 focus:outline-none"
+            />
+            <Button onClick={() => void browse()} disabled={submitting}>
+              Browse…
+            </Button>
+          </div>
+        </Field>
+
+        <Field label="Name" htmlFor={nameInputId}>
+          <input
+            id={nameInputId}
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+              setNameEdited(true);
+            }}
+            placeholder="runner"
+            disabled={submitting}
+            className="rounded-md border border-line bg-bg px-3 py-2 text-[13px] text-fg placeholder:text-fg-3 focus:border-fg-3 focus:outline-none"
+          />
+        </Field>
+      </form>
+    </Modal>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label htmlFor={htmlFor} className="text-xs font-semibold text-fg">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/src/components/projectScopedStartModals.test.tsx
+++ b/src/components/projectScopedStartModals.test.tsx
@@ -1,0 +1,187 @@
+/** @vitest-environment jsdom */
+
+import { act, createElement } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ProjectRow } from "../lib/api";
+
+const mocks = vi.hoisted(() => ({
+  crewList: vi.fn(async () => [
+    { id: "crew-1", name: "Crew", runner_count: 1 },
+  ]),
+  runnerList: vi.fn(async () => [
+    {
+      id: "runner-1",
+      handle: "coder",
+      display_name: "Coder",
+      runtime: "codex",
+      command: "codex",
+      args: [],
+      env: {},
+      working_dir: null,
+    },
+  ]),
+}));
+
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  open: vi.fn(async () => null),
+}));
+
+vi.mock("../lib/api", () => ({
+  api: {
+    crew: { listAll: mocks.crewList },
+    slot: { list: vi.fn(async () => []) },
+    mission: { start: vi.fn() },
+    runner: { list: mocks.runnerList },
+    runtime: {
+      list: vi.fn(async () => [
+        { name: "codex", display_name: "Codex", command: "codex" },
+        { name: "qoder", display_name: "Qoder", command: "qodercli" },
+      ]),
+    },
+    session: {
+      startDirect: vi.fn(),
+      startRuntime: vi.fn(),
+      rename: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../lib/settings", () => ({
+  readDefaultRuntime: () =>
+    localStorage.getItem("settings.defaultChatRuntime") ?? "",
+  readDefaultWorkingDir: () => "/default",
+}));
+
+vi.mock("../lib/terminalSizing", () => ({
+  estimateMissionTerminalGrid: () => ({ cols: 80, rows: 24 }),
+}));
+
+import { StartChatModal } from "./StartChatModal";
+import { StartMissionModal } from "./StartMissionModal";
+
+const project: ProjectRow = {
+  id: "project-1",
+  name: "Runner",
+  cwd: "/projects/runner",
+  position: 0,
+  created_at: "2026-07-14T00:00:00Z",
+};
+
+function field<T extends HTMLInputElement | HTMLTextAreaElement>(
+  container: HTMLElement,
+  suffix: string,
+): T {
+  const element = container.querySelector<T>(`[id$="-${suffix}"]`);
+  if (!element) throw new Error(`missing ${suffix} field`);
+  return element;
+}
+
+async function changeField(
+  element: HTMLInputElement | HTMLTextAreaElement,
+  value: string,
+) {
+  await act(async () => {
+    const prototype =
+      element instanceof HTMLTextAreaElement
+        ? HTMLTextAreaElement.prototype
+        : HTMLInputElement.prototype;
+    Object.getOwnPropertyDescriptor(prototype, "value")?.set?.call(
+      element,
+      value,
+    );
+    element.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+describe("project-scoped chat and mission start modals", () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    const storage = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => root.unmount());
+    container.remove();
+    vi.unstubAllGlobals();
+  });
+
+  it("preserves an edited mission form when the project row refreshes", async () => {
+    const render = (row: ProjectRow) =>
+      createElement(StartMissionModal, {
+        open: true,
+        project: row,
+        onClose: () => {},
+        onStarted: () => {},
+      });
+    await act(async () => {
+      root.render(render(project));
+    });
+    await changeField(field(container, "title"), "Keep this title");
+    await changeField(field(container, "goal"), "Keep this goal");
+    await changeField(field(container, "cwd"), "/custom/mission");
+
+    await act(async () => {
+      root.render(render({ ...project, name: "Runner renamed" }));
+    });
+
+    expect(field(container, "title").value).toBe("Keep this title");
+    expect(field(container, "goal").value).toBe("Keep this goal");
+    expect(field(container, "cwd").value).toBe("/custom/mission");
+  });
+
+  it("preserves edited chat fields when the project row refreshes", async () => {
+    const render = (row: ProjectRow) =>
+      createElement(StartChatModal, {
+        open: true,
+        project: row,
+        onClose: () => {},
+        onStarted: () => {},
+      });
+    await act(async () => {
+      root.render(render(project));
+    });
+    await changeField(field(container, "title"), "Keep this chat");
+    await changeField(field(container, "cwd"), "/custom/chat");
+
+    await act(async () => {
+      root.render(render({ ...project, name: "Runner renamed" }));
+    });
+
+    expect(field(container, "title").value).toBe("Keep this chat");
+    expect(field(container, "cwd").value).toBe("/custom/chat");
+  });
+
+  it("uses the default runtime selected in Agents settings", async () => {
+    localStorage.setItem("runner.startChat.mode", "runtime");
+    localStorage.setItem("settings.defaultChatRuntime", "qoder");
+
+    await act(async () => {
+      root.render(
+        createElement(StartChatModal, {
+          open: true,
+          project,
+          onClose: () => {},
+          onStarted: () => {},
+        }),
+      );
+    });
+
+    const runtimePicker = container.querySelector<HTMLButtonElement>(
+      '[id$="-runtime"]',
+    );
+    expect(runtimePicker?.textContent).toContain("Qoder");
+    expect(field(container, "title").value).toBe("Qoder");
+  });
+});


### PR DESCRIPTION
## Summary

- replace the sidebar directory-picker shortcut with a Start Project modal
- prefill from the default working directory and keep the name derived until manually edited
- preserve project selection and refresh behavior after creation
- move project-scoped start-modal coverage and add focused StartProjectModal tests

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm run lint`
- `pnpm test` (40 files, 295 tests)
- manual smoke test

Closes #383