### PR TITLE
fix(ui): swallow opt+c in terminal panes to stop the viewport snap

### DIFF
--- a/src/components/RunnerTerminal.tsx
+++ b/src/components/RunnerTerminal.tsx
@@ -722,6 +722,14 @@ export const RunnerTerminal = forwardRef<
           return false;
         }
       }
+      // Opt+C on keyboards with swapped Cmd/Opt (external boards in the
+      // wrong mode) is almost always an intended copy: without this,
+      // xterm's third-level shift types "ç" into the PTY and the
+      // resulting data event yanks the viewport to the last row (#387).
+      // Swallow keydown and keypress both, same as Shift+Enter below.
+      if (e.altKey && !e.metaKey && !e.ctrlKey && e.code === "KeyC") {
+        return false;
+      }
       if (
         e.key === "Enter" &&
         e.shiftKey &&


### PR DESCRIPTION
## Summary

Users on keyboards with swapped Cmd/Opt (external boards in the wrong Mac/Win mode) reported that "cmd+c" snaps the terminal to the last row. Repro'd as **opt+c**: with `macOptionIsMeta` off, the chord passes xterm's third-level shift, WKWebView fires a legacy keypress with the composed `ç`, and `_keyPress` sends it as user input — the `userInitiated` data event triggers the `scrollOnUserInput` snap, and the stray `ç` lands in the agent's input frame.

The terminal's custom key handler now swallows plain opt+c (`altKey && !meta && !ctrl && code === "KeyC"`) for keydown and keypress both, mirroring the Shift+Enter interception (#99). No character, no data, no scroll. Scoped to the physical KeyC — other opt combos (European bracket/pipe layouts) untouched; cmd+c and ctrl+c unaffected.

Fixes #387

## Testing

- `pnpm exec tsc --noEmit`, `pnpm run lint` clean.
- Manual repro (opt+c while scrolled up in a busy mission terminal): jump + stray ç before, no-op after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)