### PR TITLE
feat(terminal): keep session terminals alive

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5052,12 +5052,12 @@ dependencies = [
  "alacritty_terminal",
  "anyhow",
  "base64",
+ "log",
  "regex",
  "runner-backend",
  "serde",
  "serde_json",
  "tempfile",
- "tokio",
 ]
 
 [[package]]

--- a/crates/runner-app/src/app_store.rs
+++ b/crates/runner-app/src/app_store.rs
@@ -56,9 +56,9 @@ impl StoreRefreshKind {
             {
                 Some(Self::Missions)
             }
-            "session/exit" | "session/archived" | "session/updated" | "runner/activity"
-            | "runner/changed" | "crew/changed" | "slot/changed" | "mission/changed"
-            | "project/changed" => Some(Self::All),
+            "session/exit" | "session/spawned" | "session/archived" | "session/updated"
+            | "runner/activity" | "runner/changed" | "crew/changed" | "slot/changed"
+            | "mission/changed" | "project/changed" => Some(Self::All),
             _ => None,
         }
     }
@@ -212,7 +212,6 @@ impl From<&AppSettings> for ShellSettingsSnapshot {
 pub(crate) struct AppStore {
     pub(crate) core: AppCore,
     pub(crate) bridge: Arc<TerminalBridge>,
-    pub(crate) waker: Arc<dyn Fn() + Send + Sync>,
     pub(crate) sessions: Vec<DirectSessionEntry>,
     pub(crate) runners: Vec<Runner>,
     pub(crate) crews: Vec<CrewListItem>,
@@ -247,9 +246,6 @@ impl AppStore {
                 while wake_rx.try_recv().is_ok() {}
                 if weak
                     .update(cx, |this, cx| {
-                        if this.bridge.take_session_refresh() {
-                            this.refresh_sessions_inner();
-                        }
                         this.revisions.terminal_wake = this.revisions.terminal_wake.wrapping_add(1);
                         cx.notify();
                     })
@@ -309,7 +305,6 @@ impl AppStore {
         let mut store = Self {
             core,
             bridge,
-            waker,
             sessions: Vec::new(),
             runners: Vec::new(),
             crews: Vec::new(),

--- a/crates/runner-app/src/bootstrap.rs
+++ b/crates/runner-app/src/bootstrap.rs
@@ -132,6 +132,7 @@ pub fn boot_core(paths: &NativePaths) -> Result<AppCore> {
         mcp: Arc::new(mcp::McpHandle::new()),
         windows: window_registry,
         events: event_channel.clone(),
+        session_event_observer: Default::default(),
         app_version: crate::version::display_version(),
     };
 
@@ -327,6 +328,7 @@ mod tests {
             mcp: Arc::new(mcp::McpHandle::new()),
             windows: Arc::new(windows::WindowRegistry::new()),
             events: events::EventChannel::new(),
+            session_event_observer: Default::default(),
             app_version: "0.0.0-test".into(),
         };
 

--- a/crates/runner-app/src/main.rs
+++ b/crates/runner-app/src/main.rs
@@ -42,7 +42,7 @@ use runner_backend::model::SessionStatus;
 use runner_backend::ops::session::DirectSessionEntry;
 use runner_backend::session::manager::SessionActivityState;
 use runner_backend::AppCore;
-use runner_terminal::terminal::TerminalSession;
+use runner_terminal::terminal::{TerminalSession, TerminalView};
 
 use app_settings::{settings_path, AppSettings};
 use app_store::{global_app_store, AppStore, GlobalAppStore, StoreRefreshKind, StoreRevisions};
@@ -102,6 +102,7 @@ const WINDOW_STATE_SAVE_DELAY_MS: u64 = 300;
 
 struct AttachedChat {
     terminal: Arc<TerminalSession>,
+    _terminal_view: TerminalView,
     terminal_interaction: Entity<TerminalInteraction>,
     terminal_scrollbar: Entity<Scrollbar>,
     terminal_input: Entity<TerminalInput>,
@@ -325,7 +326,11 @@ impl NativeRoot {
                     Ok(event)
                         if matches!(
                             event.name,
-                            "session/exit" | "session/updated" | "session/warning"
+                            "session/exit"
+                                | "session/spawned"
+                                | "session/updated"
+                                | "session/archived"
+                                | "session/warning"
                         ) =>
                     {
                         if chat_event_tx.unbounded_send(event).is_err() {

--- a/crates/runner-app/src/surfaces/app_shell.rs
+++ b/crates/runner-app/src/surfaces/app_shell.rs
@@ -53,19 +53,6 @@ impl NativeRoot {
     ) -> AnyElement {
         self.sync_theme(window, cx);
         window.set_rem_size(px(16. * self.settings(cx).app_zoom));
-        if self.route == AppRoute::Chat {
-            let needs_attach = self.tabs.active().is_some_and(|layout| {
-                layout.session_ids().iter().any(|session_id| {
-                    !self.chat_secondaries.contains_key(session_id)
-                        && !self.attached.contains_key(session_id)
-                })
-            });
-            if needs_attach {
-                if let Err(error) = self.ensure_owned_active_tab_attached(window, cx) {
-                    self.error = Some(error.to_string());
-                }
-            }
-        }
         if let Some(error) = self.error.take() {
             self.show_toast(error, ToastTone::Error, cx);
         }

--- a/crates/runner-app/src/surfaces/chat.rs
+++ b/crates/runner-app/src/surfaces/chat.rs
@@ -37,6 +37,7 @@ impl NativeRoot {
         match event.name {
             "session/exit" => {
                 if let Some(session_id) = session_id {
+                    self.attached.remove(&session_id);
                     let exit_code = event
                         .payload
                         .get("exit_code")
@@ -53,6 +54,32 @@ impl NativeRoot {
                     {
                         self.chat_focus.focus(window);
                     }
+                }
+            }
+            "session/archived" => {
+                if let Some(session_id) = session_id {
+                    self.attached.remove(&session_id);
+                    self.session_exit_codes.remove(&session_id);
+                    self.chat_transitions.remove(&session_id);
+                    self.stopping_sessions.remove(&session_id);
+                    self.refresh_sessions(cx);
+                    self.sync_active_chat_detail(cx);
+                }
+            }
+            "session/spawned" => {
+                if let Some(session_id) = session_id {
+                    self.attached.remove(&session_id);
+                    self.refresh_sessions(cx);
+                    if let Some(layout) =
+                        self.tabs.active().cloned().filter(|layout| {
+                            layout.session_ids().iter().any(|id| id == &session_id)
+                        })
+                    {
+                        if let Err(error) = self.ensure_attached(&layout, &session_id, window, cx) {
+                            self.chat_error = Some(error.to_string());
+                        }
+                    }
+                    self.sync_active_chat_detail(cx);
                 }
             }
             "session/warning" => {
@@ -533,7 +560,6 @@ impl NativeRoot {
                 errors.push(error.to_string());
             }
         }
-        self.refresh_sessions(cx);
         if errors.is_empty() {
             Ok(())
         } else {
@@ -543,7 +569,7 @@ impl NativeRoot {
 
     pub(crate) fn ensure_attached(
         &mut self,
-        layout: &PaneLayout,
+        _layout: &PaneLayout,
         session_id: &str,
         window: &mut Window,
         cx: &mut Context<Self>,
@@ -551,39 +577,21 @@ impl NativeRoot {
         if self.chat_secondary_state(session_id, cx).secondary {
             return Ok(());
         }
-        let _entry = runner_backend::ops::session::session_get(self.core(cx), session_id)?
+        let status = self
+            .session_entry(session_id, cx)
+            .map(|entry| entry.status)
             .with_context(|| format!("direct chat not found: {session_id}"))?;
-        let pane_id = layout
-            .root
-            .leaves()
-            .into_iter()
-            .find(|leaf| leaf.session_id.as_deref() == Some(session_id))
-            .map(|leaf| leaf.id.as_str());
-        let estimated = pane_id
-            .map(|pane_id| self.estimated_terminal_size(layout, pane_id, window, cx))
-            .unwrap_or((INITIAL_COLS, INITIAL_ROWS));
-        let size = self
-            .attached
-            .get(session_id)
-            .map(|chat| chat.terminal.size())
-            .or_else(|| {
-                runner_backend::ops::session::session_last_size(self.core(cx), session_id)
-                    .ok()
-                    .flatten()
-            })
-            .unwrap_or(estimated);
-
+        if status != SessionStatus::Running {
+            self.attached.remove(session_id);
+            return Ok(());
+        }
         if self.attached.contains_key(session_id) {
             return Ok(());
         }
 
-        let terminal = TerminalSession::attach(
-            self.core(cx).clone(),
-            session_id.to_owned(),
-            size.0,
-            size.1,
-            Arc::clone(&self.app_store.read(cx).waker),
-        )?;
+        let Some(terminal) = self.app_store.read(cx).bridge.session(session_id) else {
+            return Ok(());
+        };
         terminal.set_palette(self.settings(cx).terminal_theme.palette());
         terminal.configure(
             app_settings::TERMINAL_SCROLLBACK_LINES,
@@ -599,10 +607,6 @@ impl NativeRoot {
                 }
             },
         );
-        self.app_store
-            .read(cx)
-            .bridge
-            .attach(Arc::clone(&terminal))?;
         let terminal_scrollbar = cx.new(|_| Scrollbar::terminal(Arc::clone(&terminal)));
         let terminal_interaction = cx.new(|_| TerminalInteraction::new(Arc::clone(&terminal)));
         let terminal_focus = cx.focus_handle();
@@ -629,6 +633,7 @@ impl NativeRoot {
         self.attached.insert(
             session_id.to_owned(),
             AttachedChat {
+                _terminal_view: terminal.view(),
                 terminal,
                 terminal_interaction,
                 terminal_scrollbar,

--- a/crates/runner-app/src/surfaces/mission_workspace.rs
+++ b/crates/runner-app/src/surfaces/mission_workspace.rs
@@ -24,7 +24,6 @@ use runner_backend::model::{
 };
 use runner_backend::ops::session::SessionRow;
 use runner_backend::windows::Subject;
-use runner_terminal::terminal::{TerminalSession, UserInputMode};
 
 use super::*;
 use crate::surfaces::app_shell::{SIDEBAR_TOGGLE_GLYPH_INSET, SIDEBAR_TOGGLE_GLYPH_X};
@@ -110,6 +109,14 @@ fn resolve_slot_overlay(
     } else {
         SlotOverlayState::None
     }
+}
+
+fn transition_to_begin_on_spawn(
+    existing: Option<MissionTransitionKind>,
+) -> Option<MissionTransitionKind> {
+    existing
+        .is_none()
+        .then_some(MissionTransitionKind::Starting)
 }
 
 fn is_concurrent_resume_error(error: &str) -> bool {
@@ -298,7 +305,9 @@ impl MissionWorkspace {
                                 | "mission/changed"
                                 | "router/delivery-blocked"
                                 | "session/exit"
+                                | "session/spawned"
                                 | "session/updated"
+                                | "session/archived"
                                 | "session/warning"
                                 | "session/input-error"
                         ) =>
@@ -1234,15 +1243,12 @@ impl MissionWorkspace {
         if self.archived() || self.secondary_state(cx).secondary {
             return Ok(());
         }
-        let fallback = self.current_mission_terminal_size(window, cx);
         let mut errors = Vec::new();
         for session in self.sessions.clone() {
             if !self.open_tabs.contains(&session.session.id) {
                 continue;
             }
-            if let Err(error) =
-                self.ensure_mission_terminal_attached(&session, fallback, window, cx)
-            {
+            if let Err(error) = self.ensure_mission_terminal_attached(&session, window, cx) {
                 errors.push(error.to_string());
             }
         }
@@ -1256,7 +1262,6 @@ impl MissionWorkspace {
     fn ensure_mission_terminal_attached(
         &mut self,
         session: &SessionRow,
-        fallback: (u16, u16),
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Result<()> {
@@ -1264,27 +1269,16 @@ impl MissionWorkspace {
         if self.secondary_state(cx).secondary {
             return Ok(());
         }
+        if session.session.status != SessionStatus::Running {
+            self.attached.remove(&session_id);
+            return Ok(());
+        }
         if self.attached.contains_key(&session_id) {
             return Ok(());
         }
-        // Attach at the PTY's recorded geometry so retained output replays
-        // at the width it was painted for (the alt screen never reflows);
-        // the element then corrects the size through the PTY once it has
-        // measured itself.
-        let size = runner_backend::ops::session::session_last_size(self.core(cx), &session_id)
-            .ok()
-            .flatten()
-            .unwrap_or(fallback);
-        // Mission delivery can wait on the draft gate, so PTY input must never run on GPUI's
-        // render thread. The queued mode preserves input order on a per-session worker.
-        let terminal = TerminalSession::attach_with_input_mode(
-            self.core(cx).clone(),
-            session_id.clone(),
-            size.0,
-            size.1,
-            Arc::clone(&self.app_store.read(cx).waker),
-            UserInputMode::Queued,
-        )?;
+        let Some(terminal) = self.app_store.read(cx).bridge.session(&session_id) else {
+            return Ok(());
+        };
         terminal.set_palette(self.settings(cx).terminal_theme.palette());
         terminal.configure(
             app_settings::TERMINAL_SCROLLBACK_LINES,
@@ -1300,10 +1294,6 @@ impl MissionWorkspace {
                 }
             },
         );
-        self.app_store
-            .read(cx)
-            .bridge
-            .attach(Arc::clone(&terminal))?;
         let terminal_scrollbar = cx.new(|_| Scrollbar::terminal(Arc::clone(&terminal)));
         let terminal_interaction = cx.new(|_| TerminalInteraction::new(Arc::clone(&terminal)));
         let terminal_focus = cx.focus_handle();
@@ -1332,10 +1322,10 @@ impl MissionWorkspace {
                     }
                 });
             });
-        let baseline = terminal.output_activity().last_seq;
         self.attached.insert(
             session_id.clone(),
             AttachedChat {
+                _terminal_view: terminal.view(),
                 terminal,
                 terminal_interaction,
                 terminal_scrollbar,
@@ -1346,23 +1336,6 @@ impl MissionWorkspace {
                 scroll_accumulator: 0.,
             },
         );
-        let fresh = session.session.status == SessionStatus::Running
-            && session.session.started_at.is_some_and(|started_at| {
-                Utc::now()
-                    .signed_duration_since(started_at)
-                    .num_seconds()
-                    .abs()
-                    <= 10
-            });
-        if fresh {
-            self.begin_mission_transition(
-                &session_id,
-                MissionTransitionKind::Starting,
-                Some(baseline.saturating_sub(1)),
-                window,
-                cx,
-            );
-        }
         Ok(())
     }
 
@@ -1632,7 +1605,25 @@ impl MissionWorkspace {
                     cx.notify();
                 }
             }
-            "session/exit" | "session/updated" => {
+            "session/archived" => {
+                if let Some(session_id) = event
+                    .payload
+                    .get("session_id")
+                    .and_then(serde_json::Value::as_str)
+                {
+                    let relevant = self
+                        .sessions
+                        .iter()
+                        .any(|session| session.session.id == session_id);
+                    self.attached.remove(session_id);
+                    self.delivery_blocked.remove(session_id);
+                    self.transitions.remove(session_id);
+                    if relevant {
+                        self.refresh_open_mission(window, cx);
+                    }
+                }
+            }
+            "session/exit" | "session/spawned" | "session/updated" => {
                 if event
                     .payload
                     .get("mission_id")
@@ -1645,8 +1636,39 @@ impl MissionWorkspace {
                             .get("session_id")
                             .and_then(serde_json::Value::as_str)
                         {
+                            self.attached.remove(session_id);
                             self.delivery_blocked.remove(session_id);
                             self.transitions.remove(session_id);
+                        }
+                    } else if event.name == "session/spawned" {
+                        if let Some(session_id) = event
+                            .payload
+                            .get("session_id")
+                            .and_then(serde_json::Value::as_str)
+                        {
+                            self.attached.remove(session_id);
+                            self.delivery_blocked.remove(session_id);
+                            if let Some(kind) = transition_to_begin_on_spawn(
+                                self.transitions
+                                    .get(session_id)
+                                    .map(|transition| transition.kind),
+                            ) {
+                                let baseline = self
+                                    .app_store
+                                    .read(cx)
+                                    .bridge
+                                    .session(session_id)
+                                    .map(|terminal| terminal.output_activity().last_seq)
+                                    .unwrap_or(0)
+                                    .saturating_sub(1);
+                                self.begin_mission_transition(
+                                    session_id,
+                                    kind,
+                                    Some(baseline),
+                                    window,
+                                    cx,
+                                );
+                            }
                         }
                     }
                     self.refresh_open_mission(window, cx);
@@ -3851,6 +3873,13 @@ impl MissionWorkspace {
                 .and_then(serde_json::Value::as_str)
                 .unwrap_or_default()
                 .to_owned()
+        } else if warning {
+            event
+                .payload
+                .get("message")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or_default()
+                .to_owned()
         } else {
             serde_json::to_string_pretty(&event.payload)
                 .unwrap_or_else(|_| event.payload.to_string())
@@ -3908,15 +3937,19 @@ impl MissionWorkspace {
                             } else {
                                 theme::faint()
                             })
-                            .child(format!(
-                                "signal · {signal}{} · {}",
-                                event
-                                    .to
-                                    .as_ref()
-                                    .map(|to| format!(" → @{to}"))
-                                    .unwrap_or_default(),
-                                format_event_time(&event)
-                            )),
+                            .child(if warning {
+                                format!("warning · {}", format_event_time(&event))
+                            } else {
+                                format!(
+                                    "signal · {signal}{} · {}",
+                                    event
+                                        .to
+                                        .as_ref()
+                                        .map(|to| format!(" → @{to}"))
+                                        .unwrap_or_default(),
+                                    format_event_time(&event)
+                                )
+                            }),
                     )
                     .child(
                         div()
@@ -3931,7 +3964,7 @@ impl MissionWorkspace {
                             } else {
                                 theme::faint()
                             })
-                            .child("payload")
+                            .child(if warning { "details" } else { "payload" })
                             .child(
                                 svg()
                                     .path(if expanded {
@@ -3965,7 +3998,7 @@ impl MissionWorkspace {
                         theme::bg()
                     })
                     .p_3()
-                    .font_family("JetBrains Mono")
+                    .when(!warning, |payload| payload.font_family("JetBrains Mono"))
                     .text_size(rems(12. / 16.))
                     .line_height(rems(17. / 16.))
                     .text_color(if warning {
@@ -4236,23 +4269,44 @@ impl MissionWorkspace {
             },
             session.session.status,
         );
+        let terminal_background =
+            crate::terminal::element::to_hsla(self.terminal_style(cx).palette.background, 1.);
         let Some(chat) = self.attached.get(&session_id) else {
-            return div()
+            let pane = div()
                 .absolute()
                 .inset_0()
-                .flex()
-                .items_center()
-                .justify_center()
-                .child("Attaching terminal…")
-                .into_any_element();
+                .overflow_hidden()
+                .bg(terminal_background);
+            return match overlay {
+                SlotOverlayState::Resuming => pane
+                    .child(SessionOverlay::transition(
+                        SharedString::from(format!("mission-resuming-{session_id}")),
+                        SessionOverlayKind::Resuming,
+                    ))
+                    .into_any_element(),
+                SlotOverlayState::Starting => pane
+                    .child(SessionOverlay::transition(
+                        SharedString::from(format!("mission-starting-{session_id}")),
+                        SessionOverlayKind::Starting,
+                    ))
+                    .into_any_element(),
+                SlotOverlayState::Stopped => pane
+                    .child(self.render_mission_paused_overlay(cx))
+                    .into_any_element(),
+                SlotOverlayState::Archiving => pane.into_any_element(),
+                SlotOverlayState::None => pane
+                    .flex()
+                    .items_center()
+                    .justify_center()
+                    .child("Attaching terminal…")
+                    .into_any_element(),
+            };
         };
         let terminal = Arc::clone(&chat.terminal);
         let terminal_interaction = chat.terminal_interaction.clone();
         let terminal_input = chat.terminal_input.clone();
         let terminal_focus = chat.terminal_focus.clone();
         let terminal_scrollbar = chat.terminal_scrollbar.clone();
-        let terminal_background =
-            crate::terminal::element::to_hsla(self.terminal_style(cx).palette.background, 1.);
         let interactive = self.cached_mission_terminal_interactive(&session_id, cx);
         let key_id = session_id.clone();
         let copy_id = session_id.clone();
@@ -5403,6 +5457,22 @@ mod tests {
         assert_eq!(
             resolve_slot_overlay(false, None, SessionStatus::Running),
             SlotOverlayState::None
+        );
+    }
+
+    #[test]
+    fn session_spawn_does_not_replace_an_existing_resume_transition() {
+        assert_eq!(
+            transition_to_begin_on_spawn(None),
+            Some(MissionTransitionKind::Starting)
+        );
+        assert_eq!(
+            transition_to_begin_on_spawn(Some(MissionTransitionKind::Resuming)),
+            None
+        );
+        assert_eq!(
+            transition_to_begin_on_spawn(Some(MissionTransitionKind::Starting)),
+            None
         );
     }
 

--- a/crates/runner-app/src/surfaces/panes.rs
+++ b/crates/runner-app/src/surfaces/panes.rs
@@ -1426,13 +1426,16 @@ impl NativeRoot {
                 div()
                     .absolute()
                     .inset_0()
-                    .flex()
-                    .items_center()
-                    .justify_center()
                     .bg(terminal_background)
                     .text_size(rems(12. / 16.))
                     .text_color(theme::faint())
-                    .child("Unable to attach chat")
+                    .when(matches!(overlay, PaneOverlayState::None), |surface| {
+                        surface
+                            .flex()
+                            .items_center()
+                            .justify_center()
+                            .child("Attaching terminal…")
+                    })
                     .into_any_element()
             };
             let overlay_element = if secondary_state.secondary

--- a/crates/runner-app/tests/session_manager_integration.rs
+++ b/crates/runner-app/tests/session_manager_integration.rs
@@ -30,6 +30,7 @@ fn direct_chat_flows_from_app_core_session_manager_into_terminal_grid() {
     let temp = tempfile::tempdir().unwrap();
     let paths = NativePaths::new(temp.path().join("app-data"), temp.path().join("logs"));
     let core = boot_core(&paths).unwrap();
+    let bridge = TerminalBridge::new(core.clone(), Arc::new(|| {})).unwrap();
     let runner = runner_backend::ops::runner::runner_create(
         &core,
         CreateRunnerInput {
@@ -59,11 +60,7 @@ fn direct_chat_flows_from_app_core_session_manager_into_terminal_grid() {
         Some(24),
     )
     .unwrap();
-    let waker: Arc<dyn Fn() + Send + Sync> = Arc::new(|| {});
-    let bridge = TerminalBridge::new(core.clone(), Arc::clone(&waker)).unwrap();
-    let terminal =
-        TerminalSession::attach(core.clone(), spawned.id.clone(), 80, 24, waker).unwrap();
-    bridge.attach(Arc::clone(&terminal)).unwrap();
+    let terminal = bridge.session(&spawned.id).unwrap();
     assert_eq!(terminal.size(), (80, 24));
     terminal.resize(96, 32);
     assert_eq!(terminal.size(), (96, 32));
@@ -72,6 +69,7 @@ fn direct_chat_flows_from_app_core_session_manager_into_terminal_grid() {
     let rendered = wait_for_text(&terminal, "manager-owned-pty");
 
     runner_backend::ops::session::session_kill(&core, &spawned.id).unwrap();
+    assert_eq!(bridge.live_session_count(), 0);
     assert!(
         rendered,
         "manager output never reached the alacritty terminal grid"
@@ -83,6 +81,7 @@ fn terminal_ime_commit_forwards_utf8_through_session_manager() {
     let temp = tempfile::tempdir().unwrap();
     let paths = NativePaths::new(temp.path().join("app-data"), temp.path().join("logs"));
     let core = boot_core(&paths).unwrap();
+    let bridge = TerminalBridge::new(core.clone(), Arc::new(|| {})).unwrap();
     let runner = runner_backend::ops::runner::runner_create(
         &core,
         CreateRunnerInput {
@@ -112,11 +111,7 @@ fn terminal_ime_commit_forwards_utf8_through_session_manager() {
         Some(24),
     )
     .unwrap();
-    let waker: Arc<dyn Fn() + Send + Sync> = Arc::new(|| {});
-    let bridge = TerminalBridge::new(core.clone(), Arc::clone(&waker)).unwrap();
-    let terminal =
-        TerminalSession::attach(core.clone(), spawned.id.clone(), 80, 24, waker).unwrap();
-    bridge.attach(Arc::clone(&terminal)).unwrap();
+    let terminal = bridge.session(&spawned.id).unwrap();
 
     let mut input = TerminalInput::new(Arc::clone(&terminal));
     input.replace_and_mark_text(None, "pinyin", Some(6..6));
@@ -129,6 +124,7 @@ fn terminal_ime_commit_forwards_utf8_through_session_manager() {
     };
 
     runner_backend::ops::session::session_kill(&core, &spawned.id).unwrap();
+    assert_eq!(bridge.live_session_count(), 0);
     assert!(rendered, "committed UTF-8 did not reach the terminal grid");
     assert!(!visible.contains("pinyin"), "marked text reached the PTY");
 }
@@ -138,6 +134,7 @@ fn bridge_keeps_multiple_tab_sessions_attached_with_independent_geometry() {
     let temp = tempfile::tempdir().unwrap();
     let paths = NativePaths::new(temp.path().join("app-data"), temp.path().join("logs"));
     let core = boot_core(&paths).unwrap();
+    let bridge = TerminalBridge::new(core.clone(), Arc::new(|| {})).unwrap();
     let runner = runner_backend::ops::runner::runner_create(
         &core,
         CreateRunnerInput {
@@ -179,15 +176,8 @@ fn bridge_keeps_multiple_tab_sessions_attached_with_independent_geometry() {
         Some(40),
     )
     .unwrap();
-    let waker: Arc<dyn Fn() + Send + Sync> = Arc::new(|| {});
-    let bridge = TerminalBridge::new(core.clone(), Arc::clone(&waker)).unwrap();
-    let first_terminal =
-        TerminalSession::attach(core.clone(), first.id.clone(), 80, 24, Arc::clone(&waker))
-            .unwrap();
-    let second_terminal =
-        TerminalSession::attach(core.clone(), second.id.clone(), 120, 40, waker).unwrap();
-    bridge.attach(Arc::clone(&first_terminal)).unwrap();
-    bridge.attach(Arc::clone(&second_terminal)).unwrap();
+    let first_terminal = bridge.session(&first.id).unwrap();
+    let second_terminal = bridge.session(&second.id).unwrap();
 
     first_terminal.submit_text("first-tab-stays-live").unwrap();
     second_terminal
@@ -200,4 +190,49 @@ fn bridge_keeps_multiple_tab_sessions_attached_with_independent_geometry() {
 
     runner_backend::ops::session::session_kill(&core, &first.id).unwrap();
     runner_backend::ops::session::session_kill(&core, &second.id).unwrap();
+    assert_eq!(bridge.live_session_count(), 0);
+}
+
+#[test]
+fn bridge_releases_every_terminal_across_twenty_start_kill_cycles() {
+    let temp = tempfile::tempdir().unwrap();
+    let paths = NativePaths::new(temp.path().join("app-data"), temp.path().join("logs"));
+    let core = boot_core(&paths).unwrap();
+    let bridge = TerminalBridge::new(core.clone(), Arc::new(|| {})).unwrap();
+    let runner = runner_backend::ops::runner::runner_create(
+        &core,
+        CreateRunnerInput {
+            handle: "terminal-release".into(),
+            display_name: "Terminal release".into(),
+            runtime: "shell".into(),
+            command: "/bin/cat".into(),
+            args: Vec::new(),
+            working_dir: Some(temp.path().to_string_lossy().into_owned()),
+            system_prompt: None,
+            env: HashMap::new(),
+            model: None,
+            effort: None,
+            permission_mode: PermissionMode::Auto,
+        },
+    )
+    .unwrap();
+
+    for _ in 0..20 {
+        let spawned = runner_backend::ops::session::session_start_direct(
+            &core,
+            runner.id.clone(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(80),
+            Some(24),
+        )
+        .unwrap();
+        assert!(bridge.session(&spawned.id).is_some());
+        assert_eq!(bridge.live_session_count(), 1);
+        runner_backend::ops::session::session_kill(&core, &spawned.id).unwrap();
+        assert_eq!(bridge.live_session_count(), 0);
+    }
 }

--- a/crates/runner-backend/src/events.rs
+++ b/crates/runner-backend/src/events.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use tokio::sync::broadcast;
 
 /// One frontend-observable event. `name` is the channel the webview
-/// subscribes to (`"session/output"`, `"chat/layout-changed"`, …); every
+/// subscribes to (`"session/exit"`, `"chat/layout-changed"`, …); every
 /// producer uses a static string so a typo is greppable.
 #[derive(Debug, Clone)]
 pub struct AppEvent {
@@ -24,10 +24,8 @@ pub struct AppEvent {
     pub payload: serde_json::Value,
 }
 
-/// Buffered events per subscriber. `session/output` is the high-rate
-/// producer (coalesced PTY chunks); the buffer must absorb a burst while
-/// the forwarder serializes into the webview. A lagged subscriber drops
-/// oldest-first and logs — same failure mode as any bounded queue.
+/// Buffered events per subscriber. A lagged subscriber drops oldest-first
+/// and logs — same failure mode as any bounded queue.
 const CHANNEL_CAPACITY: usize = 8192;
 
 /// Cheap-to-clone handle on the broadcast channel. Sending never blocks;

--- a/crates/runner-backend/src/lib.rs
+++ b/crates/runner-backend/src/lib.rs
@@ -28,7 +28,7 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
 use events::EventChannel;
-use session::manager::CoreSessionEvents;
+use session::manager::{CoreSessionEvents, SessionEventObserverRegistry};
 
 /// Shared application state. One instance per process, cheap to clone
 /// (every field is an `Arc` or small value) — the Tauri layer stores it in
@@ -72,6 +72,7 @@ pub struct AppCore {
     /// frontend subscribes and forwards to its own event surface (the
     /// Tauri layer re-emits to the webview verbatim).
     pub events: EventChannel,
+    pub session_event_observer: SessionEventObserverRegistry,
     /// The application's user-facing version (the Tauri crate's
     /// `CARGO_PKG_VERSION`, which the release bump updates). Advertised by
     /// the MCP server's `ServerInfo`.
@@ -88,6 +89,7 @@ impl AppCore {
             Arc::downgrade(&self.sessions),
             Arc::clone(&self.windows),
             self.events.clone(),
+            self.session_event_observer.clone(),
         )
     }
 

--- a/crates/runner-backend/src/ops/node.rs
+++ b/crates/runner-backend/src/ops/node.rs
@@ -581,6 +581,7 @@ mod tests {
             mcp: Arc::new(McpHandle::new()),
             windows: Arc::new(WindowRegistry::new()),
             events: EventChannel::new(),
+            session_event_observer: Default::default(),
             app_version: "0.0.0-test".into(),
         }
     }

--- a/crates/runner-backend/src/ops/project.rs
+++ b/crates/runner-backend/src/ops/project.rs
@@ -1,6 +1,7 @@
 use crate::error::{Error, Result};
 use crate::repo;
 use crate::repo::project::ProjectRow;
+use crate::session::manager::{SessionEvents, SessionUpdatedEvent};
 use crate::AppCore;
 
 fn clean_value(value: String, label: &str) -> Result<String> {
@@ -133,7 +134,7 @@ pub(crate) async fn project_delete_impl(state: &AppCore, id: &str) -> Result<Vec
         archived
     };
     for session_id in &archived_ids {
-        state.sessions.purge_session_buffers(session_id);
+        state.sessions.forget_session_state(session_id);
     }
     Ok(archived_ids)
 }
@@ -151,10 +152,10 @@ pub async fn project_delete(state: &AppCore, id: String) -> Result<()> {
         .emit("chat/layout-changed", &serde_json::json!({}));
     let archived_ids = result?;
     for session_id in &archived_ids {
-        state.events.emit(
-            "session/archived",
-            &serde_json::json!({ "session_id": session_id }),
-        );
+        state.session_events().archived(&SessionUpdatedEvent {
+            session_id: session_id.clone(),
+            mission_id: None,
+        });
     }
     Ok(())
 }

--- a/crates/runner-backend/src/ops/session.rs
+++ b/crates/runner-backend/src/ops/session.rs
@@ -6,9 +6,8 @@
 //   - inject bytes into a live session's stdin
 //   - kill a live session
 //
-// `session/output` and `session/exit` events flow from the PTY reader threads
-// onto the app event channel; the frontend subscribes without going
-// through a command.
+// PTY output flows synchronously to the native terminal registry; lifecycle
+// events continue over the app event channel.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -21,7 +20,8 @@ use crate::{
     ops::{project, runner},
     repo,
     session::manager::{
-        runtime_direct_runner, OutputEvent, SessionActivityState, SessionEvents, SpawnedSession,
+        runtime_direct_runner, SessionActivityState, SessionEvents, SessionUpdatedEvent,
+        SpawnedSession,
     },
     AppCore,
 };
@@ -89,21 +89,6 @@ pub fn session_activity_snapshot(state: &AppCore) -> BTreeMap<String, SessionAct
 
 pub fn session_resize(state: &AppCore, session_id: &str, cols: u16, rows: u16) -> Result<()> {
     state.sessions.resize(session_id, cols, rows, &state.db)
-}
-
-pub fn session_output_snapshot(state: &AppCore, session_id: &str) -> Result<Vec<OutputEvent>> {
-    Ok(state.sessions.output_snapshot(session_id))
-}
-
-/// The seq the output ring had reached when the session's most
-/// recent resume started (0 for sessions that never resumed). A
-/// dedicated read command rather than a field on the snapshot or the
-/// resume RPC: the snapshot's return shape is consumed as a bare
-/// array by terminal replay, and a resume can be triggered from
-/// another window (impl 0018), so the pill effects can't rely on the
-/// resume response reaching them.
-pub fn session_replay_watermark(state: &AppCore, session_id: &str) -> Result<u64> {
-    Ok(state.sessions.replay_watermark(session_id))
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -386,7 +371,7 @@ pub fn session_get(state: &AppCore, session_id: &str) -> Result<Option<DirectSes
 
 /// The PTY geometry the manager last recorded for the session: the fork
 /// size, then every applied or persisted resize. Terminals attach and
-/// replay retained output at this size rather than at a layout estimate,
+/// create its terminal grid at this size rather than at a layout estimate,
 /// so the replay reflows the way the agent painted it.
 pub fn session_last_size(state: &AppCore, session_id: &str) -> Result<Option<(u16, u16)>> {
     let conn = state.db.get()?;
@@ -419,15 +404,11 @@ pub fn session_archive(state: &AppCore, session_id: &str) -> Result<()> {
     }
     repo::node::remove_session(&tx, session_id)?;
     tx.commit()?;
-    // Drop the in-memory output buffer for this row. Forget intentionally
-    // keeps the buffer alive across PTY exits so the chat can be reopened
-    // and replayed; archive is the explicit "I'm done with this chat"
-    // signal, so we let the buffer go.
-    state.sessions.purge_session_buffers(session_id);
-    state.events.emit(
-        "session/archived",
-        &serde_json::json!({ "session_id": session_id }),
-    );
+    state.sessions.forget_session_state(session_id);
+    state.session_events().archived(&SessionUpdatedEvent {
+        session_id: session_id.to_owned(),
+        mission_id: None,
+    });
     Ok(())
 }
 

--- a/crates/runner-backend/src/router/mod.rs
+++ b/crates/runner-backend/src/router/mod.rs
@@ -144,6 +144,7 @@ impl StdinInjector for SessionManager {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeliveryReservation {
+    Unavailable,
     Ready(u64),
     PendingInput,
     RecentlyTyping(Duration),
@@ -265,10 +266,8 @@ impl SessionOutbox {
 #[derive(Default)]
 struct RouterState {
     /// Resolved at mount from the spawned `SpawnedSession` rows. The map is
-    /// authoritative for the mission's lifetime; if a child crashes the
-    /// entry stays so subsequent injections fail visibly with a
-    /// `mission_warning` (the desired behavior — better than silently
-    /// dropping a `human_response`).
+    /// authoritative for the mission's lifetime; if a child is stopped the
+    /// entry stays so deliveries can wait for its next `Respawned` event.
     session_by_handle: HashMap<String, String>,
     /// `human_question.id` → asker handle. Populated when an `ask_human`
     /// is dispatched (the appended card's id is the canonical question_id
@@ -287,7 +286,7 @@ struct RouterState {
     blocked_unread_by_session: HashMap<String, usize>,
     /// Fresh mission rows registered before their background PTY spawn.
     /// Deliveries wait in the normal outbox until `Respawned` marks the
-    /// session live; stopped/crashed reopen sessions are not added here.
+    /// session live.
     pending_sessions: HashSet<String>,
     live_sessions: HashSet<String>,
     unread_by_handle: HashMap<String, usize>,
@@ -383,7 +382,7 @@ impl Router {
 
     /// Register existing session ids so handlers can find which PTY owns
     /// each handle. Reopen paths use this for already-live sessions; a
-    /// stopped/crashed row remains non-live so injection still warns.
+    /// stopped/crashed row remains non-live so injection waits for respawn.
     pub fn register_sessions(&self, sessions: &[(String, String)]) {
         self.register_sessions_inner(sessions, false);
     }
@@ -666,6 +665,7 @@ impl Router {
         // user's draft clears, so parking it would create a stray submit.
         let deferable = !delivery.body.is_empty();
         let mut retry = None;
+        let mut deferred_notice = None;
         let (session_id, ready) = {
             let mut state = self.state.lock().unwrap();
             let Some(session_id) = state.session_by_handle.get(handle).cloned() else {
@@ -698,7 +698,8 @@ impl Router {
                     return Ok(true);
                 }
             }
-            if state.pending_sessions.contains(&session_id) {
+            let pending_spawn = state.pending_sessions.contains(&session_id);
+            if pending_spawn || !state.live_sessions.contains(&session_id) {
                 if reconciliation.is_some() || !deferable {
                     return Ok(false);
                 }
@@ -706,12 +707,39 @@ impl Router {
                     .outbox_by_session
                     .entry(session_id.clone())
                     .or_default();
+                let first_deferred = outbox.deliveries.is_empty();
                 outbox.handle = handle.to_string();
+                outbox.pending_input_blocked = false;
                 outbox.enqueue(delivery);
                 self.blocked_transition(&mut state, &session_id);
+                drop(state);
+                if first_deferred && !pending_spawn {
+                    self.warn(format!(
+                        "delivery to @{handle} queued until the session resumes"
+                    ));
+                }
                 return Ok(true);
             }
             match self.injector.reserve_delivery(&session_id)? {
+                DeliveryReservation::Unavailable => {
+                    if reconciliation.is_some() || !deferable {
+                        return Ok(false);
+                    }
+                    state.live_sessions.remove(&session_id);
+                    let outbox = state
+                        .outbox_by_session
+                        .entry(session_id.clone())
+                        .or_default();
+                    let first_deferred = outbox.deliveries.is_empty();
+                    outbox.handle = handle.to_string();
+                    outbox.pending_input_blocked = false;
+                    outbox.enqueue(delivery);
+                    self.blocked_transition(&mut state, &session_id);
+                    if first_deferred {
+                        deferred_notice = Some(handle.to_string());
+                    }
+                    (session_id, None)
+                }
                 DeliveryReservation::Ready(token) => {
                     if let Some((now, _)) = reconciliation {
                         state
@@ -779,6 +807,11 @@ impl Router {
                 }
             }
         };
+        if let Some(handle) = deferred_notice {
+            self.warn(format!(
+                "delivery to @{handle} queued until the session resumes"
+            ));
+        }
         if let Some((session_id, delay)) = retry {
             self.schedule_outbox_retry(session_id, delay);
         }
@@ -1049,6 +1082,14 @@ impl Router {
             }
         };
         match reservation {
+            DeliveryReservation::Unavailable => {
+                let mut state = self.state.lock().unwrap();
+                state.live_sessions.remove(session_id);
+                if let Some(outbox) = state.outbox_by_session.get_mut(session_id) {
+                    outbox.pending_input_blocked = false;
+                }
+                self.blocked_transition(&mut state, session_id);
+            }
             DeliveryReservation::Ready(token) => {
                 let delivery = {
                     let mut state = self.state.lock().unwrap();
@@ -1378,8 +1419,8 @@ impl Router {
         self.state.lock().unwrap().status.insert(handle, status);
     }
 
-    /// Append a `mission_warning` event when a handler hits an unexpected
-    /// state (dead session, unmatched `human_response`, malformed payload).
+    /// Append a `mission_warning` event when a handler hits an unexpected or
+    /// deferred state (unavailable session, unmatched response, bad payload).
     /// Best-effort: a log-write failure here is logged but never panics
     /// the router thread.
     pub(crate) fn warn(&self, message: impl Into<String>) {

--- a/crates/runner-backend/src/router/tests.rs
+++ b/crates/runner-backend/src/router/tests.rs
@@ -39,8 +39,7 @@ struct RecordingInjector {
     activity: Mutex<HashMap<String, super::RunnerStatus>>,
     pushes: Mutex<Vec<(String, InjectKind, Vec<u8>)>>,
     blocked_events: Mutex<Vec<DeliveryBlockedEvent>>,
-    /// Optional `dead_session` set — `inject` errors when called with one
-    /// of these ids, simulating a crashed PTY for `mission_warning` tests.
+    /// Optional `dead_session` set simulating a stopped or crashed PTY.
     dead: Mutex<Vec<String>>,
     input: Mutex<HashMap<String, RecordingInputState>>,
     listeners: Mutex<HashMap<String, Vec<Weak<dyn SessionDeliveryListener>>>>,
@@ -283,9 +282,7 @@ impl StdinInjector for RecordingInjector {
             .iter()
             .any(|dead| dead == session_id)
         {
-            return Err(crate::error::Error::msg(format!(
-                "test: session {session_id} is dead"
-            )));
+            return Ok(DeliveryReservation::Unavailable);
         }
         let mut input = self.input.lock().unwrap();
         let input = input.entry(session_id.to_string()).or_default();
@@ -2045,36 +2042,84 @@ fn fresh_mission_start_does_not_call_reconstruct() {
 }
 
 #[test]
-fn dead_session_for_handler_target_emits_mission_warning() {
-    // The pending-ask map persists past a session crash by design — better
-    // to surface the missed wake-up than to silently drop it. The router
-    // attempts the inject, fails, and writes a mission_warning.
+fn stopped_session_delivery_waits_for_respawn() {
     let (router, injector, log, _dir) =
         fixture(vec![slot_with_runner("lead", true)], &[("lead", "S-LEAD")]);
+    let ask = log
+        .append(signal(
+            "lead",
+            "ask_human",
+            serde_json::json!({
+                "prompt": "Continue?",
+                "choices": ["Resume", "Cancel mission"],
+            }),
+        ))
+        .unwrap();
+    router.handle_event(&ask);
+    let card_id = read_signals(&log)
+        .into_iter()
+        .find(|event| {
+            event
+                .signal_type
+                .as_ref()
+                .is_some_and(|signal| signal.as_str() == "human_question")
+        })
+        .expect("router must append human_question")
+        .id;
+
     injector.mark_dead("S-LEAD");
     let ev = log
         .append(signal(
             "human",
-            "human_said",
-            serde_json::json!({ "text": "hi" }),
+            "human_response",
+            serde_json::json!({
+                "question_id": card_id,
+                "choice": "Cancel mission",
+            }),
         ))
         .unwrap();
     router.handle_event(&ev);
 
-    let warnings: Vec<_> = read_signals(&log)
+    assert!(injector.pushes_for("S-LEAD").is_empty());
+    let warnings = read_signals(&log)
         .into_iter()
-        .filter(|s| {
-            s.signal_type
+        .filter(|event| {
+            event
+                .signal_type
                 .as_ref()
-                .map(|t| t.as_str() == "mission_warning")
-                .unwrap_or(false)
+                .is_some_and(|signal| signal.as_str() == "mission_warning")
         })
-        .collect();
+        .collect::<Vec<_>>();
     assert_eq!(warnings.len(), 1);
     assert!(warnings[0].payload["message"]
         .as_str()
         .unwrap()
-        .contains("human_said injection"));
+        .contains("queued until the session resumes"));
+
+    router
+        .inject_and_submit("lead", b"second deferred delivery")
+        .unwrap();
+    assert_eq!(
+        read_signals(&log)
+            .into_iter()
+            .filter(|event| {
+                event
+                    .signal_type
+                    .as_ref()
+                    .is_some_and(|signal| signal.as_str() == "mission_warning")
+            })
+            .count(),
+        1,
+        "only the first queued delivery should add a feed warning"
+    );
+
+    injector.respawn("S-LEAD");
+    wait_until(Duration::from_millis(100), || {
+        injector
+            .submitted_bodies_for("S-LEAD")
+            .iter()
+            .any(|body| body.contains("[human_response] Cancel mission"))
+    });
 }
 
 #[test]

--- a/crates/runner-backend/src/session/manager/lifecycle.rs
+++ b/crates/runner-backend/src/session/manager/lifecycle.rs
@@ -280,18 +280,8 @@ impl SessionManager {
         session_id: &str,
         runtime_session: &RuntimeSession,
     ) -> Result<()> {
-        // Only the live PTY handle is dropped here. We deliberately keep
-        // retained output and seq state alive so that:
-        //   - `session_output_snapshot` still returns the dead session's
-        //     scrollback after kill, so navigating off the chat and
-        //     coming back doesn't blank the terminal.
-        //   - When the row is later resumed via `SessionManager::resume`,
-        //     its synthetic seam and new PTY chunks continue above
-        //     `last` instead of restarting at 1, which the frontend's
-        //     seq-merge filter (`seq <= lastWrittenSeq`) would silently
-        //     drop, losing the entire post-resume head of output.
-        // Use `purge_session_buffers` for explicit cleanup paths
-        // (archive, runner delete).
+        // Keep the sequence counter monotonic across a later respawn under
+        // this database id. The terminal registry releases the exited Term.
         if let Some(state) = self.session_state(session_id) {
             let gate = state.lock().unwrap().delivery_gate.clone();
             let mut delivery = gate.state.lock().unwrap();

--- a/crates/runner-backend/src/session/manager/mod.rs
+++ b/crates/runner-backend/src/session/manager/mod.rs
@@ -8,7 +8,7 @@
 //   - A `RuntimeSession` that the manager hands back to the runtime
 //     for every operation.
 //   - A forwarder thread that drains the runtime's `OutputStream` into
-//     `session/output` Tauri events. When the channel closes, the
+//     the process-local terminal sink. When the channel closes, the
 //     thread queries the runtime for final exit code, emits
 //     `session/exit`, and updates the DB row.
 //
@@ -16,7 +16,7 @@
 // Startup cleanup demotes stale running DB rows to stopped; user-facing
 // resume respawns a fresh PTY with the same session row id.
 
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::RecvTimeoutError;
@@ -24,7 +24,6 @@ use std::sync::{Arc, Condvar, Mutex, RwLock, Weak};
 use std::thread;
 use std::time::{Duration, Instant};
 
-use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
 use chrono::{DateTime, Utc};
 use rusqlite::params;
 use serde::Serialize;
@@ -47,7 +46,6 @@ mod spawn;
 #[cfg(test)]
 mod tests;
 
-const MAX_OUTPUT_BUFFER_CHUNKS: usize = 4096;
 const RECENT_LOCAL_INPUT_WINDOW: Duration = Duration::from_secs(2);
 const RUNNER_STATUS_APPEND_MAX_ATTEMPTS: usize = 8;
 const RUNNER_STATUS_APPEND_RETRY_DELAY: Duration = Duration::from_millis(5);
@@ -83,91 +81,6 @@ const RESIZE_SETTLE_MS: u64 = 175;
 const CLAUDE_LAUNCH_GATE_GRACE: Duration = Duration::from_millis(1500);
 #[cfg(test)]
 const CLAUDE_LAUNCH_GATE_GRACE: Duration = Duration::from_millis(0);
-
-fn scan_mode_transition(bytes: &[u8], patterns: &[(&[u8], bool)]) -> Option<bool> {
-    let mut latest: Option<(usize, bool)> = None;
-    for (needle, state) in patterns {
-        if bytes.len() < needle.len() {
-            continue;
-        }
-        if let Some(pos) = bytes.windows(needle.len()).rposition(|w| w == *needle) {
-            latest = match latest {
-                Some((p, _)) if p >= pos => latest,
-                _ => Some((pos, *state)),
-            };
-        }
-    }
-    latest.map(|(_, state)| state)
-}
-
-/// Returns the resulting alt-screen state if `bytes` contains one or
-/// more enter/exit alt-screen escapes; `None` when no such escape is
-/// present. Recognized escapes: `\x1b[?1049h` / `\x1b[?1049l` (the
-/// modern combined save-cursor + alt-screen pair claude-code / codex
-/// emit) and `\x1b[?47h` / `\x1b[?47l` (the legacy alt-screen pair,
-/// kept for older TUIs).
-///
-/// The *latest* match in the slice wins — chunks that enter then exit
-/// within a single buffer (rare but legal) resolve to the trailing
-/// state, not whichever bracket happens to come first in the linear
-/// scan.
-fn scan_alt_screen_transition(bytes: &[u8]) -> Option<bool> {
-    const PATTERNS: &[(&[u8], bool)] = &[
-        (b"\x1bc", false),
-        (b"\x1b[?1049h", true),
-        (b"\x1b[?1049l", false),
-        (b"\x1b[?47h", true),
-        (b"\x1b[?47l", false),
-    ];
-    scan_mode_transition(bytes, PATTERNS)
-}
-
-fn scan_bracketed_paste_transition(bytes: &[u8]) -> Option<bool> {
-    const PATTERNS: &[(&[u8], bool)] = &[
-        (b"\x1bc", false),
-        (b"\x1b[?2004h", true),
-        (b"\x1b[?2004l", false),
-    ];
-    scan_mode_transition(bytes, PATTERNS)
-}
-
-fn scan_mouse_mode_transition(bytes: &[u8], mode: u16) -> Option<bool> {
-    match mode {
-        1000 => scan_mode_transition(
-            bytes,
-            &[
-                (b"\x1bc", false),
-                (b"\x1b[?1000h", true),
-                (b"\x1b[?1000l", false),
-            ],
-        ),
-        1002 => scan_mode_transition(
-            bytes,
-            &[
-                (b"\x1bc", false),
-                (b"\x1b[?1002h", true),
-                (b"\x1b[?1002l", false),
-            ],
-        ),
-        1003 => scan_mode_transition(
-            bytes,
-            &[
-                (b"\x1bc", false),
-                (b"\x1b[?1003h", true),
-                (b"\x1b[?1003l", false),
-            ],
-        ),
-        1006 => scan_mode_transition(
-            bytes,
-            &[
-                (b"\x1bc", false),
-                (b"\x1b[?1006h", true),
-                (b"\x1b[?1006l", false),
-            ],
-        ),
-        _ => None,
-    }
-}
 
 /// Inputs the forwarder consumer needs to translate a
 /// `RuntimeOutput::StatusTransition` into a real `runner_status`
@@ -307,7 +220,9 @@ fn drop_streak_is_loggable(streak: u64) -> bool {
 /// a no-op or a channel-capture impl.
 pub trait SessionEvents: Send + Sync + 'static {
     fn output(&self, ev: &OutputEvent);
+    fn spawned(&self, _ev: &SessionSpawnedEvent) {}
     fn exit(&self, ev: &ExitEvent);
+    fn archived(&self, _ev: &SessionUpdatedEvent) {}
     /// Persisted session metadata changed without a lifecycle event
     /// (e.g. async agent_session_key capture). Default no-op so test
     /// fakes don't have to opt in.
@@ -322,6 +237,25 @@ pub trait SessionEvents: Send + Sync + 'static {
     /// Non-fatal, user-facing advisory (resume fallback, etc.). Default
     /// no-op so test fakes don't have to opt in.
     fn warning(&self, _ev: &WarningEvent) {}
+}
+
+#[derive(Clone, Default)]
+pub struct SessionEventObserverRegistry {
+    observer: Arc<RwLock<Option<Weak<dyn SessionEvents>>>>,
+}
+
+impl SessionEventObserverRegistry {
+    pub fn install(&self, observer: Weak<dyn SessionEvents>) {
+        *self.observer.write().unwrap() = Some(observer);
+    }
+
+    fn observer(&self) -> Option<Arc<dyn SessionEvents>> {
+        self.observer
+            .read()
+            .unwrap()
+            .as_ref()
+            .and_then(Weak::upgrade)
+    }
 }
 
 /// Payload for `runner/activity`. Derived from the same query
@@ -365,8 +299,8 @@ pub struct SessionActivityEvent {
     pub source: String,
 }
 
-/// Production emitter — emits `session/output`, `session/exit`,
-/// `session/updated`, and `runner/activity` on the app event channel.
+/// Production emitter. Raw output goes synchronously to the process-local
+/// observer; lifecycle and metadata changes stay on the app event channel.
 ///
 /// Holds the manager as `Weak`: instances get stored inside the manager's
 /// own session state (codex capture context, forwarder threads), so a
@@ -379,6 +313,7 @@ pub struct CoreSessionEvents {
     sessions: std::sync::Weak<SessionManager>,
     windows: Arc<crate::windows::WindowRegistry>,
     events: crate::events::EventChannel,
+    observer: SessionEventObserverRegistry,
 }
 
 impl CoreSessionEvents {
@@ -387,22 +322,41 @@ impl CoreSessionEvents {
         sessions: std::sync::Weak<SessionManager>,
         windows: Arc<crate::windows::WindowRegistry>,
         events: crate::events::EventChannel,
+        observer: SessionEventObserverRegistry,
     ) -> Self {
         Self {
             db,
             sessions,
             windows,
             events,
+            observer,
         }
     }
 }
 
 impl SessionEvents for CoreSessionEvents {
     fn output(&self, ev: &OutputEvent) {
-        self.events.emit("session/output", ev);
+        if let Some(observer) = self.observer.observer() {
+            observer.output(ev);
+        }
+    }
+    fn spawned(&self, ev: &SessionSpawnedEvent) {
+        if let Some(observer) = self.observer.observer() {
+            observer.spawned(ev);
+        }
+        self.events.emit("session/spawned", ev);
     }
     fn exit(&self, ev: &ExitEvent) {
+        if let Some(observer) = self.observer.observer() {
+            observer.exit(ev);
+        }
         self.events.emit("session/exit", ev);
+    }
+    fn archived(&self, ev: &SessionUpdatedEvent) {
+        if let Some(observer) = self.observer.observer() {
+            observer.archived(ev);
+        }
+        self.events.emit("session/archived", ev);
     }
     fn updated(&self, ev: &SessionUpdatedEvent) {
         self.events.emit("session/updated", ev);
@@ -434,22 +388,22 @@ impl SessionEvents for CoreSessionEvents {
     }
 }
 
-/// Contents of `session/output` events emitted to the frontend. The raw PTY
-/// bytes are base64-encoded so the event payload is valid JSON regardless of
-/// what the child wrote (ANSI escapes, split UTF-8 sequences, non-UTF-8, etc.).
-/// The frontend decodes before feeding xterm.js.
-///
-/// `mission_id` is `None` for direct-chat sessions (C8.5) — they have no
-/// parent mission and consumers should filter on `session_id` instead.
+/// Raw PTY output delivered synchronously to the process-local terminal sink.
 #[derive(Debug, Clone, Serialize)]
 pub struct OutputEvent {
     pub session_id: String,
     pub mission_id: Option<String>,
-    /// Monotonic per-session sequence number. Frontend attach uses this to
-    /// merge a replay snapshot with live events without duplicating chunks.
+    /// Monotonic per-session sequence number used by terminal readiness gates.
     pub seq: u64,
-    /// Base64-encoded raw bytes read from the PTY.
-    pub data: String,
+    pub bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct SessionSpawnedEvent {
+    pub session_id: String,
+    pub mission_id: Option<String>,
+    pub cols: u16,
+    pub rows: u16,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -528,7 +482,7 @@ struct SessionHandle {
     /// capture after the runtime has actually created its rollout file.
     codex_capture: Option<CodexCaptureContext>,
     /// Forwarder thread that drains the runtime's `OutputStream`
-    /// into `session/output` events. `kill` joins on this so callers
+    /// into the process-local terminal sink. `kill` joins on this so callers
     /// (mission_stop) get the same "no live sessions after we
     /// return" contract the portable-pty path provided.
     forwarder: Option<thread::JoinHandle<()>>,
@@ -578,8 +532,6 @@ struct PendingResize {
     generation: u64,
     cols: u16,
     rows: u16,
-    initial_cols: Option<u16>,
-    width_changed: bool,
     deadline: Instant,
     suppressed: u32,
     ioctl_count: u32,
@@ -596,33 +548,12 @@ struct SessionState {
     delivery_gate: Arc<DeliveryGate>,
     mission_status_sink: Option<ForwarderEmitCtx>,
     completion_armed: bool,
-    output_buffer: VecDeque<OutputEvent>,
     output_seq: u64,
-    /// `output_seq` at the moment the most recent resume started.
-    /// The pill fast-paths only honor TUI-ready escapes in chunks
-    /// with `seq > resume_watermark_seq`, so pre-resume bytes kept
-    /// in the ring (claude-code) can never clear a resuming overlay
-    /// that's waiting on the *new* PTY. 0 outside resume flows.
-    resume_watermark_seq: u64,
-    alt_screen_on: bool,
-    bracketed_paste_on: bool,
-    mouse_1000_on: bool,
-    mouse_1002_on: bool,
-    mouse_1003_on: bool,
-    mouse_1006_on: bool,
-    /// Cols of the last PTY winsize applied (seeded at spawn, updated by
-    /// `resize`). Gates the resize ring purge: rows-only changes — the
-    /// frontend's SIGWINCH nudge dance on every tab return — can't garble
-    /// replay reflow (wrap depends on cols alone), so the ring survives
-    /// them; only a real width change still purges.
-    last_pty_cols: Option<u16>,
     /// Latest grid measurement, including pushes that arrive before a PTY
     /// handle exists. Spawn and resume reconcile this under the state lock.
     last_requested_size: Option<(u16, u16)>,
     last_requested_size_dirty: bool,
-    /// Cached from the effective agent runtime when the handle is installed.
-    clears_on_resize: bool,
-    /// Present while resize persistence and ring coherence await settlement.
+    /// Present while resize persistence awaits settlement.
     pending_resize: Option<PendingResize>,
     resuming: bool,
     killed: bool,
@@ -637,19 +568,9 @@ impl SessionState {
             && self.last_local_input_at.is_none()
             && self.mission_status_sink.is_none()
             && !self.completion_armed
-            && self.output_buffer.is_empty()
             && self.output_seq == 0
-            && self.resume_watermark_seq == 0
-            && !self.alt_screen_on
-            && !self.bracketed_paste_on
-            && !self.mouse_1000_on
-            && !self.mouse_1002_on
-            && !self.mouse_1003_on
-            && !self.mouse_1006_on
-            && self.last_pty_cols.is_none()
             && self.last_requested_size.is_none()
             && !self.last_requested_size_dirty
-            && !self.clears_on_resize
             && self.pending_resize.is_none()
             && !self.resuming
             && !self.killed
@@ -890,14 +811,14 @@ impl SessionManager {
     }
 
     pub fn reserve_delivery(&self, session_id: &str) -> Result<router::DeliveryReservation> {
-        let session = self
-            .session_state(session_id)
-            .ok_or_else(|| Error::msg(format!("session not found: {session_id}")))?;
+        let Some(session) = self.session_state(session_id) else {
+            return Ok(router::DeliveryReservation::Unavailable);
+        };
         let gate = session.lock().unwrap().delivery_gate.clone();
         let mut delivery = gate.state.lock().unwrap();
         let session = session.lock().unwrap();
         if session.handle.is_none() {
-            return Err(Error::msg(format!("session not found: {session_id}")));
+            return Ok(router::DeliveryReservation::Unavailable);
         }
         if delivery.in_flight {
             return Ok(router::DeliveryReservation::InFlight);
@@ -957,10 +878,12 @@ impl SessionManager {
         handle: SessionHandle,
         mission_status_sink: Option<ForwarderEmitCtx>,
         initial_size: Option<(u16, u16)>,
-        agent_runtime: &str,
         pool: &DbPool,
+        events: &dyn SessionEvents,
     ) {
         let initial_size = initial_size.expect("spawn size must be resolved before handle install");
+        let mission_id = handle.mission_id.clone();
+        let mut terminal_size = initial_size;
         let state = self.session_state_or_insert(session_id);
         let gate = state.lock().unwrap().delivery_gate.clone();
         {
@@ -976,8 +899,6 @@ impl SessionManager {
             state.handle = Some(handle);
             state.mission_status_sink = mission_status_sink;
             state.killed = false;
-            state.last_pty_cols = Some(initial_size.0);
-            state.clears_on_resize = output::runtime_clears_on_resize(agent_runtime);
 
             let requested_size = state.last_requested_size;
             if let Some((cols, rows)) = requested_size.filter(|size| *size != initial_size) {
@@ -989,7 +910,7 @@ impl SessionManager {
                     .clone();
                 match self.runtime.resize(&rt_session, cols, rows) {
                     Ok(()) => {
-                        state.last_pty_cols = Some(cols);
+                        terminal_size = (cols, rows);
                         log::info!(
                             "pty size reconciled after fork: session={session_id} {cols}x{rows} \
                              (pushed mid-fork)"
@@ -1024,6 +945,12 @@ impl SessionManager {
             }
             state.pending_resize = None;
         }
+        events.spawned(&SessionSpawnedEvent {
+            session_id: session_id.to_owned(),
+            mission_id,
+            cols: terminal_size.0,
+            rows: terminal_size.1,
+        });
         self.notify_delivery_event(session_id, router::SessionDeliveryEvent::Respawned);
     }
 

--- a/crates/runner-backend/src/session/manager/output.rs
+++ b/crates/runner-backend/src/session/manager/output.rs
@@ -1,9 +1,5 @@
 use super::*;
 
-pub(super) const PURGE_RESUME_RESET: &[u8] = b"\x1bc";
-pub(super) const KEEP_RESUME_SEAM: &[u8] =
-    b"\x1b[0m\x1b[?2004l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\r\n";
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) enum LocalInputClass {
     SetPending,
@@ -60,8 +56,8 @@ pub(super) fn update_local_input_state(
 
 impl SessionManager {
     /// Forwarder thread shared by `spawn`, `spawn_direct`, and `resume`.
-    /// Drains the runtime's `OutputStream` into `session/output`
-    /// events, then on channel close queries the runtime for the
+    /// Drains the runtime's `OutputStream` into the terminal sink,
+    /// then on channel close queries the runtime for the
     /// final exit code, flips the DB row, emits `session/exit`, and
     /// clears the live handle. `kill` joins this handle so
     /// `mission_stop` gets the no-lying-about-termination contract.
@@ -96,8 +92,8 @@ impl SessionManager {
         let stop = output.stop_flag();
         thread::spawn(move || {
             // Drain PTY output until the runtime closes the channel
-            // OR `kill` flips the stop flag. Stream chunks flow as
-            // `session/output` events. StatusTransition is routed
+            // OR `kill` flips the stop flag. Stream chunks flow to
+            // the terminal sink. StatusTransition is routed
             // into either the mission event log or a direct-chat
             // live status event so the UI sees busy/idle flips.
             //
@@ -490,16 +486,10 @@ impl SessionManager {
             .load(std::sync::atomic::Ordering::Relaxed);
         let (settle_generation, resize_result) = {
             let mut session = state.lock().unwrap();
-            let initial_cols = session
-                .pending_resize
-                .as_ref()
-                .map_or(session.last_pty_cols, |pending| pending.initial_cols);
             session.last_requested_size = Some((cols, rows));
             session.last_requested_size_dirty = true;
 
             let mut ioctl_count = 0;
-            let previous_cols = session.last_pty_cols;
-            let mut width_changed = false;
             let resize_result = if session.killed || session.resuming {
                 Ok(())
             } else if let Some(rt_session) = session
@@ -508,12 +498,9 @@ impl SessionManager {
                 .map(|handle| handle.runtime_session.clone())
             {
                 ioctl_count = 1;
-                let result = self.runtime.resize(&rt_session, cols, rows);
-                if result.is_ok() {
-                    width_changed = previous_cols != Some(cols);
-                    session.last_pty_cols = Some(cols);
-                }
-                result.map_err(Into::into)
+                self.runtime
+                    .resize(&rt_session, cols, rows)
+                    .map_err(Into::into)
             } else {
                 Ok(())
             };
@@ -525,7 +512,6 @@ impl SessionManager {
                     pending.deadline = Instant::now() + Duration::from_millis(settle_ms);
                     pending.suppressed += 1;
                     pending.ioctl_count += ioctl_count;
-                    pending.width_changed |= width_changed;
                     None
                 }
                 None => {
@@ -537,8 +523,6 @@ impl SessionManager {
                         generation,
                         cols,
                         rows,
-                        initial_cols,
-                        width_changed,
                         deadline: Instant::now() + Duration::from_millis(settle_ms),
                         suppressed: 0,
                         ioctl_count,
@@ -552,7 +536,6 @@ impl SessionManager {
         if let Some(generation) = settle_generation {
             let session_id = session_id.to_string();
             let state = Arc::clone(&state);
-            let runtime = Arc::clone(&self.runtime);
             thread::spawn(move || loop {
                 let wait = {
                     let state = state.lock().unwrap();
@@ -569,12 +552,7 @@ impl SessionManager {
                     thread::sleep(wait);
                     continue;
                 }
-                Self::settle_pending_resize(
-                    &session_id,
-                    &state,
-                    runtime.as_ref(),
-                    Some(generation),
-                );
+                Self::settle_pending_resize(&session_id, &state, Some(generation));
                 return;
             });
         }
@@ -584,7 +562,6 @@ impl SessionManager {
     fn settle_pending_resize(
         session_id: &str,
         state: &Arc<Mutex<SessionState>>,
-        runtime: &dyn SessionRuntime,
         expected_generation: Option<u64>,
     ) {
         // The runtime resolves a reusable session id to the live child. Keep
@@ -651,267 +628,38 @@ impl SessionManager {
             }
         };
 
-        let Some(rt_session) = state
-            .handle
-            .as_ref()
-            .map(|handle| handle.runtime_session.clone())
-        else {
-            log::debug!(
-                "resize trace: session={session_id} pushes={} immediate_ioctls={} \
-                 settle_ioctls=0 total_ioctls={} persisted={persisted} purge=false",
-                pending.suppressed + 1,
-                pending.ioctl_count,
-                pending.ioctl_count,
-            );
-            return;
-        };
-
-        let should_purge = state.clears_on_resize
-            && pending.width_changed
-            && state.last_pty_cols == Some(pending.cols);
-        let (settle_ioctl_count, purged) = if should_purge {
-            let retained_output = std::mem::take(&mut state.output_buffer);
-            let nudged_rows = if pending.rows > 1 {
-                pending.rows - 1
-            } else {
-                pending.rows + 1
-            };
-            let (count, result) = match runtime.resize(&rt_session, pending.cols, nudged_rows) {
-                Ok(()) => (2, runtime.resize(&rt_session, pending.cols, pending.rows)),
-                Err(error) => (1, Err(error)),
-            };
-            if let Err(error) = result {
-                state.output_buffer = retained_output;
-                log::warn!(
-                    "resize repaint nudge failed: session={session_id} {}x{} \
-                     ({} coalesced): {error}",
-                    pending.cols,
-                    pending.rows,
-                    pending.suppressed,
-                );
-                (count, false)
-            } else {
-                (count, true)
-            }
-        } else {
-            (0, false)
-        };
-        if purged {
-            log::info!(
-                "resize ring purge: session={session_id} cols {} -> {} ({} coalesced)",
-                pending
-                    .initial_cols
-                    .map_or_else(|| "none".to_string(), |cols| cols.to_string()),
-                pending.cols,
-                pending.suppressed,
-            );
-        }
         log::debug!(
             "resize trace: session={session_id} pushes={} immediate_ioctls={} \
-             settle_ioctls={settle_ioctl_count} total_ioctls={} persisted={persisted} \
-             purge={purged}",
+             settle_ioctls=0 total_ioctls={} persisted={persisted}",
             pending.suppressed + 1,
             pending.ioctl_count,
-            pending.ioctl_count + settle_ioctl_count,
+            pending.ioctl_count,
         );
     }
 
     #[cfg(test)]
     pub(crate) fn settle_pending_resize_now(&self, session_id: &str) {
         if let Some(state) = self.session_state(session_id) {
-            Self::settle_pending_resize(session_id, &state, self.runtime.as_ref(), None);
+            Self::settle_pending_resize(session_id, &state, None);
         }
     }
 
-    /// Return the bounded in-memory PTY output snapshot for a session.
-    ///
-    /// Tauri events are live-only; without this, a terminal pane mounted after
-    /// a session already produced output starts blank until the child redraws.
-    /// The snapshot is intentionally process-local and bounded: it covers
-    /// webview reloads / chat switching for live sessions without turning the
-    /// sessions table into a PTY transcript store.
-    pub fn output_snapshot(&self, session_id: &str) -> Vec<OutputEvent> {
-        let Some(state) = self.session_state(session_id) else {
-            return Vec::new();
-        };
-        let state = state.lock().unwrap();
-        let mut events: Vec<OutputEvent> = state.output_buffer.iter().cloned().collect();
-        // For sessions currently inside terminal modes that xterm
-        // reset clears, prepend a synthetic chunk restoring them.
-        // Long-running TUI sessions lose the
-        // original enter-alt-screen escape from the bounded
-        // 4096-chunk buffer over time, so a re-attach that just
-        // replays the remaining chunks lands mid-alt-screen content
-        // into xterm's main screen — visible as stacked redraws in
-        // scrollback and a blank alt-screen pane on route remount.
-        // Bracketed paste and mouse reporting have the same problem
-        // after a terminal reset: their enable escapes may have fallen
-        // out of the ring even though the live child still expects the
-        // modes. seq=0 sits below every real event's monotonic seq so
-        // replay merge filters don't drop it on re-replay.
-        let mut synthetic_prefix = Vec::new();
-        if state.alt_screen_on {
-            synthetic_prefix.extend_from_slice(b"\x1b[?1049h");
+    #[cfg(test)]
+    pub(crate) fn settle_pending_resize_generation_now(&self, session_id: &str, generation: u64) {
+        if let Some(state) = self.session_state(session_id) {
+            Self::settle_pending_resize(session_id, &state, Some(generation));
         }
-        if state.bracketed_paste_on {
-            synthetic_prefix.extend_from_slice(b"\x1b[?2004h");
-        }
-        if state.mouse_1000_on {
-            synthetic_prefix.extend_from_slice(b"\x1b[?1000h");
-        }
-        if state.mouse_1002_on {
-            synthetic_prefix.extend_from_slice(b"\x1b[?1002h");
-        }
-        if state.mouse_1003_on {
-            synthetic_prefix.extend_from_slice(b"\x1b[?1003h");
-        }
-        if state.mouse_1006_on {
-            synthetic_prefix.extend_from_slice(b"\x1b[?1006h");
-        }
-        if !synthetic_prefix.is_empty() {
-            events.insert(
-                0,
-                OutputEvent {
-                    session_id: session_id.into(),
-                    mission_id: None,
-                    seq: 0,
-                    data: BASE64.encode(synthetic_prefix),
-                },
-            );
-        }
-        events
     }
 
-    /// Drop the in-memory output buffer + seq counter for a session.
-    /// Called when the session is genuinely going away (archive, runner
-    /// delete) so the bounded ring buffer doesn't accumulate forever.
-    /// Safe to call on a session that's never written output.
-    pub fn purge_session_buffers(&self, session_id: &str) {
+    pub fn forget_session_state(&self, session_id: &str) {
         if let Some(state) = self.session_state(session_id) {
             let mut state = state.lock().unwrap();
-            state.output_buffer.clear();
             state.output_seq = 0;
-            state.resume_watermark_seq = 0;
-            state.alt_screen_on = false;
-            state.bracketed_paste_on = false;
-            state.mouse_1000_on = false;
-            state.mouse_1002_on = false;
-            state.mouse_1003_on = false;
-            state.mouse_1006_on = false;
-            state.last_pty_cols = None;
             state.last_requested_size = None;
             state.last_requested_size_dirty = false;
-            state.clears_on_resize = false;
             state.pending_resize = None;
         }
         self.prune_empty_session_state(session_id);
-    }
-
-    /// Record the resume watermark: the seq the ring had reached when
-    /// the current resume started. Called at the top of `resume()`
-    /// for every runtime. The purge path retains `output_seq`, so this
-    /// remains the boundary below its synthetic reset and child output.
-    pub fn set_resume_watermark(&self, session_id: &str) {
-        if let Some(state) = self.session_state(session_id) {
-            let mut state = state.lock().unwrap();
-            state.resume_watermark_seq = state.output_seq;
-        }
-    }
-
-    /// Read back the resume watermark for the pill fast-paths.
-    /// Sessions that never resumed (or whose state was purged)
-    /// report 0, which degenerates the frontend filter to
-    /// "any chunk counts".
-    pub fn replay_watermark(&self, session_id: &str) -> u64 {
-        self.session_state(session_id)
-            .map(|state| state.lock().unwrap().resume_watermark_seq)
-            .unwrap_or(0)
-    }
-
-    /// Drop only the output buffer for a session, keeping the seq
-    /// counter. Used by `resume` for runtimes that repaint their
-    /// whole frame on resume (codex — see `runtime_purges_on_resume`):
-    /// clearing the buffer means the post-resume snapshot is fresh
-    /// (no double banner / stacked agent output on remount), while
-    /// preserving the monotonic seq means the synthetic reset and new
-    /// PTY chunks continue above `last` rather than restarting at `1`,
-    /// which replay merge filters would drop.
-    pub fn purge_output_buffer(&self, session_id: &str) {
-        if let Some(state) = self.session_state(session_id) {
-            let mut state = state.lock().unwrap();
-            state.output_buffer.clear();
-            // Resume forks a new child; whether it'll be in alt-screen
-            // or bracketed-paste mode depends on the new process's own
-            // startup. Clear the state so it re-derives from emitted bytes
-            // instead of inheriting the prior child's mode.
-            state.alt_screen_on = false;
-            state.bracketed_paste_on = false;
-            state.mouse_1000_on = false;
-            state.mouse_1002_on = false;
-            state.mouse_1003_on = false;
-            state.mouse_1006_on = false;
-        }
-        self.prune_empty_session_state(session_id);
-    }
-
-    /// Update per-session terminal mode flags from a raw runtime
-    /// chunk. We take the *latest* match in the chunk as the resulting
-    /// state for each tracked mode. No-op when the chunk contains no
-    /// tracked mode-switch escape.
-    ///
-    /// Boundary caveat: an escape could be split across two
-    /// adjacent chunks if the PTY reader's buffer slice happens to
-    /// land mid-sequence. The sequences are 7-8 bytes and the
-    /// reader's reads are kilobyte-scale, so the odds are low and
-    /// the worst case is one missed transition — the next emitted
-    /// transition picks up the right state. If this turns out to
-    /// matter we can carry a small tail buffer across chunks.
-    fn update_terminal_mode_state(&self, session_id: &str, bytes: &[u8]) {
-        let alt_screen = scan_alt_screen_transition(bytes);
-        let bracketed_paste = scan_bracketed_paste_transition(bytes);
-        let mouse_1000 = scan_mouse_mode_transition(bytes, 1000);
-        let mouse_1002 = scan_mouse_mode_transition(bytes, 1002);
-        let mouse_1003 = scan_mouse_mode_transition(bytes, 1003);
-        let mouse_1006 = scan_mouse_mode_transition(bytes, 1006);
-        if alt_screen.is_none()
-            && bracketed_paste.is_none()
-            && mouse_1000.is_none()
-            && mouse_1002.is_none()
-            && mouse_1003.is_none()
-            && mouse_1006.is_none()
-        {
-            return;
-        }
-        let state = self.session_state_or_insert(session_id);
-        let mut state = state.lock().unwrap();
-        if let Some(new_state) = alt_screen {
-            state.alt_screen_on = new_state;
-        }
-        if let Some(new_state) = bracketed_paste {
-            state.bracketed_paste_on = new_state;
-        }
-        if let Some(new_state) = mouse_1000 {
-            state.mouse_1000_on = new_state;
-        }
-        if let Some(new_state) = mouse_1002 {
-            state.mouse_1002_on = new_state;
-        }
-        if let Some(new_state) = mouse_1003 {
-            state.mouse_1003_on = new_state;
-        }
-        if let Some(new_state) = mouse_1006 {
-            state.mouse_1006_on = new_state;
-        }
-    }
-
-    pub(super) fn append_synthetic_output(
-        &self,
-        session_id: &str,
-        mission_id: Option<&str>,
-        bytes: &[u8],
-        events: &dyn SessionEvents,
-    ) {
-        self.ingest_output_chunk(session_id, mission_id, bytes, events);
     }
 
     fn ingest_output_chunk(
@@ -921,10 +669,7 @@ impl SessionManager {
         bytes: &[u8],
         events: &dyn SessionEvents,
     ) {
-        // Track terminal modes before recording so that the very next
-        // snapshot reflects the latest state this chunk established.
-        self.update_terminal_mode_state(session_id, bytes);
-        let ev = self.record_output(session_id, mission_id, BASE64.encode(bytes));
+        let ev = self.record_output(session_id, mission_id, bytes);
         events.output(&ev);
     }
 
@@ -932,58 +677,18 @@ impl SessionManager {
         &self,
         session_id: &str,
         mission_id: Option<&str>,
-        data: String,
+        bytes: &[u8],
     ) -> OutputEvent {
         let state = self.session_state_or_insert(session_id);
         let mut state = state.lock().unwrap();
         state.output_seq += 1;
         let seq = state.output_seq;
 
-        let ev = OutputEvent {
+        OutputEvent {
             session_id: session_id.into(),
             mission_id: mission_id.map(str::to_string),
             seq,
-            data,
-        };
-
-        state.output_buffer.push_back(ev.clone());
-        while state.output_buffer.len() > MAX_OUTPUT_BUFFER_CHUNKS {
-            state.output_buffer.pop_front();
+            bytes: bytes.to_vec(),
         }
-        ev
     }
-}
-
-/// Whether an agent runtime repaints its whole frame on SIGWINCH.
-/// Cached in `SessionState` when a spawn or resume installs its handle.
-pub(super) fn runtime_clears_on_resize(runtime: &str) -> bool {
-    matches!(runtime, "claude-code" | "codex" | "qoder" | "trae")
-}
-
-/// Whether `resume` should drop the session's output ring before
-/// spawning the new PTY. Codex and TRAE repaint their whole frame on resume
-/// (and their own resume replays restore a deep conversation tail), so
-/// replaying retained scrollback under the new frame stacks garbled
-/// content — the artifact class from impls 0009/0011/0020. Claude Code
-/// and Qoder paint inline into the main screen: kept scrollback, then the
-/// resume banner, then the tail repaint is exactly what a physical
-/// terminal shows, so their rings are kept. Shells and future runtimes
-/// keep today's purge purely for scope. Best-effort:
-/// a DB miss fails toward the purge, i.e. today's behavior.
-pub(super) fn runtime_purges_on_resume(session_id: &str, pool: &DbPool) -> bool {
-    let Ok(conn) = pool.get() else {
-        return true;
-    };
-    let runtime = conn
-        .query_row(
-            "SELECT COALESCE(s.agent_runtime, r.runtime)
-               FROM sessions s
-               LEFT JOIN runners r ON r.id = s.runner_id
-              WHERE s.id = ?1",
-            params![session_id],
-            |r| r.get::<_, Option<String>>(0),
-        )
-        .ok()
-        .flatten();
-    !matches!(runtime.as_deref(), Some("claude-code") | Some("qoder"))
 }

--- a/crates/runner-backend/src/session/manager/spawn.rs
+++ b/crates/runner-backend/src/session/manager/spawn.rs
@@ -586,8 +586,8 @@ impl SessionManager {
             },
             spawn_emit_ctx.clone(),
             initial_size,
-            &runner.runtime,
             &pool,
+            events.as_ref(),
         );
         if first_turn_delivered_via_argv {
             self.arm_completion(&session_id);
@@ -1006,8 +1006,8 @@ impl SessionManager {
             },
             None,
             initial_size,
-            &runner.runtime,
             &pool,
+            events.as_ref(),
         );
         if first_turn_delivered_via_argv {
             self.arm_completion(&session_id);
@@ -1161,44 +1161,6 @@ impl SessionManager {
             }
             row
         };
-
-        // Stamp the resume watermark (and, for full-frame-repaint
-        // runtimes, purge the prior output buffer) up front. Two
-        // properties depend on this happening *before* any
-        // long-running step (gate, runtime.spawn, mission/runner
-        // re-lookup):
-        //
-        // 1. The frontend's resuming-pill effect calls
-        //    `session_output_snapshot` to catch a TUI-ready escape
-        //    that fired before its live listener attached. The old
-        //    PTY's chunks include the pre-stop `\x1b[?2004h`, so the
-        //    pill only honors ready escapes in chunks with
-        //    `seq > session_replay_watermark`. Stamping the watermark
-        //    at the top closes the window where the snapshot could
-        //    clear the resuming overlay before the new PTY exists.
-        // 2. The seq counter is never touched (see
-        //    `purge_output_buffer`'s contract), so the synthetic seam
-        //    and new PTY chunks continue above `last` and replay merge
-        //    filters don't drop them.
-        //
-        // Whether the ring itself survives is per-runtime: Claude and Qoder
-        // keep it because their resume flows do not replay the transcript;
-        // Codex, TRAE, and shells purge it. See `runtime_purges_on_resume`.
-        self.set_resume_watermark(session_id);
-        let purges_on_resume = output::runtime_purges_on_resume(session_id, &pool);
-        if purges_on_resume {
-            self.purge_output_buffer(session_id);
-        }
-        self.append_synthetic_output(
-            session_id,
-            snap.mission_id.as_deref(),
-            if purges_on_resume {
-                output::PURGE_RESUME_RESET
-            } else {
-                output::KEEP_RESUME_SEAM
-            },
-            events.as_ref(),
-        );
 
         // Mission resume: pull the slot + mission so we can stamp the
         // in-mission env (RUNNER_HANDLE = slot_handle, RUNNER_CREW_ID,
@@ -1518,8 +1480,8 @@ impl SessionManager {
             },
             resume_emit_ctx.clone(),
             Some(initial_size),
-            &runner.runtime,
             &pool,
+            events.as_ref(),
         );
         if snap.mission_id.is_none() {
             self.publish_direct_activity(
@@ -1529,12 +1491,6 @@ impl SessionManager {
                 events.as_ref(),
             );
         }
-
-        // (The pre-runtime.spawn purge moved up to right after
-        // snapshot collection so the frontend's snapshot fast-path
-        // can't read the stopped session's chunks during the resume
-        // window. See the call site above this function's mission
-        // lookup.)
 
         let forwarder = self.start_forwarder_thread(
             session_id.to_string(),

--- a/crates/runner-backend/src/session/manager/tests.rs
+++ b/crates/runner-backend/src/session/manager/tests.rs
@@ -79,7 +79,7 @@ fn manager_with_runtime(
 /// back what the manager handed to the runtime layer (env vars,
 /// argv, byte writes, key names, resize dimensions). Lets
 /// tests that depend on runtime-side behavior — DB writes after
-/// spawn, output buffer machinery, kill semantics, first-prompt
+/// spawn, output delivery, kill semantics, first-prompt
 /// scheduling, agent_session_key resume preservation — run
 /// without forking a real PTY.
 #[derive(Default)]
@@ -89,8 +89,6 @@ struct FakeRuntime {
     stops: std::sync::Mutex<Vec<String>>,
     stop_failures: std::sync::Mutex<HashSet<String>>,
     resizes: std::sync::Mutex<Vec<(String, u16, u16)>>,
-    resize_failures: std::sync::Mutex<HashSet<String>>,
-    output_on_resize: std::sync::Mutex<Option<Vec<u8>>>,
     /// Runs inside `spawn` once the fork is recorded — lets a test land
     /// work (a resize) between the fork and the handle install.
     spawn_hook: std::sync::Mutex<Option<Box<dyn Fn() + Send + Sync>>>,
@@ -188,21 +186,6 @@ impl FakeRuntime {
 
     fn allow_stop_for(&self, session_id: &str) {
         self.stop_failures.lock().unwrap().remove(session_id);
-    }
-
-    fn fail_resize_for(&self, session_id: &str) {
-        self.resize_failures
-            .lock()
-            .unwrap()
-            .insert(session_id.to_string());
-    }
-
-    fn allow_resize_for(&self, session_id: &str) {
-        self.resize_failures.lock().unwrap().remove(session_id);
-    }
-
-    fn emit_output_on_resize(&self, bytes: &[u8]) {
-        *self.output_on_resize.lock().unwrap() = Some(bytes.to_vec());
     }
 
     fn arm_stop_gate(&self) -> (std::sync::mpsc::Receiver<()>, std::sync::mpsc::Sender<()>) {
@@ -313,27 +296,6 @@ impl SessionRuntime for FakeRuntime {
             .lock()
             .unwrap()
             .push((session.session_id.clone(), cols, rows));
-        if self
-            .resize_failures
-            .lock()
-            .unwrap()
-            .contains(&session.session_id)
-        {
-            return Err(RuntimeError::Msg(format!(
-                "injected resize failure for {}",
-                session.session_id
-            )));
-        }
-        if let Some(bytes) = self.output_on_resize.lock().unwrap().clone() {
-            let spawns = self.spawns.lock().unwrap();
-            if let Some(tx) = spawns
-                .iter()
-                .find(|spawn| spawn.rt_session.session_id == session.session_id)
-                .and_then(|spawn| spawn.tx.as_ref())
-            {
-                let _ = tx.send(RuntimeOutput::Stream(bytes));
-            }
-        }
         Ok(())
     }
 
@@ -482,7 +444,7 @@ fn wait_for_output_event(cap: &Capture, session_id: &str) {
             return;
         }
         if Instant::now() > deadline {
-            panic!("session/output event never arrived for {session_id}");
+            panic!("session output never arrived for {session_id}");
         }
         std::thread::sleep(Duration::from_millis(20));
     }
@@ -2965,85 +2927,6 @@ fn login_shell_proxy_env_reaches_spawn_with_runner_env_taking_precedence() {
 }
 
 #[test]
-fn output_snapshot_replays_live_session_and_clears_after_forget() {
-    let pool = pool_with_schema();
-    let now = Utc::now().to_rfc3339();
-    let runner_id = ulid::Ulid::new().to_string();
-    {
-        let conn = pool.get().unwrap();
-        conn.execute(
-            "INSERT INTO runners
-                    (id, handle, display_name, runtime, command,
-                     args_json, working_dir, system_prompt, env_json,
-                     created_at, updated_at)
-                 VALUES (?1, 'buffered', 'Buffered', 'shell', '/bin/cat',
-                         NULL, NULL, NULL, NULL, ?2, ?2)",
-            params![runner_id, now],
-        )
-        .unwrap();
-    }
-
-    let mut runner = runner("/bin/cat", &[]);
-    runner.id = runner_id;
-    runner.handle = "buffered".into();
-
-    let fake = fake_runtime();
-    let mgr = mgr_with_fake(None, Arc::clone(&fake));
-    let spawned = mgr
-        .spawn_direct(
-            &runner,
-            None,
-            None,
-            None,
-            None,
-            Some("/tmp"),
-            None,
-            None,
-            std::path::Path::new("/tmp"),
-            Arc::clone(&pool),
-            capture(),
-            None,
-        )
-        .unwrap();
-
-    // Push fake output through the runtime → forwarder
-    // chain. The forwarder records it into the manager's
-    // output buffer; output_snapshot reads it back.
-    fake.push_output(0, b"hello snapshot");
-    let deadline = Instant::now() + Duration::from_secs(2);
-    let snapshot = loop {
-        let snapshot = mgr.output_snapshot(&spawned.id);
-        if !snapshot.is_empty() {
-            break snapshot;
-        }
-        if Instant::now() > deadline {
-            panic!("session output snapshot never captured live output");
-        }
-        std::thread::sleep(Duration::from_millis(20));
-    };
-
-    assert_eq!(snapshot[0].seq, 1);
-    assert!(
-        snapshot.iter().all(|ev| ev.session_id == spawned.id),
-        "snapshot must only include chunks for the requested session"
-    );
-
-    mgr.kill(&spawned.id).unwrap();
-    // After kill the buffer is intentionally preserved so a
-    // remount can replay the dead session's scrollback. Explicit
-    // cleanup is via `purge_session_buffers`.
-    assert!(
-        !mgr.output_snapshot(&spawned.id).is_empty(),
-        "kill must keep the output buffer for snapshot replay"
-    );
-    mgr.purge_session_buffers(&spawned.id);
-    assert!(
-        mgr.output_snapshot(&spawned.id).is_empty(),
-        "purge_session_buffers must drop the buffer"
-    );
-}
-
-#[test]
 fn resume_reuses_row_and_preserves_agent_session_key() {
     // Multi-chat-per-runner contract: a direct chat IS a
     // sessions row. spawn_direct creates the row and the
@@ -3194,23 +3077,6 @@ fn resume_reuses_row_and_preserves_agent_session_key() {
     mgr.kill(&session_id).unwrap();
 }
 
-/// Poll `output_snapshot` until it holds at least `min_len` chunks.
-/// The forwarder thread records chunks asynchronously, so tests that
-/// push through FakeRuntime must wait for the ring to catch up.
-fn wait_for_snapshot(mgr: &SessionManager, session_id: &str, min_len: usize) -> Vec<OutputEvent> {
-    let deadline = Instant::now() + Duration::from_secs(2);
-    loop {
-        let snapshot = mgr.output_snapshot(session_id);
-        if snapshot.len() >= min_len {
-            return snapshot;
-        }
-        if Instant::now() > deadline {
-            panic!("snapshot for {session_id} never reached {min_len} chunks");
-        }
-        std::thread::sleep(Duration::from_millis(20));
-    }
-}
-
 /// Poll the sessions row until the forwarder demotes it from
 /// `running` — `resume()` refuses rows that still look live.
 fn wait_for_db_stop(pool: &DbPool, session_id: &str) {
@@ -3232,254 +3098,6 @@ fn wait_for_db_stop(pool: &DbPool, session_id: &str) {
         }
         std::thread::sleep(Duration::from_millis(20));
     }
-}
-
-fn assert_resume_keeps_scrollback(runtime: &str) {
-    // Impl 0024: resuming an inline-repaint runtime must NOT drop the
-    // output ring — a terminal emulator keeps pre-resume scrollback
-    // above the resume repaint, and the ring has to agree with the
-    // mounted xterm so a later remount replay doesn't lose what the
-    // screen already showed. The pill race the old unconditional
-    // purge closed is carried by the resume watermark instead.
-    let pool = pool_with_schema();
-    let now = Utc::now().to_rfc3339();
-    let runner_id = ulid::Ulid::new().to_string();
-    {
-        let conn = pool.get().unwrap();
-        conn.execute(
-            "INSERT INTO runners
-                    (id, handle, display_name, runtime, command,
-                     args_json, working_dir, system_prompt, env_json,
-                     created_at, updated_at)
-                 VALUES (?1, 'keeper', 'K', ?2, '/bin/sh',
-                         NULL, NULL, NULL, NULL, ?3, ?3)",
-            params![runner_id, runtime, now],
-        )
-        .unwrap();
-    }
-    let mut runner = runner("/bin/sh", &[]);
-    runner.id = runner_id;
-    runner.handle = "keeper".into();
-    runner.runtime = runtime.into();
-
-    let fake = fake_runtime();
-    let mgr = mgr_with_fake(None, Arc::clone(&fake));
-    let events = capture();
-    let spawned = mgr
-        .spawn_direct(
-            &runner,
-            None,
-            None,
-            None,
-            None,
-            Some("/tmp"),
-            None,
-            None,
-            std::path::Path::new("/tmp"),
-            Arc::clone(&pool),
-            events.clone(),
-            None,
-        )
-        .unwrap();
-    let session_id = spawned.id.clone();
-
-    assert_eq!(
-        mgr.replay_watermark(&session_id),
-        0,
-        "fresh spawn must report watermark 0"
-    );
-
-    fake.push_output(0, b"\x1b[?2004h\x1b[?1000h\x1b[?1006hpre-resume scrollback");
-    let before_resume = wait_for_snapshot(&mgr, &session_id, 2);
-    assert_eq!(before_resume[0].seq, 0);
-    assert_eq!(
-        BASE64.decode(&before_resume[0].data).unwrap(),
-        b"\x1b[?2004h\x1b[?1000h\x1b[?1006h",
-        "snapshot prefix must restore tracked paste and mouse modes"
-    );
-    let pre_max_seq = before_resume.last().unwrap().seq;
-
-    fake.close_spawn(0);
-    wait_for_db_stop(&pool, &session_id);
-
-    let resumed = mgr
-        .resume(
-            &session_id,
-            None,
-            None,
-            std::path::Path::new("/tmp"),
-            Arc::clone(&pool),
-            events.clone(),
-        )
-        .unwrap();
-    assert_eq!(resumed.id, session_id);
-
-    assert_eq!(
-        mgr.replay_watermark(&session_id),
-        pre_max_seq,
-        "watermark must equal the pre-resume max seq"
-    );
-    let kept = BASE64.encode(b"\x1b[?2004h\x1b[?1000h\x1b[?1006hpre-resume scrollback");
-    let after_resume = mgr.output_snapshot(&session_id);
-    assert!(
-        after_resume.iter().any(|ev| ev.data == kept),
-        "{runtime} resume must keep pre-resume chunks in the ring"
-    );
-    assert_ne!(
-        after_resume.first().map(|ev| ev.seq),
-        Some(0),
-        "the seam must disable paste and mouse tracking immediately"
-    );
-    let seam = after_resume.last().unwrap();
-    assert_eq!(BASE64.decode(&seam.data).unwrap(), output::KEEP_RESUME_SEAM);
-    assert_eq!(seam.seq, pre_max_seq + 1);
-    assert!(
-        seam.seq > mgr.replay_watermark(&session_id),
-        "watermark must be stamped before the seam"
-    );
-    assert!(
-        [b"\x1b[?2004h".as_slice(), b"\x1b[?1049h", b"\x1b[?47h"]
-            .into_iter()
-            .all(|ready| !output::KEEP_RESUME_SEAM
-                .windows(ready.len())
-                .any(|window| window == ready)),
-        "seam must not contain a TUI-ready enable escape"
-    );
-    assert_eq!(
-        events.output.lock().unwrap().last().unwrap().data,
-        seam.data,
-        "synthetic seam must fan out through session/output"
-    );
-
-    // The new PTY (spawn index 1) continues the seq counter: its
-    // chunk lands after the kept scrollback and seam, strictly above
-    // the watermark, with no reset back to 1.
-    fake.push_output(1, b"post-resume repaint");
-    let snapshot = wait_for_snapshot(&mgr, &session_id, 3);
-    assert!(
-        snapshot.windows(2).all(|w| w[0].seq < w[1].seq),
-        "snapshot seqs must stay strictly monotonic across resume"
-    );
-    let new_chunk = snapshot.last().unwrap();
-    assert_eq!(new_chunk.data, BASE64.encode(b"post-resume repaint"));
-    assert!(
-        new_chunk.seq > pre_max_seq,
-        "post-resume chunk must continue above the watermark"
-    );
-
-    mgr.kill(&session_id).unwrap();
-    mgr.purge_session_buffers(&session_id);
-    assert_eq!(
-        mgr.replay_watermark(&session_id),
-        0,
-        "purge_session_buffers must reset the watermark with the rest of the state"
-    );
-}
-
-#[test]
-fn resume_keeps_scrollback_for_claude_code() {
-    assert_resume_keeps_scrollback("claude-code");
-}
-
-#[test]
-fn resume_keeps_scrollback_for_qoder() {
-    assert_resume_keeps_scrollback("qoder");
-}
-
-fn assert_resume_purges_scrollback(runtime: &str) {
-    // Codex-lineage runtimes keep the pre-0024 behavior: their full-frame repaint over
-    // retained scrollback is the stacking artifact the purge was
-    // added for, so resume still drops the ring — while the watermark
-    // is stamped uniformly (equal to the post-purge floor here).
-    let pool = pool_with_schema();
-    let now = Utc::now().to_rfc3339();
-    let runner_id = ulid::Ulid::new().to_string();
-    {
-        let conn = pool.get().unwrap();
-        conn.execute(
-            "INSERT INTO runners
-                    (id, handle, display_name, runtime, command,
-                     args_json, working_dir, system_prompt, env_json,
-                     created_at, updated_at)
-                 VALUES (?1, 'purger', 'P', ?2, '/bin/sh',
-                         NULL, NULL, NULL, NULL, ?3, ?3)",
-            params![runner_id, runtime, now],
-        )
-        .unwrap();
-    }
-    let mut runner = runner("/bin/sh", &[]);
-    runner.id = runner_id;
-    runner.handle = "purger".into();
-    runner.runtime = runtime.into();
-
-    let fake = fake_runtime();
-    let mgr = mgr_with_fake(None, Arc::clone(&fake));
-    let events = capture();
-    let spawned = mgr
-        .spawn_direct(
-            &runner,
-            None,
-            None,
-            None,
-            None,
-            Some("/tmp"),
-            None,
-            None,
-            std::path::Path::new("/tmp"),
-            Arc::clone(&pool),
-            events.clone(),
-            None,
-        )
-        .unwrap();
-    let session_id = spawned.id.clone();
-
-    fake.push_output(0, b"pre-resume frame");
-    let pre_max_seq = wait_for_snapshot(&mgr, &session_id, 1).last().unwrap().seq;
-
-    fake.close_spawn(0);
-    wait_for_db_stop(&pool, &session_id);
-
-    mgr.resume(
-        &session_id,
-        None,
-        None,
-        std::path::Path::new("/tmp"),
-        Arc::clone(&pool),
-        events.clone(),
-    )
-    .unwrap();
-
-    let reset_snapshot = mgr.output_snapshot(&session_id);
-    assert_eq!(
-        reset_snapshot.len(),
-        1,
-        "{runtime} resume must replace prior output with one reset chunk"
-    );
-    assert_eq!(
-        BASE64.decode(&reset_snapshot[0].data).unwrap(),
-        output::PURGE_RESUME_RESET
-    );
-    assert_eq!(reset_snapshot[0].seq, pre_max_seq + 1);
-    assert_eq!(
-        events.output.lock().unwrap().last().unwrap().data,
-        reset_snapshot[0].data,
-        "synthetic reset must fan out through session/output"
-    );
-    assert_eq!(
-        mgr.replay_watermark(&session_id),
-        pre_max_seq,
-        "watermark must equal the pre-resume max seq on the purge path too"
-    );
-
-    // Seq continuity across the purge: reset is `last + 1`, then the
-    // new PTY's first chunk follows it.
-    fake.push_output(1, b"fresh repaint");
-    let snapshot = wait_for_snapshot(&mgr, &session_id, 2);
-    assert_eq!(snapshot[0].seq, pre_max_seq + 1);
-    assert_eq!(snapshot[1].seq, pre_max_seq + 2);
-    assert_eq!(snapshot[1].data, BASE64.encode(b"fresh repaint"));
-
-    mgr.kill(&session_id).unwrap();
 }
 
 #[test]
@@ -3559,16 +3177,6 @@ fn resume_applies_a_size_pushed_mid_fork() {
     );
     *fake.spawn_hook.lock().unwrap() = None;
     mgr.kill(&session_id).unwrap();
-}
-
-#[test]
-fn resume_purges_scrollback_for_codex() {
-    assert_resume_purges_scrollback("codex");
-}
-
-#[test]
-fn resume_purges_scrollback_for_trae() {
-    assert_resume_purges_scrollback("trae");
 }
 
 #[test]
@@ -4375,262 +3983,6 @@ fn forwarder_status_emit_retries_brief_event_log_contention() {
 }
 
 #[test]
-fn scan_alt_screen_detects_modern_and_legacy_escapes() {
-    // No escape → no transition reported.
-    assert_eq!(scan_alt_screen_transition(b"hello world"), None);
-
-    // Modern combined pair (the one claude-code / codex emit).
-    assert_eq!(
-        scan_alt_screen_transition(b"prelude\x1b[?1049hbody"),
-        Some(true)
-    );
-    assert_eq!(
-        scan_alt_screen_transition(b"\x1b[?1049lcleanup"),
-        Some(false)
-    );
-
-    // Legacy 47h/l pair still covered (older TUIs).
-    assert_eq!(scan_alt_screen_transition(b"\x1b[?47h"), Some(true));
-    assert_eq!(scan_alt_screen_transition(b"\x1b[?47l"), Some(false));
-
-    // Latest match wins — enter followed by exit resolves to
-    // main-screen, not alt.
-    assert_eq!(
-        scan_alt_screen_transition(b"\x1b[?1049henter middle \x1b[?1049lexit"),
-        Some(false)
-    );
-    // …and exit followed by enter resolves to alt.
-    assert_eq!(
-        scan_alt_screen_transition(b"\x1b[?1049l\x1b[?1049h"),
-        Some(true)
-    );
-}
-
-#[test]
-fn scan_bracketed_paste_detects_enable_and_disable_escapes() {
-    assert_eq!(scan_bracketed_paste_transition(b"hello world"), None);
-    assert_eq!(
-        scan_bracketed_paste_transition(b"ready\x1b[?2004h"),
-        Some(true)
-    );
-    assert_eq!(
-        scan_bracketed_paste_transition(b"\x1b[?2004lprompt"),
-        Some(false)
-    );
-    assert_eq!(
-        scan_bracketed_paste_transition(b"\x1b[?2004hon\x1b[?2004loff"),
-        Some(false)
-    );
-    assert_eq!(
-        scan_bracketed_paste_transition(b"\x1b[?2004l\x1b[?2004h"),
-        Some(true)
-    );
-}
-
-#[test]
-fn scan_mouse_modes_detects_enable_disable_and_full_reset() {
-    for mode in [1000, 1002, 1003, 1006] {
-        let enable = format!("\x1b[?{mode}h");
-        let disable = format!("\x1b[?{mode}l");
-        assert_eq!(
-            scan_mouse_mode_transition(enable.as_bytes(), mode),
-            Some(true)
-        );
-        assert_eq!(
-            scan_mouse_mode_transition(disable.as_bytes(), mode),
-            Some(false)
-        );
-        assert_eq!(scan_mouse_mode_transition(b"\x1bc", mode), Some(false));
-    }
-}
-
-#[test]
-fn output_snapshot_prepends_alt_screen_enter_when_session_in_alt_screen() {
-    let pool = pool_with_schema();
-    let fake = fake_runtime();
-    let mgr = manager_with_runtime(
-        crate::shell_path::LoginShellEnv::default(),
-        Arc::clone(&fake) as Arc<dyn SessionRuntime>,
-    );
-    let runner = runner("/bin/sh", &["-c", "true"]);
-    {
-        let conn = pool.get().unwrap();
-        let now = Utc::now().to_rfc3339();
-        conn.execute(
-            "INSERT INTO runners
-                    (id, handle, display_name, runtime, command,
-                     args_json, working_dir, system_prompt, env_json,
-                     created_at, updated_at)
-                 VALUES (?1, 'r', 'r', 'shell', '/bin/sh',
-                         NULL, NULL, NULL, NULL, ?2, ?2)",
-            params![runner.id, now],
-        )
-        .unwrap();
-    }
-    let spawned = mgr
-        .spawn_direct(
-            &runner,
-            None,
-            None,
-            None,
-            None,
-            Some("/tmp"),
-            None,
-            None,
-            std::path::Path::new("/tmp"),
-            Arc::clone(&pool),
-            capture(),
-            None,
-        )
-        .unwrap();
-    // Drive a chunk that enters alt-screen + some content, then
-    // a chunk of pure content (no transition) so we exercise the
-    // "scan no-ops on chunks without escapes" branch too.
-    fake.push_output(0, b"\x1b[?1049hinitial banner");
-    fake.push_output(0, b"more painted content");
-    // Give the forwarder a beat to drain both chunks.
-    std::thread::sleep(Duration::from_millis(50));
-
-    let snapshot = mgr.output_snapshot(&spawned.id);
-    assert!(!snapshot.is_empty(), "snapshot should contain chunks");
-    // First event is the synthetic alt-screen enter, seq=0.
-    assert_eq!(snapshot[0].seq, 0);
-    assert_eq!(
-        BASE64.decode(&snapshot[0].data).unwrap(),
-        b"\x1b[?1049h",
-        "synthetic prepend must be a single bare enter-alt-screen escape"
-    );
-
-    // After an exit-alt-screen chunk, the synthetic prepend
-    // disappears and the snapshot starts at the first real event.
-    fake.push_output(0, b"\x1b[?1049lback to main");
-    std::thread::sleep(Duration::from_millis(50));
-    let snapshot2 = mgr.output_snapshot(&spawned.id);
-    assert_ne!(
-        snapshot2.first().map(|e| e.seq),
-        Some(0),
-        "main-screen sessions must not prepend the alt-screen enter"
-    );
-}
-
-#[test]
-fn output_snapshot_prepends_bracketed_paste_enable_when_session_has_it_enabled() {
-    let pool = pool_with_schema();
-    let fake = fake_runtime();
-    let mgr = manager_with_runtime(
-        crate::shell_path::LoginShellEnv::default(),
-        Arc::clone(&fake) as Arc<dyn SessionRuntime>,
-    );
-    let runner = runner("/bin/sh", &["-c", "true"]);
-    {
-        let conn = pool.get().unwrap();
-        let now = Utc::now().to_rfc3339();
-        conn.execute(
-            "INSERT INTO runners
-                    (id, handle, display_name, runtime, command,
-                     args_json, working_dir, system_prompt, env_json,
-                     created_at, updated_at)
-                 VALUES (?1, 'r', 'r', 'shell', '/bin/sh',
-                         NULL, NULL, NULL, NULL, ?2, ?2)",
-            params![runner.id, now],
-        )
-        .unwrap();
-    }
-    let spawned = mgr
-        .spawn_direct(
-            &runner,
-            None,
-            None,
-            None,
-            None,
-            Some("/tmp"),
-            None,
-            None,
-            std::path::Path::new("/tmp"),
-            Arc::clone(&pool),
-            capture(),
-            None,
-        )
-        .unwrap();
-
-    fake.push_output(0, b"\x1b[?2004hprompt ready");
-    std::thread::sleep(Duration::from_millis(50));
-
-    let snapshot = mgr.output_snapshot(&spawned.id);
-    assert!(!snapshot.is_empty(), "snapshot should contain chunks");
-    assert_eq!(snapshot[0].seq, 0);
-    assert_eq!(
-        BASE64.decode(&snapshot[0].data).unwrap(),
-        b"\x1b[?2004h",
-        "synthetic prepend must restore bracketed-paste mode"
-    );
-
-    fake.push_output(0, b"\x1b[?2004lplain prompt");
-    std::thread::sleep(Duration::from_millis(50));
-    let snapshot2 = mgr.output_snapshot(&spawned.id);
-    assert_ne!(
-        snapshot2.first().map(|e| e.seq),
-        Some(0),
-        "sessions with bracketed paste disabled must not prepend the enable escape"
-    );
-}
-
-#[test]
-fn output_snapshot_combines_alt_screen_and_bracketed_paste_prefixes() {
-    let pool = pool_with_schema();
-    let fake = fake_runtime();
-    let mgr = manager_with_runtime(
-        crate::shell_path::LoginShellEnv::default(),
-        Arc::clone(&fake) as Arc<dyn SessionRuntime>,
-    );
-    let runner = runner("/bin/sh", &["-c", "true"]);
-    {
-        let conn = pool.get().unwrap();
-        let now = Utc::now().to_rfc3339();
-        conn.execute(
-            "INSERT INTO runners
-                    (id, handle, display_name, runtime, command,
-                     args_json, working_dir, system_prompt, env_json,
-                     created_at, updated_at)
-                 VALUES (?1, 'r', 'r', 'shell', '/bin/sh',
-                         NULL, NULL, NULL, NULL, ?2, ?2)",
-            params![runner.id, now],
-        )
-        .unwrap();
-    }
-    let spawned = mgr
-        .spawn_direct(
-            &runner,
-            None,
-            None,
-            None,
-            None,
-            Some("/tmp"),
-            None,
-            None,
-            std::path::Path::new("/tmp"),
-            Arc::clone(&pool),
-            capture(),
-            None,
-        )
-        .unwrap();
-
-    fake.push_output(0, b"\x1b[?1049h\x1b[?2004hpainted prompt");
-    std::thread::sleep(Duration::from_millis(50));
-
-    let snapshot = mgr.output_snapshot(&spawned.id);
-    assert!(!snapshot.is_empty(), "snapshot should contain chunks");
-    assert_eq!(snapshot[0].seq, 0);
-    assert_eq!(
-        BASE64.decode(&snapshot[0].data).unwrap(),
-        b"\x1b[?1049h\x1b[?2004h",
-        "synthetic prepend must restore every tracked terminal mode"
-    );
-}
-
-// ---- claude-code launch gate (issue #171) -----------------------------
-
-#[test]
 fn compute_gate_wait_returns_zero_when_no_prior_spawn() {
     // First claude through the gate — `last` is None, so the
     // caller pays nothing. This is the property that makes
@@ -4726,80 +4078,6 @@ fn enter_claude_launch_gate_first_claude_does_not_sleep() {
     );
 }
 
-// Keep the resize and resume policies distinct: all four agent TUIs repaint
-// on SIGWINCH, while only Codex and TRAE purge before a process resume.
-#[test]
-fn runtime_resize_and_resume_policies_cover_supported_runtimes() {
-    let pool = db::open_in_memory().unwrap();
-    let now = chrono::Utc::now().to_rfc3339();
-    let conn = pool.get().unwrap();
-    for (runner_id, runtime) in [
-        ("r-codex", "codex"),
-        ("r-qoder", "qoder"),
-        ("r-trae", "trae"),
-        ("r-shell", "shell"),
-    ] {
-        conn.execute(
-            "INSERT INTO runners
-                    (id, handle, display_name, runtime, command,
-                     args_json, working_dir, system_prompt, env_json,
-                     created_at, updated_at)
-                 VALUES (?1, ?1, ?1, ?2, '/bin/cat',
-                         NULL, NULL, NULL, NULL, ?3, ?3)",
-            params![runner_id, runtime, now],
-        )
-        .unwrap();
-    }
-    // Runner-backed rows: agent_runtime stays NULL.
-    conn.execute(
-        "INSERT INTO sessions (id, mission_id, runner_id, cwd, status, started_at)
-             VALUES ('s-codex-runner', NULL, 'r-codex', '/tmp', 'running', ?1)",
-        params![now],
-    )
-    .unwrap();
-    conn.execute(
-        "INSERT INTO sessions (id, mission_id, runner_id, cwd, status, started_at)
-             VALUES ('s-qoder-runner', NULL, 'r-qoder', '/tmp', 'running', ?1)",
-        params![now],
-    )
-    .unwrap();
-    conn.execute(
-        "INSERT INTO sessions (id, mission_id, runner_id, cwd, status, started_at)
-             VALUES ('s-trae-runner', NULL, 'r-trae', '/tmp', 'running', ?1)",
-        params![now],
-    )
-    .unwrap();
-    conn.execute(
-        "INSERT INTO sessions (id, mission_id, runner_id, cwd, status, started_at)
-             VALUES ('s-shell-runner', NULL, 'r-shell', '/tmp', 'running', ?1)",
-        params![now],
-    )
-    .unwrap();
-    // Runtime-only chat: no runner row, agent_runtime column set.
-    conn.execute(
-        "INSERT INTO sessions
-                (id, mission_id, runner_id, cwd, status, started_at, agent_runtime)
-             VALUES ('s-claude-runtime', NULL, NULL, '/tmp', 'running', ?1, 'claude-code')",
-        params![now],
-    )
-    .unwrap();
-    drop(conn);
-
-    for runtime in ["claude-code", "codex", "qoder", "trae"] {
-        assert!(super::output::runtime_clears_on_resize(runtime));
-    }
-    assert!(super::output::runtime_purges_on_resume(
-        "s-trae-runner",
-        &pool
-    ));
-    assert!(!super::output::runtime_purges_on_resume(
-        "s-qoder-runner",
-        &pool
-    ));
-    assert!(!super::output::runtime_clears_on_resize("shell"));
-    assert!(!super::output::runtime_clears_on_resize("future-runtime"));
-}
-
 #[test]
 fn spawn_argv_injects_claude_fullscreen_for_fresh_and_resume_only() {
     let compose = |runtime: &str, plan: router::runtime::ResumePlan| {
@@ -4841,142 +4119,6 @@ fn spawn_argv_injects_claude_fullscreen_for_fresh_and_resume_only() {
     assert!(!codex.iter().any(|arg| arg == "--settings"));
 }
 
-#[test]
-fn resize_purges_ring_only_on_cols_change() {
-    let pool = pool_with_schema();
-    let now = Utc::now().to_rfc3339();
-    let runner_id = ulid::Ulid::new().to_string();
-    {
-        let conn = pool.get().unwrap();
-        conn.execute(
-            "INSERT INTO runners
-                    (id, handle, display_name, runtime, command,
-                     args_json, working_dir, system_prompt, env_json,
-                     created_at, updated_at)
-                 VALUES (?1, 'colsgate', 'ColsGate', 'claude-code', '/bin/cat',
-                         NULL, NULL, NULL, NULL, ?2, ?2)",
-            params![runner_id, now],
-        )
-        .unwrap();
-    }
-
-    let mut runner = runner("/bin/cat", &[]);
-    runner.id = runner_id;
-    runner.handle = "colsgate".into();
-    runner.runtime = "claude-code".into();
-
-    let fake = fake_runtime();
-    let mgr = mgr_with_fake(None, Arc::clone(&fake));
-    mgr.set_resize_settle_ms(3_600_000);
-    let spawned = mgr
-        .spawn_direct(
-            &runner,
-            None,
-            None,
-            None,
-            None,
-            Some("/tmp"),
-            Some(120),
-            Some(30),
-            std::path::Path::new("/tmp"),
-            Arc::clone(&pool),
-            capture(),
-            None,
-        )
-        .unwrap();
-
-    fake.push_output(0, b"history to keep");
-    let deadline = Instant::now() + Duration::from_secs(2);
-    while mgr.output_snapshot(&spawned.id).is_empty() {
-        if Instant::now() > deadline {
-            panic!("output never reached the ring");
-        }
-        std::thread::sleep(Duration::from_millis(20));
-    }
-
-    {
-        let conn = pool.get().unwrap();
-        conn.execute(
-            "UPDATE runners SET runtime = 'shell' WHERE id = ?1",
-            params![runner.id],
-        )
-        .unwrap();
-        conn.execute_batch(
-            "CREATE TABLE resize_writes (count INTEGER NOT NULL);\n\
-             INSERT INTO resize_writes VALUES (0);\n\
-             CREATE TRIGGER count_resize_writes\n\
-             AFTER UPDATE OF last_cols, last_rows ON sessions\n\
-             BEGIN UPDATE resize_writes SET count = count + 1; END;",
-        )
-        .unwrap();
-    }
-
-    mgr.resize(&spawned.id, 120, 29, &pool).unwrap();
-    mgr.resize(&spawned.id, 120, 30, &pool).unwrap();
-    assert_eq!(fake.resizes.lock().unwrap().len(), 2);
-    assert!(
-        !mgr.output_snapshot(&spawned.id).is_empty(),
-        "rows-only resize must keep the replay ring"
-    );
-
-    mgr.resize(&spawned.id, 100, 30, &pool).unwrap();
-    assert_eq!(fake.resizes.lock().unwrap().len(), 3);
-    assert!(
-        !mgr.output_snapshot(&spawned.id).is_empty(),
-        "the ring must survive until the storm settles"
-    );
-    let persisted: (u16, u16) = pool
-        .get()
-        .unwrap()
-        .query_row(
-            "SELECT last_cols, last_rows FROM sessions WHERE id = ?1",
-            params![spawned.id],
-            |row| Ok((row.get(0)?, row.get(1)?)),
-        )
-        .unwrap();
-    assert_eq!(
-        persisted,
-        (120, 30),
-        "the render-thread path must not persist before the settle"
-    );
-    let writes_before: i64 = pool
-        .get()
-        .unwrap()
-        .query_row("SELECT count FROM resize_writes", [], |row| row.get(0))
-        .unwrap();
-    assert_eq!(writes_before, 0);
-
-    mgr.settle_pending_resize_now(&spawned.id);
-    assert_eq!(
-        fake.resizes.lock().unwrap().clone(),
-        vec![
-            (spawned.id.clone(), 120, 29),
-            (spawned.id.clone(), 120, 30),
-            (spawned.id.clone(), 100, 30),
-            (spawned.id.clone(), 100, 29),
-            (spawned.id.clone(), 100, 30),
-        ]
-    );
-    assert!(
-        mgr.output_snapshot(&spawned.id).is_empty(),
-        "the settled width change purges without inserting a clear event"
-    );
-    let conn = pool.get().unwrap();
-    let settled: (u16, u16, i64) = conn
-        .query_row(
-            "SELECT s.last_cols, s.last_rows, w.count\n\
-               FROM sessions s CROSS JOIN resize_writes w\n\
-              WHERE s.id = ?1",
-            params![spawned.id],
-            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-        )
-        .unwrap();
-    assert_eq!(settled, (100, 30, 1), "one persistence write per storm");
-    drop(conn);
-
-    mgr.kill(&spawned.id).unwrap();
-}
-
 fn spawn_claude_for_resize(
     handle: &str,
 ) -> (
@@ -4984,7 +4126,6 @@ fn spawn_claude_for_resize(
     Arc<FakeRuntime>,
     Arc<SessionManager>,
     String,
-    Arc<Capture>,
 ) {
     let pool = pool_with_schema();
     let now = Utc::now().to_rfc3339();
@@ -5009,7 +4150,6 @@ fn spawn_claude_for_resize(
 
     let fake = fake_runtime();
     let mgr = mgr_with_fake(None, Arc::clone(&fake));
-    let events = capture();
     let spawned = mgr
         .spawn_direct(
             &runner,
@@ -5022,91 +4162,168 @@ fn spawn_claude_for_resize(
             Some(30),
             std::path::Path::new("/tmp"),
             Arc::clone(&pool),
-            events.clone(),
+            capture(),
             None,
         )
         .unwrap();
-
-    fake.push_output(0, b"history to keep");
-    let deadline = Instant::now() + Duration::from_secs(2);
-    while mgr.output_snapshot(&spawned.id).is_empty() {
-        if Instant::now() > deadline {
-            panic!("output never reached the ring");
-        }
-        std::thread::sleep(Duration::from_millis(20));
-    }
-    (pool, fake, mgr, spawned.id, events)
+    (pool, fake, mgr, spawned.id)
 }
 
 #[test]
-fn resize_storm_ioctls_every_push_then_nudges_once_after_purge() {
-    let (pool, fake, mgr, id, _events) = spawn_claude_for_resize("storm");
+fn resize_storm_ioctls_every_push_and_persists_once() {
+    let (pool, fake, mgr, id) = spawn_claude_for_resize("storm");
     mgr.set_resize_settle_ms(3_600_000);
+    {
+        let conn = pool.get().unwrap();
+        conn.execute_batch(
+            "CREATE TABLE resize_writes (count INTEGER NOT NULL);
+             INSERT INTO resize_writes VALUES (0);
+             CREATE TRIGGER count_resize_writes
+             AFTER UPDATE OF last_cols, last_rows ON sessions
+             BEGIN UPDATE resize_writes SET count = count + 1; END;",
+        )
+        .unwrap();
+    }
 
     for cols in [78u16, 76, 209, 76, 210] {
         mgr.resize(&id, cols, 30, &pool).unwrap();
     }
-    assert_eq!(
-        fake.resizes.lock().unwrap().clone(),
-        vec![
-            (id.clone(), 78, 30),
-            (id.clone(), 76, 30),
-            (id.clone(), 209, 30),
-            (id.clone(), 76, 30),
-            (id.clone(), 210, 30),
-        ]
-    );
-    assert!(!mgr.output_snapshot(&id).is_empty());
+    let expected = vec![
+        (id.clone(), 78, 30),
+        (id.clone(), 76, 30),
+        (id.clone(), 209, 30),
+        (id.clone(), 76, 30),
+        (id.clone(), 210, 30),
+    ];
+    assert_eq!(fake.resizes.lock().unwrap().clone(), expected);
+    let before: (u16, u16, i64) = pool
+        .get()
+        .unwrap()
+        .query_row(
+            "SELECT s.last_cols, s.last_rows, w.count
+               FROM sessions s CROSS JOIN resize_writes w
+              WHERE s.id = ?1",
+            params![id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(before, (120, 30, 0));
 
     mgr.settle_pending_resize_now(&id);
-    assert_eq!(
-        fake.resizes.lock().unwrap().clone(),
-        vec![
-            (id.clone(), 78, 30),
-            (id.clone(), 76, 30),
-            (id.clone(), 209, 30),
-            (id.clone(), 76, 30),
-            (id.clone(), 210, 30),
-            (id.clone(), 210, 29),
-            (id.clone(), 210, 30),
-        ]
-    );
-    assert!(mgr.output_snapshot(&id).is_empty());
+    assert_eq!(fake.resizes.lock().unwrap().clone(), expected);
+    let settled: (u16, u16, i64) = pool
+        .get()
+        .unwrap()
+        .query_row(
+            "SELECT s.last_cols, s.last_rows, w.count
+               FROM sessions s CROSS JOIN resize_writes w
+              WHERE s.id = ?1",
+            params![id],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(settled, (210, 30, 1));
 
     mgr.kill(&id).unwrap();
 }
 
 #[test]
-fn round_trip_resize_storm_purges_intermediate_repaints() {
-    let (pool, fake, mgr, id, _events) = spawn_claude_for_resize("roundtrip");
+fn round_trip_resize_storm_preserves_the_immediate_width_chain() {
+    let (pool, fake, mgr, id) = spawn_claude_for_resize("roundtrip");
     mgr.set_resize_settle_ms(3_600_000);
 
     for cols in [150u16, 209, 150, 120] {
         mgr.resize(&id, cols, 30, &pool).unwrap();
     }
+    let expected = vec![
+        (id.clone(), 150, 30),
+        (id.clone(), 209, 30),
+        (id.clone(), 150, 30),
+        (id.clone(), 120, 30),
+    ];
+    assert_eq!(fake.resizes.lock().unwrap().clone(), expected);
     mgr.settle_pending_resize_now(&id);
-    assert_eq!(
-        fake.resizes.lock().unwrap().clone(),
-        vec![
-            (id.clone(), 150, 30),
-            (id.clone(), 209, 30),
-            (id.clone(), 150, 30),
-            (id.clone(), 120, 30),
-            (id.clone(), 120, 29),
-            (id.clone(), 120, 30),
-        ]
-    );
-    assert!(
-        mgr.output_snapshot(&id).is_empty(),
-        "a round trip still emits intermediate full-frame repaints that must be purged"
-    );
+    assert_eq!(fake.resizes.lock().unwrap().clone(), expected);
 
     mgr.kill(&id).unwrap();
 }
 
 #[test]
-fn settle_during_inflight_kill_aborts_untouched() {
-    let (pool, fake, mgr, id, _events) = spawn_claude_for_resize("killwindow");
+fn stale_resize_settle_does_not_persist_after_respawn() {
+    let (pool, _fake, mgr, id) = spawn_claude_for_resize("stalegeneration");
+    mgr.set_resize_settle_ms(3_600_000);
+
+    mgr.resize(&id, 100, 30, &pool).unwrap();
+    let stale_generation = mgr
+        .session_state(&id)
+        .unwrap()
+        .lock()
+        .unwrap()
+        .pending_resize
+        .as_ref()
+        .unwrap()
+        .generation;
+    mgr.kill(&id).unwrap();
+    mgr.resume(
+        &id,
+        None,
+        None,
+        std::path::Path::new("/tmp"),
+        Arc::clone(&pool),
+        capture(),
+    )
+    .unwrap();
+
+    mgr.resize(&id, 110, 30, &pool).unwrap();
+    let state = mgr.session_state(&id).unwrap();
+    let current_generation = state
+        .lock()
+        .unwrap()
+        .pending_resize
+        .as_ref()
+        .unwrap()
+        .generation;
+    assert_ne!(stale_generation, current_generation);
+
+    mgr.settle_pending_resize_generation_now(&id, stale_generation);
+    assert_eq!(
+        state
+            .lock()
+            .unwrap()
+            .pending_resize
+            .as_ref()
+            .map(|pending| pending.generation),
+        Some(current_generation)
+    );
+    let before: (u16, u16) = pool
+        .get()
+        .unwrap()
+        .query_row(
+            "SELECT last_cols, last_rows FROM sessions WHERE id = ?1",
+            params![id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(before, (120, 30));
+
+    mgr.settle_pending_resize_generation_now(&id, current_generation);
+    let settled: (u16, u16) = pool
+        .get()
+        .unwrap()
+        .query_row(
+            "SELECT last_cols, last_rows FROM sessions WHERE id = ?1",
+            params![id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(settled, (110, 30));
+
+    mgr.kill(&id).unwrap();
+}
+
+#[test]
+fn settle_during_inflight_kill_abandons_persistence() {
+    let (pool, fake, mgr, id) = spawn_claude_for_resize("killwindow");
     mgr.set_resize_settle_ms(3_600_000);
 
     mgr.resize(&id, 100, 30, &pool).unwrap();
@@ -5120,119 +4337,28 @@ fn settle_during_inflight_kill_aborts_untouched() {
         .recv_timeout(Duration::from_secs(2))
         .expect("kill never reached runtime.stop");
     mgr.settle_pending_resize_now(&id);
+    let persisted: (u16, u16) = pool
+        .get()
+        .unwrap()
+        .query_row(
+            "SELECT last_cols, last_rows FROM sessions WHERE id = ?1",
+            params![id],
+            |row| Ok((row.get(0)?, row.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(persisted, (120, 30));
     assert_eq!(
         fake.resizes.lock().unwrap().clone(),
         vec![(id.clone(), 100, 30)]
     );
-    assert!(!mgr.output_snapshot(&id).is_empty());
 
     stop_release.send(()).unwrap();
     kill.join().unwrap().unwrap();
-    assert!(!mgr.output_snapshot(&id).is_empty());
 }
 
 #[test]
-fn stale_settle_after_kill_and_respawn_touches_nothing() {
-    let (pool, fake, mgr, id, _events) = spawn_claude_for_resize("respawn");
-    mgr.set_resize_settle_ms(3_600_000);
-
-    mgr.resize(&id, 100, 30, &pool).unwrap();
-    mgr.kill(&id).unwrap();
-    mgr.install_handle(
-        &id,
-        SessionHandle {
-            id: id.clone(),
-            mission_id: None,
-            runner_id: None,
-            runtime_session: RuntimeSession {
-                runtime: "fake".into(),
-                session_id: id.clone(),
-            },
-            codex_capture: None,
-            forwarder: None,
-            stop: Arc::new(AtomicBool::new(false)),
-        },
-        None,
-        Some((199, 59)),
-        "claude-code",
-        &pool,
-    );
-    mgr.append_synthetic_output(&id, None, b"fresh resume repaint", capture().as_ref());
-
-    mgr.settle_pending_resize_now(&id);
-    assert_eq!(
-        fake.resizes.lock().unwrap().clone(),
-        vec![(id.clone(), 100, 30)]
-    );
-    assert_eq!(
-        mgr.session_state(&id)
-            .unwrap()
-            .lock()
-            .unwrap()
-            .last_pty_cols,
-        Some(199),
-        "handle install must preserve the caller-supplied resume width"
-    );
-    assert!(!mgr.output_snapshot(&id).is_empty());
-
-    mgr.resize(&id, 199, 58, &pool).unwrap();
-    assert_eq!(
-        fake.resizes.lock().unwrap().clone(),
-        vec![(id.clone(), 100, 30), (id.clone(), 199, 58)]
-    );
-    assert!(!mgr.output_snapshot(&id).is_empty());
-
-    mgr.kill(&id).unwrap();
-}
-
-#[test]
-fn failed_immediate_resize_cannot_purge() {
-    let (pool, fake, mgr, id, _events) = spawn_claude_for_resize("failioctl");
-    mgr.set_resize_settle_ms(3_600_000);
-
-    fake.fail_resize_for(&id);
-    mgr.resize(&id, 100, 30, &pool).unwrap_err();
-    mgr.settle_pending_resize_now(&id);
-    assert_eq!(
-        fake.resizes.lock().unwrap().clone(),
-        vec![(id.clone(), 100, 30)]
-    );
-    assert!(!mgr.output_snapshot(&id).is_empty());
-
-    fake.allow_resize_for(&id);
-    mgr.resize(&id, 100, 30, &pool).unwrap();
-    mgr.settle_pending_resize_now(&id);
-    assert!(mgr.output_snapshot(&id).is_empty());
-
-    mgr.kill(&id).unwrap();
-}
-
-#[test]
-fn purge_precedes_nudged_repaint_and_emits_no_clear() {
-    let (pool, fake, mgr, id, events) = spawn_claude_for_resize("stormemit");
-    mgr.set_resize_settle_ms(3_600_000);
-
-    mgr.resize(&id, 100, 30, &pool).unwrap();
-    fake.emit_output_on_resize(b"fresh repaint");
-    mgr.settle_pending_resize_now(&id);
-    let snapshot = wait_for_snapshot(&mgr, &id, 2);
-    assert_eq!(snapshot.len(), 2);
-    assert!(snapshot
-        .iter()
-        .all(|event| { BASE64.decode(&event.data).unwrap() == b"fresh repaint" }));
-    assert!(events
-        .output
-        .lock()
-        .unwrap()
-        .iter()
-        .all(|event| { BASE64.decode(&event.data).unwrap() != b"\x1b[2J\x1b[H" }));
-
-    mgr.kill(&id).unwrap();
-}
-
-#[test]
-fn resize_settle_thread_applies_without_manual_nudge() {
-    let (pool, fake, mgr, id, _events) = spawn_claude_for_resize("stormthread");
+fn resize_settle_thread_persists_without_extra_ioctls() {
+    let (pool, fake, mgr, id) = spawn_claude_for_resize("stormthread");
     mgr.set_resize_settle_ms(25);
 
     for cols in [78u16, 209, 210] {
@@ -5240,25 +4366,34 @@ fn resize_settle_thread_applies_without_manual_nudge() {
     }
     let deadline = Instant::now() + Duration::from_secs(2);
     loop {
-        if mgr.output_snapshot(&id).is_empty() && fake.resizes.lock().unwrap().len() == 5 {
+        let persisted: (u16, u16) = pool
+            .get()
+            .unwrap()
+            .query_row(
+                "SELECT last_cols, last_rows FROM sessions WHERE id = ?1",
+                params![id],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .unwrap();
+        if persisted == (210, 30) {
             break;
         }
         if Instant::now() > deadline {
-            panic!("settle thread never applied the storm");
+            panic!("settle thread never persisted the storm");
         }
         std::thread::sleep(Duration::from_millis(20));
     }
     assert_eq!(
-        fake.resizes.lock().unwrap().last().cloned(),
-        Some((id.clone(), 210, 30))
+        fake.resizes.lock().unwrap().clone(),
+        vec![
+            (id.clone(), 78, 30),
+            (id.clone(), 209, 30),
+            (id.clone(), 210, 30),
+        ]
     );
 
     mgr.kill(&id).unwrap();
 }
-
-// ---------------------------------------------------------------------
-// Feature 41 — runtime override (per slot / per direct chat)
-// ---------------------------------------------------------------------
 
 #[test]
 fn runtime_direct_runner_applies_model_and_effort() {

--- a/crates/runner-backend/src/session/mod.rs
+++ b/crates/runner-backend/src/session/mod.rs
@@ -2,7 +2,7 @@
 // via the `SessionRuntime` trait. v1 implementation:
 //   * `pty_runtime::PtyRuntime` (in-process, docs/impls/archive/0011)
 //
-// The `manager` submodule owns DB persistence, output buffering, and the
+// The `manager` submodule owns DB persistence, output delivery, and the
 // kill / resume state machine; it delegates every PTY-side operation to
 // the runtime. The tmux-backed runtime that powered earlier versions
 // has been retired — see docs/impls/archive/0011-pty-host-terminal-runtime.md

--- a/crates/runner-terminal/Cargo.toml
+++ b/crates/runner-terminal/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 alacritty_terminal = "0.26"
 anyhow = "1"
 base64 = "0.22"
+log = "0.4"
 regex = "1"
 runner-backend = { path = "../runner-backend" }
 serde.workspace = true
 serde_json.workspace = true
-tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/runner-terminal/src/terminal.rs
+++ b/crates/runner-terminal/src/terminal.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::mpsc::{self, Sender};
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Instant;
 
@@ -15,13 +15,11 @@ use alacritty_terminal::term::test::TermSize;
 use alacritty_terminal::term::{Config, Term, TermMode};
 use alacritty_terminal::vte::ansi::{CursorShape, CursorStyle, Processor};
 use anyhow::{Context as _, Result};
-use base64::engine::general_purpose::STANDARD as B64;
-use base64::Engine as _;
 use regex::Regex;
-use runner_backend::events::AppEvent;
-use runner_backend::session::manager::OutputEvent;
+use runner_backend::session::manager::{
+    ExitEvent, OutputEvent, SessionEvents, SessionSpawnedEvent, SessionUpdatedEvent,
+};
 use runner_backend::AppCore;
-use tokio::sync::broadcast::error::RecvError;
 
 use crate::palette;
 
@@ -84,7 +82,6 @@ pub fn query_color_for<T>(
 #[derive(Default)]
 struct SequenceState {
     last: u64,
-    synthetic_prefix_seen: bool,
     tui_ready_seq: u64,
     last_output_at: Option<Instant>,
 }
@@ -108,14 +105,24 @@ pub struct TerminalSession {
     pub term: Arc<FairMutex<Term<EventProxy>>>,
     core: AppCore,
     session_id: String,
-    feed_gate: Mutex<()>,
     parser: Mutex<Processor>,
     sequence: Mutex<SequenceState>,
     size: Arc<Mutex<(u16, u16)>>,
     title: Arc<Mutex<String>>,
     palette: Arc<Mutex<PaletteState>>,
     waker: Arc<dyn Fn() + Send + Sync>,
+    viewers: Arc<AtomicUsize>,
     user_input: UserInput,
+}
+
+pub struct TerminalView {
+    viewers: Arc<AtomicUsize>,
+}
+
+impl Drop for TerminalView {
+    fn drop(&mut self) {
+        self.viewers.fetch_sub(1, Ordering::Release);
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -205,17 +212,18 @@ impl TerminalSession {
         let size = Arc::new(Mutex::new((cols, rows)));
         let title = Arc::new(Mutex::new(String::new()));
         let terminal_palette = Arc::new(Mutex::new(PaletteState::new(palette::RUNNER)));
+        let viewers = Arc::new(AtomicUsize::new(0));
         let session = Arc::new(Self {
             term: Arc::clone(&term),
             core: core.clone(),
             session_id: session_id.clone(),
-            feed_gate: Mutex::new(()),
             parser: Mutex::new(Processor::new()),
             sequence: Mutex::new(SequenceState::default()),
             size: Arc::clone(&size),
             title: Arc::clone(&title),
             palette: Arc::clone(&terminal_palette),
             waker,
+            viewers,
             user_input,
         });
 
@@ -279,6 +287,13 @@ impl TerminalSession {
         &self.session_id
     }
 
+    pub fn view(&self) -> TerminalView {
+        self.viewers.fetch_add(1, Ordering::AcqRel);
+        TerminalView {
+            viewers: Arc::clone(&self.viewers),
+        }
+    }
+
     pub fn title(&self) -> String {
         self.title.lock().unwrap().clone()
     }
@@ -319,55 +334,20 @@ impl TerminalSession {
     }
 
     pub fn feed_output(&self, event: &OutputEvent) -> Result<()> {
-        self.feed_encoded(event.seq, &event.data)
-    }
-
-    pub fn feed_snapshot(&self, events: &[OutputEvent]) -> Result<()> {
-        let _feed = self.feed_gate.lock().unwrap();
-        self.feed_snapshot_locked(events)
-    }
-
-    #[cfg(test)]
-    fn feed_snapshot_with_hook(&self, events: &[OutputEvent], hook: impl FnOnce()) -> Result<()> {
-        let _feed = self.feed_gate.lock().unwrap();
-        hook();
-        self.feed_snapshot_locked(events)
-    }
-
-    fn feed_snapshot_locked(&self, events: &[OutputEvent]) -> Result<()> {
-        for event in events {
-            self.feed_encoded_locked(event.seq, &event.data)?;
-        }
-        Ok(())
-    }
-
-    fn feed_encoded(&self, seq: u64, data: &str) -> Result<()> {
-        let _feed = self.feed_gate.lock().unwrap();
-        self.feed_encoded_locked(seq, data)
-    }
-
-    fn feed_encoded_locked(&self, seq: u64, data: &str) -> Result<()> {
-        let bytes = B64.decode(data).context("decode session output")?;
+        let bytes = &event.bytes;
         let mut sequence = self.sequence.lock().unwrap();
-        if seq == 0 {
-            if sequence.synthetic_prefix_seen {
-                return Ok(());
-            }
-            sequence.synthetic_prefix_seen = true;
-        } else {
-            if seq <= sequence.last {
-                return Ok(());
-            }
-            sequence.last = seq;
+        if event.seq <= sequence.last {
+            return Ok(());
         }
+        sequence.last = event.seq;
         sequence.last_output_at = Some(Instant::now());
-        if chunk_indicates_tui_ready(&bytes) {
-            sequence.tui_ready_seq = sequence.tui_ready_seq.max(seq);
+        if chunk_indicates_tui_ready(bytes) {
+            sequence.tui_ready_seq = sequence.tui_ready_seq.max(event.seq);
         }
         let mut parser = self.parser.lock().unwrap();
         let mut term = self.term.lock();
         let previous_mode = *term.mode();
-        parser.advance(&mut *term, &bytes);
+        parser.advance(&mut *term, bytes);
         let mode = *term.mode();
         if !previous_mode.intersects(TermMode::MOUSE_MODE) && mode.intersects(TermMode::MOUSE_MODE)
         {
@@ -376,7 +356,9 @@ impl TerminalSession {
         drop(term);
         drop(parser);
         drop(sequence);
-        (self.waker)();
+        if self.viewers.load(Ordering::Acquire) > 0 {
+            (self.waker)();
+        }
         Ok(())
     }
 
@@ -711,113 +693,125 @@ fn chunk_indicates_tui_ready(bytes: &[u8]) -> bool {
 
 pub struct TerminalBridge {
     core: AppCore,
-    attached: Mutex<HashMap<String, Weak<TerminalSession>>>,
-    refresh_sessions: AtomicBool,
+    sessions: Mutex<HashMap<String, Arc<TerminalSession>>>,
     waker: Arc<dyn Fn() + Send + Sync>,
 }
 
 impl TerminalBridge {
     pub fn new(core: AppCore, waker: Arc<dyn Fn() + Send + Sync>) -> Result<Arc<Self>> {
-        let mut receiver = core.events.subscribe();
         let bridge = Arc::new(Self {
             core,
-            attached: Mutex::new(HashMap::new()),
-            refresh_sessions: AtomicBool::new(false),
+            sessions: Mutex::new(HashMap::new()),
             waker,
         });
-        let weak: Weak<Self> = Arc::downgrade(&bridge);
-        thread::Builder::new()
-            .name("native-app-events".into())
-            .spawn(move || loop {
-                match receiver.blocking_recv() {
-                    Ok(event) => {
-                        let Some(bridge) = weak.upgrade() else {
-                            break;
-                        };
-                        bridge.handle_event(event);
-                    }
-                    Err(RecvError::Lagged(_)) => {
-                        let Some(bridge) = weak.upgrade() else {
-                            break;
-                        };
-                        bridge.resync_attached();
-                        bridge.refresh_sessions.store(true, Ordering::Release);
-                        (bridge.waker)();
-                    }
-                    Err(RecvError::Closed) => break,
-                }
-            })
-            .context("spawn app event thread")?;
+        let observer: Arc<dyn SessionEvents> = bridge.clone();
+        bridge
+            .core
+            .session_event_observer
+            .install(Arc::downgrade(&observer));
         Ok(bridge)
     }
 
-    pub fn attach(&self, session: Arc<TerminalSession>) -> Result<()> {
-        let session_id = session.session_id().to_owned();
-        let _feed = session.feed_gate.lock().unwrap();
-        self.attached
+    pub fn session(&self, session_id: &str) -> Option<Arc<TerminalSession>> {
+        self.sessions.lock().unwrap().get(session_id).cloned()
+    }
+
+    pub fn live_session_count(&self) -> usize {
+        self.sessions.lock().unwrap().len()
+    }
+
+    fn new_session(
+        &self,
+        session_id: &str,
+        mission_id: Option<&str>,
+        cols: u16,
+        rows: u16,
+    ) -> Result<Arc<TerminalSession>> {
+        TerminalSession::attach_with_input_mode(
+            self.core.clone(),
+            session_id.to_owned(),
+            cols,
+            rows,
+            Arc::clone(&self.waker),
+            if mission_id.is_some() {
+                UserInputMode::Queued
+            } else {
+                UserInputMode::Inline
+            },
+        )
+    }
+
+    fn replace_session(&self, event: &SessionSpawnedEvent) -> Result<()> {
+        let session = self.new_session(
+            &event.session_id,
+            event.mission_id.as_deref(),
+            event.cols,
+            event.rows,
+        )?;
+        self.sessions
             .lock()
             .unwrap()
-            .insert(session_id.clone(), Arc::downgrade(&session));
-        let snapshot =
-            runner_backend::ops::session::session_output_snapshot(&self.core, &session_id)
-                .context("load terminal output snapshot")?;
-        session.feed_snapshot_locked(&snapshot)?;
+            .insert(event.session_id.clone(), session);
         Ok(())
     }
 
-    pub fn take_session_refresh(&self) -> bool {
-        self.refresh_sessions.swap(false, Ordering::AcqRel)
+    fn remove_session(&self, session_id: &str) {
+        self.sessions.lock().unwrap().remove(session_id);
+        (self.waker)();
     }
+}
 
-    fn handle_event(&self, event: AppEvent) {
-        match event.name {
-            "session/output" => {
-                let Some(session_id) = event.payload.get("session_id").and_then(|v| v.as_str())
-                else {
-                    return;
-                };
-                let Some(seq) = event.payload.get("seq").and_then(|v| v.as_u64()) else {
-                    return;
-                };
-                let Some(data) = event.payload.get("data").and_then(|v| v.as_str()) else {
-                    return;
-                };
-                let session = self
-                    .attached
-                    .lock()
-                    .unwrap()
-                    .get(session_id)
-                    .and_then(Weak::upgrade);
-                if let Some(session) = session {
-                    let _ = session.feed_encoded(seq, data);
+impl SessionEvents for TerminalBridge {
+    fn output(&self, event: &OutputEvent) {
+        let session = self.session(&event.session_id).or_else(|| {
+            let (cols, rows) =
+                runner_backend::ops::session::session_last_size(&self.core, &event.session_id)
+                    .ok()
+                    .flatten()
+                    .unwrap_or((80, 24));
+            match self.new_session(&event.session_id, event.mission_id.as_deref(), cols, rows) {
+                Ok(session) => {
+                    self.sessions
+                        .lock()
+                        .unwrap()
+                        .insert(event.session_id.clone(), Arc::clone(&session));
+                    Some(session)
+                }
+                Err(error) => {
+                    log::error!(
+                        "create terminal for session {} output failed: {error}",
+                        event.session_id
+                    );
+                    None
                 }
             }
-            "session/exit" | "session/updated" | "session/archived" => {
-                self.refresh_sessions.store(true, Ordering::Release);
-                (self.waker)();
+        });
+        if let Some(session) = session {
+            if let Err(error) = session.feed_output(event) {
+                log::error!(
+                    "feed terminal for session {} failed: {error}",
+                    event.session_id
+                );
             }
-            _ => {}
         }
     }
 
-    fn resync_attached(&self) {
-        let sessions = {
-            let mut attached = self.attached.lock().unwrap();
-            attached.retain(|_, session| session.strong_count() > 0);
-            attached
-                .values()
-                .filter_map(Weak::upgrade)
-                .collect::<Vec<_>>()
-        };
-        for session in sessions {
-            let _feed = session.feed_gate.lock().unwrap();
-            if let Ok(snapshot) = runner_backend::ops::session::session_output_snapshot(
-                &self.core,
-                session.session_id(),
-            ) {
-                let _ = session.feed_snapshot_locked(&snapshot);
-            }
+    fn spawned(&self, event: &SessionSpawnedEvent) {
+        if let Err(error) = self.replace_session(event) {
+            log::error!(
+                "replace terminal for spawned session {} failed: {error}",
+                event.session_id
+            );
         }
+        (self.waker)();
+    }
+
+    fn exit(&self, event: &ExitEvent) {
+        self.remove_session(&event.session_id);
+    }
+
+    fn archived(&self, event: &SessionUpdatedEvent) {
+        self.remove_session(&event.session_id);
     }
 }
 
@@ -827,18 +821,15 @@ mod tests {
     use alacritty_terminal::index::{Column, Line, Point, Side};
     use alacritty_terminal::selection::SelectionType;
     use alacritty_terminal::term::cell::Flags;
-    use alacritty_terminal::term::TermMode;
     use alacritty_terminal::vte::ansi::CursorShape;
-    use std::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::{Arc, Barrier};
-    use std::thread;
-    use std::time::Duration;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
 
-    use base64::engine::general_purpose::STANDARD as B64;
-    use base64::Engine as _;
-    use runner_backend::session::manager::OutputEvent;
+    use runner_backend::session::manager::{
+        ExitEvent, OutputEvent, SessionEvents, SessionSpawnedEvent, SessionUpdatedEvent,
+    };
 
-    use super::{TerminalSession, UserInputMode};
+    use super::{TerminalBridge, TerminalSession, UserInputMode};
     use crate::replay::visible_lines;
     use runner_backend::AppCore;
 
@@ -875,6 +866,7 @@ mod tests {
             mcp: Arc::new(runner_backend::mcp::McpHandle::new()),
             windows,
             events: runner_backend::events::EventChannel::new(),
+            session_event_observer: Default::default(),
             app_version: "0.0.0-test".into(),
         }
     }
@@ -884,7 +876,7 @@ mod tests {
             session_id: "replay-race".into(),
             mission_id: None,
             seq,
-            data: B64.encode(text),
+            bytes: text.as_bytes().to_vec(),
         }
     }
 
@@ -976,86 +968,143 @@ mod tests {
     }
 
     #[test]
-    fn snapshot_batch_blocks_newer_live_output_until_replay_finishes() {
+    fn registry_creates_on_first_output_and_survives_view_drop() {
         let temp = tempfile::tempdir().unwrap();
         let core = test_core(temp.path());
-        let waker: Arc<dyn Fn() + Send + Sync> = Arc::new(|| {});
-        let terminal = TerminalSession::attach(core, "replay-race".into(), 80, 24, waker).unwrap();
-        let gate_held = Arc::new(Barrier::new(2));
-        let live_returned = Arc::new(AtomicBool::new(false));
+        let events = core.session_events();
+        let mut broadcast = core.events.subscribe();
+        let bridge = TerminalBridge::new(core, Arc::new(|| {})).unwrap();
+        assert_eq!(bridge.live_session_count(), 0);
 
-        let live_terminal = Arc::clone(&terminal);
-        let live_barrier = Arc::clone(&gate_held);
-        let live_done = Arc::clone(&live_returned);
-        let live = thread::spawn(move || {
-            live_barrier.wait();
-            live_terminal
-                .feed_output(&output(2, "live-marker"))
-                .unwrap();
-            live_done.store(true, Ordering::Release);
-        });
-        let replay_terminal = Arc::clone(&terminal);
-        let replay_barrier = Arc::clone(&gate_held);
-        let replay_live_returned = Arc::clone(&live_returned);
-        let replay = thread::spawn(move || {
-            replay_terminal
-                .feed_snapshot_with_hook(&[output(1, "snapshot-marker")], || {
-                    replay_barrier.wait();
-                    thread::sleep(Duration::from_millis(30));
-                    assert!(!replay_live_returned.load(Ordering::Acquire));
-                })
-                .unwrap();
-        });
-        replay.join().unwrap();
-        live.join().unwrap();
+        events.output(&output(1, "first-marker"));
+        assert!(broadcast.try_recv().is_err());
+        let view = bridge.session("replay-race").unwrap();
+        assert_eq!(bridge.live_session_count(), 1);
+        drop(view);
 
+        events.output(&output(2, "second-marker"));
+        let reopened = bridge.session("replay-race").unwrap();
         let rendered = {
-            let term = terminal.term.lock();
+            let term = reopened.term.lock();
             visible_lines(&*term).join("\n")
         };
-        assert!(rendered.contains("snapshot-markerlive-marker"));
+        assert!(rendered.contains("first-markersecond-marker"));
     }
 
     #[test]
-    fn native_terminal_applies_resume_seam_and_reset_bytes() {
+    fn hidden_terminal_output_does_not_wake_the_ui() {
         let temp = tempfile::tempdir().unwrap();
         let core = test_core(temp.path());
-        let waker: Arc<dyn Fn() + Send + Sync> = Arc::new(|| {});
-        let terminal = TerminalSession::attach(core, "replay-race".into(), 80, 24, waker).unwrap();
+        let wakes = Arc::new(AtomicUsize::new(0));
+        let wake_count = Arc::clone(&wakes);
+        let terminal = TerminalSession::attach(
+            core,
+            "replay-race".into(),
+            80,
+            24,
+            Arc::new(move || {
+                wake_count.fetch_add(1, Ordering::Relaxed);
+            }),
+        )
+        .unwrap();
 
-        terminal
-            .feed_output(&output(
-                1,
-                "history-marker\x1b[?2004h\x1b[?1000h\x1b[?1006h",
-            ))
-            .unwrap();
-        {
-            let term = terminal.term.lock();
-            assert!(term.mode().contains(TermMode::BRACKETED_PASTE));
-            assert!(term.mode().intersects(TermMode::MOUSE_MODE));
-            assert!(term.mode().contains(TermMode::SGR_MOUSE));
+        terminal.feed_output(&output(1, "hidden")).unwrap();
+        assert_eq!(wakes.load(Ordering::Relaxed), 0);
+
+        let view = terminal.view();
+        terminal.feed_output(&output(2, "visible")).unwrap();
+        assert_eq!(wakes.load(Ordering::Relaxed), 1);
+
+        drop(view);
+        terminal.feed_output(&output(3, "hidden-again")).unwrap();
+        assert_eq!(wakes.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn registry_removes_exit_and_archive_sessions() {
+        let temp = tempfile::tempdir().unwrap();
+        let core = test_core(temp.path());
+        let events = core.session_events();
+        let bridge = TerminalBridge::new(core, Arc::new(|| {})).unwrap();
+        events.output(&output(1, "exit-marker"));
+        let exited = Arc::downgrade(&bridge.session("replay-race").unwrap());
+        events.exit(&ExitEvent {
+            session_id: "replay-race".into(),
+            mission_id: None,
+            exit_code: Some(0),
+            success: true,
+        });
+        assert!(bridge.session("replay-race").is_none());
+        assert!(exited.upgrade().is_none());
+
+        events.output(&output(2, "archive-marker"));
+        let archived = Arc::downgrade(&bridge.session("replay-race").unwrap());
+        events.archived(&SessionUpdatedEvent {
+            session_id: "replay-race".into(),
+            mission_id: None,
+        });
+        assert_eq!(bridge.live_session_count(), 0);
+        assert!(archived.upgrade().is_none());
+    }
+
+    #[test]
+    fn registry_replaces_terminal_on_respawn_and_keeps_ready_sequence() {
+        let temp = tempfile::tempdir().unwrap();
+        let core = test_core(temp.path());
+        let events = core.session_events();
+        let bridge = TerminalBridge::new(core, Arc::new(|| {})).unwrap();
+        events.spawned(&SessionSpawnedEvent {
+            session_id: "replay-race".into(),
+            mission_id: None,
+            cols: 80,
+            rows: 24,
+        });
+        events.output(&output(1, "old-child"));
+        let old = bridge.session("replay-race").unwrap();
+
+        events.spawned(&SessionSpawnedEvent {
+            session_id: "replay-race".into(),
+            mission_id: None,
+            cols: 100,
+            rows: 30,
+        });
+        let fresh = bridge.session("replay-race").unwrap();
+        assert!(!Arc::ptr_eq(&old, &fresh));
+        assert_eq!(fresh.size(), (100, 30));
+        events.output(&output(2, "\x1b[?2004hnew-child"));
+
+        let activity = fresh.output_activity();
+        assert_eq!(activity.last_seq, 2);
+        assert_eq!(activity.tui_ready_seq, 2);
+        let rendered = visible_lines(&*fresh.term.lock()).join("\n");
+        assert!(rendered.contains("new-child"));
+        assert!(!rendered.contains("old-child"));
+    }
+
+    #[test]
+    fn registry_has_zero_live_terminals_after_twenty_spawn_exit_cycles() {
+        let temp = tempfile::tempdir().unwrap();
+        let core = test_core(temp.path());
+        let events = core.session_events();
+        let bridge = TerminalBridge::new(core, Arc::new(|| {})).unwrap();
+
+        for seq in 1..=20 {
+            events.spawned(&SessionSpawnedEvent {
+                session_id: "replay-race".into(),
+                mission_id: None,
+                cols: 80,
+                rows: 24,
+            });
+            events.output(&output(seq, "cycle"));
+            assert_eq!(bridge.live_session_count(), 1);
+            events.exit(&ExitEvent {
+                session_id: "replay-race".into(),
+                mission_id: None,
+                exit_code: Some(0),
+                success: true,
+            });
+            assert_eq!(bridge.live_session_count(), 0);
         }
-
-        terminal
-            .feed_output(&output(
-                2,
-                "\x1b[0m\x1b[?2004l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006l\r\n",
-            ))
-            .unwrap();
-        {
-            let term = terminal.term.lock();
-            assert!(visible_lines(&*term).join("\n").contains("history-marker"));
-            assert!(!term.mode().contains(TermMode::BRACKETED_PASTE));
-            assert!(!term.mode().intersects(TermMode::MOUSE_MODE));
-            assert!(!term.mode().contains(TermMode::SGR_MOUSE));
-        }
-
-        terminal.feed_output(&output(3, "\x1bc")).unwrap();
-        let term = terminal.term.lock();
-        assert!(!visible_lines(&*term).join("\n").contains("history-marker"));
-        assert!(!term.mode().contains(TermMode::BRACKETED_PASTE));
-        assert!(!term.mode().intersects(TermMode::MOUSE_MODE));
-        assert!(!term.mode().contains(TermMode::SGR_MOUSE));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- keep one long-lived alacritty Term per live backend session and feed it synchronously from raw SessionEvents output
- remove the backend output replay ring, snapshots, synthetic prefix, resize purge, and rows-nudge coherence machinery
- make chat and mission panes borrow registry terminals across tab and route changes; replace on spawn and release on exit/archive
- persist only the final terminal size once per resize storm
- queue human delivery across a stopped/resuming PTY, warn once in the feed, and flush on respawn

## Verification

- make verify
- reviewer independently reran make verify: 542 backend, 123 app, 50 app-lib, 27 terminal tests plus integrations; clippy and fmt clean
- nightly daily-drive smoke passed
- real PTY 20-cycle start/kill test ends with 0 live terminals after every cycle

## Visible lifecycle note

The Term is intentionally released on session exit per M6.8. A stopped chat or mission pane therefore shows an empty terminal background behind the Ended/Resume card; resume creates a fresh Term for the fresh child.