### PR TITLE
fix(mission): refresh sessions across resume races

### DIFF
--- a/src-tauri/src/commands/session.rs
+++ b/src-tauri/src/commands/session.rs
@@ -22,8 +22,8 @@ use crate::{
     model::{Runner, Session, SessionStatus, Timestamp},
     repo,
     session::manager::{
-        runtime_direct_runner, OutputEvent, SessionActivityState, SessionEvents, SpawnedSession,
-        TauriSessionEvents,
+        runtime_direct_runner, OutputEvent, SessionActivityState, SessionEvents,
+        SessionUpdatedEvent, SpawnedSession, TauriSessionEvents,
     },
     AppState,
 };
@@ -732,7 +732,10 @@ pub async fn session_resume(
     }
     let _ = app.emit(
         "session/updated",
-        serde_json::json!({ "session_id": session_id }),
+        SessionUpdatedEvent {
+            session_id,
+            mission_id: spawned.mission_id.clone(),
+        },
     );
     Ok(spawned)
 }

--- a/src-tauri/src/session/manager/spawn.rs
+++ b/src-tauri/src/session/manager/spawn.rs
@@ -1079,6 +1079,8 @@ impl SessionManager {
             let state = self.session_state_or_insert(session_id);
             let mut state = state.lock().unwrap();
             if state.resuming {
+                // Frontend benign-race handling matches this fragment in
+                // src/lib/missionResume.ts; keep the wording synchronized.
                 return Err(Error::msg(format!(
                     "session {session_id} is already being resumed"
                 )));
@@ -1099,6 +1101,8 @@ impl SessionManager {
             let row = crate::repo::session::get_row(&conn, session_id)?
                 .ok_or_else(|| Error::msg(format!("session not found: {session_id}")))?;
             if matches!(row.status, crate::model::SessionStatus::Running) {
+                // Frontend benign-race handling matches this fragment in
+                // src/lib/missionResume.ts; keep the wording synchronized.
                 return Err(Error::msg(format!(
                     "session {session_id} is already running — attach instead"
                 )));

--- a/src/lib/missionResume.test.ts
+++ b/src/lib/missionResume.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { SessionRow } from "./api";
+import { resumeStoppedMissionSessions } from "./missionResume";
+
+function session(id: string, status: SessionRow["status"]): SessionRow {
+  return {
+    id,
+    mission_id: "mission-1",
+    runner_id: `runner-${id}`,
+    cwd: null,
+    status,
+    pid: status === "running" ? 123 : null,
+    started_at: null,
+    stopped_at: null,
+    handle: id,
+    runtime: "codex",
+    lead: id === "session-a",
+    agent_session_key: null,
+  };
+}
+
+describe("resumeStoppedMissionSessions", () => {
+  it("re-fetches sessions before choosing which slots to resume", async () => {
+    const list = vi
+      .fn<(missionId: string) => Promise<SessionRow[]>>()
+      .mockResolvedValueOnce([
+        session("session-a", "running"),
+        session("session-b", "stopped"),
+      ])
+      .mockResolvedValueOnce([
+        session("session-a", "running"),
+        session("session-b", "running"),
+      ]);
+    const resume = vi.fn().mockResolvedValue(undefined);
+
+    const result = await resumeStoppedMissionSessions(
+      "mission-1",
+      { cols: 180, rows: 48 },
+      { list, resume },
+    );
+
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(list.mock.invocationCallOrder[0]).toBeLessThan(
+      resume.mock.invocationCallOrder[0],
+    );
+    expect(resume).toHaveBeenCalledOnce();
+    expect(resume).toHaveBeenCalledWith("session-b", 180, 48);
+    expect(result).toEqual({
+      sessions: [
+        session("session-a", "running"),
+        session("session-b", "running"),
+      ],
+      error: null,
+    });
+  });
+
+  it("refreshes and continues when a racing resume reports already running", async () => {
+    const list = vi
+      .fn<(missionId: string) => Promise<SessionRow[]>>()
+      .mockResolvedValueOnce([
+        session("session-a", "stopped"),
+        session("session-b", "stopped"),
+      ])
+      .mockResolvedValueOnce([
+        session("session-a", "running"),
+        session("session-b", "stopped"),
+      ])
+      .mockResolvedValueOnce([
+        session("session-a", "running"),
+        session("session-b", "running"),
+      ]);
+    const resume = vi
+      .fn()
+      .mockRejectedValueOnce(
+        "session_resume: session session-a is already running — attach instead",
+      )
+      .mockResolvedValueOnce(undefined);
+
+    const result = await resumeStoppedMissionSessions("mission-1", null, {
+      list,
+      resume,
+    });
+
+    expect(list).toHaveBeenCalledTimes(3);
+    expect(resume.mock.calls).toEqual([
+      ["session-a", null, null],
+      ["session-b", null, null],
+    ]);
+    expect(result.error).toBeNull();
+    expect(result.sessions.every((row) => row.status === "running")).toBe(true);
+  });
+
+  it("refreshes and continues while a racing resume is still in flight", async () => {
+    const list = vi
+      .fn<(missionId: string) => Promise<SessionRow[]>>()
+      .mockResolvedValueOnce([
+        session("session-a", "stopped"),
+        session("session-b", "stopped"),
+      ])
+      .mockResolvedValueOnce([
+        session("session-a", "stopped"),
+        session("session-b", "stopped"),
+      ])
+      .mockResolvedValueOnce([
+        session("session-a", "running"),
+        session("session-b", "running"),
+      ]);
+    const resume = vi
+      .fn()
+      .mockRejectedValueOnce(
+        "session_resume: session session-a is already being resumed",
+      )
+      .mockResolvedValueOnce(undefined);
+
+    const result = await resumeStoppedMissionSessions("mission-1", null, {
+      list,
+      resume,
+    });
+
+    expect(list).toHaveBeenCalledTimes(3);
+    expect(resume.mock.calls).toEqual([
+      ["session-a", null, null],
+      ["session-b", null, null],
+    ]);
+    expect(result.error).toBeNull();
+    expect(result.sessions.every((row) => row.status === "running")).toBe(true);
+  });
+
+  it("keeps resuming other slots after a real failure", async () => {
+    const failed = new Error("spawn failed");
+    const list = vi
+      .fn<(missionId: string) => Promise<SessionRow[]>>()
+      .mockResolvedValueOnce([
+        session("session-a", "stopped"),
+        session("session-b", "stopped"),
+      ])
+      .mockResolvedValueOnce([
+        session("session-a", "crashed"),
+        session("session-b", "running"),
+      ]);
+    const resume = vi
+      .fn()
+      .mockRejectedValueOnce(failed)
+      .mockResolvedValueOnce(undefined);
+
+    const result = await resumeStoppedMissionSessions("mission-1", null, {
+      list,
+      resume,
+    });
+
+    expect(resume).toHaveBeenCalledTimes(2);
+    expect(result.error).toBe(failed);
+  });
+});

--- a/src/lib/missionResume.ts
+++ b/src/lib/missionResume.ts
@@ -1,0 +1,68 @@
+import type { SessionRow } from "./api";
+import type { TerminalGridSize } from "./terminalSizing";
+
+interface MissionResumeApi {
+  list: (missionId: string) => Promise<SessionRow[]>;
+  resume: (
+    sessionId: string,
+    cols: number | null,
+    rows: number | null,
+  ) => Promise<unknown>;
+}
+
+export interface MissionResumeResult {
+  sessions: SessionRow[];
+  error: unknown | null;
+}
+
+// Keep these fragments synchronized with SessionManager::resume_with_fresh_fallback.
+const CONCURRENT_RESUME_ERRORS = [
+  "is already being resumed",
+  "is already running — attach instead",
+];
+
+function isConcurrentResumeError(error: unknown): boolean {
+  const message = String(error);
+  return CONCURRENT_RESUME_ERRORS.some((fragment) => message.includes(fragment));
+}
+
+export async function resumeStoppedMissionSessions(
+  missionId: string,
+  dims: TerminalGridSize | null,
+  sessionApi: MissionResumeApi,
+): Promise<MissionResumeResult> {
+  let sessions = await sessionApi.list(missionId);
+  let firstError: unknown | null = null;
+
+  for (const candidate of sessions) {
+    const current = sessions.find((session) => session.id === candidate.id);
+    if (current?.status === "running") continue;
+
+    try {
+      await sessionApi.resume(
+        candidate.id,
+        dims?.cols ?? null,
+        dims?.rows ?? null,
+      );
+    } catch (error) {
+      if (!isConcurrentResumeError(error)) {
+        firstError ??= error;
+        continue;
+      }
+
+      try {
+        sessions = await sessionApi.list(missionId);
+      } catch (refreshError) {
+        firstError ??= refreshError;
+      }
+    }
+  }
+
+  try {
+    sessions = await sessionApi.list(missionId);
+  } catch (refreshError) {
+    firstError ??= refreshError;
+  }
+
+  return { sessions, error: firstError };
+}

--- a/src/pages/MissionWorkspace.tsx
+++ b/src/pages/MissionWorkspace.tsx
@@ -97,6 +97,7 @@ import {
 } from "../lib/archivingState";
 import { eventMatchesShortcut } from "../lib/keymap";
 import { useMissionDeliveryBlocked } from "../lib/deliveryBlocked";
+import { resumeStoppedMissionSessions } from "../lib/missionResume";
 
 const RAIL_STORAGE_WIDTH = "runner.mission.rail.width";
 const RAIL_MIN = 200;
@@ -121,6 +122,12 @@ function workspaceDimsFromContainer(
   container: HTMLElement,
 ): { cols: number; rows: number } | null {
   return terminalGridFromElement(container);
+}
+
+function actionFailureMessage(action: string, error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error);
+  const detail = raw.replace(/^[a-z][a-z0-9_]*:\s*/i, "");
+  return `Couldn't ${action}: ${detail}`;
 }
 
 // Rendered by PersistentSurfaces (not a route element), which passes the
@@ -328,7 +335,7 @@ export default function MissionWorkspace({
         }
         ingest(evs);
       } catch (e) {
-        if (!cancelled) setError(String(e));
+        if (!cancelled) setError(actionFailureMessage("load the mission", e));
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -552,8 +559,9 @@ export default function MissionWorkspace({
       setMission(next);
       const rows = await api.session.list(mission.id);
       setSessions(rows);
+      setError(null);
     } catch (e) {
-      setError(String(e));
+      setError(actionFailureMessage("stop the mission", e));
     }
   }, [mission]);
 
@@ -562,8 +570,9 @@ export default function MissionWorkspace({
     try {
       const next = await api.mission.pin(mission.id, !mission.pinned_at);
       setMission(next);
+      setError(null);
     } catch (e) {
-      setError(String(e));
+      setError(actionFailureMessage("update the mission pin", e));
     }
   }, [mission]);
 
@@ -580,8 +589,9 @@ export default function MissionWorkspace({
     try {
       const updated = await api.mission.rename(mission.id, trimmed);
       setMission(updated);
+      setError(null);
     } catch (e) {
-      setError(String(e));
+      setError(actionFailureMessage("rename the mission", e));
     }
   }, [mission]);
 
@@ -600,9 +610,10 @@ export default function MissionWorkspace({
     try {
       clearLastMissionTerminalId(mission.id);
       await api.mission.archive(mission.id);
+      setError(null);
       navigate("/runners");
     } catch (e) {
-      setError(String(e));
+      setError(actionFailureMessage("archive the mission", e));
     } finally {
       setTimeout(() => unmarkArchivingMission(mission.id), 0);
     }
@@ -685,8 +696,9 @@ export default function MissionWorkspace({
       setOpenTabs(rows.map((s) => s.id));
       setActiveTab("feed");
       setResetConfirmOpen(false);
+      setError(null);
     } catch (e) {
-      setError(String(e));
+      setError(actionFailureMessage("reset the mission", e));
     }
   }, [mission, setResetConfirmOpen, measureSlotDims]);
 
@@ -697,7 +709,6 @@ export default function MissionWorkspace({
   const resumeMission = useCallback(async () => {
     if (!mission) return;
     setResumingAll(true);
-    let firstErr: string | null = null;
     try {
       // ONE current measurement for every stopped slot (see
       // `measureSlotDims` for the freshness priority). All panes share
@@ -709,46 +720,30 @@ export default function MissionWorkspace({
       // conversation history at 80 cols — for main-screen TUIs those
       // hard-wrapped narrow lines stick in scrollback.
       const sharedDims = measureSlotDims();
-      // Best-effort over every stopped slot. Don't bail on the first
-      // failure — earlier slots may have already resumed, and the
-      // user wants the UI to reflect whatever actually came up.
-      // Errors are collected and surfaced after the refresh.
-      for (const s of sessions) {
-        if (s.status === "running") continue;
-        try {
-          await api.session.resume(
-            s.id,
-            sharedDims?.cols ?? null,
-            sharedDims?.rows ?? null,
-          );
-        } catch (e) {
-          if (firstErr == null) firstErr = String(e);
-        }
-      }
+      const result = await resumeStoppedMissionSessions(
+        mission.id,
+        sharedDims,
+        api.session,
+      );
+      setSessions(result.sessions);
+      // Mission Resume implies the user wants to see the slots come
+      // back to life. Reopen any tabs they'd previously closed.
+      setOpenTabs((prev) => {
+        const next = new Set(prev);
+        for (const row of result.sessions) next.add(row.id);
+        return Array.from(next);
+      });
+      setError(
+        result.error == null
+          ? null
+          : actionFailureMessage("resume the mission", result.error),
+      );
+    } catch (e) {
+      setError(actionFailureMessage("resume the mission", e));
     } finally {
-      // Refresh in finally so a partial failure (one slot resumed,
-      // a later one threw) still updates the row list + opens tabs
-      // for the slots that did come back. Without this the UI stays
-      // stuck reading "paused" while the resumed PTYs are live.
-      try {
-        const rows = await api.session.list(mission.id);
-        setSessions(rows);
-        // Mission Resume implies the user wants to see the slots
-        // come back to life. Reopen any tabs they'd previously
-        // closed — resume isn't a useful action if the panes are
-        // hidden.
-        setOpenTabs((prev) => {
-          const next = new Set(prev);
-          for (const r of rows) next.add(r.id);
-          return Array.from(next);
-        });
-      } catch (e) {
-        if (firstErr == null) firstErr = String(e);
-      }
-      if (firstErr != null) setError(firstErr);
       setResumingAll(false);
     }
-  }, [mission, sessions, measureSlotDims]);
+  }, [mission, measureSlotDims]);
 
   const archivingMission = useArchivingMission(mission?.id);
 
@@ -1126,8 +1121,18 @@ export default function MissionWorkspace({
         </header>
 
       {error ? (
-        <div className="mx-8 mt-3 rounded border border-danger/40 bg-danger/10 px-3 py-2 text-sm text-danger">
-          {error}
+        <div
+          role="alert"
+          className="mx-8 mt-3 flex items-start justify-between gap-3 rounded border border-danger/40 bg-danger/10 px-3 py-2 text-sm text-danger"
+        >
+          <span>{error}</span>
+          <button
+            type="button"
+            onClick={() => setError(null)}
+            className="cursor-pointer text-xs text-danger/80 hover:text-danger"
+          >
+            Dismiss
+          </button>
         </div>
       ) : null}
 


### PR DESCRIPTION
Fixes #399.

Summary:
- refresh mission workspaces from mission-scoped session lifecycle events
- re-fetch sessions before Resume and absorb concurrent resume races
- make workspace action errors human-readable, dismissible, and success-cleared
- cover fresh-list and both backend race variants with Vitest

Validation:
- pnpm exec tsc --noEmit
- pnpm run lint
- pnpm test (42 files, 322 tests)
- cargo fmt --check
- cargo test --workspace
- cargo clippy -- -D warnings
- git diff --check