### PR TITLE
fix(window): preserve traffic light position on resize

### DIFF
--- a/src-tauri/src/commands/window.rs
+++ b/src-tauri/src/commands/window.rs
@@ -6,6 +6,15 @@
 // mounts the same React bundle; an optional initial route rides as a URL hash
 // fragment that a tiny frontend bootstrap consumes on mount.
 
+#[cfg(target_os = "macos")]
+use std::{cell::RefCell, collections::HashMap, ptr::NonNull, sync::Arc};
+
+#[cfg(target_os = "macos")]
+use block2::RcBlock;
+#[cfg(target_os = "macos")]
+use objc2_app_kit::{NSWindow, NSWindowButton, NSWindowDidResizeNotification, NSWindowStyleMask};
+#[cfg(target_os = "macos")]
+use objc2_foundation::{NSNotification, NSNotificationCenter};
 use tauri::{AppHandle, Manager, State, WebviewUrl, WebviewWindowBuilder};
 
 use crate::error::{Error, Result};
@@ -145,10 +154,27 @@ const TITLEBAR_HEIGHT: f64 = 44.0;
 #[cfg(target_os = "macos")]
 const TRAFFIC_LIGHT_X: f64 = 16.0;
 
+#[cfg(target_os = "macos")]
+type ObserverCleanup = Box<dyn FnOnce()>;
+
+// objc2 observer tokens are !Send. Both `with_webview` and Tauri's window
+// lifecycle callback run on the macOS main thread, so the token stays there.
+#[cfg(target_os = "macos")]
+thread_local! {
+    static TITLEBAR_RESIZE_OBSERVERS: RefCell<HashMap<String, ObserverCleanup>> =
+        RefCell::new(HashMap::new());
+}
+
 #[tauri::command]
-pub fn window_set_titlebar_zoom(window: tauri::WebviewWindow, zoom: f64) -> Result<()> {
+pub fn window_set_titlebar_zoom(
+    window: tauri::WebviewWindow,
+    state: State<AppState>,
+    zoom: f64,
+) -> Result<()> {
     #[cfg(target_os = "macos")]
     {
+        state.windows.set_titlebar_zoom(window.label(), zoom);
+
         if window
             .is_fullscreen()
             .map_err(|e| Error::msg(e.to_string()))?
@@ -156,55 +182,115 @@ pub fn window_set_titlebar_zoom(window: tauri::WebviewWindow, zoom: f64) -> Resu
             return Ok(());
         }
 
-        let titlebar_height = TITLEBAR_HEIGHT * zoom;
+        let label = window.label().to_string();
+        let windows = Arc::clone(&state.windows);
         window
             .with_webview(move |webview| {
-                use objc2_app_kit::{NSWindow, NSWindowButton};
-
                 let ns_window: &NSWindow = unsafe { &*webview.ns_window().cast() };
-                let Some(close) = ns_window.standardWindowButton(NSWindowButton::CloseButton)
-                else {
-                    return;
-                };
-                let Some(minimize) =
-                    ns_window.standardWindowButton(NSWindowButton::MiniaturizeButton)
-                else {
-                    return;
-                };
-                let Some(maximize) = ns_window.standardWindowButton(NSWindowButton::ZoomButton)
-                else {
-                    return;
-                };
-                let Some(button_group) = (unsafe { close.superview() }) else {
-                    return;
-                };
-                let Some(titlebar_container) = (unsafe { button_group.superview() }) else {
-                    return;
-                };
-
-                let close_rect = close.frame();
-                let button_height = close_rect.size.height;
-                let spacing = minimize.frame().origin.x - close_rect.origin.x;
-
-                let mut titlebar_rect = titlebar_container.frame();
-                titlebar_rect.size.height = titlebar_height;
-                titlebar_rect.origin.y = ns_window.frame().size.height - titlebar_height;
-                titlebar_container.setFrame(titlebar_rect);
-
-                for (index, button) in [close, minimize, maximize].into_iter().enumerate() {
-                    let mut rect = button.frame();
-                    rect.origin.x = TRAFFIC_LIGHT_X + index as f64 * spacing;
-                    rect.origin.y = (titlebar_height - button_height) / 2.0;
-                    button.setFrameOrigin(rect.origin);
-                }
+                apply_titlebar_frames(ns_window, zoom);
+                install_titlebar_resize_observer(label, ns_window, windows);
             })
             .map_err(|e| Error::msg(e.to_string()))?;
     }
 
     #[cfg(not(target_os = "macos"))]
-    let _ = (window, zoom);
+    let _ = (window, state, zoom);
 
     Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn apply_titlebar_frames(ns_window: &NSWindow, zoom: f64) {
+    if ns_window
+        .styleMask()
+        .contains(NSWindowStyleMask::FullScreen)
+    {
+        return;
+    }
+
+    let Some(close) = ns_window.standardWindowButton(NSWindowButton::CloseButton) else {
+        return;
+    };
+    let Some(minimize) = ns_window.standardWindowButton(NSWindowButton::MiniaturizeButton) else {
+        return;
+    };
+    let Some(maximize) = ns_window.standardWindowButton(NSWindowButton::ZoomButton) else {
+        return;
+    };
+    let Some(button_group) = (unsafe { close.superview() }) else {
+        return;
+    };
+    let Some(titlebar_container) = (unsafe { button_group.superview() }) else {
+        return;
+    };
+
+    let titlebar_height = TITLEBAR_HEIGHT * zoom;
+    let close_rect = close.frame();
+    let button_height = close_rect.size.height;
+    let spacing = minimize.frame().origin.x - close_rect.origin.x;
+
+    let mut titlebar_rect = titlebar_container.frame();
+    titlebar_rect.size.height = titlebar_height;
+    titlebar_rect.origin.y = ns_window.frame().size.height - titlebar_height;
+    titlebar_container.setFrame(titlebar_rect);
+
+    for (index, button) in [close, minimize, maximize].into_iter().enumerate() {
+        let mut rect = button.frame();
+        rect.origin.x = TRAFFIC_LIGHT_X + index as f64 * spacing;
+        rect.origin.y = (titlebar_height - button_height) / 2.0;
+        button.setFrameOrigin(rect.origin);
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn install_titlebar_resize_observer(
+    label: String,
+    ns_window: &NSWindow,
+    windows: Arc<crate::windows::WindowRegistry>,
+) {
+    TITLEBAR_RESIZE_OBSERVERS.with(|observers| {
+        let mut observers = observers.borrow_mut();
+        if observers.contains_key(&label) {
+            return;
+        }
+
+        let observed_label = label.clone();
+        let block = RcBlock::new(move |notification: NonNull<NSNotification>| {
+            let Some(zoom) = windows.titlebar_zoom(&observed_label) else {
+                return;
+            };
+            let Some(object) = (unsafe { notification.as_ref() }).object() else {
+                return;
+            };
+            let ns_window = unsafe { &*std::ptr::from_ref(&*object).cast::<NSWindow>() };
+            apply_titlebar_frames(ns_window, zoom);
+        });
+        let center = NSNotificationCenter::defaultCenter();
+        let observer = unsafe {
+            center.addObserverForName_object_queue_usingBlock(
+                Some(NSWindowDidResizeNotification),
+                Some(ns_window),
+                None,
+                &block,
+            )
+        };
+
+        observers.insert(
+            label,
+            Box::new(move || {
+                let center = NSNotificationCenter::defaultCenter();
+                unsafe { center.removeObserver((*observer).as_ref()) };
+            }),
+        );
+    });
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) fn uninstall_titlebar_resize_observer(label: &str) {
+    let cleanup = TITLEBAR_RESIZE_OBSERVERS.with(|observers| observers.borrow_mut().remove(label));
+    if let Some(cleanup) = cleanup {
+        cleanup();
+    }
 }
 
 #[cfg(test)]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -535,6 +535,8 @@ pub fn run() {
                     event: tauri::WindowEvent::Destroyed,
                     ..
                 } => {
+                    #[cfg(target_os = "macos")]
+                    commands::window::uninstall_titlebar_resize_observer(&label);
                     if let Some(state) = app_handle.try_state::<AppState>() {
                         state.windows.unregister(&label);
                     }

--- a/src-tauri/src/windows.rs
+++ b/src-tauri/src/windows.rs
@@ -50,12 +50,16 @@ pub struct WindowEntry {
 /// other in-memory registries in this crate (`BusRegistry`, `RouterRegistry`).
 pub struct WindowRegistry {
     entries: Mutex<HashMap<String, WindowEntry>>,
+    #[cfg(target_os = "macos")]
+    titlebar_zooms: Mutex<HashMap<String, f64>>,
 }
 
 impl WindowRegistry {
     pub fn new() -> Self {
         WindowRegistry {
             entries: Mutex::new(HashMap::new()),
+            #[cfg(target_os = "macos")]
+            titlebar_zooms: Mutex::new(HashMap::new()),
         }
     }
 
@@ -71,6 +75,21 @@ impl WindowRegistry {
     /// of that subject (if any) becomes primary automatically.
     pub fn unregister(&self, label: &str) {
         self.entries.lock().unwrap().remove(label);
+        #[cfg(target_os = "macos")]
+        self.titlebar_zooms.lock().unwrap().remove(label);
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn set_titlebar_zoom(&self, label: &str, zoom: f64) {
+        self.titlebar_zooms
+            .lock()
+            .unwrap()
+            .insert(label.to_string(), zoom);
+    }
+
+    #[cfg(target_os = "macos")]
+    pub fn titlebar_zoom(&self, label: &str) -> Option<f64> {
+        self.titlebar_zooms.lock().unwrap().get(label).copied()
     }
 
     /// Update a window's subjects without touching `focused_at` — navigating
@@ -234,6 +253,24 @@ mod tests {
 
         reg.unregister("main");
         assert!(reg.snapshot().is_empty());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn titlebar_zoom_is_window_scoped_and_removed_on_unregister() {
+        let reg = WindowRegistry::new();
+        reg.register("main");
+        reg.register("window-a");
+
+        reg.set_titlebar_zoom("main", 0.8);
+        reg.set_titlebar_zoom("window-a", 1.5);
+
+        assert_eq!(reg.titlebar_zoom("main"), Some(0.8));
+        assert_eq!(reg.titlebar_zoom("window-a"), Some(1.5));
+
+        reg.unregister("window-a");
+        assert_eq!(reg.titlebar_zoom("window-a"), None);
+        assert_eq!(reg.titlebar_zoom("main"), Some(0.8));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reapply custom macOS titlebar frames from an AppKit resize observer
- retain the latest titlebar zoom per window
- clean up native observers and zoom state when secondary windows close

## Validation

- cargo fmt --check
- cargo clippy
- cargo test --workspace
- manual live-resize smoke test passed
- working-tree review clean

Closes #395