### PR TITLE
feat(ui): redesign mission feed

### DIFF
--- a/design/mission-feed-composer.pen
+++ b/design/mission-feed-composer.pen
@@ -1,5 +1,5 @@
 {
-  "version": "2.14",
+  "version": "2.17",
   "children": [
     {
       "type": "frame",
@@ -250,6 +250,7 @@
             "top": 1
           },
           "strokeAlignment": "inner",
+          "strokeLinejoin": "round",
           "layout": "vertical",
           "padding": [
             12,
@@ -314,6 +315,7 @@
             "top": 1
           },
           "strokeAlignment": "inner",
+          "strokeLinejoin": "round",
           "layout": "vertical",
           "padding": [
             12,
@@ -591,6 +593,4668 @@
               "fill": "$accent",
               "width": 2,
               "height": 14
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "rAJ00",
+      "x": 40,
+      "y": 1196,
+      "name": "Feed · chat-style messages",
+      "clip": true,
+      "width": 960,
+      "fill": "$bg",
+      "cornerRadius": 10,
+      "stroke": "$border",
+      "strokeWidth": 1,
+      "layout": "vertical",
+      "gap": 16,
+      "padding": [
+        16,
+        0
+      ],
+      "children": [
+        {
+          "type": "frame",
+          "id": "f6Mqf",
+          "name": "Mission divider",
+          "width": "fill_container",
+          "gap": 10,
+          "padding": [
+            0,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "rectangle",
+              "id": "g9eewo",
+              "name": "Divider line L",
+              "fill": "$border",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "text",
+              "id": "Ulslz",
+              "name": "Divider label",
+              "fill": "$text-low",
+              "content": "MISSION STARTED · 10:02 AM",
+              "fontFamily": "$font-ui",
+              "fontSize": 10,
+              "fontWeight": "600",
+              "letterSpacing": 0.8
+            },
+            {
+              "type": "rectangle",
+              "id": "k2rDd",
+              "name": "Divider line R",
+              "fill": "$border",
+              "width": "fill_container",
+              "height": 1
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "hBfbj",
+          "name": "Goal message group",
+          "width": "fill_container",
+          "gap": 12,
+          "padding": [
+            0,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "wCZLn",
+              "name": "Avatar",
+              "clip": true,
+              "width": 35,
+              "height": 35,
+              "fill": "$raised",
+              "cornerRadius": 8,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "AiLtE",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "nPRvv",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "y2WTB",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "i1JNl0",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "qoU4C",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "m89sw",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "s2MkY",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "Dbjpd",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "rpd9Q",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "C4PNq",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "VWWqh",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "LSKj2",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "b1S7e",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "VR9zp",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "r2C4B",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "IAhcs",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "r2pqVh",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "Ojubt",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "gGnf5",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "H89vXR",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "g9PlK",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "HRX6s",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "uvjMW",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "tqqFd",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "cVSvd",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "PUJMI",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "VjlJs",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "Ti8L2",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "Hphc7",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "L9KR2",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "rMNk9",
+              "name": "Content",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Uizlf",
+                  "name": "Header",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "gCyfO",
+                      "name": "Author",
+                      "fill": "$warn",
+                      "content": "you",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "C0w61",
+                      "name": "Goal chip",
+                      "fill": "$raised",
+                      "cornerRadius": 4,
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "S7Tu8u",
+                          "name": "Chip label",
+                          "fill": "$text-mid",
+                          "content": "GOAL",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 9,
+                          "fontWeight": "600",
+                          "letterSpacing": 0.6
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "q9dpE",
+                      "name": "Time",
+                      "fill": "$text-low",
+                      "content": "10:02 AM",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "UR82d",
+                  "name": "Goal body",
+                  "fill": "$text-hi",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Rebase PR #293 on latest main, unify the dataless-file detection into one shared helper, and drive CI green. Do not merge — report final state.",
+                  "lineHeight": 1.55,
+                  "fontFamily": "$font-ui",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Q3Yohx",
+          "name": "Coder message group",
+          "width": "fill_container",
+          "gap": 12,
+          "padding": [
+            0,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "EnKfl",
+              "name": "Avatar",
+              "clip": true,
+              "width": 35,
+              "height": 35,
+              "fill": "$raised",
+              "cornerRadius": 8,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "V7Dan",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "jVoQ0",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "EhiHi",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "RwLv1",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "vIqKs",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "Huoum",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "YpI8t",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "ShDJg",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "aMPSa",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "opPtb",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "jiSFJ",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "crXxF",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ChNy2",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "OdH6P",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "cWUnm",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "GywXj",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "e5t0S",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "yhECA",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Z6ACC",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "SWYXj",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "e6yCGW",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "hF3qW",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "LB5V5",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "J4O5kq",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "BavCz",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "WAgny",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "y5xPc",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "e5ecN3",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "MAcEk",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "boHY4",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "sHr2j",
+              "name": "Content",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "sAkMu",
+                  "name": "Header",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "El8c6",
+                      "name": "Author",
+                      "fill": "$accent",
+                      "content": "@coder",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "i2OmX",
+                      "name": "Time",
+                      "fill": "$text-low",
+                      "content": "10:05 AM",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "c9WtPr",
+                  "name": "Body para",
+                  "fill": "$text-hi",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Rebased onto origin/main — three conflicts resolved. Plan for the unified detector:",
+                  "lineHeight": 1.55,
+                  "fontFamily": "$font-ui",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "frame",
+                  "id": "oZnu7",
+                  "name": "Bullet list",
+                  "width": "fill_container",
+                  "layout": "vertical",
+                  "gap": 5,
+                  "padding": [
+                    2,
+                    0,
+                    2,
+                    8
+                  ],
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "uNII1",
+                      "name": "List item",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "l7lclz",
+                          "name": "Bullet",
+                          "fill": "$text-mid",
+                          "content": "•",
+                          "lineHeight": 1.55,
+                          "fontFamily": "$font-ui",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "nhkf9",
+                          "name": "Item line",
+                          "width": "fill_container",
+                          "gap": 5,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "O8mAe",
+                              "name": "Item text",
+                              "fill": "$text-hi",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Extend the pure decision helper so it takes the flag bits too",
+                              "lineHeight": 1.55,
+                              "fontFamily": "$font-ui",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "Ojebt",
+                      "name": "List item",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "Jhgj9",
+                          "name": "Bullet",
+                          "fill": "$text-mid",
+                          "content": "•",
+                          "lineHeight": 1.55,
+                          "fontFamily": "$font-ui",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "uk6IW",
+                          "name": "Item line",
+                          "width": "fill_container",
+                          "gap": 5,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "j1cny",
+                              "name": "Item text",
+                              "fill": "$text-hi",
+                              "content": "Keep",
+                              "lineHeight": 1.55,
+                              "fontFamily": "$font-ui",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "u1y1t",
+                              "name": "Code pill",
+                              "fill": "$raised",
+                              "cornerRadius": 4,
+                              "padding": [
+                                1,
+                                5
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "mKwR2",
+                                  "name": "Code",
+                                  "fill": "$accent",
+                                  "content": "is_dataless_file(path)",
+                                  "fontFamily": "$font-mono",
+                                  "fontSize": 11.5,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "d0YQBH",
+                              "name": "Item text tail",
+                              "fill": "$text-hi",
+                              "content": "as the path-level wrapper",
+                              "lineHeight": 1.55,
+                              "fontFamily": "$font-ui",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "FKSoM",
+                      "name": "List item",
+                      "width": "fill_container",
+                      "gap": 8,
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "VsVFA",
+                          "name": "Bullet",
+                          "fill": "$text-mid",
+                          "content": "•",
+                          "lineHeight": 1.55,
+                          "fontFamily": "$font-ui",
+                          "fontSize": 13,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "OQfxR",
+                          "name": "Item line",
+                          "width": "fill_container",
+                          "gap": 5,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Ynhe3",
+                              "name": "Item text",
+                              "fill": "$text-hi",
+                              "textGrowth": "fixed-width",
+                              "width": "fill_container",
+                              "content": "Both call sites use the shared helper — cover ingest semantics preserved",
+                              "lineHeight": 1.55,
+                              "fontFamily": "$font-ui",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "ipvps",
+                  "name": "Continuation message",
+                  "width": "fill_container",
+                  "gap": 5,
+                  "padding": [
+                    6,
+                    0,
+                    0,
+                    0
+                  ],
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "m4vkx",
+                      "name": "Cont text",
+                      "fill": "$text-hi",
+                      "content": "All availability reads now go through",
+                      "lineHeight": 1.55,
+                      "fontFamily": "$font-ui",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "V29sP",
+                      "name": "Code pill",
+                      "fill": "$raised",
+                      "cornerRadius": 4,
+                      "padding": [
+                        1,
+                        5
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "jSWII",
+                          "name": "Code",
+                          "fill": "$accent",
+                          "content": "is_file_downloaded",
+                          "fontFamily": "$font-mono",
+                          "fontSize": 11.5,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "MREGM",
+                      "name": "Cont tail",
+                      "fill": "$text-hi",
+                      "content": "— the per-book probe loop is gone.",
+                      "lineHeight": 1.55,
+                      "fontFamily": "$font-ui",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "cEkGq",
+          "name": "Signal line",
+          "width": "fill_container",
+          "gap": 6,
+          "padding": [
+            0,
+            16,
+            0,
+            63
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "icon",
+              "id": "jcnXX",
+              "name": "Signal icon",
+              "width": 12,
+              "height": 12,
+              "icon": "zap",
+              "library": "lucide",
+              "fill": "$text-low"
+            },
+            {
+              "type": "text",
+              "id": "fQIeo",
+              "name": "Signal author",
+              "fill": "$text-mid",
+              "content": "@coder",
+              "fontFamily": "$font-mono",
+              "fontSize": 11,
+              "fontWeight": "600"
+            },
+            {
+              "type": "text",
+              "id": "rx6Db",
+              "name": "Signal label",
+              "fill": "$text-low",
+              "content": "signal · ask_lead → @lead · 10:06 AM",
+              "fontFamily": "$font-ui",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "frame",
+              "id": "HTO2b",
+              "name": "Signal spacer",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "text",
+              "id": "rjUxp",
+              "name": "Payload hint",
+              "fill": "$text-low",
+              "content": "payload ▾",
+              "fontFamily": "$font-ui",
+              "fontSize": 10,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "P9eZ3",
+          "name": "Ask-human group",
+          "width": "fill_container",
+          "gap": 12,
+          "padding": [
+            0,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "iWPcv",
+              "name": "Avatar",
+              "clip": true,
+              "width": 35,
+              "height": 35,
+              "fill": "$raised",
+              "cornerRadius": 8,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ZLNQJ",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "a8d2AC",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "n8lOv",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "xnJZ1",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "VAbiQ",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "Z5FmU",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "xp3mr",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "oWP3y",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "E5mjAh",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "wmkc3",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "oBNmc",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "f0JMTm",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Z7Uy7",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "LAC7Y",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "LdcPU",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "wJnTy",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "spLsh",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "eTmKc",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "l9vQcz",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "bjwVp",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "h7Exp",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "B8kQtO",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "CCveG",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "B2yfI",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "a9ukR",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "tLnMq",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "cQGzG",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "G7g2B",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "M4L1N",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "R3TudG",
+                      "name": "Pixel",
+                      "fill": "$accent",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "qOk93",
+              "name": "Content",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 6,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "p91GQ",
+                  "name": "Header",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "mwRt5",
+                      "name": "Author",
+                      "fill": "$accent",
+                      "content": "@coder",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "xnz1L",
+                      "name": "Input chip",
+                      "fill": "#FFB0201F",
+                      "cornerRadius": 4,
+                      "padding": [
+                        2,
+                        6
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "ZOYUa",
+                          "name": "Chip label",
+                          "fill": "$warn",
+                          "content": "NEEDS YOUR INPUT",
+                          "fontFamily": "$font-ui",
+                          "fontSize": 9,
+                          "fontWeight": "600",
+                          "letterSpacing": 0.6
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "tshYQ",
+                      "name": "Chain",
+                      "fill": "$text-mid",
+                      "content": "→ you",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "gkRta",
+                      "name": "Time",
+                      "fill": "$text-low",
+                      "content": "10:14 AM",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "C5HAo",
+                  "name": "Ask card",
+                  "width": "fill_container",
+                  "fill": "#FFB0200D",
+                  "cornerRadius": 8,
+                  "stroke": "#FFB02059",
+                  "strokeWidth": 1,
+                  "layout": "vertical",
+                  "gap": 10,
+                  "padding": 12,
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ziUlr",
+                      "name": "Prompt",
+                      "fill": "$text-hi",
+                      "textGrowth": "fixed-width",
+                      "width": "fill_container",
+                      "content": "Mission aaasdf has no target repository and its steps do not specify an implementable change. How should I proceed?",
+                      "lineHeight": 1.55,
+                      "fontFamily": "$font-ui",
+                      "fontSize": 13,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "u5h5Oa",
+                      "name": "Choices",
+                      "width": "fill_container",
+                      "layout": "vertical",
+                      "gap": 6,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "be5DX",
+                          "name": "Choice primary",
+                          "width": "fill_container",
+                          "fill": "$accent",
+                          "cornerRadius": 6,
+                          "padding": [
+                            9,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "DFO4z",
+                              "name": "Choice label",
+                              "fill": "$accent-ink",
+                              "content": "Provide the repository path and concrete expected behavior",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 12,
+                              "fontWeight": "600"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "gNg2L",
+                          "name": "Choice secondary",
+                          "width": "fill_container",
+                          "fill": "$panel",
+                          "cornerRadius": 6,
+                          "stroke": "$border",
+                          "strokeWidth": 1,
+                          "padding": [
+                            9,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "Otb5b",
+                              "name": "Choice label",
+                              "fill": "$text-hi",
+                              "content": "Cancel this placeholder mission",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 12,
+                              "fontWeight": "500"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "lN1Ke",
+          "name": "You reply group",
+          "width": "fill_container",
+          "gap": 12,
+          "padding": [
+            0,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "IaJTy",
+              "name": "Avatar",
+              "clip": true,
+              "width": 35,
+              "height": 35,
+              "fill": "$raised",
+              "cornerRadius": 8,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "NHBAc",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "O5SWvG",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "h6opJv",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "f2QSz",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "MXpu5",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "vb8IC",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "HTSQR",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "B1Vf1",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "jAy8O",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "xrhLe",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "xMpxg",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "KiTlJ",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "AFYaj",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "Y9KDVy",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "twLTq",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "ZLAIK",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "W6rJKt",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "VB06I",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "hD6cS",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "x1fRN",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "M730w",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "V6Qezn",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "YzbeN",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "EbIbH",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "YIqdv",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "V5349",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "EF5ms",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "sOEoY",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "AI5sy",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "UKaHJ",
+                      "name": "Pixel",
+                      "fill": "$warn",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "URvV0",
+              "name": "Content",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "xvM8s",
+                  "name": "Header",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "UHqwf",
+                      "name": "Author",
+                      "fill": "$warn",
+                      "content": "you",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "N0Oti",
+                      "name": "Time",
+                      "fill": "$text-low",
+                      "content": "10:15 AM",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "SQ8Ht",
+                  "name": "Body",
+                  "fill": "$text-hi",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Use ~/repos/yicheng47/quill — the expected behavior is written up in issue #293.",
+                  "lineHeight": 1.55,
+                  "fontFamily": "$font-ui",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "rGxFV",
+          "name": "Reviewer message group",
+          "width": "fill_container",
+          "gap": 12,
+          "padding": [
+            0,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "taTkn",
+              "name": "Avatar",
+              "clip": true,
+              "width": 35,
+              "height": 35,
+              "fill": "$raised",
+              "cornerRadius": 8,
+              "layout": "vertical",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "q36si",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "j2KS7",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "RiMTO",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "wV3RE",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "WyUFY",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "GSZqA",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "vDjOV",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "I4mX3",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "gGkgx",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "mjAHC",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "n4rx53",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "KS743",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "LkbGo",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "vcR4y",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "d5Yvo",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "keQZY",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "TgIvB",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "LPcoi",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "jz199",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "t5Hsi3",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "N9iugE",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "f39JC7",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "L6F3B",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "V3ZC8m",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "E37sAu",
+                  "name": "Pixel row",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "id": "C8xNI",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "Bn9d5",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "qgD8o",
+                      "name": "Pixel",
+                      "fill": "#00000000",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "qyNlw",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    },
+                    {
+                      "type": "rectangle",
+                      "id": "viLwf",
+                      "name": "Pixel",
+                      "fill": "#C792EA",
+                      "width": 7,
+                      "height": 7
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "vkVnv",
+              "name": "Content",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "TuH3C",
+                  "name": "Header",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "hkYHP",
+                      "name": "Author",
+                      "fill": "#C792EA",
+                      "content": "@reviewer",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 13,
+                      "fontWeight": "600"
+                    },
+                    {
+                      "type": "text",
+                      "id": "qpSgK",
+                      "name": "Target",
+                      "fill": "$text-mid",
+                      "content": "→ @coder",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "text",
+                      "id": "A6aoJT",
+                      "name": "Time",
+                      "fill": "$text-low",
+                      "content": "10:31 AM",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 11,
+                      "fontWeight": "normal"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "l2Em54",
+                  "name": "Body",
+                  "fill": "$text-hi",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Full-diff review vs origin/main is clean — no must-fix findings. The cover-ingest deferral from #301 is preserved.",
+                  "lineHeight": 1.55,
+                  "fontFamily": "$font-ui",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "WGfDp",
+          "name": "Composer",
+          "width": "fill_container",
+          "stroke": "$border",
+          "strokeWidth": {
+            "top": 1
+          },
+          "strokeAlignment": "inner",
+          "strokeLinejoin": "round",
+          "layout": "vertical",
+          "padding": [
+            12,
+            24,
+            16,
+            24
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "sTlBs",
+              "name": "composerBox",
+              "width": "fill_container",
+              "fill": "$panel",
+              "cornerRadius": 8,
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "gap": 8,
+              "padding": [
+                10,
+                12
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "RUbmE",
+                  "name": "placeholder",
+                  "fill": "$text-low",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Message the crew — @handle to address one runner",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 13,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "note",
+      "id": "Rauwg",
+      "x": 1060,
+      "y": 1196,
+      "name": "Chat-style feed notes",
+      "width": 560,
+      "height": 620,
+      "content": "FEED · CHAT-STYLE MESSAGES — decisions to confirm\n\n1. Row anatomy (Discord/Slack-like): identicon avatar (35px, revives spec 11), header = author + context + time, body below. Consecutive events from the same author within ~5 min collapse into one group (avatar + header shown once).\n\n2. Redundancy fix: raw ask_human signal rows are HIDDEN — the needs-your-input card already shows prompt + choices + on_behalf_of chain. Card gets the asker's avatar and a NEEDS YOUR INPUT chip instead of a separate JSON block.\n\n3. Remaining system signals (ask_lead, mission_warning, unknown types) become one-line compact rows: zap icon + author + type + time, payload expandable on click ('payload ▾'). No more JSON boxes in the main flow.\n\n4. mission_start renders as the thin centered divider (Discord date-divider style). mission_goal renders as a normal 'you' message with a GOAL chip.\n\n5. Identity colors: you = amber (warn). Runners get a deterministic per-handle hue (coder=green accent, reviewer=violet, ...) applied to avatar + name.\n\nOPEN QUESTIONS\n· Identicon pixel avatar vs initial-letter avatar?\n· Per-runner hues, or keep all runners accent green?\n· Grouping window: 5 min ok? Group across a signal row or break?\n· Hide ask_lead one-liner too once the lead replies, or keep visible?"
+    },
+    {
+      "type": "frame",
+      "id": "xQqXy",
+      "x": 40,
+      "y": 2223,
+      "name": "Mission workspace — inbox delivery blocked",
+      "width": 1440,
+      "height": 900,
+      "fill": "#15161B",
+      "cornerRadius": 12,
+      "children": [
+        {
+          "type": "frame",
+          "id": "rJunz",
+          "name": "Sidebar",
+          "width": 240,
+          "height": "fill_container",
+          "fill": "#272930",
+          "stroke": "#272930",
+          "strokeWidth": {
+            "right": 1
+          },
+          "strokeAlignment": "inner",
+          "strokeLinejoin": "round",
+          "layout": "vertical",
+          "gap": 4,
+          "padding": [
+            16,
+            20,
+            20,
+            20
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "jXZgp",
+              "name": "brand",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "o4Aqd9",
+                  "name": "brandLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "QklGq",
+                      "name": "brandIcon",
+                      "width": 32,
+                      "height": 32,
+                      "layout": "none",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "v0qXw",
+                          "x": 9,
+                          "y": 9,
+                          "width": 14,
+                          "height": 14,
+                          "icon": "chevron-right",
+                          "library": "lucide",
+                          "fill": "#00FF9C"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "P7E3G",
+                          "x": 3,
+                          "y": 3,
+                          "opacity": 0.4,
+                          "width": 9,
+                          "height": 9,
+                          "icon": "chevron-right",
+                          "library": "lucide",
+                          "fill": "#00FF9C"
+                        },
+                        {
+                          "type": "icon",
+                          "id": "m0nqC",
+                          "x": 3,
+                          "y": 20,
+                          "opacity": 0.4,
+                          "width": 9,
+                          "height": 9,
+                          "icon": "chevron-right",
+                          "library": "lucide",
+                          "fill": "#00FF9C"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "text",
+                      "id": "zQm6B",
+                      "fill": "#DCDCE0",
+                      "content": "Runner",
+                      "fontFamily": "Inter",
+                      "fontSize": 18,
+                      "fontWeight": "600"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "UOfCr",
+              "width": "fill_container",
+              "height": 14
+            },
+            {
+              "type": "text",
+              "id": "ePqRj",
+              "name": "cfg4",
+              "fill": "#5A5C66",
+              "content": "WORKSPACE",
+              "fontFamily": "JetBrains Mono",
+              "fontSize": 10,
+              "fontWeight": "600",
+              "letterSpacing": 1
+            },
+            {
+              "type": "frame",
+              "id": "M0lit",
+              "name": "nav_r",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "WwRXY",
+                  "name": "runnerIcon",
+                  "width": 12,
+                  "height": 12,
+                  "icon": "terminal",
+                  "library": "lucide",
+                  "fill": "#9A9BA5"
+                },
+                {
+                  "type": "text",
+                  "id": "AtIhb",
+                  "fill": "#9A9BA5",
+                  "content": "runner",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Tn1yu",
+              "name": "nav_c",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "s6J7VW",
+                  "name": "crewIcon",
+                  "width": 12,
+                  "height": 12,
+                  "icon": "users",
+                  "library": "lucide",
+                  "fill": "#9A9BA5"
+                },
+                {
+                  "type": "text",
+                  "id": "mcc0V",
+                  "fill": "#9A9BA5",
+                  "content": "crew",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "BNG7w",
+              "name": "nav_s",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": 10,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "icon",
+                  "id": "Z9mpyK",
+                  "name": "searchIcon",
+                  "width": 12,
+                  "height": 12,
+                  "icon": "search",
+                  "library": "lucide",
+                  "fill": "#9A9BA5"
+                },
+                {
+                  "type": "text",
+                  "id": "pzNPF",
+                  "name": "searchLbl",
+                  "fill": "#9A9BA5",
+                  "content": "search",
+                  "fontFamily": "Inter",
+                  "fontSize": 14,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "cgPqN",
+              "name": "missionSpacer",
+              "width": "fill_container",
+              "height": 20
+            },
+            {
+              "type": "frame",
+              "id": "vjJHn",
+              "name": "MissionHeader",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "EyPoC",
+                  "name": "MissionHeaderLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "izJN0",
+                      "name": "missionChev",
+                      "width": 10,
+                      "height": 10,
+                      "icon": "chevron-down",
+                      "library": "lucide",
+                      "fill": "#5A5C66"
+                    },
+                    {
+                      "type": "text",
+                      "id": "hr4Vm",
+                      "name": "missionLabel",
+                      "fill": "#5A5C66",
+                      "content": "MISSION",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "WkoKa",
+                      "name": "MissionCount",
+                      "fill": "#15161B",
+                      "cornerRadius": 999,
+                      "padding": [
+                        1,
+                        5
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "C9T5q",
+                          "name": "missionBadgeTxt",
+                          "fill": "#5A5C66",
+                          "content": "1",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "Y315c",
+                  "name": "AddMissionBtn",
+                  "cornerRadius": 4,
+                  "padding": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "MZLwU",
+                      "name": "addMissionIcon",
+                      "width": 12,
+                      "height": 12,
+                      "icon": "plus",
+                      "library": "lucide",
+                      "fill": "#9A9BA5"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "t32M9x",
+              "name": "Mission1",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "K83WXR",
+                  "fill": "#00FF9C",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "uqXKQ",
+                  "fill": "#9A9BA5",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Create a temp go pr…",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "knZMn",
+              "name": "sessSpacer",
+              "width": "fill_container",
+              "height": 32
+            },
+            {
+              "type": "frame",
+              "id": "AlNuJ",
+              "name": "SessionHeader",
+              "width": "fill_container",
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "CFsgj",
+                  "name": "SessionHeaderLeft",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "Ed8UQ",
+                      "name": "sessionChev",
+                      "width": 10,
+                      "height": 10,
+                      "icon": "chevron-down",
+                      "library": "lucide",
+                      "fill": "#5A5C66"
+                    },
+                    {
+                      "type": "text",
+                      "id": "Lgm4H",
+                      "name": "sessionLabel",
+                      "fill": "#5A5C66",
+                      "content": "CHAT",
+                      "fontFamily": "JetBrains Mono",
+                      "fontSize": 10,
+                      "fontWeight": "600",
+                      "letterSpacing": 1
+                    },
+                    {
+                      "type": "frame",
+                      "id": "c5ORR",
+                      "name": "SessionCount",
+                      "fill": "#15161B",
+                      "cornerRadius": 999,
+                      "padding": [
+                        1,
+                        5
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "FXcS5",
+                          "name": "sessionBadgeTxt",
+                          "fill": "#5A5C66",
+                          "content": "2",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 10,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "lSQVD",
+                  "name": "AddSessionBtn",
+                  "cornerRadius": 4,
+                  "padding": 4,
+                  "justifyContent": "center",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "icon",
+                      "id": "OoxUA",
+                      "name": "addMissionIcon",
+                      "width": 12,
+                      "height": 12,
+                      "icon": "plus",
+                      "library": "lucide",
+                      "fill": "#9A9BA5"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "F8m563",
+              "name": "sess1_active",
+              "width": "fill_container",
+              "fill": "#15161B",
+              "cornerRadius": 6,
+              "stroke": "#272930",
+              "strokeWidth": 1,
+              "strokeAlignment": "inner",
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "y28pd1",
+                  "fill": "#00FF9C",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "EbbbS",
+                  "fill": "#DCDCE0",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "Wire up event bus…",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "kjHIK",
+              "name": "mr2",
+              "width": "fill_container",
+              "cornerRadius": 6,
+              "gap": 8,
+              "padding": [
+                8,
+                10
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "ellipse",
+                  "id": "CspHK",
+                  "fill": "#00FF9C",
+                  "width": 6,
+                  "height": 6
+                },
+                {
+                  "type": "text",
+                  "id": "NzluE",
+                  "fill": "#9A9BA5",
+                  "textGrowth": "fixed-width",
+                  "width": "fill_container",
+                  "content": "@architect chat",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "o6CSD5",
+          "name": "Main",
+          "width": "fill_container",
+          "height": "fill_container",
+          "fill": "#15161B",
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "X0ISc",
+              "name": "Topbar",
+              "width": "fill_container",
+              "fill": "#1D1E23",
+              "stroke": "#272930",
+              "strokeWidth": {
+                "bottom": 1
+              },
+              "strokeAlignment": "inner",
+              "strokeLinejoin": "round",
+              "gap": 16,
+              "padding": [
+                14,
+                24
+              ],
+              "justifyContent": "space_between",
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "lDWtE",
+                  "name": "tb_left",
+                  "width": "fill_container",
+                  "gap": 14,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "a83c6F",
+                      "name": "avatar",
+                      "width": 36,
+                      "height": 36,
+                      "fill": "#15161B",
+                      "cornerRadius": 8,
+                      "stroke": "#272930",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "YGlu6",
+                          "width": 18,
+                          "height": 18,
+                          "icon": "flag",
+                          "library": "lucide",
+                          "fill": "#00FF9C"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "IesPM",
+                      "name": "tb_titles",
+                      "layout": "vertical",
+                      "gap": 3,
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "hDrZD",
+                          "name": "title_row",
+                          "gap": 10,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "y262V",
+                              "fill": "#DCDCE0",
+                              "content": "Wire up event bus watcher",
+                              "fontFamily": "Inter",
+                              "fontSize": 15,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "Hw6zQ",
+                              "name": "mission_chip",
+                              "fill": "#272930",
+                              "cornerRadius": 4,
+                              "padding": [
+                                2,
+                                8
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "Km84f",
+                                  "fill": "#9A9BA5",
+                                  "content": "MISSION",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 9,
+                                  "fontWeight": "700",
+                                  "letterSpacing": 0.5
+                                }
+                              ]
+                            },
+                            {
+                              "type": "frame",
+                              "id": "ywpMH",
+                              "name": "status_badge",
+                              "fill": "#272930",
+                              "cornerRadius": 999,
+                              "gap": 6,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "ellipse",
+                                  "id": "E7WiR",
+                                  "fill": "#5A5C66",
+                                  "width": 6,
+                                  "height": 6
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "Q09swN",
+                                  "fill": "#9A9BA5",
+                                  "content": "stopped",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "500"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "G0LU63",
+                          "name": "meta_row",
+                          "gap": 8,
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "L9X42",
+                              "fill": "#9A9BA5",
+                              "content": "runners-feature",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "u0Ogb",
+                              "fill": "#5A5C66",
+                              "content": "·",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "qlpSo",
+                              "fill": "#9A9BA5",
+                              "content": "3 runners",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "ODE2i",
+                              "fill": "#5A5C66",
+                              "content": "·",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "text",
+                              "id": "hyPMs",
+                              "fill": "#9A9BA5",
+                              "content": "started 14m ago",
+                              "fontFamily": "Inter",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "c3IJc",
+                  "name": "tb_right",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "OzhTR",
+                      "name": "stop_btn",
+                      "fill": "#0F2418",
+                      "cornerRadius": 6,
+                      "stroke": "#1F4D33",
+                      "strokeWidth": 1,
+                      "strokeAlignment": "inner",
+                      "gap": 6,
+                      "padding": [
+                        6,
+                        10
+                      ],
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "hu9ji",
+                          "width": 12,
+                          "height": 12,
+                          "icon": "play",
+                          "library": "lucide",
+                          "fill": "#00FF9C"
+                        },
+                        {
+                          "type": "text",
+                          "id": "V0vZP",
+                          "fill": "#00FF9C",
+                          "content": "Resume",
+                          "fontFamily": "Inter",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "clplg",
+                      "name": "tb_kebab",
+                      "width": 28,
+                      "height": 28,
+                      "cornerRadius": 6,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "hiHui",
+                          "width": 16,
+                          "height": 16,
+                          "icon": "ellipsis",
+                          "library": "lucide",
+                          "fill": "#9A9BA5"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Z1p0L",
+              "name": "Body",
+              "width": "fill_container",
+              "height": "fill_container",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "m44EOX",
+                  "name": "Center",
+                  "width": "fill_container",
+                  "height": "fill_container",
+                  "layout": "vertical",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "jmckH",
+                      "name": "TabStrip",
+                      "width": "fill_container",
+                      "height": 38,
+                      "fill": "#1D1E23",
+                      "stroke": "#272930",
+                      "strokeWidth": {
+                        "bottom": 1
+                      },
+                      "strokeAlignment": "inner",
+                      "strokeLinejoin": "round",
+                      "gap": 4,
+                      "padding": [
+                        0,
+                        24
+                      ],
+                      "alignItems": "end",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "Nl3et",
+                          "name": "feedTab_active",
+                          "stroke": "#272930",
+                          "strokeAlignment": "inner",
+                          "gap": 6,
+                          "padding": [
+                            10,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "PJfto",
+                              "name": "feedLabel",
+                              "fill": "#5A5C66",
+                              "content": "feed",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "SeRAX",
+                          "name": "ptyTab_inactive",
+                          "stroke": "#00FF9C",
+                          "strokeWidth": {
+                            "bottom": 2
+                          },
+                          "strokeAlignment": "inner",
+                          "strokeLinejoin": "round",
+                          "gap": 8,
+                          "padding": [
+                            10,
+                            14
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "Qjwjp",
+                              "name": "ptyIcon",
+                              "width": 12,
+                              "height": 12,
+                              "icon": "terminal",
+                              "library": "lucide",
+                              "fill": "#DCDCE0"
+                            },
+                            {
+                              "type": "text",
+                              "id": "B0o3m",
+                              "name": "ptyLabel",
+                              "fill": "#DCDCE0",
+                              "content": "@architect pty",
+                              "fontFamily": "Inter",
+                              "fontSize": 13,
+                              "fontWeight": "500"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "z18t4",
+                              "name": "ptyCloseBtn",
+                              "width": 16,
+                              "height": 16,
+                              "cornerRadius": 3,
+                              "justifyContent": "center",
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "icon",
+                                  "id": "v49nK",
+                                  "name": "ptyCloseIcon",
+                                  "width": 11,
+                                  "height": 11,
+                                  "icon": "x",
+                                  "library": "lucide",
+                                  "fill": "#5A5C66"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "hEBU6",
+                      "name": "term",
+                      "clip": true,
+                      "width": "fill_container",
+                      "height": "fill_container",
+                      "fill": "#15161B",
+                      "layout": "vertical",
+                      "gap": 4,
+                      "padding": [
+                        16,
+                        40
+                      ],
+                      "children": [
+                        {
+                          "type": "text",
+                          "id": "g2a87z",
+                          "fill": "#DCDCE0",
+                          "content": "$ claude --session-id 01993b21-7e4f-7d9a-bb02-8a6f7c92c0a1",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "F1Dq0C",
+                          "fill": "#00FF9C",
+                          "content": "✻ Welcome to Claude Code",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "X80iVh",
+                          "fill": "#9A9BA5",
+                          "content": " cwd:   /Users/jason/go/src/github.com/yicheng47/runner",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "wJsqs",
+                          "fill": "#39E5FF",
+                          "content": "▶ Mission: Wire up event bus watcher",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "text",
+                          "id": "Wg5pO",
+                          "fill": "#DCDCE0",
+                          "content": "⏺ Decomposing into 4 phases. Dispatching task 1 to @impl…",
+                          "fontFamily": "JetBrains Mono",
+                          "fontSize": 12,
+                          "fontWeight": "normal"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "TdKJa",
+                          "name": "termTail",
+                          "width": "fill_container",
+                          "height": "fill_container",
+                          "layout": "vertical",
+                          "gap": 6,
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "xd9tg",
+                              "name": "tailSpacer",
+                              "width": "fill_container",
+                              "height": "fill_container"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "si8xJ",
+                              "name": "tuiInputBox",
+                              "width": "fill_container",
+                              "cornerRadius": 6,
+                              "stroke": "#3A3D46",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "padding": [
+                                8,
+                                10
+                              ],
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "TkPnh",
+                                  "name": "tuiDraft",
+                                  "fill": "#DCDCE0",
+                                  "content": "› fix the watcher debounce first, then re-run the▌",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 12,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            },
+                            {
+                              "type": "text",
+                              "id": "XMHXp",
+                              "name": "tuiHint",
+                              "fill": "#5A5C66",
+                              "content": "? for shortcuts",
+                              "fontFamily": "JetBrains Mono",
+                              "fontSize": 11,
+                              "fontWeight": "normal"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "C4j4Dn",
+                      "layoutPosition": "absolute",
+                      "x": 0,
+                      "y": 50,
+                      "name": "pillOverlay",
+                      "width": 920,
+                      "padding": [
+                        0,
+                        16
+                      ],
+                      "justifyContent": "end",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "KbbmZ",
+                          "name": "InboxBlockedPill",
+                          "fill": "#1D1E23",
+                          "cornerRadius": 8,
+                          "stroke": "#FFB4543D",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
+                          "effect": {
+                            "type": "shadow",
+                            "shadowType": "outer",
+                            "color": "#00000066",
+                            "offset": {
+                              "x": 0,
+                              "y": 4
+                            },
+                            "blur": 16
+                          },
+                          "gap": 8,
+                          "padding": [
+                            8,
+                            12
+                          ],
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "b6fET",
+                              "name": "pillIcon",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "mail",
+                              "library": "lucide",
+                              "fill": "#FFB454"
+                            },
+                            {
+                              "type": "text",
+                              "id": "INp3m",
+                              "name": "pillTitle",
+                              "fill": "#FFB454",
+                              "content": "Inbox waiting (2)",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "600"
+                            },
+                            {
+                              "type": "text",
+                              "id": "m5mYr",
+                              "name": "pillBody",
+                              "fill": "#9A9BA5",
+                              "content": "— typing detected, delivery paused",
+                              "fontFamily": "Inter",
+                              "fontSize": 12,
+                              "fontWeight": "normal"
+                            },
+                            {
+                              "type": "frame",
+                              "id": "vd9AL",
+                              "name": "pillClearBtn",
+                              "fill": "#FFB4541A",
+                              "cornerRadius": 6,
+                              "stroke": "#FFB45466",
+                              "strokeWidth": 1,
+                              "strokeAlignment": "inner",
+                              "gap": 6,
+                              "padding": [
+                                4,
+                                8
+                              ],
+                              "alignItems": "center",
+                              "children": [
+                                {
+                                  "type": "text",
+                                  "id": "xup5P",
+                                  "name": "btnLabel",
+                                  "fill": "#FFB454",
+                                  "content": "Clear input",
+                                  "fontFamily": "Inter",
+                                  "fontSize": 11,
+                                  "fontWeight": "600"
+                                },
+                                {
+                                  "type": "text",
+                                  "id": "eEkth",
+                                  "name": "btnKey",
+                                  "fill": "#FFB454B3",
+                                  "content": "↵",
+                                  "fontFamily": "JetBrains Mono",
+                                  "fontSize": 10,
+                                  "fontWeight": "normal"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "LMQ7c",
+          "name": "Runners rail",
+          "width": 280,
+          "height": "fill_container",
+          "fill": "#1D1E23",
+          "stroke": "#272930",
+          "strokeWidth": {
+            "left": 1
+          },
+          "strokeAlignment": "inner",
+          "strokeLinejoin": "round",
+          "layout": "vertical",
+          "gap": 12,
+          "padding": [
+            14,
+            20,
+            20,
+            20
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "F2HWM",
+              "name": "panel_header",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 14,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ecMYu",
+                  "name": "panel_topbar",
+                  "width": "fill_container",
+                  "height": 36,
+                  "gap": 2,
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "n36Cg",
+                      "name": "topbar_left",
+                      "gap": 2,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "F0pEdW",
+                          "name": "btn_runners",
+                          "width": 26,
+                          "height": 26,
+                          "fill": "#272930",
+                          "cornerRadius": 6,
+                          "stroke": "#3A3D45",
+                          "strokeWidth": 1,
+                          "strokeAlignment": "inner",
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "uNPEc",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "users",
+                              "library": "lucide",
+                              "fill": "#E9EAEE"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "frame",
+                          "id": "chxXI",
+                          "name": "btn_mission",
+                          "width": 26,
+                          "height": 26,
+                          "fill": "#00000000",
+                          "cornerRadius": 6,
+                          "stroke": "#00000000",
+                          "strokeAlignment": "inner",
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "WLizu",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "info",
+                              "library": "lucide",
+                              "fill": "#9A9BA5"
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "P0Jn8",
+                      "name": "topbar_right",
+                      "gap": 2,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "jBsls",
+                          "name": "panelCollapse",
+                          "width": 24,
+                          "height": 24,
+                          "cornerRadius": 6,
+                          "justifyContent": "center",
+                          "alignItems": "center",
+                          "children": [
+                            {
+                              "type": "icon",
+                              "id": "cyGEw",
+                              "width": 14,
+                              "height": 14,
+                              "icon": "panel-right-close",
+                              "library": "lucide",
+                              "fill": "#9A9BA5"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "frame",
+                  "id": "wgbdk",
+                  "name": "topbar_div",
+                  "width": "fill_container",
+                  "height": 1,
+                  "fill": "#272930"
+                },
+                {
+                  "type": "text",
+                  "id": "a2GFuq",
+                  "fill": "#5A5C66",
+                  "content": "RUNNER SESSIONS",
+                  "fontFamily": "JetBrains Mono",
+                  "fontSize": 10,
+                  "fontWeight": "600",
+                  "letterSpacing": 1
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Y9o2J",
+              "name": "Runner card architect",
+              "width": "fill_container",
+              "fill": "$bg",
+              "cornerRadius": 6,
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "WakeI",
+                  "name": "Card header",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "R72DoX",
+                      "name": "Identity",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "wPNCe",
+                          "name": "Avatar wrap",
+                          "width": 25,
+                          "height": 25,
+                          "layout": "none",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "geozv",
+                              "x": 0,
+                              "y": 0,
+                              "name": "Avatar",
+                              "clip": true,
+                              "width": 25,
+                              "height": 25,
+                              "fill": "$raised",
+                              "cornerRadius": 6,
+                              "layout": "vertical",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "n5qJV",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "jK8ZY",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "ZPCrz",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "uIHyE",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "ULdZE",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "GG8EW",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "fm8wf",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "i0ZAuK",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "sqSMT",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "GOgBo",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "anNuc",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "B3uRzs",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "XnFmK",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "IhuKq",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "prWIT",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "gSo0T",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "A9oCGT",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "uVU0m",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "bLH3F",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "GRmKk",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "lqVTw",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "Y5jZz",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "ZfPlk",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "Ikd2w",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "PoUqe",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "MjFDe",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "eDtpb",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "zwzbc",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "eQWUZ",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "J5iX4",
+                                      "name": "Pixel",
+                                      "fill": "$accent",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "soK8Q",
+                              "x": 17,
+                              "y": 17,
+                              "name": "Presence dot",
+                              "fill": "#00FF9C66",
+                              "width": 9,
+                              "height": 9,
+                              "stroke": "#15161B",
+                              "strokeWidth": 2,
+                              "strokeAlignment": "outer"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "HQeBh",
+                          "name": "Handle",
+                          "fill": "$accent",
+                          "content": "@architect",
+                          "fontFamily": "$font-mono",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        },
+                        {
+                          "type": "frame",
+                          "id": "UUVYH",
+                          "name": "Lead badge",
+                          "fill": "#FFB02033",
+                          "cornerRadius": 3,
+                          "padding": [
+                            1,
+                            5
+                          ],
+                          "children": [
+                            {
+                              "type": "text",
+                              "id": "DqZgd",
+                              "name": "Lead label",
+                              "fill": "$warn",
+                              "content": "LEAD",
+                              "fontFamily": "$font-ui",
+                              "fontSize": 9,
+                              "fontWeight": "700",
+                              "letterSpacing": 0.5
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "TBj73",
+                      "name": "Pty button",
+                      "width": 24,
+                      "height": 24,
+                      "cornerRadius": 4,
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "jNJfJ",
+                          "name": "Terminal icon",
+                          "width": 12,
+                          "height": 12,
+                          "icon": "terminal",
+                          "library": "lucide",
+                          "fill": "$text-mid"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "ZW3d4",
+                  "name": "Status subtitle",
+                  "fill": "$text-mid",
+                  "content": "idle",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "rectangle",
+                  "id": "PnAIg",
+                  "name": "Key divider",
+                  "fill": "#272930A6",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "I5FuKV",
+                  "name": "Session key row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "MQzgy",
+                      "name": "Key label",
+                      "fill": "$text-low",
+                      "content": "session_key",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 10,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "BoXAd",
+                      "name": "Key spacer",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "mkoze",
+                      "name": "Key value",
+                      "fill": "$text-mid",
+                      "content": "01KZMR6Z…S61",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 10,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "icon",
+                      "id": "RIxBB",
+                      "name": "Copy icon",
+                      "width": 11,
+                      "height": 11,
+                      "icon": "copy",
+                      "library": "lucide",
+                      "fill": "$text-low"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "K2603",
+              "name": "Runner card impl",
+              "width": "fill_container",
+              "fill": "$bg",
+              "cornerRadius": 6,
+              "stroke": "#00FF9C99",
+              "strokeWidth": 1,
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "Y1JRS",
+                  "name": "Card header",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "u9WvV",
+                      "name": "Identity",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "nS7Tc",
+                          "name": "Avatar wrap",
+                          "width": 25,
+                          "height": 25,
+                          "layout": "none",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "k89r8r",
+                              "x": 0,
+                              "y": 0,
+                              "name": "Avatar",
+                              "clip": true,
+                              "width": 25,
+                              "height": 25,
+                              "fill": "$raised",
+                              "cornerRadius": 6,
+                              "layout": "vertical",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "dw2qC",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "zXOcH",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "ZkpA9",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "R97zx",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "YDwLS",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "ehRbI",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "JkAnA",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "d3Tj4",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "GSycj",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "dRhKs",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "ePeav",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "q33iss",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "O8RVWX",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "PLCaY",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "RdcGN",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "I4qUD",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "rZUXK",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "MJ5nW",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "Mtq6M",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "HzKmL",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "Wt9Zc",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "gnCGi",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "iRmfd",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "CcDLp",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "FnxAa",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "gRE3j",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "TlOX0",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "z5sCcT",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "vjm5k",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "AZrwf",
+                                      "name": "Pixel",
+                                      "fill": "#62D9F5",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "nnoEs",
+                              "x": 17,
+                              "y": 17,
+                              "name": "Presence dot",
+                              "fill": "#00FF9C",
+                              "width": 9,
+                              "height": 9,
+                              "stroke": "#15161B",
+                              "strokeWidth": 2,
+                              "strokeAlignment": "outer"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "IR9Jp",
+                          "name": "Handle",
+                          "fill": "#62D9F5",
+                          "content": "@impl",
+                          "fontFamily": "$font-mono",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "C1fbc6",
+                      "name": "Pty button",
+                      "width": 24,
+                      "height": 24,
+                      "cornerRadius": 4,
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "RrWlJ",
+                          "name": "Terminal icon",
+                          "width": 12,
+                          "height": 12,
+                          "icon": "terminal",
+                          "library": "lucide",
+                          "fill": "$text-mid"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "Cgo0x",
+                  "name": "Status subtitle",
+                  "fill": "$text-mid",
+                  "content": "busy",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "rectangle",
+                  "id": "QetbB",
+                  "name": "Key divider",
+                  "fill": "#272930A6",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "C398oC",
+                  "name": "Session key row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "mWkQ5",
+                      "name": "Key label",
+                      "fill": "$text-low",
+                      "content": "session_key",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 10,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "huZvf",
+                      "name": "Key spacer",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "h9VQqG",
+                      "name": "Key value",
+                      "fill": "$text-mid",
+                      "content": "01KZMR71…H4C",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 10,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "icon",
+                      "id": "zNYX6",
+                      "name": "Copy icon",
+                      "width": 11,
+                      "height": 11,
+                      "icon": "copy",
+                      "library": "lucide",
+                      "fill": "$text-low"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Shu8J",
+              "name": "Runner card reviewer",
+              "width": "fill_container",
+              "fill": "$bg",
+              "cornerRadius": 6,
+              "stroke": "$border",
+              "strokeWidth": 1,
+              "layout": "vertical",
+              "gap": 6,
+              "padding": 12,
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "DUZJE",
+                  "name": "Card header",
+                  "width": "fill_container",
+                  "justifyContent": "space_between",
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "frame",
+                      "id": "ma7i7",
+                      "name": "Identity",
+                      "gap": 8,
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "frame",
+                          "id": "pLSrM",
+                          "name": "Avatar wrap",
+                          "width": 25,
+                          "height": 25,
+                          "layout": "none",
+                          "children": [
+                            {
+                              "type": "frame",
+                              "id": "DBtbE",
+                              "x": 0,
+                              "y": 0,
+                              "name": "Avatar",
+                              "clip": true,
+                              "width": 25,
+                              "height": 25,
+                              "fill": "$raised",
+                              "cornerRadius": 6,
+                              "layout": "vertical",
+                              "children": [
+                                {
+                                  "type": "frame",
+                                  "id": "NHqlK",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "eh4sh",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "PsFBg",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "M2pgg",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "LczeN",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "ag717",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "I6KPJA",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "DaTyt",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "VlkhW",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "nvKKr",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "TaSZQ",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "FB0ez",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "GXZMZ",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "xzyRe",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "iIH1P",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "fivo7",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "yogXN",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "qKDsS",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "SuOHs",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "apzYc",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "uXuoG",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "WLZOA",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "eit7Q",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "GtB7T",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                },
+                                {
+                                  "type": "frame",
+                                  "id": "O40S2W",
+                                  "name": "Pixel row",
+                                  "children": [
+                                    {
+                                      "type": "rectangle",
+                                      "id": "dCLam",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "BwPxY",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "rT0L1",
+                                      "name": "Pixel",
+                                      "fill": "#00000000",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "W2iJfR",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    },
+                                    {
+                                      "type": "rectangle",
+                                      "id": "k4Jth2",
+                                      "name": "Pixel",
+                                      "fill": "#C792EA",
+                                      "width": 5,
+                                      "height": 5
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "ellipse",
+                              "id": "n9IIZ",
+                              "x": 17,
+                              "y": 17,
+                              "name": "Presence dot",
+                              "fill": "#5A5C66",
+                              "width": 9,
+                              "height": 9,
+                              "stroke": "#15161B",
+                              "strokeWidth": 2,
+                              "strokeAlignment": "outer"
+                            }
+                          ]
+                        },
+                        {
+                          "type": "text",
+                          "id": "DwtZO",
+                          "name": "Handle",
+                          "fill": "#C792EA",
+                          "content": "@reviewer",
+                          "fontFamily": "$font-mono",
+                          "fontSize": 13,
+                          "fontWeight": "600"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "frame",
+                      "id": "oBsmQ",
+                      "name": "Pty button",
+                      "width": 24,
+                      "height": 24,
+                      "cornerRadius": 4,
+                      "stroke": "$border",
+                      "strokeWidth": 1,
+                      "justifyContent": "center",
+                      "alignItems": "center",
+                      "children": [
+                        {
+                          "type": "icon",
+                          "id": "m30nWR",
+                          "name": "Terminal icon",
+                          "width": 12,
+                          "height": 12,
+                          "icon": "terminal",
+                          "library": "lucide",
+                          "fill": "$text-mid"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "DTXt7",
+                  "name": "Status subtitle",
+                  "fill": "$text-mid",
+                  "content": "stopped",
+                  "fontFamily": "$font-ui",
+                  "fontSize": 11,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "rectangle",
+                  "id": "vgmM1",
+                  "name": "Key divider",
+                  "fill": "#272930A6",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "Uw3fc",
+                  "name": "Session key row",
+                  "width": "fill_container",
+                  "gap": 8,
+                  "alignItems": "center",
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "g8OGF",
+                      "name": "Key label",
+                      "fill": "$text-low",
+                      "content": "session_key",
+                      "fontFamily": "$font-ui",
+                      "fontSize": 10,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "frame",
+                      "id": "ktBFh",
+                      "name": "Key spacer",
+                      "width": "fill_container",
+                      "height": 1
+                    },
+                    {
+                      "type": "text",
+                      "id": "n3AOzE",
+                      "name": "Key value",
+                      "fill": "$text-mid",
+                      "content": "NULL",
+                      "fontFamily": "$font-mono",
+                      "fontSize": 10,
+                      "fontWeight": "normal"
+                    },
+                    {
+                      "type": "icon",
+                      "id": "BRQg3",
+                      "name": "Copy icon",
+                      "width": 11,
+                      "height": 11,
+                      "icon": "copy",
+                      "library": "lucide",
+                      "fill": "$text-low"
+                    }
+                  ]
+                }
+              ]
             }
           ]
         }

--- a/docs/features/58-runner-crew-detail-redesign.md
+++ b/docs/features/58-runner-crew-detail-redesign.md
@@ -1,0 +1,40 @@
+# Runner & crew detail redesign
+
+Tracking issue: [#393](https://github.com/yicheng47/runner/issues/393). Status: planned.
+
+## Motivation
+
+Both detail pages are MVP drafts implemented straight from the historical MVP canvas (`design/runner-mvp-design.pen`, frames `ocAFJ` and `CUKjM`) and both bury their primary content under prompt prose.
+
+**Crew detail** (`src/pages/CrewEditor.tsx`, `/crews/:crewId`): the slot roster — who is actually in this crew — renders last, below the Purpose, Default goal, and Team conventions sections. With real prose in those sections the slots land below the fold; the page reads as a text editor with a roster appendix. Each `SlotRow` also packs handle, LEAD badge, runtime select, model-override chip, source-runner attribution, a line-clamped system-prompt preview, and the effective command line into one dense row, so the load-bearing facts (who, which engine, who leads) don't pop.
+
+**Runner detail** (`src/pages/RunnerDetail.tsx`, `/runners/:handle`): the full default system prompt renders as an unbounded `<pre>` dump at the top of the two-thirds column. Any real prompt is hundreds of lines, pushing "Crews using this runner" and the working-dir info far below the fold. The "Chat now" card duplicates the header's Chat now button and exists mostly to display the working directory; identity (display name) floats as a lone paragraph under the breadcrumb.
+
+## Scope
+
+Presentation-only redesign of the two pages. Same data, same commands, no backend or API changes.
+
+Design first, in Pencil, per repo convention: new feature-scoped file (e.g. `design/58-runner-crew-detail.pen`) with one frame per page; review before any code. The MVP canvas stays untouched as the historical record.
+
+Direction to explore in the design pass (not binding until frames are approved):
+
+- **Crew detail**: slots become the hero, directly under the header/toolbar. Prose config (purpose, goal, conventions) demoted to a secondary presentation — collapsed sections, a side column, or a config tab — collapsed by default when content is long. Slot rows restructured so identity and role read at a glance (avatar/handle/LEAD first-class), with runtime/model overrides and command detail tucked behind hover or disclosure affordances. Keep drag-reorder, set-lead, override editing, and remove flows functionally intact.
+- **Runner detail**: identity block (handle, display name, runtime, avatar) plus activity as the hero. System prompt shown clamped with expand/collapse instead of a full dump. Consolidate the "Chat now" card into the header action + a Details row for working dir. "Crews using this runner" stays one glance away.
+
+## Non-Goals
+
+- New capabilities on either page (no new fields, no new slot operations).
+- Changes to `RunnerEditDrawer`, `AddSlotModal`, or `StartMissionModal` beyond what the new layouts require for visual consistency.
+- List pages (`Runners.tsx`, `Crews.tsx`) — separate surfaces, already covered by feature 56.
+
+## Implementation Phases
+
+1. **Design** — Pencil frames for both pages in a feature-scoped `.pen`; iterate with the user until approved.
+2. **Crew detail** — reorder sections (slots first), restructure `SlotRow` per the approved frame, keep reorder/lead/override/remove behaviors and their tests green.
+3. **Runner detail** — new layout: identity hero, clamped prompt block, card consolidation.
+
+## Verification
+
+- `pnpm exec tsc --noEmit` and `pnpm run lint` clean after each phase.
+- Existing Vitest suites (`CrewEditor.test.tsx`, `RunnerRuntimeModelReset.test.tsx`) still pass; extend where row restructuring moves behavior.
+- Manual pass with a worst-case fixture: a runner with a multi-hundred-line system prompt, a crew with 5+ slots and long purpose/goal/conventions prose — slots visible without scrolling on the crew page, prompt collapsed by default on the runner page.

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -20,6 +20,7 @@ links to its tracking issue.
 - [53 — Session fork](./53-session-fork.md) — branch a chat into a new session: native full-history fork for claude-code via `--resume <key> --fork-session`, bounded ring-transcript handoff draft for other runtimes; original session untouched.
 - [56 — Backend list pagination](./56-backend-list-pagination.md) — Runners/Crews pagination moves into SQL (`page`/`page_size`/`query` with LIMIT/OFFSET and the search filter server-side); the pager becomes one slim row flush under the cards, hidden at a single page, with no half-clipped card above it ([#377](https://github.com/yicheng47/runner/issues/377)).
 - [57 — Start Project modal](./57-start-project-modal.md) — replace the bare directory-picker "Add project" flow with a modal mirroring the chat/mission start modals: directory field prefilled from `settings.defaultWorkingDir`, name field defaulting to the directory basename and following it until manually edited ([#383](https://github.com/yicheng47/runner/issues/383)).
+- [58 — Runner & crew detail redesign](./58-runner-crew-detail-redesign.md) — Pencil-first redesign of both MVP-draft detail pages: crew detail puts the slot roster above the prose config sections instead of below them, runner detail clamps the system-prompt dump and consolidates redundant cards ([#393](https://github.com/yicheng47/runner/issues/393)).
 
 ## Archive
 

--- a/docs/impls/0044-chat-style-feed.md
+++ b/docs/impls/0044-chat-style-feed.md
@@ -1,0 +1,51 @@
+# Chat-style mission feed: Discord-like rows and identicon identity
+
+## Status
+
+Planned. Design: `design/mission-feed-composer.pen` — frame "Feed · chat-style messages" (`rAJ00`), updated "Runners rail" (`LMQ7c`), decision notes (`Rauwg`). Builds on the #392 working-tree fixes already present in `MessageBody.tsx` / `EventFeed.tsx` (list gutter, mission-goal row, spacing). Revives the identicon idea from `docs/features/archive/11-runner-avatar.md`, which was specced but never shipped.
+
+## Problem
+
+The feed renders three different anatomies for what is conversationally the same thing: runner/human messages are bare header+body rows, the mission goal was (until the #392 fix) a bordered mono payload block, and signals are JSON boxes — including the raw `ask_human` signal, which renders its full JSON right above the `human_question` card that presents the same prompt, choices, and attribution properly. Identity is a monospace handle with a single accent color for every runner, so multi-runner missions have nothing for the eye to lock onto, and the rail's busy/idle state lives in a separate dot glyph next to the handle.
+
+## Key Decisions
+
+1. **Discord/Slack row anatomy.** Every conversational event renders as avatar + header (author, context, time) + body. Consecutive message-like events from the same author within a 5-minute window collapse into one group: avatar and header render once, subsequent bodies stack under them. Any non-message block (divider, signal line, ask card) breaks the group. Grouping is a pure function over the filtered event list so it is unit-testable.
+
+2. **`RunnerAvatar` identicon, deterministic from the handle.** 5×5 symmetric pixel grid (columns mirrored) generated from a handle hash, rendered on a raised rounded square — 35px in the feed, 25px in the rail. The same hash picks the runner's hue from a fixed palette of carbon-legible colors (accent green, cyan, violet, orange, …); the hue also colors the handle text wherever it appears. Amber (`warn`) is reserved for the human — "you" always renders amber with a fixed pattern and is never assigned to a runner. The LEAD marker stays a badge, not a color.
+
+3. **Message-like events share one renderer.** `message`, `human_said`, `human_response`, and `mission_goal` all go through the same message-row path. `mission_goal` keeps its small `GOAL` chip in the header (from the #392 fix) and an optional `→ @target`. `mission_start` becomes a thin centered divider (`MISSION STARTED · time`), Discord date-divider style.
+
+4. **Raw `ask_human` signals are hidden.** They are worker→router plumbing fully duplicated by the router's `human_question`; `isHiddenSystemSignal` grows to cover them. The `AskHumanCard` absorbs the identity: it renders inside the asker's avatar row with a `NEEDS YOUR INPUT` chip and the `→ you` chain in the header; card internals (prompt, choice buttons, resolved state) are unchanged.
+
+5. **Remaining signals become one-line rows.** `ask_lead`, `mission_warning`, and unknown types render as a single indented line — zap icon, author handle, `signal · type`, time — with a `payload ▾` disclosure that expands the existing payload rendering (the current JSON box body) inline. `mission_warning` keeps a danger tint on the line so diagnostics still stand out. Answered `ask_lead` lines stay visible; the feed remains a faithful log, no fading.
+
+6. **Rail cards adopt the same identity.** In `RunnersRail`, the avatar (25px) with the runner hue replaces the inline status dot; PTY/runner status moves onto the avatar corner as a presence dot (busy accent, idle dim accent, stopped gray, crashed danger — same priority order as today's `dotClass`). Handle text takes the hue. The rest of the card (LEAD badge, Open-PTY button, status subtitle, `session_key` row) is already aligned between code and the updated design frame and does not change structurally.
+
+## Goals
+
+- One visual grammar for every conversational turn; system rows visibly distinct but quiet.
+- A three-runner mission is scannable by color and pattern without reading handles.
+- Pure presentation: no event-schema, router, log, or backend changes; archived missions replay identically.
+
+## Non-Goals
+
+- Reactions, replies, hover action toolbars, message editing — Discord look, not Discord features.
+- Composer changes (shipped in impl 0042) or `AskHumanCard` flow/button changes.
+- Avatar images/uploads or per-runner color configuration; the mapping is deterministic.
+- Persisting payload-disclosure open state.
+
+## Implementation Notes
+
+- `src/components/ui/RunnerAvatar.tsx` — new. Props: `seed`, `size`, optional `presence`. Exports `hueForSeed(seed)` for handle coloring; special-cases the human seed to `warn`.
+- `src/lib/eventFeed.ts` — add `groupFeedBlocks(events)` returning typed blocks (`divider` | `message-group` | `signal` | `ask-card`); extend the hidden-signal predicate with `ask_human`.
+- `src/components/EventFeed.tsx` — render from `groupFeedBlocks`; message-group renderer (avatar column + header + stacked bodies via `MessageBody`); divider renderer; signal one-liner with payload disclosure reusing `renderPayload` as the expanded body.
+- `src/components/AskHumanCard.tsx` — header row becomes avatar + chip + chain per design; accepts the asker handle it already receives.
+- `src/components/RunnersRail.tsx` — swap dot for `RunnerAvatar` with presence; hue on handle text.
+- `src/components/MessageBody.tsx` — no changes beyond the #392 fixes already in the tree.
+
+## Validation
+
+- Vitest: `groupFeedBlocks` — same-author grouping inside/outside the 5-minute window, group break on interleaved signal, `mission_goal`/`human_said` classified message-like, `ask_human` hidden, `mission_start` → divider; `hueForSeed` determinism and human reservation.
+- Manual: live 2-slot mission — grouped runner turns, goal row, divider, signal disclosure toggle, ask card with avatar; archived mission replay renders identically; rail presence dot tracks busy/idle/stopped.
+- `pnpm exec tsc --noEmit`, `pnpm run lint`, `pnpm test`.

--- a/src/components/AskHumanCard.tsx
+++ b/src/components/AskHumanCard.tsx
@@ -10,6 +10,7 @@ import { useState } from "react";
 import { api } from "../lib/api";
 import type { HumanQuestionPayload } from "../lib/types";
 import { MessageBody } from "./MessageBody";
+import { RunnerAvatar, hueForSeed } from "./ui/RunnerAvatar";
 
 interface AskHumanCardProps {
   missionId: string;
@@ -44,10 +45,7 @@ export function AskHumanCard({
     : ["yes", "no"]; // sensible fallback so the card always has buttons
 
   const onBehalf = payload.on_behalf_of;
-  // Attribution chain: when an `ask_human` carries `on_behalf_of`, the
-  // worker who originally asked is shown alongside the lead so the human
-  // sees `*@impl → @architect → you*` (per design frame `Z7Dbo`).
-  const chain = onBehalf ? `@${onBehalf} → @${asker} → you` : `@${asker} → you`;
+  const chain = onBehalf ? `@${onBehalf} → @${asker} → you` : "→ you";
 
   const resolved = resolvedChoice != null;
 
@@ -70,76 +68,76 @@ export function AskHumanCard({
   }
 
   return (
-    <div className="rounded-lg border border-warn/60 bg-warn/10 p-4">
-      <div className="flex items-baseline justify-between gap-2">
-        <div className="flex items-baseline gap-2 min-w-0">
-          <span className="text-[12px] font-semibold text-warn">
-            needs your input
+    <div className="flex gap-3 px-4">
+      <RunnerAvatar seed={asker} size={35} />
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-2">
+          <span
+            className="truncate font-mono text-[13px] font-semibold"
+            style={{ color: hueForSeed(asker) }}
+          >
+            @{asker}
           </span>
-          <span className="text-[11px] font-mono text-fg-2 truncate">
+          <span className="shrink-0 rounded bg-warn/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.06em] text-warn">
+            Needs your input
+          </span>
+          <span className="truncate font-mono text-[11px] text-fg-2">
             {chain}
           </span>
-        </div>
-        <span className="text-[11px] text-fg-3">{formatTs(ts)}</span>
-      </div>
-      <div className="mt-2 text-[13px] leading-relaxed text-fg">
-        {payload.prompt ? (
-          <MessageBody text={payload.prompt} />
-        ) : (
-          <span className="text-fg-3">(no prompt)</span>
-        )}
-      </div>
-      {/* Choices stack vertically as full-width buttons. Multi-choice
-          asks (3–4 long options) used to wrap across rows in a tight
-          horizontal flex, hard to scan; vertical full-width matches
-          Pencil node `Z7Dbo` and gives each option its own line.
-          Primary action (first choice) is the green-filled CTA;
-          subsequent options are outlined buttons. */}
-      <div className="mt-3 flex flex-col gap-1.5">
-        {choices.map((c, idx) => {
-          const isPrimary = idx === 0;
-          const isPicked = resolved
-            ? c === resolvedChoice
-            : pickedChoice === c;
-          return (
-            <button
-              key={c}
-              type="button"
-              onClick={() => submit(c)}
-              disabled={submitting || resolved}
-              className={
-                isPrimary
-                  ? `flex w-full cursor-pointer items-center rounded-md px-3.5 py-2.5 text-left text-[12px] font-semibold transition-all ${
-                      isPicked
-                        ? "bg-accent text-accent-ink"
-                        : "bg-accent text-accent-ink hover:bg-accent/90 hover:shadow-[0_0_0_1px_var(--color-accent)] hover:-translate-y-px"
-                    } disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0 disabled:hover:shadow-none`
-                  : `flex w-full cursor-pointer items-center rounded-md border border-line bg-panel px-3.5 py-2.5 text-left text-[12px] font-medium text-fg transition-all ${
-                      isPicked ? "border-accent text-accent" : ""
-                    } hover:border-fg-3 hover:bg-raised hover:text-fg disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-panel disabled:hover:border-line`
-              }
-            >
-              {c}
-            </button>
-          );
-        })}
-        {resolved ? (
-          <span className="mt-1 text-[11px] text-fg-3">
-            answered: <span className="text-fg-2">{resolvedChoice}</span>
+          <span className="shrink-0 text-[11px] text-fg-3">
+            {formatTs(ts)}
           </span>
-        ) : null}
+        </div>
+        <div className="mt-1.5 rounded-lg border border-warn/60 bg-warn/10 p-4">
+          <div className="text-[13px] leading-relaxed text-fg">
+            {payload.prompt ? (
+              <MessageBody text={payload.prompt} />
+            ) : (
+              <span className="text-fg-3">(no prompt)</span>
+            )}
+          </div>
+          <div className="mt-3 flex flex-col gap-1.5">
+            {choices.map((c, idx) => {
+              const isPrimary = idx === 0;
+              const isPicked = resolved
+                ? c === resolvedChoice
+                : pickedChoice === c;
+              return (
+                <button
+                  key={c}
+                  type="button"
+                  onClick={() => submit(c)}
+                  disabled={submitting || resolved}
+                  className={
+                    isPrimary
+                      ? `flex w-full cursor-pointer items-center rounded-md px-3.5 py-2.5 text-left text-[12px] font-semibold transition-all ${
+                          isPicked
+                            ? "bg-accent text-accent-ink"
+                            : "bg-accent text-accent-ink hover:bg-accent/90 hover:shadow-[0_0_0_1px_var(--color-accent)] hover:-translate-y-px"
+                        } disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:translate-y-0 disabled:hover:shadow-none`
+                      : `flex w-full cursor-pointer items-center rounded-md border border-line bg-panel px-3.5 py-2.5 text-left text-[12px] font-medium text-fg transition-all ${
+                          isPicked ? "border-accent text-accent" : ""
+                        } hover:border-fg-3 hover:bg-raised hover:text-fg disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:bg-panel disabled:hover:border-line`
+                  }
+                >
+                  {c}
+                </button>
+              );
+            })}
+            {resolved ? (
+              <span className="mt-1 text-[11px] text-fg-3">
+                answered: <span className="text-fg-2">{resolvedChoice}</span>
+              </span>
+            ) : null}
+          </div>
+        </div>
       </div>
     </div>
   );
 }
 
 function formatTs(ts: string): string {
-  // Display the local-time HH:MM:SS slice only — the workspace feed is
-  // always anchored to "now" so the date is implied.
-  try {
-    const d = new Date(ts);
-    return d.toLocaleTimeString();
-  } catch {
-    return ts;
-  }
+  const date = new Date(ts);
+  if (Number.isNaN(date.getTime())) return ts;
+  return date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
 }

--- a/src/components/EventFeed.tsx
+++ b/src/components/EventFeed.tsx
@@ -1,44 +1,20 @@
-// Scrollable feed that renders one row per appended event. Three variants
-// align with arch §5.2 + design frame `5DIkl`:
-//   - message rows (kind: message): from / to / payload.text
-//   - signal rows (kind: signal): from / signal type, JSON-ish payload
-//   - ask-human cards (signal type: human_question): rich card variant
-//     consumed by AskHumanCard
-//
-// User-authored signals (`human_said`, `human_response`) render as
-// message rows so they look like normal chat turns in the feed.
-//
-// Router-internal plumbing (`inbox_read`, `runner_status`) is hidden by
-// default — the audit trail lives in `<mission_dir>/events.ndjson`, and
-// the feed is a reading surface for humans collaborating with runners.
-// `mission_warning` is intentionally kept (and rendered at full strength):
-// it's a diagnostic the user should see. See spec
-// `docs/features/archive/08-hide-system-signals-from-feed.md`.
-
-import { useEffect, useRef, useState } from "react";
+import { ChevronDown, Zap } from "lucide-react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 
 import { AskHumanCard } from "./AskHumanCard";
 import { MessageBody } from "./MessageBody";
-import { isHumanAuthored } from "../lib/eventFeed";
+import { RunnerAvatar, hueForSeed } from "./ui/RunnerAvatar";
+import {
+  groupFeedBlocks,
+  isHumanAuthored,
+  type FeedBlock,
+} from "../lib/eventFeed";
 import type {
   Event,
   HumanQuestionPayload,
   HumanResponsePayload,
   HumanSaidPayload,
 } from "../lib/types";
-
-// Router-internal plumbing rows that the reader never needs to see in
-// the feed. `runner_status` is already projected onto the RunnersRail
-// busy/idle badge; `inbox_read` is just a watermark advance. The full
-// stream still lives in NDJSON on disk, and the parent workspace keeps
-// receiving every event so projections (status map, watermark) stay
-// intact.
-function isHiddenSystemSignal(ev: Event): boolean {
-  return (
-    ev.kind === "signal" &&
-    (ev.type === "inbox_read" || ev.type === "runner_status")
-  );
-}
 
 interface EventFeedProps {
   missionId: string;
@@ -67,6 +43,7 @@ export function EventFeed({
 }: EventFeedProps) {
   const scrollRef = useRef<HTMLDivElement | null>(null);
   const wasNearBottomRef = useRef(true);
+  const blocks = useMemo(() => groupFeedBlocks(events), [events]);
   // Tail id of the last event we processed in the append effect. Without
   // this we can't distinguish a true append from a re-render with the
   // same events array — both fire the effect under StrictMode.
@@ -143,23 +120,25 @@ export function EventFeed({
       <div
         ref={scrollRef}
         onScroll={onScroll}
-        className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-10 py-6"
+        className="flex min-h-0 flex-1 flex-col gap-[18px] overflow-y-auto px-6 py-6"
       >
-        {events.length === 0 ? (
-          <p className="text-[12px] text-fg-3">No events yet.</p>
+        {blocks.length === 0 ? (
+          <p className="px-4 text-[12px] text-fg-3">No events yet.</p>
         ) : (
-          events
-            .filter((ev) => !isHiddenSystemSignal(ev))
-            .map((ev) => (
-              <EventRow
-                key={ev.id}
-                event={ev}
-                missionId={missionId}
-                resolvedAsks={resolvedAsks}
-                askersByQuestion={askersByQuestion}
-                onError={onError}
-              />
-            ))
+          blocks.map((block) => (
+            <FeedBlockRow
+              key={
+                block.kind === "message-group"
+                  ? block.events[0].id
+                  : block.event.id
+              }
+              block={block}
+              missionId={missionId}
+              resolvedAsks={resolvedAsks}
+              askersByQuestion={askersByQuestion}
+              onError={onError}
+            />
+          ))
         )}
       </div>
       {hasNewSinceLeftBottom ? (
@@ -175,154 +154,190 @@ export function EventFeed({
   );
 }
 
-function EventRow({
-  event,
+function FeedBlockRow({
+  block,
   missionId,
   resolvedAsks,
   askersByQuestion,
   onError,
 }: {
-  event: Event;
+  block: FeedBlock;
   missionId: string;
   resolvedAsks: Record<string, string>;
   askersByQuestion: Record<string, string>;
   onError?: (msg: string) => void;
 }) {
-  // human_question — render the rich card. Asker derived from the
-  // originating ask_human (via askersByQuestion). Fall back to the
-  // event's `from` (which is "router") if we haven't paired it yet.
-  if (event.kind === "signal" && event.type === "human_question") {
-    const payload = event.payload as HumanQuestionPayload;
-    const asker = askersByQuestion[event.id] ?? "?";
-    const resolvedChoice = resolvedAsks[event.id] ?? null;
+  if (block.kind === "divider") {
+    return <MissionDivider event={block.event} />;
+  }
+
+  if (block.kind === "message-group") {
+    return (
+      <MessageGroup block={block} askersByQuestion={askersByQuestion} />
+    );
+  }
+
+  if (block.kind === "ask-card") {
+    const event = block.event;
     return (
       <AskHumanCard
         missionId={missionId}
         questionId={event.id}
-        asker={asker}
-        payload={payload}
+        asker={askersByQuestion[event.id] ?? "?"}
+        payload={event.payload as HumanQuestionPayload}
         ts={event.ts}
-        resolvedChoice={resolvedChoice}
+        resolvedChoice={resolvedAsks[event.id] ?? null}
         onError={onError}
       />
     );
   }
 
-  if (event.kind === "message") {
-    const text = (event.payload as { text?: string })?.text ?? "";
-    const human = event.from === "human";
-    return (
-      <div className="flex flex-col gap-1">
-        <div className="flex items-baseline gap-2 text-[11px] text-fg-3">
+  return <SignalRow event={block.event} />;
+}
+
+function MissionDivider({ event }: { event: Event }) {
+  return (
+    <div className="flex items-center gap-2.5 px-4">
+      <span className="h-px min-w-0 flex-1 bg-line" />
+      <span className="shrink-0 text-[10px] font-semibold uppercase tracking-[0.08em] text-fg-3">
+        Mission started · {formatTs(event.ts)}
+      </span>
+      <span className="h-px min-w-0 flex-1 bg-line" />
+    </div>
+  );
+}
+
+function MessageGroup({
+  block,
+  askersByQuestion,
+}: {
+  block: Extract<FeedBlock, { kind: "message-group" }>;
+  askersByQuestion: Record<string, string>;
+}) {
+  const first = block.events[0];
+  const human = block.author === "human";
+  const target = messageTarget(first, askersByQuestion);
+  const goal = first.kind === "signal" && first.type === "mission_goal";
+
+  return (
+    <div className="flex gap-3 px-4">
+      <RunnerAvatar seed={block.author} size={35} />
+      <div className="min-w-0 flex-1">
+        <div className="flex min-w-0 items-center gap-2 text-[11px] text-fg-3">
           <span
-            className={`font-mono text-[12px] font-semibold ${
-              human ? "text-warn" : "text-accent"
-            }`}
+            className="truncate font-mono text-[13px] font-semibold"
+            style={{ color: hueForSeed(block.author) }}
           >
-            {human ? "you" : `@${event.from}`}
+            {human ? "you" : `@${block.author}`}
           </span>
-          <span>message</span>
-          {event.to ? (
-            <span className="font-mono text-[12px] text-fg-2">
-              → @{event.to}
+          {goal ? (
+            <span className="rounded bg-raised px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.06em] text-fg-2">
+              Goal
             </span>
           ) : null}
-          <span>·</span>
-          <span>{formatTs(event.ts)}</span>
-        </div>
-        <div className="text-[13px] leading-relaxed text-fg">
-          <MessageBody text={text} />
-        </div>
-      </div>
-    );
-  }
-
-  // User-authored signals render as message rows (header + plain text
-  // body via MessageBody), so an MCP or historical `human_said` and a
-  // `human_response` from AskHumanCard look like normal chat turns
-  // instead of a JSON-y signal box. Target derivation differs by type:
-  // human_said carries `payload.target`; human_response is paired back
-  // to the original asker via askersByQuestion[question_id].
-  if (
-    event.kind === "signal" &&
-    (event.type === "human_said" || event.type === "human_response")
-  ) {
-    let target: string | null;
-    let text: string;
-    if (event.type === "human_said") {
-      const p = (event.payload ?? {}) as Partial<HumanSaidPayload>;
-      text = p.text ?? "";
-      target = p.target ?? null;
-    } else {
-      const p = (event.payload ?? {}) as Partial<HumanResponsePayload>;
-      text = p.choice ?? "";
-      target = p.question_id ? askersByQuestion[p.question_id] ?? "?" : "?";
-    }
-    return (
-      <div className="flex flex-col gap-1">
-        <div className="flex items-baseline gap-2 text-[11px] text-fg-3">
-          <span
-            className={`font-mono text-[12px] font-semibold ${
-              event.from === "human" ? "text-warn" : "text-accent"
-            }`}
-          >
-            {event.from === "human" ? "you" : `@${event.from}`}
-          </span>
-          <span>message</span>
           {target ? (
-            <span className="font-mono text-[12px] text-fg-2">
+            <span className="truncate font-mono text-[11px] text-fg-2">
               → @{target}
             </span>
           ) : null}
-          <span>·</span>
-          <span>{formatTs(event.ts)}</span>
+          <span className="shrink-0">{formatTs(first.ts)}</span>
         </div>
-        <div className="text-[13px] leading-relaxed text-fg">
-          <MessageBody text={text} />
+        <div className="space-y-1.5 text-[13px] leading-relaxed text-fg">
+          {block.events.map((event) => {
+            const text = messageText(event);
+            return (
+              <div key={event.id}>
+                {text ? (
+                  <MessageBody text={text} />
+                ) : event.kind === "signal" && event.type === "mission_goal" ? (
+                  <span className="text-fg-3">(no text)</span>
+                ) : null}
+              </div>
+            );
+          })}
         </div>
-      </div>
-    );
-  }
-
-  // Default signal row. `inbox_read` / `runner_status` are filtered out
-  // upstream (see isHiddenSystemSignal); `mission_warning` reaches here
-  // and renders at full strength so the diagnostic stands out.
-  return (
-    <div className="flex flex-col gap-1">
-      <div className="flex items-baseline gap-2 text-[11px] text-fg-3">
-        <span className="font-mono text-[12px] font-semibold text-accent">
-          @{event.from}
-        </span>
-        <span>signal · {event.type ?? "?"}</span>
-        <span>·</span>
-        <span>{formatTs(event.ts)}</span>
-      </div>
-      <div className="rounded-md border border-line bg-bg p-3 font-mono text-[12px] leading-snug text-fg-2">
-        {renderPayload(event)}
       </div>
     </div>
   );
 }
 
-function renderPayload(event: Event): React.ReactNode {
-  // Common signal shapes get shorter inline renderings; everything else
-  // falls back to formatted JSON. The v0 router never emits opaque blobs
-  // so this stays readable.
+function messageText(event: Event): string {
+  if (event.kind === "message") {
+    return (event.payload as { text?: string } | null)?.text ?? "";
+  }
+  if (event.type === "human_said") {
+    return ((event.payload ?? {}) as Partial<HumanSaidPayload>).text ?? "";
+  }
+  if (event.type === "human_response") {
+    return ((event.payload ?? {}) as Partial<HumanResponsePayload>).choice ?? "";
+  }
+  const payload = (event.payload ?? {}) as { text?: string };
+  return typeof payload.text === "string" ? payload.text : "";
+}
+
+function messageTarget(
+  event: Event,
+  askersByQuestion: Record<string, string>,
+): string | null {
+  if (event.kind === "message") return event.to;
+  if (event.type === "human_said") {
+    return ((event.payload ?? {}) as Partial<HumanSaidPayload>).target ?? null;
+  }
+  if (event.type === "human_response") {
+    const payload = (event.payload ?? {}) as Partial<HumanResponsePayload>;
+    return payload.question_id
+      ? askersByQuestion[payload.question_id] ?? "?"
+      : "?";
+  }
+  const payload = (event.payload ?? {}) as { target?: string };
+  return typeof payload.target === "string" ? payload.target : null;
+}
+
+function SignalRow({ event }: { event: Event }) {
+  const warning = event.type === "mission_warning";
+  const tone = warning ? "text-danger" : "text-fg-3";
+
+  return (
+    <details className="group pr-4 pl-[63px]">
+      <summary className="flex min-w-0 cursor-pointer list-none items-center gap-1.5 text-[11px] [&::-webkit-details-marker]:hidden">
+        <Zap aria-hidden className={`h-3 w-3 shrink-0 ${tone}`} />
+        <span
+          className="shrink-0 font-mono font-semibold"
+          style={{ color: hueForSeed(event.from) }}
+        >
+          @{event.from}
+        </span>
+        <span className={`min-w-0 truncate ${tone}`}>
+          signal · {event.type ?? "?"}
+          {event.to ? ` → @${event.to}` : ""} · {formatTs(event.ts)}
+        </span>
+        <span
+          className={`ml-auto inline-flex shrink-0 items-center gap-0.5 text-[10px] ${tone}`}
+        >
+          payload
+          <ChevronDown
+            aria-hidden
+            className="h-3 w-3 transition-transform group-open:rotate-180"
+          />
+        </span>
+      </summary>
+      <div
+        className={`mt-2 ml-[18px] rounded-md border p-3 font-mono text-[12px] leading-snug ${
+          warning
+            ? "border-danger/30 bg-danger/5 text-danger"
+            : "border-line bg-bg text-fg-2"
+        }`}
+      >
+        {renderPayload(event)}
+      </div>
+    </details>
+  );
+}
+
+function renderPayload(event: Event): ReactNode {
   const p = event.payload as Record<string, unknown> | null | undefined;
   if (!p || typeof p !== "object") {
     return <span>{String(p ?? "")}</span>;
-  }
-  if (event.type === "mission_goal") {
-    const text = typeof p.text === "string" ? p.text : "";
-    const target = typeof p.target === "string" ? p.target : null;
-    return (
-      <div className="text-fg">
-        {text ? <MessageBody text={text} /> : <span>(no text)</span>}
-        {target ? (
-          <div className="mt-1 text-fg-3">→ @{target}</div>
-        ) : null}
-      </div>
-    );
   }
   if (event.type === "ask_lead") {
     const q = typeof p.question === "string" ? p.question : "";
@@ -338,14 +353,15 @@ function renderPayload(event: Event): React.ReactNode {
       </span>
     );
   }
-  return <pre className="whitespace-pre-wrap break-all">{JSON.stringify(p, null, 2)}</pre>;
+  return (
+    <pre className="whitespace-pre-wrap break-all">
+      {JSON.stringify(p, null, 2)}
+    </pre>
+  );
 }
 
 function formatTs(ts: string): string {
-  try {
-    const d = new Date(ts);
-    return d.toLocaleTimeString();
-  } catch {
-    return ts;
-  }
+  const date = new Date(ts);
+  if (Number.isNaN(date.getTime())) return ts;
+  return date.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
 }

--- a/src/components/MessageBody.tsx
+++ b/src/components/MessageBody.tsx
@@ -4,7 +4,7 @@
 // codex is markdown by convention. Plain-text rendering loses that
 // structure (lists collapse into one line, code becomes prose, etc.).
 //
-// Styling tuned for a chat-log feel: tight line-height, generous
+// Styling tuned for a chat-log feel: relaxed line-height, generous
 // monospace blocks, accent green for inline code so it pops against
 // the carbon background. Lists keep their bullets and indentation.
 
@@ -54,13 +54,16 @@ export function MessageBody({ text }: { text: string }) {
             );
           },
           pre: ({ children }) => <pre className="my-2">{children}</pre>,
+          // pl-* (not ml-*): outside-positioned markers draw in the
+          // list's own padding gutter, so numbers stay inside the
+          // message block instead of hanging past its left edge (#392).
           ul: ({ children }) => (
-            <ul className="my-1 ml-5 list-disc space-y-0.5">{children}</ul>
+            <ul className="my-1.5 list-disc pl-6 space-y-1">{children}</ul>
           ),
           ol: ({ children }) => (
-            <ol className="my-1 ml-5 list-decimal space-y-0.5">{children}</ol>
+            <ol className="my-1.5 list-decimal pl-6 space-y-1">{children}</ol>
           ),
-          li: ({ children }) => <li className="leading-snug">{children}</li>,
+          li: ({ children }) => <li className="leading-relaxed">{children}</li>,
           h1: ({ children }) => (
             <h1 className="mt-3 mb-1.5 text-[14px] font-semibold text-fg">
               {children}
@@ -77,7 +80,7 @@ export function MessageBody({ text }: { text: string }) {
             </h3>
           ),
           p: ({ children }) => (
-            <p className="my-1 leading-relaxed">{children}</p>
+            <p className="my-1.5 leading-relaxed">{children}</p>
           ),
           blockquote: ({ children }) => (
             <blockquote className="my-2 border-l-2 border-line pl-3 text-fg-2">

--- a/src/components/RunnersRail.tsx
+++ b/src/components/RunnersRail.tsx
@@ -7,6 +7,11 @@
 import { Terminal } from "lucide-react";
 
 import { CopyValueButton } from "./ui/CopyValueButton";
+import {
+  RunnerAvatar,
+  hueForSeed,
+  type RunnerPresence,
+} from "./ui/RunnerAvatar";
 import type { SessionRow } from "../lib/api";
 
 interface RunnersRailProps {
@@ -40,17 +45,14 @@ export function RunnersRail({
           const isLead = s.handle === leadHandle;
           const ptyStatus = s.status;
           const runnerStatus = status[s.handle];
-          // Dot priority: crashed (red) > stopped (gray) > runner busy (green)
-          // > runner idle (dim green). Default to "busy" when no runner_status
-          // has landed yet — a freshly-started PTY is producing startup output.
-          const dotClass =
+          const presence: RunnerPresence =
             ptyStatus === "crashed"
-              ? "bg-danger"
+              ? "crashed"
               : ptyStatus !== "running"
-                ? "bg-fg-3"
+                ? "stopped"
                 : runnerStatus === "idle"
-                  ? "bg-accent/40"
-                  : "bg-accent";
+                  ? "idle"
+                  : "busy";
           const subtitle =
             ptyStatus === "running"
               ? runnerStatus
@@ -78,12 +80,16 @@ export function RunnersRail({
               }`}
             >
               <div className="flex items-center justify-between gap-2">
-                <div className="flex items-center gap-1.5 min-w-0">
-                  <span
-                    className={`inline-flex h-1.5 w-1.5 shrink-0 rounded-full ${dotClass}`}
-                    title={ptyStatus}
+                <div className="flex min-w-0 items-center gap-2">
+                  <RunnerAvatar
+                    seed={s.handle}
+                    size={25}
+                    presence={presence}
                   />
-                  <span className="truncate font-mono text-[13px] font-semibold text-fg">
+                  <span
+                    className="truncate font-mono text-[13px] font-semibold"
+                    style={{ color: hueForSeed(s.handle) }}
+                  >
                     @{s.handle}
                   </span>
                   {isLead ? (

--- a/src/components/ui/RunnerAvatar.test.ts
+++ b/src/components/ui/RunnerAvatar.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { hueForSeed } from "./RunnerAvatar";
+
+describe("hueForSeed", () => {
+  it("is deterministic for runner seeds", () => {
+    expect(hueForSeed("coder")).toBe("var(--color-accent)");
+    expect(hueForSeed("reviewer")).toBe("#c792ea");
+    expect(hueForSeed("coder")).toBe(hueForSeed("coder"));
+  });
+
+  it("reserves the human warning hue", () => {
+    expect(hueForSeed("human")).toBe("var(--color-warn)");
+    expect(hueForSeed("coder")).not.toBe("var(--color-warn)");
+    expect(hueForSeed("reviewer")).not.toBe("var(--color-warn)");
+  });
+});

--- a/src/components/ui/RunnerAvatar.tsx
+++ b/src/components/ui/RunnerAvatar.tsx
@@ -1,0 +1,116 @@
+const HUMAN_SEED = "human";
+const HUMAN_HUE = "var(--color-warn)";
+const RUNNER_HUES = [
+  "#ff8a4c",
+  "#c792ea",
+  "#f07178",
+  "var(--color-accent)",
+  "#62d9f5",
+  "#a3e635",
+  "#7aa2f7",
+  "#ff6b9d",
+  "#c3e88d",
+] as const;
+
+const HUMAN_SOURCE_CELLS = [
+  true,
+  false,
+  true,
+  false,
+  true,
+  true,
+  true,
+  true,
+  false,
+  false,
+  true,
+  true,
+  true,
+  false,
+  true,
+] as const;
+
+export type RunnerPresence = "busy" | "idle" | "stopped" | "crashed";
+
+interface RunnerAvatarProps {
+  seed: string;
+  size: number;
+  presence?: RunnerPresence;
+}
+
+function fnv1a(seed: string): number {
+  let hash = 0x811c9dc5;
+  for (const byte of new TextEncoder().encode(seed)) {
+    hash ^= byte;
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash;
+}
+
+// eslint-disable-next-line react-refresh/only-export-components
+export const hueForSeed = (seed: string): string => {
+  if (seed === HUMAN_SEED) return HUMAN_HUE;
+  const hash = fnv1a(seed);
+  return RUNNER_HUES[(hash >>> 16) % RUNNER_HUES.length];
+};
+
+function cellsForSeed(seed: string): boolean[] {
+  const hash = fnv1a(seed);
+  const source: boolean[] =
+    seed === HUMAN_SEED
+      ? [...HUMAN_SOURCE_CELLS]
+      : Array.from({ length: 15 }, (_, bit) => Boolean(hash & (1 << bit)));
+  if (!source.some(Boolean)) source[8] = true;
+
+  return Array.from({ length: 25 }, (_, index) => {
+    const row = Math.floor(index / 5);
+    const column = index % 5;
+    const sourceColumn = column < 3 ? column : 4 - column;
+    return source[row * 3 + sourceColumn];
+  });
+}
+
+const PRESENCE_CLASS: Record<RunnerPresence, string> = {
+  busy: "bg-accent",
+  idle: "bg-accent/40",
+  stopped: "bg-fg-3",
+  crashed: "bg-danger",
+};
+
+export function RunnerAvatar({ seed, size, presence }: RunnerAvatarProps) {
+  const hue = hueForSeed(seed);
+  const cells = cellsForSeed(seed);
+
+  return (
+    <span
+      aria-hidden
+      className="relative inline-flex shrink-0"
+      style={{ width: size, height: size }}
+    >
+      <svg
+        viewBox="0 0 5 5"
+        className="h-full w-full overflow-hidden bg-raised"
+        style={{ borderRadius: Math.max(4, Math.round(size * 0.23)) }}
+        shapeRendering="crispEdges"
+      >
+        {cells.map((painted, index) =>
+          painted ? (
+            <rect
+              key={index}
+              x={index % 5}
+              y={Math.floor(index / 5)}
+              width="1"
+              height="1"
+              fill={hue}
+            />
+          ) : null,
+        )}
+      </svg>
+      {presence ? (
+        <span
+          className={`absolute -bottom-px -right-px h-[9px] w-[9px] rounded-full border-2 border-bg ${PRESENCE_CLASS[presence]}`}
+        />
+      ) : null}
+    </span>
+  );
+}

--- a/src/lib/eventFeed.test.ts
+++ b/src/lib/eventFeed.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 
 import type { Event } from "./types";
-import { isHumanAuthored } from "./eventFeed";
+import { groupFeedBlocks, isHumanAuthored } from "./eventFeed";
 
-function event(overrides: Partial<Event>): Event {
+let nextId = 0;
+
+function event(overrides: Partial<Event> = {}): Event {
   return {
-    id: "01KTEST",
+    id: `01KTEST${nextId++}`,
     ts: "2026-08-01T00:00:00Z",
     crew_id: "crew-1",
     mission_id: "mission-1",
@@ -39,5 +41,139 @@ describe("isHumanAuthored", () => {
         event({ kind: "signal", from: "human", type: "mission_goal" }),
       ),
     ).toBe(false);
+  });
+});
+
+describe("groupFeedBlocks", () => {
+  it("groups consecutive messages from the same author inside five minutes", () => {
+    const first = event({ ts: "2026-08-01T00:00:00Z" });
+    const second = event({ ts: "2026-08-01T00:05:00Z" });
+
+    expect(groupFeedBlocks([first, second])).toEqual([
+      { kind: "message-group", author: "coder", events: [first, second] },
+    ]);
+  });
+
+  it("starts a new group outside the five-minute window", () => {
+    const first = event({ ts: "2026-08-01T00:00:00Z" });
+    const second = event({ ts: "2026-08-01T00:05:01Z" });
+
+    expect(groupFeedBlocks([first, second])).toEqual([
+      { kind: "message-group", author: "coder", events: [first] },
+      { kind: "message-group", author: "coder", events: [second] },
+    ]);
+  });
+
+  it("breaks a message group around an interleaved signal", () => {
+    const first = event({ ts: "2026-08-01T00:00:00Z" });
+    const signal = event({
+      kind: "signal",
+      type: "ask_lead",
+      ts: "2026-08-01T00:01:00Z",
+    });
+    const second = event({ ts: "2026-08-01T00:02:00Z" });
+
+    expect(groupFeedBlocks([first, signal, second])).toEqual([
+      { kind: "message-group", author: "coder", events: [first] },
+      { kind: "signal", event: signal },
+      { kind: "message-group", author: "coder", events: [second] },
+    ]);
+  });
+
+  it("classifies mission_goal and human_said as separate message-like blocks", () => {
+    const goal = event({
+      kind: "signal",
+      from: "human",
+      type: "mission_goal",
+      payload: { text: "Ship it" },
+    });
+    const said = event({
+      kind: "signal",
+      from: "human",
+      type: "human_said",
+      ts: "2026-08-01T00:01:00Z",
+      payload: { text: "Keep going" },
+    });
+
+    expect(groupFeedBlocks([goal, said])).toEqual([
+      { kind: "message-group", author: "human", events: [goal] },
+      { kind: "message-group", author: "human", events: [said] },
+    ]);
+  });
+
+  it("starts a new group when the routing target changes", () => {
+    const direct = event({ to: "reviewer" });
+    const broadcast = event({ ts: "2026-08-01T00:01:00Z" });
+    const otherDirect = event({
+      to: "lead",
+      ts: "2026-08-01T00:02:00Z",
+    });
+
+    expect(groupFeedBlocks([direct, broadcast, otherDirect])).toEqual([
+      { kind: "message-group", author: "coder", events: [direct] },
+      { kind: "message-group", author: "coder", events: [broadcast] },
+      { kind: "message-group", author: "coder", events: [otherDirect] },
+    ]);
+  });
+
+  it("keeps human signals for different routes in separate groups", () => {
+    const said = event({
+      kind: "signal",
+      from: "human",
+      type: "human_said",
+      payload: { text: "First", target: "reviewer" },
+    });
+    const otherSaid = event({
+      kind: "signal",
+      from: "human",
+      type: "human_said",
+      ts: "2026-08-01T00:01:00Z",
+      payload: { text: "Second", target: "lead" },
+    });
+    const response = event({
+      kind: "signal",
+      from: "human",
+      type: "human_response",
+      ts: "2026-08-01T00:02:00Z",
+      payload: { choice: "yes", question_id: "question-1" },
+    });
+    const otherResponse = event({
+      kind: "signal",
+      from: "human",
+      type: "human_response",
+      ts: "2026-08-01T00:03:00Z",
+      payload: { choice: "no", question_id: "question-2" },
+    });
+
+    expect(
+      groupFeedBlocks([said, otherSaid, response, otherResponse]),
+    ).toEqual([
+      { kind: "message-group", author: "human", events: [said] },
+      { kind: "message-group", author: "human", events: [otherSaid] },
+      { kind: "message-group", author: "human", events: [response] },
+      { kind: "message-group", author: "human", events: [otherResponse] },
+    ]);
+  });
+
+  it("hides raw ask_human signals", () => {
+    const askHuman = event({ kind: "signal", type: "ask_human" });
+
+    expect(groupFeedBlocks([askHuman])).toEqual([]);
+  });
+
+  it("maps mission_start to a divider", () => {
+    const missionStart = event({ kind: "signal", type: "mission_start" });
+
+    expect(groupFeedBlocks([missionStart])).toEqual([
+      { kind: "divider", event: missionStart },
+    ]);
+  });
+
+  it("maps human_question to an ask card", () => {
+    const question = event({ kind: "signal", type: "human_question" });
+
+    expect(groupFeedBlocks([question])).toEqual([
+      { kind: "ask-card", event: question },
+    ]);
   });
 });

--- a/src/lib/eventFeed.ts
+++ b/src/lib/eventFeed.ts
@@ -1,5 +1,98 @@
 import type { Event } from "./types";
 
+const GROUP_WINDOW_MS = 5 * 60 * 1000;
+
+export type FeedBlock =
+  | { kind: "divider"; event: Event }
+  | { kind: "message-group"; author: string; events: Event[] }
+  | { kind: "signal"; event: Event }
+  | { kind: "ask-card"; event: Event };
+
+// Router watermarks/status stay in the NDJSON audit trail but add no value to
+// the reading surface. ask_human is hidden because human_question projects the
+// same prompt, choices, and attribution into the interactive card.
+export function isHiddenSystemSignal(event: Event): boolean {
+  return (
+    event.kind === "signal" &&
+    (event.type === "inbox_read" ||
+      event.type === "runner_status" ||
+      event.type === "ask_human")
+  );
+}
+
+function isMessageLike(event: Event): boolean {
+  return (
+    event.kind === "message" ||
+    (event.kind === "signal" &&
+      (event.type === "human_said" ||
+        event.type === "human_response" ||
+        event.type === "mission_goal"))
+  );
+}
+
+function isMissionGoal(event: Event): boolean {
+  return event.kind === "signal" && event.type === "mission_goal";
+}
+
+function groupingRoute(event: Event): string {
+  if (event.kind === "message") return `target:${event.to ?? ""}`;
+  const payload = (event.payload ?? {}) as Record<string, unknown>;
+  if (event.type === "human_said") {
+    return `target:${typeof payload.target === "string" ? payload.target : ""}`;
+  }
+  if (event.type === "human_response") {
+    return `question:${
+      typeof payload.question_id === "string" ? payload.question_id : ""
+    }`;
+  }
+  return "";
+}
+
+function canJoinGroup(
+  group: Extract<FeedBlock, { kind: "message-group" }>,
+  event: Event,
+) {
+  if (group.author !== event.from) return false;
+  const first = group.events[0];
+  if (isMissionGoal(first) || isMissionGoal(event)) return false;
+  if (groupingRoute(first) !== groupingRoute(event)) return false;
+  const previous = Date.parse(group.events[group.events.length - 1].ts);
+  const current = Date.parse(event.ts);
+  const gap = current - previous;
+  return Number.isFinite(gap) && gap >= 0 && gap <= GROUP_WINDOW_MS;
+}
+
+export function groupFeedBlocks(events: Event[]): FeedBlock[] {
+  const blocks: FeedBlock[] = [];
+
+  for (const event of events) {
+    if (isHiddenSystemSignal(event)) continue;
+
+    if (isMessageLike(event)) {
+      const previous = blocks[blocks.length - 1];
+      if (
+        previous?.kind === "message-group" &&
+        canJoinGroup(previous, event)
+      ) {
+        previous.events.push(event);
+      } else {
+        blocks.push({ kind: "message-group", author: event.from, events: [event] });
+      }
+      continue;
+    }
+
+    if (event.kind === "signal" && event.type === "mission_start") {
+      blocks.push({ kind: "divider", event });
+    } else if (event.kind === "signal" && event.type === "human_question") {
+      blocks.push({ kind: "ask-card", event });
+    } else {
+      blocks.push({ kind: "signal", event });
+    }
+  }
+
+  return blocks;
+}
+
 export function isHumanAuthored(event: Event): boolean {
   return (
     (event.kind === "message" && event.from === "human") ||


### PR DESCRIPTION
## Summary

- render mission events as grouped chat-style avatar rows with goal dividers and expandable signal lines
- add deterministic runner identicons, per-handle hues, ask-card identity, and rail presence overlays
- preserve the inherited #392 message-body spacing/list fixes
- include the separately scoped #393 runner and crew detail redesign plan as requested

## Validation

- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm test (318 passed)
- git diff --check
- manual smoke test passed

## Review

- working-tree review completed before commit
- final verdict clean with no remaining must-fix issues