### PR TITLE
fix(router): route synthetic wake busy through the session manager

### DIFF
--- a/crates/runner-core/src/event_log/log.rs
+++ b/crates/runner-core/src/event_log/log.rs
@@ -141,9 +141,9 @@ impl EventLog {
     /// processing flow through the same channel, so a stuck flock
     /// would freeze them all.
     ///
-    /// On contention the caller is expected to drop the event (status
-    /// transitions are observability, not load-bearing) and bump a
-    /// streak counter for visibility.
+    /// On contention the caller decides whether to drop or retry. The
+    /// session forwarder uses a short bounded retry because its status
+    /// transitions feed the router's reconciliation gate.
     pub fn try_append(&self, draft: EventDraft) -> std::result::Result<Event, TryAppendError> {
         let file = OpenOptions::new()
             .create(true)
@@ -493,8 +493,8 @@ fn parse_id(line: &[u8]) -> Result<String> {
 #[derive(Debug)]
 pub enum TryAppendError {
     /// Another writer holds the file lock right now. Caller should
-    /// drop the event and try again on the next transition rather
-    /// than blocking the producer thread.
+    /// either drop the event or retry with its own bounded policy
+    /// rather than blocking the producer thread.
     Contended,
     /// I/O error opening the file or any other append failure.
     Failed(Error),

--- a/src-tauri/src/router/mod.rs
+++ b/src-tauri/src/router/mod.rs
@@ -29,7 +29,7 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 use runner_core::event_log::EventLog;
-use runner_core::model::{Event, EventKind, SignalType};
+use runner_core::model::{Event, EventDraft, EventKind, SignalType};
 use serde::Serialize;
 use tauri::Emitter;
 
@@ -68,6 +68,8 @@ pub trait StdinInjector: Send + Sync + 'static {
     fn inject_reserved(&self, session_id: &str, token: u64, bytes: &[u8]) -> Result<bool>;
 
     fn finish_delivery(&self, session_id: &str, token: u64);
+
+    fn synthesize_wake_busy(&self, session_id: &str, draft: EventDraft) -> Result<()>;
 
     fn register_delivery_listener(
         &self,
@@ -125,6 +127,10 @@ impl StdinInjector for SessionManager {
 
     fn finish_delivery(&self, session_id: &str, token: u64) {
         SessionManager::finish_delivery(self, session_id, token)
+    }
+
+    fn synthesize_wake_busy(&self, session_id: &str, draft: EventDraft) -> Result<()> {
+        SessionManager::synthesize_wake_busy(self, session_id, draft)
     }
 
     fn register_delivery_listener(
@@ -587,26 +593,40 @@ impl Router {
     /// without this, a slow-to-respond agent could appear `idle` to the
     /// user immediately after a nudge. Latest-wins absorbs the
     /// follow-up forwarder event without churn.
+    ///
+    /// Post-issue-#385: the append routes through the SessionManager
+    /// (not `log.append`) so the forwarder dedup key
+    /// (`session.activity`) updates atomically with the event — a
+    /// direct append left the key stale and the paired end-of-turn
+    /// idle was deduped away, sticking the rail on busy.
     fn synthesize_wake_busy(&self, handle: &str) {
         if handle == "human" {
             return;
         }
-        {
+        let session_id = {
             let state = self.state.lock().unwrap();
             if matches!(state.status.get(handle), Some(RunnerStatus::Busy)) {
                 return;
             }
-        }
-        let draft = runner_core::model::EventDraft::signal(
+            state.session_by_handle.get(handle).cloned()
+        };
+        let Some(session_id) = session_id else {
+            log::error!(
+                "cannot synthesize runner_status busy for @{handle} on mission {}: no session",
+                self.mission_id,
+            );
+            return;
+        };
+        let draft = EventDraft::signal(
             self.crew_id.clone(),
             self.mission_id.clone(),
             handle,
             SignalType::new("runner_status"),
             serde_json::json!({ "state": "busy" }),
         );
-        if let Err(e) = self.log.append(draft) {
+        if let Err(e) = self.injector.synthesize_wake_busy(&session_id, draft) {
             log::error!(
-                "failed to append synthetic runner_status busy for @{handle} on mission {}: {e}",
+                "failed to synthesize runner_status busy for @{handle} on mission {}: {e}",
                 self.mission_id,
             );
             return;

--- a/src-tauri/src/router/tests.rs
+++ b/src-tauri/src/router/tests.rs
@@ -34,8 +34,9 @@ enum InjectKind {
 
 /// Records every `inject` / `inject_paste_with_verify` call so
 /// handler outputs can be asserted.
-#[derive(Default)]
 struct RecordingInjector {
+    status_log: Arc<EventLog>,
+    activity: Mutex<HashMap<String, super::RunnerStatus>>,
     pushes: Mutex<Vec<(String, InjectKind, Vec<u8>)>>,
     blocked_events: Mutex<Vec<DeliveryBlockedEvent>>,
     /// Optional `dead_session` set — `inject` errors when called with one
@@ -54,6 +55,22 @@ struct RecordingInputState {
 }
 
 impl RecordingInjector {
+    fn new(status_log: Arc<EventLog>) -> Self {
+        Self {
+            status_log,
+            activity: Mutex::new(HashMap::new()),
+            pushes: Mutex::new(Vec::new()),
+            blocked_events: Mutex::new(Vec::new()),
+            dead: Mutex::new(Vec::new()),
+            input: Mutex::new(HashMap::new()),
+            listeners: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn activity_for(&self, session_id: &str) -> Option<super::RunnerStatus> {
+        self.activity.lock().unwrap().get(session_id).copied()
+    }
+
     fn pushes_for(&self, session_id: &str) -> Vec<String> {
         self.pushes
             .lock()
@@ -333,6 +350,15 @@ impl StdinInjector for RecordingInjector {
         }
     }
 
+    fn synthesize_wake_busy(&self, session_id: &str, draft: EventDraft) -> Result<()> {
+        self.status_log.append(draft)?;
+        self.activity
+            .lock()
+            .unwrap()
+            .insert(session_id.to_string(), super::RunnerStatus::Busy);
+        Ok(())
+    }
+
     fn register_delivery_listener(
         &self,
         session_id: &str,
@@ -403,7 +429,7 @@ fn fixture(
 ) {
     let dir = tempfile::tempdir().unwrap();
     let log = Arc::new(EventLog::open(dir.path()).unwrap());
-    let injector = Arc::new(RecordingInjector::default());
+    let injector = Arc::new(RecordingInjector::new(Arc::clone(&log)));
     let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
     let notifier: Arc<dyn RouterUiNotifier> = injector.clone();
     let router = Router::new(
@@ -1745,7 +1771,7 @@ fn pending_ask_map_reconstructs_from_log_on_reopen() {
 
     // First mount handles the ask live (appends human_question).
     {
-        let injector = Arc::new(RecordingInjector::default());
+        let injector = Arc::new(RecordingInjector::new(Arc::clone(&log)));
         let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
         let router = Router::new(
             "mission-1".into(),
@@ -1782,7 +1808,7 @@ fn pending_ask_map_reconstructs_from_log_on_reopen() {
 
     // Reopen: build router #2, fold projection state from history. This
     // is the path mission_resume / mount-on-app-restart will follow.
-    let injector = Arc::new(RecordingInjector::default());
+    let injector = Arc::new(RecordingInjector::new(Arc::clone(&log)));
     let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
     let router2 = Router::new(
         "mission-1".into(),
@@ -1889,7 +1915,7 @@ fn reconstruct_recovers_latest_runner_status_only() {
     ))
     .unwrap();
 
-    let injector = Arc::new(RecordingInjector::default());
+    let injector = Arc::new(RecordingInjector::new(Arc::clone(&log)));
     let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
     let router = Router::new(
         "mission-1".into(),
@@ -1979,7 +2005,7 @@ fn fresh_mission_start_does_not_call_reconstruct() {
     ))
     .unwrap();
 
-    let injector = Arc::new(RecordingInjector::default());
+    let injector = Arc::new(RecordingInjector::new(Arc::clone(&log)));
     let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
     let router = Router::new(
         "mission-1".into(),
@@ -2077,7 +2103,7 @@ fn reconstruct_tolerates_malformed_lines_like_the_bus() {
     let roster = vec![slot_with_runner("lead", true)];
     // First mount handles the ask live — appends human_question.
     {
-        let injector = Arc::new(RecordingInjector::default());
+        let injector = Arc::new(RecordingInjector::new(Arc::clone(&log)));
         let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
         let router = Router::new(
             "mission-1".into(),
@@ -2106,7 +2132,7 @@ fn reconstruct_tolerates_malformed_lines_like_the_bus() {
         .id;
 
     // Reopen + reconstruct: must not fail despite the malformed middle line.
-    let injector = Arc::new(RecordingInjector::default());
+    let injector = Arc::new(RecordingInjector::new(Arc::clone(&log)));
     let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
     let router2 = Router::new(
         "mission-1".into(),
@@ -2151,7 +2177,7 @@ fn directed_wake_synthesizes_busy_and_idle_clears_it() {
     // `idle` was emitted. The router now synthesizes `runner_status busy`
     // (with `from = recipient`) for any wake nudge, and the existing
     // worker-emitted `idle` clears it.
-    let (router, _injector, log, _dir) = fixture(
+    let (router, injector, log, _dir) = fixture(
         vec![
             slot_with_runner("lead", true),
             slot_with_runner("impl", false),
@@ -2186,6 +2212,11 @@ fn directed_wake_synthesizes_busy_and_idle_clears_it() {
         router.state.lock().unwrap().status.get("impl"),
         Some(super::RunnerStatus::Busy),
     ));
+    assert_eq!(
+        injector.activity_for("S-IMPL"),
+        Some(super::RunnerStatus::Busy),
+        "synthetic busy must update the session-side activity store",
+    );
 
     // A second directed wake while still busy must not churn another
     // busy event into the log — the dedupe guard suppresses it.
@@ -2245,7 +2276,7 @@ fn synthetic_busy_replays_through_existing_runner_status_projection() {
 
     // First mount: drive a directed message to synthesize busy.
     {
-        let injector = Arc::new(RecordingInjector::default());
+        let injector = Arc::new(RecordingInjector::new(Arc::clone(&log)));
         let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
         let router = Router::new(
             "mission-1".into(),
@@ -2268,7 +2299,7 @@ fn synthetic_busy_replays_through_existing_runner_status_projection() {
     }
 
     // Reopen + reconstruct.
-    let injector = Arc::new(RecordingInjector::default());
+    let injector = Arc::new(RecordingInjector::new(Arc::clone(&log)));
     let injector_dyn: Arc<dyn StdinInjector> = injector.clone();
     let router2 = Router::new(
         "mission-1".into(),

--- a/src-tauri/src/session/manager/mod.rs
+++ b/src-tauri/src/session/manager/mod.rs
@@ -49,6 +49,8 @@ mod tests;
 
 const MAX_OUTPUT_BUFFER_CHUNKS: usize = 4096;
 const RECENT_LOCAL_INPUT_WINDOW: Duration = Duration::from_secs(2);
+const RUNNER_STATUS_APPEND_MAX_ATTEMPTS: usize = 8;
+const RUNNER_STATUS_APPEND_RETRY_DELAY: Duration = Duration::from_millis(5);
 pub(crate) const DEFAULT_PTY_SIZE: (u16, u16) = (80, 24);
 
 /// How long a cols-change resize storm must stay quiet before the
@@ -257,22 +259,30 @@ impl ForwarderEmitCtx {
         )
     }
 
-    /// Non-blocking append of a forwarder-emitted `runner_status`
-    /// row. The consumer thread runs this on every status
-    /// transition; it must not block (it shares the mpsc receiver
-    /// with the terminal output stream and the exit-event reap, so
-    /// a stuck flock would freeze them too). Wire shape mirrors
-    /// `cli/src/signal.rs::run_status` so router / UI projections
-    /// can't tell the two apart except by `payload.source`.
+    /// Bounded append of a forwarder-emitted `runner_status` row.
+    /// Each flock attempt is non-blocking; brief contention is retried
+    /// because the router's reconciliation gate now depends on these
+    /// events, while persistent contention still gives up quickly so
+    /// terminal output and exit-event reap cannot freeze behind it.
     fn try_append_runner_status(&self, state: RunnerStatus, source: &'static str) -> AppendOutcome {
-        match self
-            .event_log
-            .try_append(self.runner_status_draft(state, source))
-        {
-            Ok(_) => AppendOutcome::Ok,
+        match self.try_append_with_retry(self.runner_status_draft(state, source)) {
+            Ok(()) => AppendOutcome::Ok,
             Err(TryAppendError::Contended) => AppendOutcome::Contended,
             Err(TryAppendError::Failed(_)) => AppendOutcome::Failed,
         }
+    }
+
+    fn try_append_with_retry(&self, draft: EventDraft) -> std::result::Result<(), TryAppendError> {
+        for attempt in 1..=RUNNER_STATUS_APPEND_MAX_ATTEMPTS {
+            match self.event_log.try_append(draft.clone()) {
+                Ok(_) => return Ok(()),
+                Err(TryAppendError::Contended) if attempt < RUNNER_STATUS_APPEND_MAX_ATTEMPTS => {
+                    thread::sleep(RUNNER_STATUS_APPEND_RETRY_DELAY);
+                }
+                Err(error) => return Err(error),
+            }
+        }
+        unreachable!("bounded append loop always returns")
     }
 
     fn append_runner_status(
@@ -986,6 +996,23 @@ impl SessionManager {
         }
         session.activity = Some(state);
         true
+    }
+
+    pub(crate) fn synthesize_wake_busy(&self, session_id: &str, draft: EventDraft) -> Result<()> {
+        let session = self
+            .session_state(session_id)
+            .ok_or_else(|| Error::msg(format!("session not found: {session_id}")))?;
+        let mut session = session.lock().unwrap();
+        let sink = session.mission_status_sink.as_ref().ok_or_else(|| {
+            Error::msg(format!("session has no mission status sink: {session_id}"))
+        })?;
+        match sink.try_append_with_retry(draft) {
+            Ok(()) => {}
+            Err(TryAppendError::Contended) => return Err(Error::msg("event log busy")),
+            Err(TryAppendError::Failed(error)) => return Err(error.into()),
+        }
+        session.activity = Some(SessionActivityState::Busy);
+        Ok(())
     }
 
     pub(crate) fn publish_direct_activity(

--- a/src-tauri/src/session/manager/tests.rs
+++ b/src-tauri/src/session/manager/tests.rs
@@ -2574,6 +2574,217 @@ fn mission_status_transition_appends_once_without_session_status_event() {
 }
 
 #[test]
+fn synthetic_wake_busy_updates_activity_and_allows_final_idle() {
+    let pool = pool_with_schema();
+    let mission = Mission {
+        crew_id: "c".into(),
+        ..mission()
+    };
+    let runner = runner("/bin/cat", &[]);
+    let slot_id = insert_crew_runner(&pool, &mission.id, &runner.id);
+    let mut slot = slot_for(&runner);
+    slot.id = slot_id;
+    slot.crew_id = mission.crew_id.clone();
+
+    let app_data = tempfile::tempdir().unwrap();
+    let events_log_path =
+        runner_core::event_log::path::events_path(app_data.path(), &mission.crew_id, &mission.id);
+    let mission_dir =
+        runner_core::event_log::path::mission_dir(app_data.path(), &mission.crew_id, &mission.id);
+    let fake = fake_runtime();
+    let mgr = mgr_with_fake(None, Arc::clone(&fake));
+    let cap = capture();
+    let spawned = mgr
+        .spawn(
+            &mission,
+            &runner,
+            &slot,
+            app_data.path(),
+            events_log_path,
+            Arc::clone(&pool),
+            Arc::clone(&cap) as Arc<dyn SessionEvents>,
+            None,
+        )
+        .unwrap();
+
+    fake.push_status(0, RunnerStatus::Idle);
+    fake.push_output(0, b"initial-idle-synced");
+    wait_for_output_event(&cap, &spawned.id);
+    cap.output.lock().unwrap().clear();
+
+    let log = EventLog::open(&mission_dir).unwrap();
+    mgr.synthesize_wake_busy(
+        &spawned.id,
+        EventDraft::signal(
+            mission.crew_id.clone(),
+            mission.id.clone(),
+            runner.handle.clone(),
+            SignalType::new("runner_status"),
+            serde_json::json!({ "state": "busy" }),
+        ),
+    )
+    .unwrap();
+
+    assert_eq!(
+        mgr.activity_snapshot().get(&spawned.id),
+        Some(&SessionActivityState::Busy),
+        "synthetic busy must update the session-side dedup key",
+    );
+    let after_busy: Vec<_> = log
+        .read_from(0)
+        .unwrap()
+        .into_iter()
+        .map(|entry| entry.event)
+        .filter(|event| {
+            event
+                .signal_type
+                .as_ref()
+                .is_some_and(|ty| ty.as_str() == "runner_status")
+        })
+        .collect();
+    assert_eq!(after_busy.len(), 2);
+    assert_eq!(after_busy[1].payload["state"], "busy");
+
+    fake.push_status(0, RunnerStatus::Idle);
+    fake.push_output(0, b"final-idle-drained");
+    wait_for_output_event(&cap, &spawned.id);
+
+    let statuses: Vec<_> = log
+        .read_from(0)
+        .unwrap()
+        .into_iter()
+        .map(|entry| entry.event)
+        .filter(|event| {
+            event
+                .signal_type
+                .as_ref()
+                .is_some_and(|ty| ty.as_str() == "runner_status")
+        })
+        .collect();
+    assert_eq!(statuses.len(), 3);
+    assert_eq!(statuses[2].payload["state"], "idle");
+    assert_eq!(statuses[2].payload["source"], "forwarder");
+    assert_eq!(
+        mgr.activity_snapshot().get(&spawned.id),
+        Some(&SessionActivityState::Idle),
+    );
+
+    mgr.kill(&spawned.id).unwrap();
+}
+
+#[test]
+fn suppressed_busy_then_agent_output_and_quiet_appends_final_idle() {
+    let pool = pool_with_schema();
+    let mission = Mission {
+        crew_id: "c".into(),
+        ..mission()
+    };
+    let runner = runner("/bin/cat", &[]);
+    let slot_id = insert_crew_runner(&pool, &mission.id, &runner.id);
+    let mut slot = slot_for(&runner);
+    slot.id = slot_id;
+    slot.crew_id = mission.crew_id.clone();
+
+    let app_data = tempfile::tempdir().unwrap();
+    let events_log_path =
+        runner_core::event_log::path::events_path(app_data.path(), &mission.crew_id, &mission.id);
+    let mission_dir =
+        runner_core::event_log::path::mission_dir(app_data.path(), &mission.crew_id, &mission.id);
+    let fake = fake_runtime();
+    let mgr = mgr_with_fake(None, Arc::clone(&fake));
+    let cap = capture();
+    let spawned = mgr
+        .spawn(
+            &mission,
+            &runner,
+            &slot,
+            app_data.path(),
+            events_log_path,
+            Arc::clone(&pool),
+            Arc::clone(&cap) as Arc<dyn SessionEvents>,
+            None,
+        )
+        .unwrap();
+
+    fake.push_status(0, RunnerStatus::Idle);
+    fake.push_output(0, b"initial-idle-synced");
+    wait_for_output_event(&cap, &spawned.id);
+    cap.output.lock().unwrap().clear();
+
+    mgr.inject_direct_stdin(&spawned.id, b"router nudge", cap.as_ref())
+        .unwrap();
+    assert!(
+        mgr.session_state(&spawned.id)
+            .unwrap()
+            .lock()
+            .unwrap()
+            .suppress_local_input_busy,
+        "unsubmitted nudge body must open the suppressed-busy window",
+    );
+
+    let log = EventLog::open(&mission_dir).unwrap();
+    mgr.synthesize_wake_busy(
+        &spawned.id,
+        EventDraft::signal(
+            mission.crew_id.clone(),
+            mission.id.clone(),
+            runner.handle.clone(),
+            SignalType::new("runner_status"),
+            serde_json::json!({ "state": "busy" }),
+        ),
+    )
+    .unwrap();
+
+    fake.push_status(0, RunnerStatus::Busy);
+    fake.push_output(0, b"agent output");
+    fake.push_status(0, RunnerStatus::Idle);
+    fake.push_output(0, b"quiet-transition-drained");
+
+    let deadline = Instant::now() + Duration::from_secs(2);
+    let statuses = loop {
+        let statuses: Vec<_> = log
+            .read_from(0)
+            .unwrap()
+            .into_iter()
+            .map(|entry| entry.event)
+            .filter(|event| {
+                event
+                    .signal_type
+                    .as_ref()
+                    .is_some_and(|ty| ty.as_str() == "runner_status")
+            })
+            .collect();
+        if statuses.last().is_some_and(|event| {
+            event.payload.get("state").and_then(|state| state.as_str()) == Some("idle")
+        }) && statuses.len() >= 3
+        {
+            break statuses;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "final idle was not appended after the suppressed busy"
+        );
+        std::thread::sleep(Duration::from_millis(10));
+    };
+
+    assert_eq!(
+        statuses
+            .iter()
+            .map(|event| event.payload["state"].as_str().unwrap())
+            .collect::<Vec<_>>(),
+        vec!["idle", "busy", "idle"],
+        "the suppressed forwarder busy must not swallow the paired idle",
+    );
+    assert_eq!(statuses[2].payload["source"], "forwarder");
+    assert_eq!(
+        mgr.activity_snapshot().get(&spawned.id),
+        Some(&SessionActivityState::Idle),
+    );
+
+    mgr.kill(&spawned.id).unwrap();
+}
+
+#[test]
 fn mission_typing_stays_idle_until_submit() {
     let pool = pool_with_schema();
     let mission_base = Mission {
@@ -3818,7 +4029,7 @@ fn codex_mission_resume_grants_event_log_dir_to_sandbox() {
 // a FakeRuntime SessionHandle for those tests is gone too.
 
 #[test]
-fn forwarder_status_emit_does_not_block_under_event_log_contention() {
+fn forwarder_status_emit_stays_bounded_under_event_log_contention() {
     // Issue #124 / @reviewer P1: the forwarder consumer drains
     // terminal output, exit-event reap, AND `runner_status`
     // emission through the same thread. If `try_append_runner_status`
@@ -3828,8 +4039,8 @@ fn forwarder_status_emit_does_not_block_under_event_log_contention() {
     // Construct a real ForwarderEmitCtx against a tempdir,
     // steal the flock from another "process" (a parallel fd
     // holding LOCK_EX), and assert that
-    // `try_append_runner_status` returns `Contended` within a
-    // hard 100ms bound.
+    // `try_append_runner_status` exhausts its bounded retries and
+    // returns `Contended` within a hard 100ms bound.
     use fs2::FileExt;
     use std::fs::OpenOptions;
     let dir = tempfile::tempdir().unwrap();
@@ -3883,6 +4094,61 @@ fn forwarder_status_emit_does_not_block_under_event_log_contention() {
     blocker.unlock().unwrap();
     let outcome = ctx.try_append_runner_status(RunnerStatus::Busy, "forwarder");
     assert!(matches!(outcome, AppendOutcome::Ok));
+}
+
+#[test]
+fn forwarder_status_emit_retries_brief_event_log_contention() {
+    use fs2::FileExt;
+    use std::fs::OpenOptions;
+
+    let dir = tempfile::tempdir().unwrap();
+    let event_log = Arc::new(EventLog::open(dir.path()).unwrap());
+    let blocker = OpenOptions::new()
+        .create(true)
+        .read(true)
+        .append(true)
+        .open(event_log.path())
+        .unwrap();
+    blocker.lock_exclusive().unwrap();
+
+    let ctx = ForwarderEmitCtx {
+        crew_id: "test-crew".into(),
+        mission_id: "test-mission".into(),
+        handle: "tester".into(),
+        event_log: Arc::clone(&event_log),
+    };
+    assert!(matches!(
+        event_log.try_append(ctx.runner_status_draft(RunnerStatus::Idle, "forwarder")),
+        Err(TryAppendError::Contended),
+    ));
+
+    let (started_tx, started_rx) = std::sync::mpsc::channel();
+    let retry_ctx = ctx.clone();
+    let append = std::thread::spawn(move || {
+        started_tx.send(()).unwrap();
+        retry_ctx.try_append_runner_status(RunnerStatus::Idle, "forwarder")
+    });
+    started_rx.recv().unwrap();
+    // Keep the unlock well inside the ~35ms retry budget so a loaded CI
+    // machine can't slip it past the last attempt.
+    std::thread::sleep(Duration::from_millis(5));
+    blocker.unlock().unwrap();
+
+    assert!(matches!(append.join().unwrap(), AppendOutcome::Ok));
+    let statuses: Vec<_> = event_log
+        .read_from(0)
+        .unwrap()
+        .into_iter()
+        .map(|entry| entry.event)
+        .filter(|event| {
+            event
+                .signal_type
+                .as_ref()
+                .is_some_and(|ty| ty.as_str() == "runner_status")
+        })
+        .collect();
+    assert_eq!(statuses.len(), 1);
+    assert_eq!(statuses[0].payload["state"], "idle");
 }
 
 #[test]


### PR DESCRIPTION
Fixes #385.

## Root cause

Two independent "is this runner busy" stores could diverge: the router's `synthesize_wake_busy` appended a synthetic `runner_status` busy directly to the log without updating `session.activity` — the dedup key the forwarder consults. When the agent's first output byte landed inside the suppressed-busy window, the forwarder's busy was swallowed with `activity` still `Idle`, so the end-of-turn idle was deduped as a no-op and the rail stayed `busy` forever. A stuck handle is also permanently ineligible for the reconciliation nudge, so this could silently stall missions.

## Changes

- `synthesize_wake_busy` now routes its append through the `SessionManager`, which writes the event and updates `session.activity` under one session lock — the two stores can no longer drift, and the existing dedup works as intended. Wakes at a dead slot no longer append an uncleareable busy (early return instead).
- `try_append_runner_status` retries on flock contention (8 attempts × 5 ms, bounded < 50 ms) instead of dropping — status events are load-bearing now that the reconciliation gate reads them.
- Regression tests: both stores updated by the synthetic busy with the final idle emitted; the suppressed-busy → output → quiet sequence still yields a logged idle; bounded retry recovers a contended append; retry budget stays bounded under persistent contention.

## Checks

- `cargo test --workspace` (540 runner + 8 CLI + 16 roundtrip + 22 runner-core), `cargo clippy`, `cargo fmt --check` — all green locally.
- Crew-reviewed on the working-tree diff (mission `01KZMYBZPR…`): no must-fix findings; both reviewer nice-to-haves folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
