### PR TITLE
fix(session): require a valid working directory for direct chats

### DIFF
--- a/crates/runner-backend/src/session/launch.rs
+++ b/crates/runner-backend/src/session/launch.rs
@@ -279,7 +279,10 @@ pub fn render_launch_script(script: &LaunchScript) -> RuntimeResult<String> {
         out.push_str(&format!("export {}={}\n", k, shell_quote(v)));
     }
     if let Some(cwd) = &script.cwd {
-        out.push_str(&format!("cd {}\n", shell_quote(&cwd.display().to_string())));
+        let quoted = shell_quote(&cwd.display().to_string());
+        out.push_str(&format!(
+            "cd {quoted} || {{ echo \"runner: working directory not found:\" {quoted} >&2; exit 1; }}\n"
+        ));
     }
     let cmd = shell_quote(&script.command);
     let args = script
@@ -508,7 +511,9 @@ mod tests {
         let foo_idx = body.find("export FOO=").unwrap();
         assert!(baz_idx < foo_idx, "envs should be alphabetical: {body}");
         assert!(body.contains("export BAZ='with space'\n"));
-        assert!(body.contains("cd '/work/proj'\n"));
+        assert!(body.contains(
+            "cd '/work/proj' || { echo \"runner: working directory not found:\" '/work/proj' >&2; exit 1; }\n"
+        ));
         assert!(body.contains("exec 'claude' '--permission-mode' 'acceptEdits'\n"));
     }
 

--- a/crates/runner-backend/src/session/manager/mod.rs
+++ b/crates/runner-backend/src/session/manager/mod.rs
@@ -989,19 +989,17 @@ impl SessionManager {
 /// `runner/activity` event. Best-effort: if the DB roundtrip fails we drop
 /// the emission rather than failing the spawn/reap path. Runners list will
 /// reconcile via the next emission or a manual refresh.
-/// Resolve the cwd the codex_capture watcher should match against,
-/// falling back to the parent process's cwd when the spawn didn't
-/// set one (the child inherits parent's cwd, which is what codex
-/// stamps into the rollout's `payload.cwd`).
+/// Resolve the cwd the codex_capture watcher should match against.
+/// portable-pty substitutes $HOME when the spawn has no cwd (or a
+/// nonexistent one), so the fallback must be the home dir — that is
+/// what codex stamps into the rollout's `payload.cwd`.
 fn capture_cwd(explicit: Option<String>) -> Option<String> {
     if let Some(cwd) = explicit {
         if !cwd.is_empty() {
             return Some(cwd);
         }
     }
-    std::env::current_dir()
-        .ok()
-        .and_then(|p| p.into_os_string().into_string().ok())
+    std::env::var_os("HOME").and_then(|h| h.into_string().ok())
 }
 
 /// Outcome of resolving a runtime override against a runner row

--- a/crates/runner-backend/src/session/manager/spawn.rs
+++ b/crates/runner-backend/src/session/manager/spawn.rs
@@ -814,10 +814,24 @@ impl SessionManager {
         let plan = router::runtime::resume_plan(&runner.runtime, None);
 
         // Working directory precedence: explicit `cwd` arg (Chat now
-        // dialog folder) ► runner's `working_dir` ► inherit parent's.
+        // dialog folder) ► runner's `working_dir`. A direct chat must
+        // name a real directory: portable-pty silently substitutes
+        // $HOME for a missing or nonexistent cwd, which strands the
+        // agent in the wrong place and breaks codex session-key
+        // capture (the rollout cwd can never match the row).
         let resolved_cwd: Option<String> = cwd
             .map(|s| s.to_string())
             .or_else(|| runner.working_dir.clone());
+        let Some(chat_cwd) = resolved_cwd.as_deref().filter(|c| !c.is_empty()) else {
+            return Err(Error::msg(
+                "select a working directory before starting a chat",
+            ));
+        };
+        if !std::path::Path::new(chat_cwd).is_dir() {
+            return Err(Error::msg(format!(
+                "working directory does not exist: {chat_cwd}"
+            )));
+        }
 
         // Direct chats are off-bus: RUNNER_HANDLE is the runner template's
         // own handle, no slot/mission env vars.

--- a/crates/runner-backend/src/session/manager/tests.rs
+++ b/crates/runner-backend/src/session/manager/tests.rs
@@ -1912,7 +1912,7 @@ fn spawn_direct_writes_session_with_null_mission_id_and_emits_activity() {
     runner.handle = "directrunner".into();
     let project = {
         let conn = pool.get().unwrap();
-        crate::repo::project::create(&conn, "Runner", "/project").unwrap()
+        crate::repo::project::create(&conn, "Runner", "/tmp").unwrap()
     };
 
     let cap = capture();


### PR DESCRIPTION
## Summary

Root-cause fix for the missing codex `session_key` on the native line: portable-pty silently substitutes `$HOME` for a None or nonexistent cwd, so the agent ran in the wrong directory and the codex rollout cwd could never match the session row.

- `spawn_direct` rejects an empty or nonexistent working directory with a clear error before any row is created (Start Chat modal surfaces it).
- Launch script guards `cd` with an explicit `runner:` error + exit 1 — a directory deleted after chat creation fails honestly on resume.
- `capture_cwd` falls back to the home dir (portable-pty's actual behavior) instead of the app process cwd.

Identical change staged on `main` (`fix/session-cwd-validation`) — this is the parity-layer mirror.

## Checks

- `make verify` green; session tests 175 passed; clippy `-D warnings` clean.
- One test fixture (`/project`) updated to a real directory — correctly rejected by the new validation.