### PR TITLE
feat(session): pre-seed codex project trust before spawn

### DIFF
--- a/docs/impls/0045-codex-trust-preseed.md
+++ b/docs/impls/0045-codex-trust-preseed.md
@@ -1,0 +1,46 @@
+# Codex trust pre-seeding: mark the project trusted before spawn
+
+## Status
+
+Planned. Fixes [#404](https://github.com/yicheng47/runner/issues/404) and absorbs the codex half of the #403 trust pre-seeding direction. Supersedes the boot-stall cue previously specced under this number (`BootWatch` byte-budget heuristic) — that mission was archived and its working-tree changes reverted; the general "agent needs you" tier remains future work under `docs/features/52-hook-based-session-status.md`. Approach validated against orca (`~/repos/ai/orca`): `src/main/agent-trust-presets.ts` documents the artifact and why CLI flags are not equivalent; the format is verified there against codex's own source (`codex-rs/tui/src/onboarding/trust_directory.rs`).
+
+## Problem
+
+A codex session spawned in a project codex has never seen boots into the "Do you trust this folder?" onboarding modal. The dialog paints one screen and goes quiet: the byte-flow `IdleDetector` reports Idle, the rail shows a dim presence dot, and the mission reads as stopped while the first-turn goal argv (`spawn.rs`, `first_turn_argv`) sits undelivered behind it. Stray or injected input can answer the modal wrong and kill the CLI. Live repro 2026-08-17: the mission created to fix this bug was itself stopped by it. Claude-code does not hit this in practice; trae and qoder are second-class runtimes — support on demand if an issue appears.
+
+## Key Decisions
+
+1. **Prevent, don't detect.** Before spawning codex, write the exact trust artifact codex writes after the user accepts the dialog, so the dialog never renders and the first turn delivers normally. No detection heuristic: the reverted `BootWatch` byte-budget cue is dropped, and the broader "waiting on something" state arrives later with spec 52's hook-based status.
+
+2. **The artifact is a `trust_level` entry in `~/.codex/config.toml`.** Codex records per-project trust as `[projects."<absolute path>"]` with `trust_level = "trusted"`. Edit via `toml_edit::DocumentMut` — already a dependency, same doc-preserving pattern as `codex_write_at` in `commands/mcp.rs` — so the user's existing config survives byte-for-byte outside the added block. Match codex's own serialization: an explicit `[projects."<path>"]` table header, not an inline table.
+
+3. **Insert-only, never overwrite.** If the project already has any `trust_level` entry — `trusted` or `untrusted` — leave it untouched. Starting a session in a folder is the operator's trust decision and runner materializes it, but an explicit `untrusted` marking is also an operator decision and outranks ours. No write also means no file churn on the common already-trusted path.
+
+4. **Canonicalize, and resolve worktrees to the main repo root.** Codex realpaths before comparing, so seed the realpath of the resolved spawn cwd (macOS `/tmp` vs `/private/tmp`). If the cwd is a linked git worktree (`.git` is a file with `gitdir:` pointing into `<main>/.git/worktrees/<name>`), codex resolves trust at the **main repo root** — seed that instead. Validate the worktree backlink (`<gitdir>/gitdir` must point back to the cwd's `.git` file) before widening, so workspace-controlled `.git` contents can't trick us into trusting an arbitrary path — mirror orca's `resolveCodexProjectTrustRoot` checks. Harmless today; correct the day spec 61's worktree isolation lands.
+
+5. **Seed on every codex spawn path, non-fatally.** Mission spawn, direct chat, and resume all seed, gated on effective runtime == `codex` — the same no-op-for-other-runtimes shape as `enter_claude_launch_gate`. Seeding failure (unreadable config, permissions) logs a WARN and the spawn proceeds: the worst case is the dialog appearing, which is exactly today's behavior. Fail-safe forward too — if a codex update changes the trust format, the dialog comes back; nothing breaks.
+
+## Goals
+
+- A codex mission session in a fresh project delivers its first turn without human intervention; the trust dialog never renders.
+- The user's `~/.codex/config.toml` is preserved exactly outside the single added block; repeat spawns are no-ops.
+- No schema changes, no migrations, no frontend work.
+
+## Non-Goals
+
+- Claude-code, trae, or qoder trust handling — codex only, others on demand.
+- Boot-stall detection heuristics (superseded) or hook-based needs-you status (spec 52).
+- Login prompts or other boot-time modals that cannot be pre-seeded.
+- Flipping an existing `untrusted` entry.
+
+## Implementation Notes
+
+- New module `src-tauri/src/session/codex_trust.rs`: `seed_project_trust(cwd: &Path)` resolving config path from `$HOME`, with a path-injected `seed_project_trust_at(cwd, config_path)` seam for tests (same `_at` pattern as `IdleDetector`). Internals: realpath → worktree-root resolution (decision 4) → `toml_edit` insert-if-absent (decisions 2–3).
+- `src-tauri/src/session/manager/spawn.rs`: call after cwd resolution, before `runtime.spawn`, on the mission-spawn, `spawn_direct*`, and resume paths, gated on the effective runtime.
+- Constant for the config location beside `codex_path()` reuse — don't duplicate the `~/.codex/config.toml` literal; share or mirror `commands/mcp.rs::codex_path`.
+
+## Validation
+
+- Rust unit tests (`codex_trust.rs`, temp dirs): empty/missing config → block created; unrelated existing config preserved verbatim; existing `trusted` entry → file untouched; existing `untrusted` entry → file untouched; linked-worktree cwd → main root seeded; worktree with a forged `gitdir:` and no valid backlink → cwd seeded, not the forged target; symlinked cwd → realpath seeded.
+- Manual: remove the project's `[projects."…"]` entry from `~/.codex/config.toml`, start a codex mission — no trust dialog, first turn delivers; re-check config.toml diff is exactly one block; restart the mission — file unchanged.
+- `cargo test --workspace`.

--- a/src-tauri/src/commands/mcp.rs
+++ b/src-tauri/src/commands/mcp.rs
@@ -85,12 +85,14 @@ fn home_dir() -> Result<PathBuf> {
         .ok_or_else(|| Error::msg("HOME env var not set"))
 }
 
+const CODEX_CONFIG_RELATIVE_PATH: &str = ".codex/config.toml";
+
 fn claude_code_path() -> Result<PathBuf> {
     Ok(home_dir()?.join(".claude.json"))
 }
 
-fn codex_path() -> Result<PathBuf> {
-    Ok(home_dir()?.join(".codex").join("config.toml"))
+pub(crate) fn codex_path() -> Result<PathBuf> {
+    Ok(home_dir()?.join(CODEX_CONFIG_RELATIVE_PATH))
 }
 
 fn qoder_path() -> Result<PathBuf> {

--- a/src-tauri/src/session/codex_trust.rs
+++ b/src-tauri/src/session/codex_trust.rs
@@ -1,0 +1,502 @@
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use crate::error::{Error, Result};
+
+static CONFIG_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(not(test))]
+pub(crate) fn seed_project_trust(cwd: &Path) -> Result<()> {
+    let config_path = crate::commands::mcp::codex_path()?;
+    let home = config_path.parent().and_then(Path::parent).ok_or_else(|| {
+        Error::msg(format!(
+            "invalid codex config path: {}",
+            config_path.display()
+        ))
+    })?;
+    seed_project_trust_at_with_home(cwd, &config_path, Some(home))
+}
+
+#[cfg(test)]
+pub(crate) fn seed_project_trust(_cwd: &Path) -> Result<()> {
+    // SessionManager tests use mocked runtimes and must not mutate the developer's Codex config.
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn seed_project_trust_at(cwd: &Path, config_path: &Path) -> Result<()> {
+    seed_project_trust_at_with_home(cwd, config_path, None)
+}
+
+fn seed_project_trust_at_with_home(
+    cwd: &Path,
+    config_path: &Path,
+    home: Option<&Path>,
+) -> Result<()> {
+    let project_root = resolve_project_trust_root(cwd)?;
+    if is_broad_trust_root(&project_root, home) {
+        log::debug!(
+            "skipping broad codex project trust root: cwd={} root={}",
+            cwd.display(),
+            project_root.display()
+        );
+        return Ok(());
+    }
+
+    let _guard = CONFIG_LOCK
+        .lock()
+        .map_err(|_| Error::msg("codex trust config lock poisoned"))?;
+    let write_path = resolve_config_write_path(config_path)?;
+    let raw = if write_path.exists() {
+        fs::read_to_string(&write_path)
+            .map_err(|e| Error::msg(format!("read {}: {e}", write_path.display())))?
+    } else {
+        String::new()
+    };
+    let mut doc: toml_edit::DocumentMut = raw
+        .parse()
+        .map_err(|e| Error::msg(format!("parse {}: {e}", write_path.display())))?;
+
+    if doc.get("projects").is_none() {
+        let mut projects = toml_edit::Table::new();
+        projects.set_implicit(true);
+        doc["projects"] = toml_edit::Item::Table(projects);
+    }
+    let projects = doc["projects"]
+        .as_table_mut()
+        .ok_or_else(|| Error::msg("projects is not a table"))?;
+    let project_key = project_root.to_string_lossy();
+
+    if let Some(project) = projects.get_mut(project_key.as_ref()) {
+        let table = project
+            .as_table_mut()
+            .ok_or_else(|| Error::msg(format!("projects.{project_key} is not a table")))?;
+        if table.contains_key("trust_level") {
+            return Ok(());
+        }
+        table["trust_level"] = toml_edit::value("trusted");
+    } else {
+        let mut project = toml_edit::Table::new();
+        project["trust_level"] = toml_edit::value("trusted");
+        projects.insert(project_key.as_ref(), toml_edit::Item::Table(project));
+    }
+
+    write_config_atomically(&write_path, doc.to_string().as_bytes())?;
+    Ok(())
+}
+
+fn resolve_project_trust_root(cwd: &Path) -> Result<PathBuf> {
+    let cwd = fs::canonicalize(cwd)
+        .map_err(|e| Error::msg(format!("realpath {}: {e}", cwd.display())))?;
+    for ancestor in cwd.ancestors() {
+        let git_marker = ancestor.join(".git");
+        if git_marker.is_dir() {
+            return Ok(ancestor.to_path_buf());
+        }
+        if git_marker.is_file() {
+            return Ok(
+                resolve_worktree_main_root(ancestor).unwrap_or_else(|| ancestor.to_path_buf())
+            );
+        }
+    }
+    Ok(cwd)
+}
+
+fn is_broad_trust_root(project_root: &Path, home: Option<&Path>) -> bool {
+    if project_root.parent().is_none() {
+        return true;
+    }
+    home.map(|home| fs::canonicalize(home).unwrap_or_else(|_| home.to_path_buf()))
+        .as_deref()
+        == Some(project_root)
+}
+
+fn resolve_config_write_path(config_path: &Path) -> Result<PathBuf> {
+    match fs::symlink_metadata(config_path) {
+        Ok(metadata) if metadata.file_type().is_symlink() => fs::canonicalize(config_path)
+            .map_err(|e| Error::msg(format!("realpath {}: {e}", config_path.display()))),
+        Ok(_) => Ok(config_path.to_path_buf()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(config_path.to_path_buf()),
+        Err(e) => Err(Error::msg(format!(
+            "metadata {}: {e}",
+            config_path.display()
+        ))),
+    }
+}
+
+fn write_config_atomically(path: &Path, contents: &[u8]) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| Error::msg(format!("config path has no parent: {}", path.display())))?;
+    fs::create_dir_all(parent)
+        .map_err(|e| Error::msg(format!("mkdir {}: {e}", parent.display())))?;
+    let permissions = fs::metadata(path)
+        .ok()
+        .map(|metadata| metadata.permissions());
+    let mut temp = tempfile::NamedTempFile::new_in(parent)
+        .map_err(|e| Error::msg(format!("create temp file in {}: {e}", parent.display())))?;
+    if let Some(permissions) = permissions {
+        temp.as_file()
+            .set_permissions(permissions)
+            .map_err(|e| Error::msg(format!("set temp permissions for {}: {e}", path.display())))?;
+    }
+    temp.write_all(contents)
+        .map_err(|e| Error::msg(format!("write temp config for {}: {e}", path.display())))?;
+    temp.as_file()
+        .sync_all()
+        .map_err(|e| Error::msg(format!("sync temp config for {}: {e}", path.display())))?;
+    temp.persist(path)
+        .map_err(|e| Error::msg(format!("persist {}: {}", path.display(), e.error)))?;
+    Ok(())
+}
+
+fn resolve_worktree_main_root(cwd: &Path) -> Option<PathBuf> {
+    let git_file = cwd.join(".git");
+    let git_dir_reference = fs::read_to_string(&git_file).ok()?;
+    let git_dir_path = git_dir_reference.trim().strip_prefix("gitdir:")?.trim();
+    if git_dir_path.is_empty() {
+        return None;
+    }
+    let git_dir_path = Path::new(git_dir_path);
+    let git_dir = if git_dir_path.is_absolute() {
+        git_dir_path.to_path_buf()
+    } else {
+        cwd.join(git_dir_path)
+    };
+    let worktrees_dir = git_dir.parent()?;
+    if worktrees_dir.file_name()? != "worktrees" {
+        return None;
+    }
+
+    let backlink_reference = fs::read_to_string(git_dir.join("gitdir")).ok()?;
+    let backlink_path = backlink_reference.trim();
+    if backlink_path.is_empty() {
+        return None;
+    }
+    let backlink_path = Path::new(backlink_path);
+    let backlink = if backlink_path.is_absolute() {
+        backlink_path.to_path_buf()
+    } else {
+        git_dir.join(backlink_path)
+    };
+    let canonical_backlink = fs::canonicalize(backlink).ok()?;
+    let canonical_git_file = fs::canonicalize(&git_file).ok()?;
+    if canonical_backlink != canonical_git_file {
+        return None;
+    }
+
+    let main_root = worktrees_dir.parent()?.parent()?;
+    fs::canonicalize(main_root).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+    use std::sync::{Arc, Barrier};
+    use std::thread;
+
+    fn trust_level(config_path: &Path, project_path: &Path) -> Option<String> {
+        let raw = fs::read_to_string(config_path).unwrap();
+        let doc: toml_edit::DocumentMut = raw.parse().unwrap();
+        doc.get("projects")?
+            .as_table()?
+            .get(project_path.to_string_lossy().as_ref())?
+            .as_table()?
+            .get("trust_level")?
+            .as_str()
+            .map(str::to_owned)
+    }
+
+    #[test]
+    fn empty_config_creates_explicit_project_block() {
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().join("project");
+        let config_path = temp.path().join("codex/config.toml");
+        fs::create_dir_all(&cwd).unwrap();
+        fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        fs::write(&config_path, "").unwrap();
+
+        seed_project_trust_at(&cwd, &config_path).unwrap();
+
+        let cwd = fs::canonicalize(cwd).unwrap();
+        assert_eq!(
+            fs::read_to_string(config_path).unwrap(),
+            format!(
+                "[projects.\"{}\"]\ntrust_level = \"trusted\"\n",
+                cwd.display()
+            )
+        );
+    }
+
+    #[test]
+    fn missing_config_creates_parent_and_project_block() {
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().join("project");
+        let config_path = temp.path().join("codex/config.toml");
+        fs::create_dir_all(&cwd).unwrap();
+
+        seed_project_trust_at(&cwd, &config_path).unwrap();
+
+        let cwd = fs::canonicalize(cwd).unwrap();
+        assert_eq!(trust_level(&config_path, &cwd).as_deref(), Some("trusted"));
+    }
+
+    #[test]
+    fn subdirectory_of_repo_seeds_repo_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let repo = temp.path().join("repo");
+        let cwd = repo.join("packages/app");
+        let config_path = temp.path().join("config.toml");
+        fs::create_dir_all(repo.join(".git")).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+
+        seed_project_trust_at(&cwd, &config_path).unwrap();
+
+        let repo = fs::canonicalize(repo).unwrap();
+        let cwd = fs::canonicalize(cwd).unwrap();
+        assert_eq!(trust_level(&config_path, &repo).as_deref(), Some("trusted"));
+        assert_eq!(trust_level(&config_path, &cwd), None);
+    }
+
+    #[test]
+    fn subdirectory_of_linked_worktree_seeds_main_repo_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let main = temp.path().join("main");
+        let worktree = temp.path().join("feature");
+        let cwd = worktree.join("packages/app");
+        let git_dir = main.join(".git/worktrees/feature");
+        let config_path = temp.path().join("config.toml");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+        fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", git_dir.display()),
+        )
+        .unwrap();
+        fs::write(
+            git_dir.join("gitdir"),
+            format!("{}\n", worktree.join(".git").display()),
+        )
+        .unwrap();
+
+        seed_project_trust_at(&cwd, &config_path).unwrap();
+
+        let main = fs::canonicalize(main).unwrap();
+        let worktree = fs::canonicalize(worktree).unwrap();
+        let cwd = fs::canonicalize(cwd).unwrap();
+        assert_eq!(trust_level(&config_path, &main).as_deref(), Some("trusted"));
+        assert_eq!(trust_level(&config_path, &worktree), None);
+        assert_eq!(trust_level(&config_path, &cwd), None);
+    }
+
+    #[test]
+    fn no_git_ancestor_seeds_cwd() {
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().join("plain/nested");
+        let config_path = temp.path().join("config.toml");
+        fs::create_dir_all(&cwd).unwrap();
+
+        seed_project_trust_at(&cwd, &config_path).unwrap();
+
+        let cwd = fs::canonicalize(cwd).unwrap();
+        assert_eq!(trust_level(&config_path, &cwd).as_deref(), Some("trusted"));
+    }
+
+    #[test]
+    fn home_git_marker_does_not_widen_trust_to_home() {
+        let temp = tempfile::tempdir().unwrap();
+        let home = temp.path().join("home");
+        let cwd = home.join("Downloads/project");
+        let config_path = home.join(".codex/config.toml");
+        fs::create_dir_all(home.join(".git")).unwrap();
+        fs::create_dir_all(&cwd).unwrap();
+
+        seed_project_trust_at_with_home(&cwd, &config_path, Some(&home)).unwrap();
+
+        assert!(!config_path.exists());
+    }
+
+    #[test]
+    fn filesystem_root_is_rejected_as_too_broad() {
+        assert!(is_broad_trust_root(Path::new("/"), None));
+    }
+
+    #[test]
+    fn unrelated_config_is_preserved_verbatim() {
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().join("project");
+        let config_path = temp.path().join("config.toml");
+        fs::create_dir_all(&cwd).unwrap();
+        let existing = "# keep this comment\nmodel = \"gpt-5\"\n\n[mcp_servers.runner]\ncommand = \"/runner\"\n";
+        fs::write(&config_path, existing).unwrap();
+
+        seed_project_trust_at(&cwd, &config_path).unwrap();
+
+        let cwd = fs::canonicalize(cwd).unwrap();
+        assert_eq!(
+            fs::read_to_string(config_path).unwrap(),
+            format!(
+                "{existing}\n[projects.\"{}\"]\ntrust_level = \"trusted\"\n",
+                cwd.display()
+            )
+        );
+    }
+
+    #[test]
+    fn existing_trusted_entry_is_untouched() {
+        assert_existing_entry_is_untouched("trusted");
+    }
+
+    #[test]
+    fn existing_untrusted_entry_is_untouched() {
+        assert_existing_entry_is_untouched("untrusted");
+    }
+
+    fn assert_existing_entry_is_untouched(level: &str) {
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().join("project");
+        let config_path = temp.path().join("config.toml");
+        fs::create_dir_all(&cwd).unwrap();
+        let cwd = fs::canonicalize(cwd).unwrap();
+        let existing = format!(
+            "# unchanged\n[projects.\"{}\"]\ntrust_level = \"{level}\" # operator choice\n",
+            cwd.display()
+        );
+        fs::write(&config_path, &existing).unwrap();
+
+        seed_project_trust_at(&cwd, &config_path).unwrap();
+
+        assert_eq!(fs::read_to_string(config_path).unwrap(), existing);
+    }
+
+    #[test]
+    fn linked_worktree_seeds_main_repo_root() {
+        let temp = tempfile::tempdir().unwrap();
+        let main = temp.path().join("main");
+        let worktree = temp.path().join("feature");
+        let git_dir = main.join(".git/worktrees/feature");
+        let config_path = temp.path().join("config.toml");
+        fs::create_dir_all(&git_dir).unwrap();
+        fs::create_dir_all(&worktree).unwrap();
+        fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", git_dir.display()),
+        )
+        .unwrap();
+        fs::write(
+            git_dir.join("gitdir"),
+            format!("{}\n", worktree.join(".git").display()),
+        )
+        .unwrap();
+
+        seed_project_trust_at(&worktree, &config_path).unwrap();
+
+        let main = fs::canonicalize(main).unwrap();
+        let worktree = fs::canonicalize(worktree).unwrap();
+        assert_eq!(trust_level(&config_path, &main).as_deref(), Some("trusted"));
+        assert_eq!(trust_level(&config_path, &worktree), None);
+    }
+
+    #[test]
+    fn forged_gitdir_without_backlink_does_not_widen_trust() {
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().join("project");
+        let forged_main = temp.path().join("forged-main");
+        let forged_git_dir = forged_main.join(".git/worktrees/forged");
+        let config_path = temp.path().join("config.toml");
+        fs::create_dir_all(&cwd).unwrap();
+        fs::create_dir_all(&forged_git_dir).unwrap();
+        fs::write(
+            cwd.join(".git"),
+            format!("gitdir: {}\n", forged_git_dir.display()),
+        )
+        .unwrap();
+
+        seed_project_trust_at(&cwd, &config_path).unwrap();
+
+        let cwd = fs::canonicalize(cwd).unwrap();
+        let forged_main = fs::canonicalize(forged_main).unwrap();
+        assert_eq!(trust_level(&config_path, &cwd).as_deref(), Some("trusted"));
+        assert_eq!(trust_level(&config_path, &forged_main), None);
+    }
+
+    #[test]
+    fn symlinked_cwd_seeds_realpath() {
+        let temp = tempfile::tempdir().unwrap();
+        let target = temp.path().join("target");
+        let linked = temp.path().join("linked");
+        let config_path = temp.path().join("config.toml");
+        fs::create_dir_all(&target).unwrap();
+        symlink(&target, &linked).unwrap();
+
+        seed_project_trust_at(&linked, &config_path).unwrap();
+
+        let target = fs::canonicalize(target).unwrap();
+        assert_eq!(
+            trust_level(&config_path, &target).as_deref(),
+            Some("trusted")
+        );
+        assert_eq!(trust_level(&config_path, &linked), None);
+    }
+
+    #[test]
+    fn atomic_write_preserves_config_symlink() {
+        let temp = tempfile::tempdir().unwrap();
+        let cwd = temp.path().join("project");
+        let target = temp.path().join("dotfiles/codex-config.toml");
+        let config_path = temp.path().join("home/.codex/config.toml");
+        fs::create_dir_all(&cwd).unwrap();
+        fs::create_dir_all(target.parent().unwrap()).unwrap();
+        fs::create_dir_all(config_path.parent().unwrap()).unwrap();
+        fs::write(&target, "model = \"gpt-5\"\n").unwrap();
+        symlink(&target, &config_path).unwrap();
+
+        seed_project_trust_at(&cwd, &config_path).unwrap();
+
+        let cwd = fs::canonicalize(cwd).unwrap();
+        assert!(fs::symlink_metadata(&config_path)
+            .unwrap()
+            .file_type()
+            .is_symlink());
+        assert_eq!(trust_level(&target, &cwd).as_deref(), Some("trusted"));
+    }
+
+    #[test]
+    fn concurrent_seeds_preserve_every_project_entry() {
+        let temp = tempfile::tempdir().unwrap();
+        let config_path = Arc::new(temp.path().join("config.toml"));
+        let projects: Vec<PathBuf> = (0..8)
+            .map(|index| temp.path().join(format!("project-{index}")))
+            .collect();
+        for project in &projects {
+            fs::create_dir_all(project).unwrap();
+        }
+        let barrier = Arc::new(Barrier::new(projects.len()));
+        let threads: Vec<_> = projects
+            .iter()
+            .cloned()
+            .map(|project| {
+                let barrier = Arc::clone(&barrier);
+                let config_path = Arc::clone(&config_path);
+                thread::spawn(move || {
+                    barrier.wait();
+                    seed_project_trust_at(&project, &config_path).unwrap();
+                })
+            })
+            .collect();
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
+        for project in projects {
+            let project = fs::canonicalize(project).unwrap();
+            assert_eq!(
+                trust_level(&config_path, &project).as_deref(),
+                Some("trusted")
+            );
+        }
+    }
+}

--- a/src-tauri/src/session/manager/spawn.rs
+++ b/src-tauri/src/session/manager/spawn.rs
@@ -86,6 +86,23 @@ impl SessionManager {
         }
         *last = Some(Instant::now());
     }
+
+    fn seed_codex_project_trust(&self, session_id: &str, runtime: &str, cwd: Option<&Path>) {
+        if runtime != "codex" {
+            return;
+        }
+        let Some(cwd) = cwd else {
+            log::debug!("skipping codex project trust seed without cwd: session={session_id}");
+            return;
+        };
+        if let Err(e) = crate::session::codex_trust::seed_project_trust(cwd) {
+            log::warn!(
+                "failed to seed codex project trust: session={session_id} cwd={} error={e}",
+                cwd.display()
+            );
+        }
+    }
+
     /// Build a `SpawnSpec` skeleton with the manager's stable inputs
     /// (shell PATH, runner env after merging system vars). The
     /// runtime adapter argv (resume_plan + trailing_runtime_args)
@@ -459,6 +476,7 @@ impl SessionManager {
 
         let spawn_started_at_dt = Utc::now();
         let initial_size = spec.initial_size;
+        self.seed_codex_project_trust(&session_id, &runner.runtime, spec.cwd.as_deref());
         let (rt_session, output) = self
             .runtime
             .spawn(spec)
@@ -892,6 +910,7 @@ impl SessionManager {
         }
 
         let spawn_started_at_dt = Utc::now();
+        self.seed_codex_project_trust(&session_id, &runner.runtime, spec.cwd.as_deref());
         let (rt_session, output) = match self.runtime.spawn(spec) {
             Ok(p) => p,
             Err(e) => {
@@ -1388,6 +1407,7 @@ impl SessionManager {
         // N stopped slots can spawn as fast as the runtime allows.
         // See issue #171.
         let spawn_started_at_dt = Utc::now();
+        self.seed_codex_project_trust(session_id, &runner.runtime, spec.cwd.as_deref());
         let (rt_session, output) = match self.runtime.spawn(spec) {
             Ok(p) => p,
             Err(e) => {

--- a/src-tauri/src/session/mod.rs
+++ b/src-tauri/src/session/mod.rs
@@ -9,6 +9,7 @@
 // for the rationale.
 
 pub mod codex_capture;
+pub(crate) mod codex_trust;
 pub mod launch;
 pub mod manager;
 #[cfg(unix)]


### PR DESCRIPTION
Fixes #404.

A codex session spawned in a project codex has never seen boots into the "Do you trust this folder?" onboarding modal: the mission's first-turn argv sits undelivered, the byte-flow idle detector reports Idle, and the mission reads as stopped. Per `docs/impls/0045-codex-trust-preseed.md`, prevent the dialog instead of detecting the stall: before every codex spawn, write the trust entry codex itself records after the user accepts.

- New `session/codex_trust.rs`: insert-only upsert of `[projects."<root>"] trust_level = "trusted"` into `~/.codex/config.toml` via `toml_edit` (user config preserved verbatim; atomic write keeps a symlinked config in place).
- Trust root resolution: realpath, repo-root ancestor walk, linked-worktree main-root resolution with backlink validation; refuses to widen trust to `$HOME` or `/`.
- Seeded on all codex spawn paths (mission, direct, respawn), gated on effective runtime, non-fatal on failure — worst case the dialog appears, which is today's behavior.
- Existing `trusted`/`untrusted` entries are never modified.

Supersedes the boot-stall cue approach; spec rewritten in `docs/impls/0045-codex-trust-preseed.md`. Validation: 15 unit tests in the new module plus `cargo test --workspace` (562 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)