### PR TITLE
fix(ui): restore sidebar scroll and first-paint transitions

### DIFF
--- a/crates/runner-app/src/surfaces/chat.rs
+++ b/crates/runner-app/src/surfaces/chat.rs
@@ -69,6 +69,9 @@ impl NativeRoot {
             "session/spawned" => {
                 if let Some(session_id) = session_id {
                     self.attached.remove(&session_id);
+                    if let Some(transition) = self.chat_transitions.get_mut(&session_id) {
+                        transition.baseline_seq = 0;
+                    }
                     self.refresh_sessions(cx);
                     if let Some(layout) =
                         self.tabs.active().cloned().filter(|layout| {
@@ -185,15 +188,15 @@ impl NativeRoot {
                         .map(|chat| chat.terminal.output_activity());
                     let output_seen = activity
                         .is_some_and(|activity| activity.last_seq > transition.baseline_seq);
-                    let ready_signal_seen = activity
-                        .is_some_and(|activity| activity.tui_ready_seq > transition.baseline_seq);
+                    let first_paint_seen = activity
+                        .is_some_and(|activity| activity.first_paint_seq > transition.baseline_seq);
                     let output_idle_for = activity
                         .and_then(|activity| activity.last_output_at)
                         .map(|last| now.saturating_duration_since(last));
                     let settled = chat_lifecycle::transition_should_settle(
                         transition.kind,
                         now.saturating_duration_since(transition.started_at),
-                        ready_signal_seen,
+                        first_paint_seen,
                         output_seen,
                         output_idle_for,
                     );

--- a/crates/runner-app/src/surfaces/chat_lifecycle.rs
+++ b/crates/runner-app/src/surfaces/chat_lifecycle.rs
@@ -70,11 +70,11 @@ pub(crate) fn ended_subtitle(
 pub(crate) fn transition_should_settle(
     kind: TransitionKind,
     elapsed: Duration,
-    ready_signal_seen: bool,
+    first_paint_seen: bool,
     output_seen: bool,
     output_idle_for: Option<Duration>,
 ) -> bool {
-    ready_signal_seen
+    first_paint_seen
         || elapsed >= TRANSITION_HARD_TIMEOUT
         || (output_seen
             && elapsed >= TRANSITION_MIN_VISIBLE
@@ -141,7 +141,7 @@ mod tests {
     }
 
     #[test]
-    fn transition_settling_keeps_resume_visible_for_silent_agents() {
+    fn transition_settling_uses_first_paint_with_timeout_and_idle_backstops() {
         assert!(transition_should_settle(
             TransitionKind::Resuming,
             Duration::from_millis(20),

--- a/crates/runner-app/src/surfaces/mission_workspace.rs
+++ b/crates/runner-app/src/surfaces/mission_workspace.rs
@@ -1393,7 +1393,7 @@ impl MissionWorkspace {
                         },
                         now.saturating_duration_since(transition.started_at),
                         activity.is_some_and(|activity| {
-                            activity.tui_ready_seq > transition.baseline_seq
+                            activity.first_paint_seq > transition.baseline_seq
                         }),
                         activity
                             .is_some_and(|activity| activity.last_seq > transition.baseline_seq),
@@ -1648,23 +1648,15 @@ impl MissionWorkspace {
                         {
                             self.attached.remove(session_id);
                             self.delivery_blocked.remove(session_id);
-                            if let Some(kind) = transition_to_begin_on_spawn(
-                                self.transitions
-                                    .get(session_id)
-                                    .map(|transition| transition.kind),
-                            ) {
-                                let baseline = self
-                                    .app_store
-                                    .read(cx)
-                                    .bridge
-                                    .session(session_id)
-                                    .map(|terminal| terminal.output_activity().last_seq)
-                                    .unwrap_or(0)
-                                    .saturating_sub(1);
+                            let existing = self.transitions.get_mut(session_id).map(|transition| {
+                                transition.baseline_seq = 0;
+                                transition.kind
+                            });
+                            if let Some(kind) = transition_to_begin_on_spawn(existing) {
                                 self.begin_mission_transition(
                                     session_id,
                                     kind,
-                                    Some(baseline),
+                                    Some(0),
                                     window,
                                     cx,
                                 );

--- a/crates/runner-app/src/surfaces/sidebar.rs
+++ b/crates/runner-app/src/surfaces/sidebar.rs
@@ -22,6 +22,27 @@ use runner_backend::repo::node::{NodeRow, NodeType};
 
 const SIDEBAR_ROW_FONT_SIZE: f32 = 13.;
 
+// Shared with the layout probe so the production flex constraints stay under test.
+fn sidebar_scroll_frame() -> gpui::Div {
+    div().relative().min_h(px(0.)).flex_1().flex().flex_col()
+}
+
+fn sidebar_scroll_container(
+    id: &'static str,
+    scroll: &gpui::ScrollHandle,
+) -> gpui::Stateful<gpui::Div> {
+    div()
+        .id(id)
+        .relative()
+        .min_h(px(0.))
+        .flex_1()
+        .flex()
+        .flex_col()
+        .overflow_y_scroll()
+        .scrollbar_width(px(0.))
+        .track_scroll(scroll)
+}
+
 #[derive(Clone, Copy)]
 enum ArchiveErrorTarget {
     App,
@@ -1600,14 +1621,7 @@ impl Sidebar {
         }));
         let root_attention = rollups.get(&None).copied().unwrap_or_default();
 
-        let mut scroll = div()
-            .id("sidebar-node-scroll")
-            .relative()
-            .min_h(px(0.))
-            .flex_1()
-            .overflow_y_scroll()
-            .scrollbar_width(px(0.))
-            .track_scroll(&self.scroll);
+        let mut scroll = sidebar_scroll_container("sidebar-node-scroll", &self.scroll);
         if !pinned.is_empty() {
             let visible = pinned
                 .iter()
@@ -1733,7 +1747,6 @@ impl Sidebar {
         scroll = scroll.child(
             div()
                 .mt_5()
-                .min_h(px(0.))
                 .flex_1()
                 .flex()
                 .flex_col()
@@ -1804,7 +1817,6 @@ impl Sidebar {
                     let has_rows = !root_rows.is_empty();
                     div()
                         .id("root-chat-scope")
-                        .min_h(rems(28. / 16.))
                         .flex_1()
                         .px_3()
                         .pt_1()
@@ -1854,6 +1866,7 @@ impl Sidebar {
             .flex_1()
             .flex()
             .flex_col()
+            .overflow_hidden()
             .pb_3()
             .child(
                 div().flex_none().child(section_title("WORKSPACE")).child(
@@ -1907,10 +1920,7 @@ impl Sidebar {
                     .bg(theme::sidebar_selected_border()),
             )
             .child(
-                div()
-                    .relative()
-                    .min_h(px(0.))
-                    .flex_1()
+                sidebar_scroll_frame()
                     .child(scroll)
                     .child(self.scrollbar.clone()),
             )
@@ -3153,7 +3163,117 @@ pub(crate) fn session_label(entry: &DirectSessionEntry) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui::{
+        prelude::*, size, Context, Render, ScrollHandle, TestAppContext, VisualTestContext, Window,
+    };
     use runner_backend::events::AppEvent;
+
+    struct SidebarScrollLayoutTest {
+        scroll: ScrollHandle,
+        block_wrapper_scroll: ScrollHandle,
+        constrained_section_scroll: ScrollHandle,
+        short_scroll: ScrollHandle,
+    }
+
+    impl Render for SidebarScrollLayoutTest {
+        fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+            div()
+                .size_full()
+                .flex()
+                .child(sidebar_scroll_column(
+                    self.scroll.clone(),
+                    "test-sidebar-node-scroll",
+                    true,
+                    false,
+                    6,
+                    12,
+                ))
+                .child(sidebar_scroll_column(
+                    self.block_wrapper_scroll.clone(),
+                    "test-block-wrapper-sidebar-node-scroll",
+                    false,
+                    false,
+                    6,
+                    12,
+                ))
+                .child(sidebar_scroll_column(
+                    self.constrained_section_scroll.clone(),
+                    "test-constrained-section-sidebar-node-scroll",
+                    true,
+                    true,
+                    6,
+                    12,
+                ))
+                .child(sidebar_scroll_column(
+                    self.short_scroll.clone(),
+                    "test-short-sidebar-node-scroll",
+                    true,
+                    false,
+                    1,
+                    2,
+                ))
+        }
+    }
+
+    fn sidebar_scroll_column(
+        scroll_handle: ScrollHandle,
+        id: &'static str,
+        flex_frame: bool,
+        constrain_sections: bool,
+        project_count: usize,
+        chat_count: usize,
+    ) -> AnyElement {
+        let projects = div()
+            .flex()
+            .flex_col()
+            .children((0..project_count).map(|_| div().h(px(40.)).flex_none()));
+        let mut chat_scope = div()
+            .flex_1()
+            .flex()
+            .flex_col()
+            .children((0..chat_count).map(|_| div().h(px(28.)).flex_none()));
+        if constrain_sections {
+            chat_scope = chat_scope.min_h(rems(28. / 16.));
+        }
+        let chats_selector = format!("TEST_CHATS_{id}");
+        let mut chats = div()
+            .debug_selector(move || chats_selector.clone())
+            .mt(px(20.))
+            .flex_1()
+            .flex()
+            .flex_col()
+            .child(div().h(px(24.)).flex_none())
+            .child(chat_scope);
+        if constrain_sections {
+            chats = chats.min_h(px(0.));
+        }
+        let scroll = sidebar_scroll_container(id, &scroll_handle)
+            .child(projects)
+            .child(chats);
+        let wrapper = if flex_frame {
+            sidebar_scroll_frame().child(scroll)
+        } else {
+            div().relative().min_h(px(0.)).flex_1().child(scroll)
+        };
+
+        div()
+            .w(px(240.))
+            .h_full()
+            .flex_none()
+            .flex()
+            .flex_col()
+            .overflow_hidden()
+            .child(
+                div()
+                    .min_h(px(0.))
+                    .flex_1()
+                    .flex()
+                    .flex_col()
+                    .overflow_hidden()
+                    .child(wrapper),
+            )
+            .into_any_element()
+    }
 
     fn appended_event(signal: &str) -> AppEvent {
         AppEvent {
@@ -3208,5 +3328,56 @@ mod tests {
             Some("tab-1"),
             "tab-1"
         ));
+    }
+
+    #[test]
+    fn sidebar_scroll_layout_reports_overflow_and_fills_short_lists() {
+        let mut cx = TestAppContext::single();
+        let scroll = ScrollHandle::new();
+        let test_scroll = scroll.clone();
+        let block_wrapper_scroll = ScrollHandle::new();
+        let test_block_wrapper_scroll = block_wrapper_scroll.clone();
+        let constrained_section_scroll = ScrollHandle::new();
+        let test_constrained_section_scroll = constrained_section_scroll.clone();
+        let short_scroll = ScrollHandle::new();
+        let test_short_scroll = short_scroll.clone();
+        let window = cx.add_window(move |_, _| SidebarScrollLayoutTest {
+            scroll: test_scroll,
+            block_wrapper_scroll: test_block_wrapper_scroll,
+            constrained_section_scroll: test_constrained_section_scroll,
+            short_scroll: test_short_scroll,
+        });
+        cx.run_until_parked();
+        let mut window = VisualTestContext::from_window(window.into(), &cx);
+        window.simulate_resize(size(px(960.), px(160.)));
+        window.run_until_parked();
+
+        let viewport = f32::from(scroll.bounds().size.height);
+        let max_offset = f32::from(scroll.max_offset().height);
+        let block_wrapper_viewport = f32::from(block_wrapper_scroll.bounds().size.height);
+        let block_wrapper_max_offset = f32::from(block_wrapper_scroll.max_offset().height);
+        let constrained_section_max_offset =
+            f32::from(constrained_section_scroll.max_offset().height);
+        let constrained_chats_height = f32::from(
+            window
+                .debug_bounds("TEST_CHATS_test-constrained-section-sidebar-node-scroll")
+                .unwrap()
+                .size
+                .height,
+        );
+        let short_chats_height = f32::from(
+            window
+                .debug_bounds("TEST_CHATS_test-short-sidebar-node-scroll")
+                .unwrap()
+                .size
+                .height,
+        );
+        assert_eq!(viewport, 160.);
+        assert_eq!(max_offset, 460.);
+        assert_eq!(block_wrapper_viewport, 620.);
+        assert_eq!(block_wrapper_max_offset, 0.);
+        assert_eq!(constrained_section_max_offset, 100.);
+        assert_eq!(constrained_chats_height, 0.);
+        assert_eq!(short_chats_height, 100.);
     }
 }

--- a/crates/runner-terminal/src/terminal.rs
+++ b/crates/runner-terminal/src/terminal.rs
@@ -82,7 +82,9 @@ pub fn query_color_for<T>(
 #[derive(Default)]
 struct SequenceState {
     last: u64,
+    // No production reader after M6.11; kept as a cheaper mode-level signal should one appear.
     tui_ready_seq: u64,
+    first_paint_seq: u64,
     last_output_at: Option<Instant>,
 }
 
@@ -148,6 +150,7 @@ pub struct TerminalScrollState {
 pub struct TerminalOutputActivity {
     pub last_seq: u64,
     pub tui_ready_seq: u64,
+    pub first_paint_seq: u64,
     pub last_output_at: Option<Instant>,
 }
 
@@ -329,6 +332,7 @@ impl TerminalSession {
         TerminalOutputActivity {
             last_seq: sequence.last,
             tui_ready_seq: sequence.tui_ready_seq,
+            first_paint_seq: sequence.first_paint_seq,
             last_output_at: sequence.last_output_at,
         }
     }
@@ -348,6 +352,14 @@ impl TerminalSession {
         let mut term = self.term.lock();
         let previous_mode = *term.mode();
         parser.advance(&mut *term, bytes);
+        if sequence.first_paint_seq == 0
+            && term
+                .grid()
+                .display_iter()
+                .any(|cell| !cell.c.is_whitespace())
+        {
+            sequence.first_paint_seq = event.seq;
+        }
         let mode = *term.mode();
         if !previous_mode.intersects(TermMode::MOUSE_MODE) && mode.intersects(TermMode::MOUSE_MODE)
         {
@@ -1048,7 +1060,7 @@ mod tests {
     }
 
     #[test]
-    fn registry_replaces_terminal_on_respawn_and_keeps_ready_sequence() {
+    fn registry_replaces_terminal_on_respawn_and_resets_first_paint() {
         let temp = tempfile::tempdir().unwrap();
         let core = test_core(temp.path());
         let events = core.session_events();
@@ -1061,6 +1073,7 @@ mod tests {
         });
         events.output(&output(1, "old-child"));
         let old = bridge.session("replay-race").unwrap();
+        assert_eq!(old.output_activity().first_paint_seq, 1);
 
         events.spawned(&SessionSpawnedEvent {
             session_id: "replay-race".into(),
@@ -1071,11 +1084,13 @@ mod tests {
         let fresh = bridge.session("replay-race").unwrap();
         assert!(!Arc::ptr_eq(&old, &fresh));
         assert_eq!(fresh.size(), (100, 30));
+        assert_eq!(fresh.output_activity().first_paint_seq, 0);
         events.output(&output(2, "\x1b[?2004hnew-child"));
 
         let activity = fresh.output_activity();
         assert_eq!(activity.last_seq, 2);
         assert_eq!(activity.tui_ready_seq, 2);
+        assert_eq!(activity.first_paint_seq, 2);
         let rendered = visible_lines(&*fresh.term.lock()).join("\n");
         assert!(rendered.contains("new-child"));
         assert!(!rendered.contains("old-child"));
@@ -1258,6 +1273,7 @@ mod tests {
         let first = terminal.output_activity();
         assert_eq!(first.last_seq, 1);
         assert_eq!(first.tui_ready_seq, 0);
+        assert_eq!(first.first_paint_seq, 1);
         assert!(first.last_output_at.is_some());
 
         terminal
@@ -1266,6 +1282,33 @@ mod tests {
         let ready = terminal.output_activity();
         assert_eq!(ready.last_seq, 2);
         assert_eq!(ready.tui_ready_seq, 2);
+        assert_eq!(ready.first_paint_seq, 1);
         assert!(ready.last_output_at >= first.last_output_at);
+    }
+
+    #[test]
+    fn first_paint_requires_a_visible_non_whitespace_cell() {
+        let temp = tempfile::tempdir().unwrap();
+        let core = test_core(temp.path());
+        let terminal =
+            TerminalSession::attach(core, "replay-race".into(), 8, 3, Arc::new(|| {})).unwrap();
+
+        terminal
+            .feed_output(&output(1, "\x1b[?1049h\x1b[2J\x1b[H"))
+            .unwrap();
+        let alternate_screen = terminal.output_activity();
+        assert_eq!(alternate_screen.tui_ready_seq, 1);
+        assert_eq!(alternate_screen.first_paint_seq, 0);
+
+        terminal
+            .feed_output(&output(2, "\x1b[31m   \x1b[0m\x1b[2;2H"))
+            .unwrap();
+        assert_eq!(terminal.output_activity().first_paint_seq, 0);
+
+        terminal.feed_output(&output(3, "x")).unwrap();
+        assert_eq!(terminal.output_activity().first_paint_seq, 3);
+
+        terminal.feed_output(&output(4, "later")).unwrap();
+        assert_eq!(terminal.output_activity().first_paint_seq, 3);
     }
 }

--- a/docs/impls/gpui-rewrite/briefs/m6-10-11-sidebar-overflow-first-paint.md
+++ b/docs/impls/gpui-rewrite/briefs/m6-10-11-sidebar-overflow-first-paint.md
@@ -1,0 +1,43 @@
+# Mission brief — M6.10 + M6.11: sidebar overflow, first-paint pill
+
+Drafted 2026-08-22 02:05. Start with `mission_start` on crew `codex-crew` (`01KVG1NCM4RJC23Q4ZQ5Z8SBHH`), project `runner` (`01KZGS24S5103N6B2HV72ZG1AD`), cwd the `runner-gpui` worktree, title `M6.10 + M6.11 — Sidebar overflow, first-paint pill`, the text below as `goal_override`. No Sparkle update while the crew runs.
+
+---
+
+Implement **M6.10 and M6.11** together (`docs/impls/gpui-rewrite/m6-consolidation.md` §M6.10, §M6.11 — read both in full first; they carry the traces with file:line). Two small, unrelated fixes in the app crate, one mission, one feature branch in this worktree (no separate worktree). `gpui-nightly` is at `49825f6`; leave uncommitted docs under `docs/impls/gpui-rewrite/` alone. Standing GPUI rules in `impl_log.md` apply (notify scope, no stateful `cx.new` in render, `current_view()` only while rendering, and the new one: inside an `overflow_y_scroll` container children must be content-sized).
+
+## M6.10 — sidebar sections overflow into the Settings footer
+
+Symptom: with six projects expanded, the CHATS & MISSIONS header is pushed to the bottom of the sidebar and its rows paint over the Settings footer row; no scrollbar appears.
+
+Cause (`crates/runner-app/src/surfaces/sidebar.rs`, `render_sidebar_contents` ~1563–1916): the entity root is `min_h_0 flex_1` holding one `overflow_y_scroll` container `#sidebar-node-scroll` (native bar hidden via `scrollbar_width(0)`, custom `Scrollbar::app` overlay fed by the handle's `max_offset`). Inside it, PINNED is content-sized but the PROJECTS section and the CHATS & MISSIONS section (~1736, `.mt_5().min_h(px(0.)).flex_1()`) and the chats row scope `#root-chat-scope` (~1807, `.min_h(rems(28./16.)).flex_1()`) are `min_h_0 flex_1`. Inside a scroll viewport a `min_h_0 flex_1` child is sized to the viewport, never to its content, so the content height never exceeds the container: `max_offset` stays 0, the scrollbar hides itself, and the squeezed chats section's unclipped rows paint past the container and the footer.
+
+Parity (decision 1: `main` is the source of truth): `main`'s sidebar (`git show main:src/components/Sidebar.tsx`, line 2085) is one `flex min-h-0 flex-1 flex-col overflow-y-auto` column; its sections are `flex flex-1 flex-col` **without** `min-h-0` (2264, 2316), so CSS keeps them at content height and the column scrolls as one list. Match that:
+
+1. Remove `min_h(px(0.))` from the PROJECTS and CHATS & MISSIONS sections and the `min_h(rems(28./16.))` floor from `#root-chat-scope` inside the scroll container; keep `flex_1` so a short list still fills the column. Verify with `max_offset` that the scroll range equals content minus viewport once the content is taller than the sidebar.
+2. Add `overflow_hidden()` on the entity root column (the `min_h_0 flex_1 flex_col pb_3` div returned by `render_sidebar_contents`) as a belt-and-braces clip so nothing can paint over the footer again whatever the content does.
+3. The custom scrollbar must appear when the content overflows and track the wheel and the thumb drag; the sidebar resize handle, ⌘K search and the footer stay reachable.
+4. Do not turn the sections into two independently scrolling panes — that is explicitly not parity; out of scope.
+
+Tests: a layout-level test if the crate has a pattern for measuring elements (look for existing sidebar tests and `gpui::TestAppContext` use); otherwise a unit test on whatever pure helper you extract. At minimum prove in the handoff with numbers: content height, viewport height, `max_offset` after the fix on a short window with six projects.
+
+## M6.11 — the Starting/Resuming pill settles before the TUI paints
+
+Symptom: the Starting pill disappears, then the Claude session takes a few more seconds to appear over a blank alternate screen.
+
+Cause: `chunk_indicates_tui_ready` (`crates/runner-terminal/src/terminal.rs:~706`) marks the TUI ready on the first `ESC[?2004h` / `?1049h` / `?47h`, and `chat_lifecycle::transition_should_settle` (`crates/runner-app/src/surfaces/chat_lifecycle.rs`, call sites `chat.rs:~166` and `mission_workspace.rs:~1412`) drops the pill as soon as `tui_ready_seq` passes the transition's `baseline_seq`. Claude Code's fullscreen renderer — Runner's default since M6.6 — writes `?1049h` at process start, seconds before its first frame; the default renderer's `?2004h` arrived with the first frame, so the old timing was a coincidence.
+
+Fix — a first-paint signal from the native seam:
+
+1. In `TerminalSession::feed_output`, after `parser.advance`, until a first paint has been recorded for the current child: check whether any visible line of the `Term` carries non-whitespace (`replay::visible_lines` or a cheaper `grid().display_iter()` scan that stops at the first non-blank cell) and record `first_paint_seq = seq`. Reset it when the `Term` is replaced on respawn (M6.8's registry replacement path) so a Resume measures its own first paint. One walk per chunk until the first paint, then no cost.
+2. Expose `first_paint_seq` on `TerminalOutputActivity`; `transition_should_settle` settles `Starting` and `Resuming` on `first_paint_seen` (first paint after the baseline) instead of `ready_signal_seen`. Keep `TRANSITION_HARD_TIMEOUT` (10 s) and the output-idle rule as backstops; keep `tui_ready_seq` in place for any other reader (grep before touching it).
+3. A shell chat settles on its prompt, a claude chat settles on its first frame under both renderers (`/tui default` and fullscreen), codex on its first frame; resume behaves the same. Tests in `chat_lifecycle.rs` (pure function) and a `runner-terminal` test feeding bytes: `?1049h` + `2J` alone does not set `first_paint_seq`; the first printable cell does; respawn resets it.
+4. Check, do not change unless broken: the backend's first-turn delivery under the fullscreen renderer (`CLAUDE_LAUNCH_GATE_GRACE` 1500 ms plus the verified-paste capture loop in `session/manager/output.rs`) — start a mission with a claude lead and confirm the brief lands in the input box, not into a Claude that has not drawn it yet. Report what you saw.
+
+## Gates
+
+- `make verify` green; `git diff --check` clean.
+- Handoff: one impl_log paragraph per item (the human writes the log), the M6.10 numbers, and a daily-drive checklist: six expanded projects + a dozen chats on a short window (scrollbar visible, footer clean, wheel and thumb drag work, resize handle reachable); start a claude chat under fullscreen and under `/tui default` (pill stays until the first frame, disappears on it); a shell chat; a codex chat; resume a stopped claude chat; start a mission with a claude lead (brief lands in the input box).
+- **Do not commit, push, open a PR, or merge.** Stop at a clean working-tree review on the feature branch.
+
+reviewer: hunts — (1) any remaining `min_h_0`/`min_h(...)` on a child of `#sidebar-node-scroll`; (2) the scrollbar overlay's `max_offset` math after the change, wheel + drag; (3) the root clip hiding something that must overflow (context menus, tooltips, the drag ghost — check they are rendered outside the clipped root via overlays); (4) first-paint false positives — a cursor-only or SGR-only chunk must not count, a line of spaces must not count; (5) first-paint not reset on respawn, or `baseline_seq` semantics broken for Resume; (6) the 10 s timeout or idle rule regressed; (7) the per-chunk grid walk surviving past the first paint (cost), or taking the `Term` lock re-entrantly; (8) first-turn paste racing the fullscreen renderer.


### PR DESCRIPTION
## Summary

- Make the sidebar scroll frame and `#sidebar-node-scroll` flex columns, keep overflowing sections content-sized, and clip the sidebar entity above the footer.
- Add layout regression coverage for long overflow, block-frame failure, constrained-section failure, and short-list fill behavior.
- Record terminal `first_paint_seq` from the first visible non-whitespace cell and settle Starting/Resuming transitions from that signal while retaining timeout and idle backstops.
- Reset first-paint state with the replacement terminal on respawn and include the M6.10/M6.11 mission brief.

## Review notes

The clean working-tree review found that the complete M6.10 cause was `Display::Block` on both the scroll frame and scroll container. The section minimum-height constraints were inert until the container became a flex column. The final layout probe reports 620 px content in a 160 px viewport with a 460 px max offset; its negative controls reproduce the former 620/0 block-frame state and the 100 px constrained-section range with a zero-height chats section.

The backend first-turn path was checked but not changed: supported agent prompts are passed as positional argv before spawn, so the retired post-spawn paste race described in the original brief no longer exists.

## Verification

- `make verify`
- `git diff --check`
- Clean feature-branch working-tree review before commit