### PR TITLE
feat(ui): add sidebar entry points

### DIFF
--- a/crates/runner-app/Cargo.toml
+++ b/crates/runner-app/Cargo.toml
@@ -5,10 +5,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 publish = false
-default-run = "runner-app"
+default-run = "Runner"
 
 [[bin]]
-name = "runner-app"
+name = "Runner"
 path = "src/main.rs"
 
 [features]

--- a/crates/runner-app/src/surfaces/app_shell.rs
+++ b/crates/runner-app/src/surfaces/app_shell.rs
@@ -66,10 +66,10 @@ impl NativeRoot {
         let workspace = self.render_entity_surface(window, cx);
         let sidebar = self.render_app_sidebar(window, cx);
         let preview_trigger = self.render_sidebar_preview_trigger(cx);
-        let modal = (self.route != AppRoute::Settings)
-            .then_some(self.start_chat_modal.as_ref())
-            .flatten()
-            .map(|_| self.render_start_chat_modal(cx));
+        let modal = self
+            .start_chat_modal
+            .is_some()
+            .then(|| self.render_start_chat_modal(cx));
         let chat_rename_modal = (self.route == AppRoute::Chat)
             .then_some(self.chat_rename_modal.as_ref())
             .flatten()
@@ -112,7 +112,6 @@ impl NativeRoot {
                     .child(workspace),
             )
             .children(preview_trigger)
-            .children(modal)
             .children(chat_rename_modal)
             .children(sidebar_overlays)
             .children(entity_overlays);
@@ -137,6 +136,7 @@ impl NativeRoot {
             .text_color(theme::text())
             .child(chrome)
             .children(settings)
+            .children(modal)
             .children(settings_confirm)
             .child(command_palette)
             .children(toast)

--- a/crates/runner-app/src/surfaces/mission_workspace.rs
+++ b/crates/runner-app/src/surfaces/mission_workspace.rs
@@ -24,6 +24,7 @@ use runner_backend::model::{
 };
 use runner_backend::ops::session::SessionRow;
 use runner_backend::windows::Subject;
+use runner_terminal::input_state::ECHO_WINDOW;
 
 use super::*;
 use crate::surfaces::app_shell::{SIDEBAR_TOGGLE_GLYPH_INSET, SIDEBAR_TOGGLE_GLYPH_X};
@@ -2507,7 +2508,7 @@ impl MissionWorkspace {
         }
     }
 
-    fn clear_mission_input(
+    fn submit_or_clear_mission_input(
         &mut self,
         session_id: &str,
         window: &mut Window,
@@ -2521,9 +2522,18 @@ impl MissionWorkspace {
             cx.notify();
             return;
         };
-        if let Err(error) = chat.terminal.send_key("enter", false, false, false, None) {
+        let terminal = Arc::clone(&chat.terminal);
+        if let Err(error) = terminal.send_key("enter", false, false, false, None) {
             self.error = Some(error.to_string());
+            cx.notify();
+            return;
         }
+        let reset_guard = terminal.input_reset_guard();
+        cx.spawn(async move |_, cx| {
+            cx.background_executor().timer(ECHO_WINDOW).await;
+            terminal.reset_input_state(reset_guard);
+        })
+        .detach();
         chat.terminal_focus.focus(window);
         cx.notify();
     }
@@ -4294,10 +4304,10 @@ impl MissionWorkspace {
                     .on_click(move |_, window, cx| {
                         cx.stop_propagation();
                         clear_root.update(cx, |this, cx| {
-                            this.clear_mission_input(&session_id, window, cx)
+                            this.submit_or_clear_mission_input(&session_id, window, cx)
                         });
                     })
-                    .child("Submit draft")
+                    .child("Submit / clear")
                     .child(
                         div()
                             .font_family("Menlo")

--- a/crates/runner-app/src/surfaces/sidebar.rs
+++ b/crates/runner-app/src/surfaces/sidebar.rs
@@ -14,8 +14,8 @@ use gpui::{
     radians, svg, DragMoveEvent, FontWeight, PathPromptOptions, Transformation, WeakEntity,
 };
 use runner_app::ui::{
-    working_dir_text_field, ButtonVariant, ConfirmDialog, Field, Modal, OverlayWidth, TextField,
-    Tooltip, WorkingDirField,
+    focus_ring, working_dir_text_field, ButtonVariant, ConfirmDialog, Field, Modal, OverlayWidth,
+    TextField, Tooltip, WorkingDirField,
 };
 use runner_backend::ops::mission::{MissionActivityState, MissionSummary};
 use runner_backend::repo::node::{NodeRow, NodeType};
@@ -166,20 +166,20 @@ enum SidebarMenuAction {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum WorkspaceEntry {
-    NewChat,
+    NewTab,
     Runner,
     Crew,
 }
 
 const WORKSPACE_ENTRIES: [WorkspaceEntry; 3] = [
-    WorkspaceEntry::NewChat,
+    WorkspaceEntry::NewTab,
     WorkspaceEntry::Runner,
     WorkspaceEntry::Crew,
 ];
 
 impl WorkspaceEntry {
     fn selectable(self) -> bool {
-        !matches!(self, Self::NewChat)
+        !matches!(self, Self::NewTab)
     }
 
     fn selected(self, route: &AppRoute) -> bool {
@@ -187,7 +187,7 @@ impl WorkspaceEntry {
             return false;
         }
         match self {
-            Self::NewChat => unreachable!(),
+            Self::NewTab => unreachable!(),
             Self::Runner => matches!(route, AppRoute::Runners | AppRoute::RunnerDetail(_)),
             Self::Crew => matches!(route, AppRoute::Crews | AppRoute::CrewEditor(_)),
         }
@@ -1778,16 +1778,14 @@ impl Sidebar {
         let workspace_rows = WORKSPACE_ENTRIES.map(|entry| {
             let active = entry.selected(&route);
             match entry {
-                WorkspaceEntry::NewChat => {
-                    let root = cx.entity();
+                WorkspaceEntry::NewTab => {
+                    let shell = self.shell.clone();
                     workspace_new_chat_row(move |window, cx| {
-                        root.update(cx, |this, cx| {
-                            this.handle_sidebar_menu_action(
-                                SidebarMenuAction::NewChat(None),
-                                window,
-                                cx,
-                            )
-                        });
+                        if let Some(shell) = shell.upgrade() {
+                            shell.update(cx, |shell, shell_cx| {
+                                shell.open_new_tab_modal(&NewTab, window, shell_cx)
+                            });
+                        }
                     })
                 }
                 WorkspaceEntry::Runner => {
@@ -3048,8 +3046,7 @@ fn project_row_action(
         .focus_visible(|button| {
             button
                 .opacity(1.)
-                .border_1()
-                .border_color(theme::border_strong())
+                .shadow(focus_ring(theme::border_strong()))
         })
         .child(
             svg()
@@ -3449,15 +3446,15 @@ mod tests {
         assert_eq!(
             WORKSPACE_ENTRIES,
             [
-                WorkspaceEntry::NewChat,
+                WorkspaceEntry::NewTab,
                 WorkspaceEntry::Runner,
                 WorkspaceEntry::Crew,
             ]
         );
-        assert!(!WorkspaceEntry::NewChat.selectable());
-        assert!(!WorkspaceEntry::NewChat.selected(&AppRoute::Runners));
-        assert!(!WorkspaceEntry::NewChat.selected(&AppRoute::Crews));
-        assert!(!WorkspaceEntry::NewChat.selected(&AppRoute::Settings));
+        assert!(!WorkspaceEntry::NewTab.selectable());
+        assert!(!WorkspaceEntry::NewTab.selected(&AppRoute::Runners));
+        assert!(!WorkspaceEntry::NewTab.selected(&AppRoute::Crews));
+        assert!(!WorkspaceEntry::NewTab.selected(&AppRoute::Settings));
         assert!(WorkspaceEntry::Runner.selectable());
         assert!(WorkspaceEntry::Crew.selectable());
     }

--- a/crates/runner-app/src/surfaces/sidebar.rs
+++ b/crates/runner-app/src/surfaces/sidebar.rs
@@ -87,7 +87,7 @@ impl SidebarRow {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 enum SidebarRenameTarget {
     Tab {
         node_id: String,
@@ -153,18 +153,45 @@ impl Render for SidebarNodeDrag {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 enum SidebarMenuAction {
     NewChat(Option<String>),
     NewMission(Option<String>),
-    OpenInNewWindow(String),
     TogglePin { node_id: String, pinned: bool },
     Rename(SidebarRenameTarget),
-    RemoveTabFromProject(Vec<String>),
-    RemoveMissionFromProject(String),
     ArchiveTab(Vec<String>),
     ArchiveMission(String),
     DeleteProject(String),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WorkspaceEntry {
+    NewChat,
+    Runner,
+    Crew,
+}
+
+const WORKSPACE_ENTRIES: [WorkspaceEntry; 3] = [
+    WorkspaceEntry::NewChat,
+    WorkspaceEntry::Runner,
+    WorkspaceEntry::Crew,
+];
+
+impl WorkspaceEntry {
+    fn selectable(self) -> bool {
+        !matches!(self, Self::NewChat)
+    }
+
+    fn selected(self, route: &AppRoute) -> bool {
+        if !self.selectable() {
+            return false;
+        }
+        match self {
+            Self::NewChat => unreachable!(),
+            Self::Runner => matches!(route, AppRoute::Runners | AppRoute::RunnerDetail(_)),
+            Self::Crew => matches!(route, AppRoute::Crews | AppRoute::CrewEditor(_)),
+        }
+    }
 }
 
 pub(crate) struct Sidebar {
@@ -856,62 +883,17 @@ impl Sidebar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let pinned = node.pinned_position.is_some();
-        let mut entries = vec![
-            (
-                UiMenuItem::new(if pinned { "Unpin" } else { "Pin" }).icon(if pinned {
-                    "pin-off.svg"
-                } else {
-                    "pin.svg"
-                }),
-                SidebarMenuAction::TogglePin {
-                    node_id: node.id.clone(),
-                    pinned,
-                },
-            ),
-            (
-                UiMenuItem::new("Rename tab").icon("pencil.svg"),
-                SidebarMenuAction::Rename(SidebarRenameTarget::Tab {
-                    node_id: node.id.clone(),
-                    original: layout.name.clone().unwrap_or_default(),
-                }),
-            ),
-            (
-                UiMenuItem::new("Open in New Window").icon("app-window.svg"),
-                SidebarMenuAction::OpenInNewWindow(format!(
-                    "/chats/{}",
-                    layout
-                        .focused_session_id()
-                        .unwrap_or(&members[0].session_id)
-                )),
-            ),
-        ];
-        if node_project_id(&self.app_store.read(cx).nodes, &node).is_some() {
-            entries.push((
-                UiMenuItem::new("Remove from project").icon("folder-minus.svg"),
-                SidebarMenuAction::RemoveTabFromProject(
-                    members
-                        .iter()
-                        .map(|member| member.session_id.clone())
-                        .collect(),
-                ),
-            ));
-        }
-        entries.push((
-            UiMenuItem::new(if layout.root.leaves().len() > 1 {
-                "Archive all"
-            } else {
-                "Archive"
-            })
-            .icon("archive.svg")
-            .destructive(true),
-            SidebarMenuAction::ArchiveTab(
-                members
-                    .iter()
-                    .map(|member| member.session_id.clone())
-                    .collect(),
-            ),
-        ));
+        let multi_pane = layout.root.leaves().len() > 1;
+        let entries = tab_menu_entries(
+            &node.id,
+            node.pinned_position.is_some(),
+            layout.name.unwrap_or_default(),
+            multi_pane,
+            members
+                .into_iter()
+                .map(|member| member.session_id)
+                .collect(),
+        );
         self.open_sidebar_context_menu(position, 160., entries, window, cx);
     }
 
@@ -923,44 +905,29 @@ impl Sidebar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let pinned = node.pinned_position.is_some();
-        let mut entries = vec![
-            (
-                UiMenuItem::new(if pinned { "Unpin" } else { "Pin" }).icon(if pinned {
-                    "pin-off.svg"
-                } else {
-                    "pin.svg"
-                }),
-                SidebarMenuAction::TogglePin {
-                    node_id: node.id,
-                    pinned,
-                },
-            ),
-            (
-                UiMenuItem::new("Rename").icon("pencil.svg"),
-                SidebarMenuAction::Rename(SidebarRenameTarget::Mission {
-                    mission_id: summary.mission.id.clone(),
-                    original: summary.mission.title.clone(),
-                }),
-            ),
-            (
-                UiMenuItem::new("Open in New Window").icon("app-window.svg"),
-                SidebarMenuAction::OpenInNewWindow(format!("/missions/{}", summary.mission.id)),
-            ),
-        ];
-        if summary.mission.project_id.is_some() {
-            entries.push((
-                UiMenuItem::new("Remove from project").icon("folder-minus.svg"),
-                SidebarMenuAction::RemoveMissionFromProject(summary.mission.id.clone()),
-            ));
-        }
-        entries.push((
-            UiMenuItem::new("Archive")
-                .icon("archive.svg")
-                .destructive(true),
-            SidebarMenuAction::ArchiveMission(summary.mission.id),
-        ));
+        let entries = mission_menu_entries(
+            &node.id,
+            node.pinned_position.is_some(),
+            &summary.mission.id,
+            summary.mission.title,
+        );
         self.open_sidebar_context_menu(position, 160., entries, window, cx);
+    }
+
+    fn open_project_create_menu(
+        &mut self,
+        project_id: String,
+        position: gpui::Point<gpui::Pixels>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.open_sidebar_context_menu(
+            position,
+            160.,
+            project_create_menu_entries(&project_id),
+            window,
+            cx,
+        );
     }
 
     fn open_project_menu(
@@ -970,32 +937,7 @@ impl Sidebar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let entries = vec![
-            (
-                UiMenuItem::new("New chat in project").icon("message-square-plus.svg"),
-                SidebarMenuAction::NewChat(Some(project.id.clone())),
-            ),
-            (
-                UiMenuItem::new("New mission in project").icon("flag.svg"),
-                SidebarMenuAction::NewMission(Some(project.id.clone())),
-            ),
-            (
-                UiMenuItem::new("Rename project")
-                    .icon("pencil.svg")
-                    .separator_before(true),
-                SidebarMenuAction::Rename(SidebarRenameTarget::Project {
-                    project_id: project.id.clone(),
-                    original: project.name,
-                }),
-            ),
-            (
-                UiMenuItem::new("Delete project")
-                    .icon("trash.svg")
-                    .separator_before(true)
-                    .destructive(true),
-                SidebarMenuAction::DeleteProject(project.id),
-            ),
-        ];
+        let entries = project_menu_entries(project.id, project.name);
         self.open_sidebar_context_menu(position, 200., entries, window, cx);
     }
 
@@ -1034,14 +976,6 @@ impl Sidebar {
                     });
                 }
             }
-            SidebarMenuAction::OpenInNewWindow(route) => {
-                cx.defer(move |cx| {
-                    if let Err(error) = open_new_runner_window(Some(route), cx) {
-                        eprintln!("Runner new window failed: {error:#}");
-                    }
-                    cx.activate(true);
-                });
-            }
             SidebarMenuAction::TogglePin { node_id, pinned } => {
                 match runner_backend::ops::node::node_set_pinned(self.core(cx), node_id, !pinned) {
                     Ok(_) => self.refresh_store(StoreRefreshKind::All, cx),
@@ -1072,26 +1006,6 @@ impl Sidebar {
                     }
                 };
                 self.begin_sidebar_rename(target, value, placeholder, window, cx);
-            }
-            SidebarMenuAction::RemoveTabFromProject(session_ids) => {
-                match runner_backend::ops::session::session_set_project(
-                    self.core(cx),
-                    session_ids,
-                    None,
-                ) {
-                    Ok(()) => self.refresh_store(StoreRefreshKind::All, cx),
-                    Err(error) => self.report_error(error.to_string(), cx),
-                }
-            }
-            SidebarMenuAction::RemoveMissionFromProject(mission_id) => {
-                match runner_backend::ops::mission::mission_set_project(
-                    self.core(cx),
-                    &mission_id,
-                    None,
-                ) {
-                    Ok(_) => self.refresh_store(StoreRefreshKind::All, cx),
-                    Err(error) => self.report_error(error.to_string(), cx),
-                }
             }
             SidebarMenuAction::ArchiveTab(session_ids) => {
                 self.archive_sidebar_tab(session_ids, window, cx)
@@ -1861,6 +1775,47 @@ impl Sidebar {
                         )
                 })),
         );
+        let workspace_rows = WORKSPACE_ENTRIES.map(|entry| {
+            let active = entry.selected(&route);
+            match entry {
+                WorkspaceEntry::NewChat => {
+                    let root = cx.entity();
+                    workspace_new_chat_row(move |window, cx| {
+                        root.update(cx, |this, cx| {
+                            this.handle_sidebar_menu_action(
+                                SidebarMenuAction::NewChat(None),
+                                window,
+                                cx,
+                            )
+                        });
+                    })
+                }
+                WorkspaceEntry::Runner => {
+                    workspace_row("workspace-runner", "terminal.svg", "runner", active, {
+                        let shell = self.shell.clone();
+                        move |window, cx| {
+                            if let Some(shell) = shell.upgrade() {
+                                shell.update(cx, |shell, shell_cx| {
+                                    shell.open_runners(window, shell_cx)
+                                });
+                            }
+                        }
+                    })
+                }
+                WorkspaceEntry::Crew => {
+                    workspace_row("workspace-crew", "users.svg", "crew", active, {
+                        let shell = self.shell.clone();
+                        move |window, cx| {
+                            if let Some(shell) = shell.upgrade() {
+                                shell.update(cx, |shell, shell_cx| {
+                                    shell.open_crews(window, shell_cx)
+                                });
+                            }
+                        }
+                    })
+                }
+            }
+        });
         div()
             .min_h(px(0.))
             .flex_1()
@@ -1876,38 +1831,7 @@ impl Sidebar {
                         .flex()
                         .flex_col()
                         .gap(rems(2. / 16.))
-                        .child(workspace_row(
-                            "workspace-runner",
-                            "terminal.svg",
-                            "runner",
-                            matches!(&route, AppRoute::Runners | AppRoute::RunnerDetail(_)),
-                            {
-                                let shell = self.shell.clone();
-                                move |window, cx| {
-                                    if let Some(shell) = shell.upgrade() {
-                                        shell.update(cx, |shell, shell_cx| {
-                                            shell.open_runners(window, shell_cx)
-                                        });
-                                    }
-                                }
-                            },
-                        ))
-                        .child(workspace_row(
-                            "workspace-crew",
-                            "users.svg",
-                            "crew",
-                            matches!(&route, AppRoute::Crews | AppRoute::CrewEditor(_)),
-                            {
-                                let shell = self.shell.clone();
-                                move |window, cx| {
-                                    if let Some(shell) = shell.upgrade() {
-                                        shell.update(cx, |shell, shell_cx| {
-                                            shell.open_crews(window, shell_cx)
-                                        });
-                                    }
-                                }
-                            },
-                        )),
+                        .children(workspace_rows),
                 ),
             )
             .child(
@@ -2277,6 +2201,8 @@ impl Sidebar {
             .rename
             .as_ref()
             .is_some_and(|rename| rename.target.matches(NodeType::Project, &project.id));
+        let create_menu_root = cx.entity();
+        let create_project_id = project.id.clone();
         let menu_root = cx.entity();
         let menu_project = project.clone();
         let toggle_id = project.id.clone();
@@ -2331,20 +2257,39 @@ impl Sidebar {
             )
             .children(collapsed.then(|| attention_indicator(attention)))
             .child(
-                IconButton::new(
-                    SharedString::from(format!("sidebar-project-actions-{}", project.id)),
-                    "more-horizontal.svg",
-                )
-                .size(IconButtonSize::Xs)
-                .stop_click_propagation(true)
-                .reveal_on_group_hover("sidebar-row-actions")
-                .tooltip("Project actions")
-                .on_press(move |window, cx| {
-                    let position = window.mouse_position();
-                    menu_root.update(cx, |this, cx| {
-                        this.open_project_menu(menu_project.clone(), position, window, cx)
-                    });
-                }),
+                div()
+                    .flex()
+                    .items_center()
+                    .gap_2()
+                    .child(project_row_action(
+                        SharedString::from(format!("sidebar-project-create-{}", project.id)),
+                        "plus.svg",
+                        12.,
+                        "New in project",
+                        move |window, cx| {
+                            let position = window.mouse_position();
+                            create_menu_root.update(cx, |this, cx| {
+                                this.open_project_create_menu(
+                                    create_project_id.clone(),
+                                    position,
+                                    window,
+                                    cx,
+                                )
+                            });
+                        },
+                    ))
+                    .child(project_row_action(
+                        SharedString::from(format!("sidebar-project-actions-{}", project.id)),
+                        "more-horizontal.svg",
+                        14.,
+                        "Project actions",
+                        move |window, cx| {
+                            let position = window.mouse_position();
+                            menu_root.update(cx, |this, cx| {
+                                this.open_project_menu(menu_project.clone(), position, window, cx)
+                            });
+                        },
+                    )),
             )
             .on_click(cx.listener(move |this, _, _, cx| {
                 this.toggle_project(&toggle_id, cx);
@@ -2889,6 +2834,120 @@ impl NativeRoot {
     }
 }
 
+fn tab_menu_entries(
+    node_id: &str,
+    pinned: bool,
+    original: String,
+    multi_pane: bool,
+    session_ids: Vec<String>,
+) -> Vec<(UiMenuItem, SidebarMenuAction)> {
+    vec![
+        (
+            UiMenuItem::new(if pinned { "Unpin" } else { "Pin" }).icon(if pinned {
+                "pin-off.svg"
+            } else {
+                "pin.svg"
+            }),
+            SidebarMenuAction::TogglePin {
+                node_id: node_id.to_owned(),
+                pinned,
+            },
+        ),
+        (
+            UiMenuItem::new("Rename tab").icon("pencil.svg"),
+            SidebarMenuAction::Rename(SidebarRenameTarget::Tab {
+                node_id: node_id.to_owned(),
+                original,
+            }),
+        ),
+        (
+            UiMenuItem::new(if multi_pane { "Archive all" } else { "Archive" })
+                .icon("archive.svg")
+                .destructive(true),
+            SidebarMenuAction::ArchiveTab(session_ids),
+        ),
+    ]
+}
+
+fn mission_menu_entries(
+    node_id: &str,
+    pinned: bool,
+    mission_id: &str,
+    original: String,
+) -> Vec<(UiMenuItem, SidebarMenuAction)> {
+    vec![
+        (
+            UiMenuItem::new(if pinned { "Unpin" } else { "Pin" }).icon(if pinned {
+                "pin-off.svg"
+            } else {
+                "pin.svg"
+            }),
+            SidebarMenuAction::TogglePin {
+                node_id: node_id.to_owned(),
+                pinned,
+            },
+        ),
+        (
+            UiMenuItem::new("Rename").icon("pencil.svg"),
+            SidebarMenuAction::Rename(SidebarRenameTarget::Mission {
+                mission_id: mission_id.to_owned(),
+                original,
+            }),
+        ),
+        (
+            UiMenuItem::new("Archive")
+                .icon("archive.svg")
+                .destructive(true),
+            SidebarMenuAction::ArchiveMission(mission_id.to_owned()),
+        ),
+    ]
+}
+
+fn project_create_menu_entries(project_id: &str) -> Vec<(UiMenuItem, SidebarMenuAction)> {
+    vec![
+        (
+            UiMenuItem::new("New chat").icon("message-square-plus.svg"),
+            SidebarMenuAction::NewChat(Some(project_id.to_owned())),
+        ),
+        (
+            UiMenuItem::new("New mission").icon("flag.svg"),
+            SidebarMenuAction::NewMission(Some(project_id.to_owned())),
+        ),
+    ]
+}
+
+fn project_menu_entries(
+    project_id: String,
+    project_name: String,
+) -> Vec<(UiMenuItem, SidebarMenuAction)> {
+    vec![
+        (
+            UiMenuItem::new("New chat in project").icon("message-square-plus.svg"),
+            SidebarMenuAction::NewChat(Some(project_id.clone())),
+        ),
+        (
+            UiMenuItem::new("New mission in project").icon("flag.svg"),
+            SidebarMenuAction::NewMission(Some(project_id.clone())),
+        ),
+        (
+            UiMenuItem::new("Rename project")
+                .icon("pencil.svg")
+                .separator_before(true),
+            SidebarMenuAction::Rename(SidebarRenameTarget::Project {
+                project_id: project_id.clone(),
+                original: project_name,
+            }),
+        ),
+        (
+            UiMenuItem::new("Delete project")
+                .icon("trash.svg")
+                .separator_before(true)
+                .destructive(true),
+            SidebarMenuAction::DeleteProject(project_id),
+        ),
+    ]
+}
+
 fn node_project_id(nodes: &[NodeRow], node: &NodeRow) -> Option<String> {
     let parent = nodes
         .iter()
@@ -2915,6 +2974,102 @@ fn section_title(label: &'static str) -> AnyElement {
         .text_color(theme::faint())
         .child(label)
         .into_any_element()
+}
+
+fn workspace_new_chat_row(on_click: impl Fn(&mut Window, &mut gpui::App) + 'static) -> AnyElement {
+    div()
+        .id("workspace-new-chat")
+        .w_full()
+        .px(rems(10. / 16.))
+        .py(rems(6. / 16.))
+        .flex()
+        .items_center()
+        .gap_2()
+        .rounded_sm()
+        .border_1()
+        .border_color(gpui::transparent_black())
+        .cursor_pointer()
+        .hover(|row| {
+            row.border_color(theme::sidebar_selected_border())
+                .bg(theme::with_alpha(theme::sidebar_selected(), 0.4))
+        })
+        .child(
+            svg()
+                .path("message-square-plus.svg")
+                .size(rems(12. / 16.))
+                .flex_none()
+                .text_color(theme::accent()),
+        )
+        .child(
+            div()
+                .min_w(px(0.))
+                .flex_1()
+                .text_size(rems(14. / 16.))
+                .font_weight(FontWeight::SEMIBOLD)
+                .text_color(theme::muted())
+                .child("New chat"),
+        )
+        .child(
+            div()
+                .flex_none()
+                .text_size(rems(11. / 16.))
+                .font_weight(FontWeight::MEDIUM)
+                .text_color(theme::faint())
+                .child("⌘N"),
+        )
+        .on_click(move |_, window, cx| on_click(window, cx))
+        .into_any_element()
+}
+
+fn project_row_action(
+    id: SharedString,
+    icon: &'static str,
+    icon_size: f32,
+    tooltip: &'static str,
+    on_press: impl Fn(&mut Window, &mut gpui::App) + 'static,
+) -> AnyElement {
+    let id = gpui::ElementId::from(id);
+    let tooltip_id = (id.clone(), "tooltip");
+    let on_press = Rc::new(on_press);
+    let key_press = Rc::clone(&on_press);
+    let button = div()
+        .id(id)
+        .tab_index(0)
+        .tab_stop(true)
+        .size(rems(1.))
+        .flex()
+        .items_center()
+        .justify_center()
+        .rounded_sm()
+        .opacity(0.)
+        .group_hover("sidebar-row-actions", |button| button.opacity(1.))
+        .cursor_pointer()
+        .hover(|button| button.bg(theme::raised()))
+        .focus_visible(|button| {
+            button
+                .opacity(1.)
+                .border_1()
+                .border_color(theme::border_strong())
+        })
+        .child(
+            svg()
+                .path(icon)
+                .size(rems(icon_size / 16.))
+                .text_color(theme::muted())
+                .group_hover("sidebar-row-actions", |icon| icon.text_color(theme::text())),
+        )
+        .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+        .on_click(move |_, window, cx| {
+            cx.stop_propagation();
+            on_press(window, cx);
+        })
+        .on_key_down(move |event: &KeyDownEvent, window, cx| {
+            if matches!(event.keystroke.key.as_str(), "enter" | "space") {
+                cx.stop_propagation();
+                key_press(window, cx);
+            }
+        });
+    Tooltip::new(tooltip_id, tooltip, button).into_any_element()
 }
 
 fn workspace_row(
@@ -3280,6 +3435,123 @@ mod tests {
             name: "event/appended",
             payload: serde_json::json!({ "event": { "type": signal } }),
         }
+    }
+
+    fn menu_labels(entries: &[(UiMenuItem, SidebarMenuAction)]) -> Vec<&str> {
+        entries
+            .iter()
+            .map(|(item, _)| item.label.as_ref())
+            .collect()
+    }
+
+    #[test]
+    fn workspace_starts_with_a_non_selectable_new_chat_action() {
+        assert_eq!(
+            WORKSPACE_ENTRIES,
+            [
+                WorkspaceEntry::NewChat,
+                WorkspaceEntry::Runner,
+                WorkspaceEntry::Crew,
+            ]
+        );
+        assert!(!WorkspaceEntry::NewChat.selectable());
+        assert!(!WorkspaceEntry::NewChat.selected(&AppRoute::Runners));
+        assert!(!WorkspaceEntry::NewChat.selected(&AppRoute::Crews));
+        assert!(!WorkspaceEntry::NewChat.selected(&AppRoute::Settings));
+        assert!(WorkspaceEntry::Runner.selectable());
+        assert!(WorkspaceEntry::Crew.selectable());
+    }
+
+    #[test]
+    fn project_create_menu_uses_short_labels_and_project_targets() {
+        let entries = project_create_menu_entries("project-1");
+        assert_eq!(menu_labels(&entries), ["New chat", "New mission"]);
+        assert_eq!(
+            entries
+                .iter()
+                .map(|(_, action)| action.clone())
+                .collect::<Vec<_>>(),
+            [
+                SidebarMenuAction::NewChat(Some("project-1".into())),
+                SidebarMenuAction::NewMission(Some("project-1".into())),
+            ]
+        );
+
+        let project_entries = project_menu_entries("project-1".into(), "Runner".into());
+        assert_eq!(
+            menu_labels(&project_entries),
+            [
+                "New chat in project",
+                "New mission in project",
+                "Rename project",
+                "Delete project",
+            ]
+        );
+    }
+
+    #[test]
+    fn tab_and_mission_menus_have_the_trimmed_item_lists() {
+        let tab_entries = tab_menu_entries(
+            "tab-1",
+            false,
+            "My tab".into(),
+            false,
+            vec!["session-1".into(), "session-2".into()],
+        );
+        assert_eq!(menu_labels(&tab_entries), ["Pin", "Rename tab", "Archive"]);
+        assert!(tab_entries[2].0.destructive);
+        assert_eq!(
+            tab_entries
+                .iter()
+                .map(|(_, action)| action.clone())
+                .collect::<Vec<_>>(),
+            [
+                SidebarMenuAction::TogglePin {
+                    node_id: "tab-1".into(),
+                    pinned: false,
+                },
+                SidebarMenuAction::Rename(SidebarRenameTarget::Tab {
+                    node_id: "tab-1".into(),
+                    original: "My tab".into(),
+                }),
+                SidebarMenuAction::ArchiveTab(vec!["session-1".into(), "session-2".into(),]),
+            ]
+        );
+
+        let multi_pane_entries = tab_menu_entries(
+            "tab-1",
+            false,
+            "My tab".into(),
+            true,
+            vec!["session-1".into(), "session-2".into()],
+        );
+        assert_eq!(
+            menu_labels(&multi_pane_entries),
+            ["Pin", "Rename tab", "Archive all"]
+        );
+        assert!(multi_pane_entries[2].0.destructive);
+
+        let mission_entries =
+            mission_menu_entries("mission-node-1", false, "mission-1", "My mission".into());
+        assert_eq!(menu_labels(&mission_entries), ["Pin", "Rename", "Archive"]);
+        assert!(mission_entries[2].0.destructive);
+        assert_eq!(
+            mission_entries
+                .iter()
+                .map(|(_, action)| action.clone())
+                .collect::<Vec<_>>(),
+            [
+                SidebarMenuAction::TogglePin {
+                    node_id: "mission-node-1".into(),
+                    pinned: false,
+                },
+                SidebarMenuAction::Rename(SidebarRenameTarget::Mission {
+                    mission_id: "mission-1".into(),
+                    original: "My mission".into(),
+                }),
+                SidebarMenuAction::ArchiveMission("mission-1".into()),
+            ]
+        );
     }
 
     #[test]

--- a/crates/runner-app/src/surfaces/start_chat.rs
+++ b/crates/runner-app/src/surfaces/start_chat.rs
@@ -159,7 +159,7 @@ impl NativeRoot {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.route == AppRoute::Settings || self.start_chat_modal.is_some() {
+        if self.start_chat_modal.is_some() {
             return;
         }
         let active_project_id = self.active_project_id(cx);

--- a/crates/runner-app/src/ui/button.rs
+++ b/crates/runner-app/src/ui/button.rs
@@ -491,7 +491,7 @@ pub fn is_activation_key(event: &KeyDownEvent) -> bool {
     matches!(event.keystroke.key.as_str(), "enter" | "space")
 }
 
-pub(crate) fn focus_ring(color: gpui::Hsla) -> Vec<BoxShadow> {
+pub fn focus_ring(color: gpui::Hsla) -> Vec<BoxShadow> {
     vec![
         BoxShadow {
             color: theme::bg(),

--- a/crates/runner-app/src/ui/mod.rs
+++ b/crates/runner-app/src/ui/mod.rs
@@ -30,7 +30,9 @@ fn zoom_from_rem_size(rem_size: Pixels) -> f32 {
 pub use avatar::{
     cells_for_seed, hue_for_seed, lead_badge, AvatarHue, RunnerAvatar, RunnerPresence,
 };
-pub use button::{Button, ButtonSize, ButtonVariant, IconButton, IconButtonSize, PressHandler};
+pub use button::{
+    focus_ring, Button, ButtonSize, ButtonVariant, IconButton, IconButtonSize, PressHandler,
+};
 pub use copy_value_button::CopyValueButton;
 pub use duplicate_subject_overlay::{DuplicateSubjectKind, DuplicateSubjectOverlay};
 pub use field::{

--- a/crates/runner-app/tests/bundle_mac.rs
+++ b/crates/runner-app/tests/bundle_mac.rs
@@ -66,6 +66,7 @@ fn nightly_plist_uses_the_isolated_rolling_channel() {
         "com.wycstudios.runner.nightly"
     );
     assert_eq!(plist_value(&plist, "CFBundleName"), "Runner Nightly");
+    assert_eq!(plist_value(&plist, "CFBundleExecutable"), "Runner");
     assert_eq!(
         plist_value(&plist, "SUFeedURL"),
         "https://github.com/yicheng47/runner/releases/download/nightly/appcast.xml"
@@ -101,6 +102,7 @@ fn production_plist_keeps_the_marketing_version_separate_from_the_stamp() {
         "com.wycstudios.runner"
     );
     assert_eq!(plist_value(&plist, "CFBundleName"), "Runner");
+    assert_eq!(plist_value(&plist, "CFBundleExecutable"), "Runner");
     assert_eq!(
         plist_value(&plist, "SUFeedURL"),
         "https://github.com/yicheng47/runner/releases/latest/download/appcast.xml"

--- a/crates/runner-app/tests/bundle_mac.rs
+++ b/crates/runner-app/tests/bundle_mac.rs
@@ -15,6 +15,12 @@ fn run(args: &[&str]) -> std::process::Output {
         .unwrap()
 }
 
+fn bundle_version() -> String {
+    let output = run(&["--print-version"]);
+    assert!(output.status.success());
+    String::from_utf8(output.stdout).unwrap().trim().to_owned()
+}
+
 fn plist_value<'a>(plist: &'a str, key: &str) -> &'a str {
     let marker = format!("<key>{key}</key>");
     let after_key = plist.split_once(&marker).unwrap().1;
@@ -43,6 +49,7 @@ fn assert_update_preferences(plist: &str) {
 
 #[test]
 fn nightly_plist_uses_the_isolated_rolling_channel() {
+    let version = bundle_version();
     let output = run(&[
         "--channel",
         "nightly",
@@ -65,7 +72,7 @@ fn nightly_plist_uses_the_isolated_rolling_channel() {
     );
     assert_eq!(
         plist_value(&plist, "CFBundleShortVersionString"),
-        "0.6.0-nightly.20260821.1432"
+        format!("{version}.20260821.1432")
     );
     assert_eq!(plist_value(&plist, "CFBundleVersion"), "20260821.1432");
     assert_eq!(
@@ -77,6 +84,7 @@ fn nightly_plist_uses_the_isolated_rolling_channel() {
 
 #[test]
 fn production_plist_keeps_the_marketing_version_separate_from_the_stamp() {
+    let version = bundle_version();
     let output = run(&[
         "--channel",
         "production",
@@ -97,7 +105,10 @@ fn production_plist_keeps_the_marketing_version_separate_from_the_stamp() {
         plist_value(&plist, "SUFeedURL"),
         "https://github.com/yicheng47/runner/releases/latest/download/appcast.xml"
     );
-    assert_eq!(plist_value(&plist, "CFBundleShortVersionString"), "0.6.0");
+    assert_eq!(
+        plist_value(&plist, "CFBundleShortVersionString"),
+        version.strip_suffix("-nightly").unwrap_or(&version)
+    );
     assert_eq!(plist_value(&plist, "CFBundleVersion"), "20260821.1432");
     assert_eq!(
         plist_value(&plist, "SUPublicEDKey"),

--- a/crates/runner-terminal/src/input_state.rs
+++ b/crates/runner-terminal/src/input_state.rs
@@ -1,7 +1,10 @@
 use std::time::{Duration, Instant};
 
 use alacritty_terminal::grid::Dimensions as _;
+use alacritty_terminal::index::{Column, Line};
+use alacritty_terminal::term::cell::Flags;
 use alacritty_terminal::term::Term;
+use alacritty_terminal::vte::ansi::Color;
 use serde::{Deserialize, Serialize};
 
 pub use runner_backend::session::manager::{InputObservation, InputState};
@@ -27,14 +30,23 @@ struct Composer {
     last_form: String,
     visible: bool,
     submitted_form: Option<String>,
+    placeholder_style: Option<CellStyle>,
 }
 
 #[derive(Clone, Debug)]
 struct Probe {
     typed: String,
     rows_before: Vec<String>,
+    styles_before: Vec<Vec<CellStyle>>,
     started: Instant,
     weak_match: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct CellStyle {
+    fg: Color,
+    bg: Color,
+    flags: Flags,
 }
 
 #[derive(Clone, Debug)]
@@ -58,6 +70,7 @@ pub struct InputTracker {
     composing: bool,
     reported: Option<ReportedState>,
     public_since: Instant,
+    input_revision: u64,
 }
 
 impl InputTracker {
@@ -67,6 +80,7 @@ impl InputTracker {
             composing: false,
             reported: None,
             public_since: now,
+            input_revision: 0,
         }
     }
 
@@ -81,6 +95,7 @@ impl InputTracker {
         now: Instant,
         term: &Term<T>,
     ) -> Option<InputObservation> {
+        self.input_revision = self.input_revision.wrapping_add(1);
         self.expire_probe(now);
         match event {
             InputEvent::Composing { composing } => self.composing = *composing,
@@ -114,14 +129,18 @@ impl InputTracker {
                         &probe.typed,
                         probe.weak_match,
                     ) {
-                        Some(matched) => TrackerState::Drafting(Composer {
-                            row: matched.row,
-                            prefix: matched.prefix,
-                            empty_forms: vec![probe.rows_before[matched.row].clone()],
-                            last_form: rows_after[matched.row].clone(),
-                            visible: true,
-                            submitted_form: None,
-                        }),
+                        Some(matched) => {
+                            let placeholder_style = probe_placeholder_style(&probe, &matched, term);
+                            TrackerState::Drafting(Composer {
+                                row: matched.row,
+                                prefix: matched.prefix,
+                                empty_forms: vec![probe.rows_before[matched.row].clone()],
+                                last_form: rows_after[matched.row].clone(),
+                                visible: true,
+                                submitted_form: None,
+                                placeholder_style,
+                            })
+                        }
                         None => TrackerState::Probing(probe),
                     }
                 }
@@ -138,10 +157,13 @@ impl InputTracker {
                     probe.weak_match,
                 ) {
                     let before = &probe.rows_before[matched.row];
-                    if composer_is_empty(before, &matched.prefix, &composer.empty_forms)
+                    if composer_text_is_empty(before, &matched.prefix, &composer.empty_forms)
                         && !composer.empty_forms.contains(before)
                     {
                         composer.empty_forms.push(before.clone());
+                    }
+                    if let Some(style) = probe_placeholder_style(&probe, &matched, term) {
+                        composer.placeholder_style = Some(style);
                     }
                     composer.row = matched.row;
                     composer.prefix = matched.prefix;
@@ -161,18 +183,27 @@ impl InputTracker {
         self.emit_if_changed(now)
     }
 
+    pub fn reset_guard(&self) -> u64 {
+        self.input_revision
+    }
+
+    pub fn reset_if_unchanged(&mut self, guard: u64, now: Instant) -> Option<InputObservation> {
+        if self.input_revision != guard {
+            return None;
+        }
+        self.state = TrackerState::Idle;
+        self.composing = false;
+        self.input_revision = self.input_revision.wrapping_add(1);
+        self.emit_if_changed(now)
+    }
+
     fn observe_content<T>(&mut self, text: &str, pasted: bool, now: Instant, term: &Term<T>) {
         if text.is_empty() {
             return;
         }
         let state = std::mem::replace(&mut self.state, TrackerState::Idle);
         self.state = match state {
-            TrackerState::Idle => TrackerState::Probing(Probe {
-                typed: probe_text(text),
-                rows_before: visible_rows(term),
-                started: now,
-                weak_match: pasted && weak_paste_match(text),
-            }),
+            TrackerState::Idle => TrackerState::Probing(new_probe(text, pasted, now, term)),
             TrackerState::Probing(mut probe) => {
                 probe.typed.push_str(&probe_text(text));
                 probe.weak_match |= pasted && weak_paste_match(text);
@@ -191,12 +222,7 @@ impl InputTracker {
                 TrackerState::Drafting(composer)
             }
             TrackerState::Submitted(composer) => TrackerState::Reprobing {
-                probe: Probe {
-                    typed: probe_text(text),
-                    rows_before: visible_rows(term),
-                    started: now,
-                    weak_match: pasted && weak_paste_match(text),
-                },
+                probe: new_probe(text, pasted, now, term),
                 composer,
             },
         };
@@ -243,7 +269,7 @@ impl InputTracker {
                 TrackerState::Drafting(composer)
             };
         };
-        if composer_is_empty(&current, &composer.prefix, &composer.empty_forms) {
+        if composer_is_empty(term, composer.row, &current, &composer) {
             return TrackerState::Idle;
         }
         if !current.starts_with(&composer.prefix) {
@@ -263,7 +289,7 @@ impl InputTracker {
             composer.visible = true;
         }
 
-        if composer_is_empty(&current, &composer.prefix, &composer.empty_forms) {
+        if composer_is_empty(term, composer.row, &current, &composer) {
             return TrackerState::Idle;
         }
 
@@ -371,6 +397,100 @@ fn visible_rows<T>(term: &Term<T>) -> Vec<String> {
         .collect()
 }
 
+fn visible_row_styles<T>(term: &Term<T>) -> Vec<Vec<CellStyle>> {
+    (0..term.screen_lines())
+        .map(|row| {
+            let grid = term.grid();
+            let row = &grid[Line(row as i32)];
+            (0..grid.columns())
+                .filter_map(|column| {
+                    let cell = &row[Column(column)];
+                    (!cell
+                        .flags
+                        .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER))
+                    .then(|| {
+                        std::iter::repeat_n(
+                            cell_style(cell),
+                            1 + cell.zerowidth().map_or(0, <[_]>::len),
+                        )
+                    })
+                })
+                .flatten()
+                .collect()
+        })
+        .collect()
+}
+
+fn new_probe<T>(text: &str, pasted: bool, now: Instant, term: &Term<T>) -> Probe {
+    Probe {
+        typed: probe_text(text),
+        rows_before: visible_rows(term),
+        styles_before: visible_row_styles(term),
+        started: now,
+        weak_match: pasted && weak_paste_match(text),
+    }
+}
+
+fn cell_style(cell: &alacritty_terminal::term::cell::Cell) -> CellStyle {
+    let mut flags = cell.flags;
+    flags.remove(
+        Flags::WIDE_CHAR
+            | Flags::WIDE_CHAR_SPACER
+            | Flags::LEADING_WIDE_CHAR_SPACER
+            | Flags::WRAPLINE,
+    );
+    CellStyle {
+        fg: cell.fg,
+        bg: cell.bg,
+        flags,
+    }
+}
+
+fn snapshot_content_style(text: &str, styles: &[CellStyle], prefix: &str) -> Option<CellStyle> {
+    text.chars()
+        .zip(styles)
+        .skip(prefix.chars().count())
+        .find_map(|(character, style)| (!character.is_whitespace()).then_some(*style))
+}
+
+fn row_content_style<T>(term: &Term<T>, row: usize, prefix: &str) -> Option<CellStyle> {
+    let grid = term.grid();
+    let row = &grid[Line(row as i32)];
+    let mut prefix_characters = prefix.chars().count();
+    for column in 0..grid.columns() {
+        let cell = &row[Column(column)];
+        if cell
+            .flags
+            .intersects(Flags::WIDE_CHAR_SPACER | Flags::LEADING_WIDE_CHAR_SPACER)
+        {
+            continue;
+        }
+        if prefix_characters > 0 {
+            prefix_characters =
+                prefix_characters.saturating_sub(1 + cell.zerowidth().map_or(0, <[_]>::len));
+            continue;
+        }
+        if !cell.c.is_whitespace() {
+            return Some(cell_style(cell));
+        }
+    }
+    None
+}
+
+fn probe_placeholder_style<T>(
+    probe: &Probe,
+    matched: &EchoMatch,
+    term: &Term<T>,
+) -> Option<CellStyle> {
+    let placeholder = snapshot_content_style(
+        &probe.rows_before[matched.row],
+        &probe.styles_before[matched.row],
+        &matched.prefix,
+    );
+    let draft = row_content_style(term, matched.row, &matched.prefix);
+    placeholder.filter(|style| Some(*style) != draft)
+}
+
 fn locate_echo(
     before: &[String],
     after: &[String],
@@ -473,8 +593,16 @@ fn looks_like_prompt_prefix(prefix: &str) -> bool {
     prefix.chars().last().is_some_and(char::is_whitespace) && !last.is_alphanumeric()
 }
 
-fn composer_is_empty(current: &str, prefix: &str, empty_forms: &[String]) -> bool {
+fn composer_text_is_empty(current: &str, prefix: &str, empty_forms: &[String]) -> bool {
     empty_forms.iter().any(|form| current == form) || current.trim_end() == prefix.trim_end()
+}
+
+fn composer_is_empty<T>(term: &Term<T>, row: usize, current: &str, composer: &Composer) -> bool {
+    composer_text_is_empty(current, &composer.prefix, &composer.empty_forms)
+        || (current != composer.last_form
+            && composer.placeholder_style.is_some_and(|placeholder| {
+                row_content_style(term, row, &composer.prefix) == Some(placeholder)
+            }))
 }
 
 fn relocate_row<T>(term: &Term<T>, prefix: &str, old_row: usize) -> Option<usize> {
@@ -612,6 +740,190 @@ mod tests {
             .observe_output(start + Duration::from_millis(10), &term)
             .unwrap();
         assert_eq!(idle.state, InputState::Idle);
+    }
+
+    #[test]
+    fn claude_styled_rotated_placeholder_returns_drafting_to_idle() {
+        let start = Instant::now();
+        let mut term = new_term(50, 4);
+        feed(
+            &mut term,
+            b"\x1b[2;1H\xe2\x9d\xaf \x1b[2mTry refactoring this file\x1b[22m",
+        );
+        let mut tracker = InputTracker::new(start);
+        tracker.initial_observation(start);
+        tracker.observe_input(
+            &InputEvent::Key {
+                kind: InputKind::Content { text: "h".into() },
+            },
+            start,
+            &term,
+        );
+        feed(&mut term, b"\r\x1b[K\xe2\x9d\xaf h");
+        assert_eq!(
+            tracker
+                .observe_output(start + Duration::from_millis(1), &term)
+                .unwrap()
+                .state,
+            InputState::Drafting
+        );
+
+        feed(
+            &mut term,
+            b"\r\x1b[K\xe2\x9d\xaf \x1b[2mTry writing a test\x1b[22m",
+        );
+        assert_eq!(
+            tracker
+                .observe_output(start + Duration::from_millis(2), &term)
+                .unwrap()
+                .state,
+            InputState::Idle
+        );
+    }
+
+    #[test]
+    fn restyled_live_draft_stays_drafting() {
+        let start = Instant::now();
+        let mut term = new_term(50, 4);
+        feed(
+            &mut term,
+            b"\x1b[2;1H\xe2\x9d\xaf \x1b[2mTry refactoring this file\x1b[22m",
+        );
+        let mut tracker = InputTracker::new(start);
+        tracker.initial_observation(start);
+        tracker.observe_input(
+            &InputEvent::Key {
+                kind: InputKind::Content {
+                    text: "hello world".into(),
+                },
+            },
+            start,
+            &term,
+        );
+        feed(&mut term, b"\r\x1b[K\xe2\x9d\xaf hello world");
+        assert_eq!(
+            tracker
+                .observe_output(start + Duration::from_millis(1), &term)
+                .unwrap()
+                .state,
+            InputState::Drafting
+        );
+
+        feed(
+            &mut term,
+            b"\r\x1b[K\xe2\x9d\xaf \x1b[2mhello world\x1b[22m",
+        );
+        assert!(tracker
+            .observe_output(start + Duration::from_millis(2), &term)
+            .is_none());
+        assert_eq!(tracker.current_reported_state().state, InputState::Drafting);
+    }
+
+    #[test]
+    fn codex_styled_rotated_placeholder_returns_drafting_to_idle() {
+        let start = Instant::now();
+        let mut term = new_term(50, 4);
+        feed(
+            &mut term,
+            b"\x1b[2;1H\xe2\x94\x82 \xe2\x80\xba \x1b[38;5;8mAsk Codex\x1b[39m             \xe2\x94\x82",
+        );
+        let mut tracker = InputTracker::new(start);
+        tracker.initial_observation(start);
+        tracker.observe_input(
+            &InputEvent::Key {
+                kind: InputKind::Content { text: "h".into() },
+            },
+            start,
+            &term,
+        );
+        feed(
+            &mut term,
+            b"\r\x1b[K\xe2\x94\x82 \xe2\x80\xba h                     \xe2\x94\x82",
+        );
+        assert_eq!(
+            tracker
+                .observe_output(start + Duration::from_millis(1), &term)
+                .unwrap()
+                .state,
+            InputState::Drafting
+        );
+
+        feed(
+            &mut term,
+            b"\r\x1b[K\xe2\x94\x82 \xe2\x80\xba \x1b[38;5;8mReview this repository\x1b[39m\xe2\x94\x82",
+        );
+        assert_eq!(
+            tracker
+                .observe_output(start + Duration::from_millis(2), &term)
+                .unwrap()
+                .state,
+            InputState::Idle
+        );
+    }
+
+    #[test]
+    fn explicit_reset_forces_a_draft_idle_once() {
+        let start = Instant::now();
+        let mut term = new_term(40, 4);
+        feed(&mut term, b"\x1b[2;1H\xe2\x9d\xaf Try a task");
+        let mut tracker = InputTracker::new(start);
+        tracker.initial_observation(start);
+        tracker.observe_input(
+            &InputEvent::Key {
+                kind: InputKind::Content { text: "h".into() },
+            },
+            start,
+            &term,
+        );
+        feed(&mut term, b"\r\x1b[K\xe2\x9d\xaf h");
+        assert_eq!(
+            tracker
+                .observe_output(start + Duration::from_millis(1), &term)
+                .unwrap()
+                .state,
+            InputState::Drafting
+        );
+
+        let guard = tracker.reset_guard();
+        let reset = tracker
+            .reset_if_unchanged(guard, start + Duration::from_millis(2))
+            .unwrap();
+        assert_eq!(reset.state, InputState::Idle);
+        assert!(!reset.composing);
+        assert!(tracker
+            .reset_if_unchanged(guard, start + Duration::from_millis(3))
+            .is_none());
+    }
+
+    #[test]
+    fn explicit_reset_does_not_clear_input_observed_after_the_guard() {
+        let start = Instant::now();
+        let mut term = new_term(40, 4);
+        feed(&mut term, b"\x1b[2;1H\xe2\x9d\xaf Try a task");
+        let mut tracker = InputTracker::new(start);
+        tracker.initial_observation(start);
+        tracker.observe_input(
+            &InputEvent::Key {
+                kind: InputKind::Content { text: "h".into() },
+            },
+            start,
+            &term,
+        );
+        feed(&mut term, b"\r\x1b[K\xe2\x9d\xaf h");
+        tracker.observe_output(start + Duration::from_millis(1), &term);
+        let guard = tracker.reset_guard();
+        tracker.observe_input(
+            &InputEvent::Key {
+                kind: InputKind::Content { text: "i".into() },
+            },
+            start + Duration::from_millis(2),
+            &term,
+        );
+
+        assert!(tracker
+            .reset_if_unchanged(guard, start + Duration::from_millis(3))
+            .is_none());
+        assert_eq!(tracker.current_reported_state().state, InputState::Drafting);
     }
 
     #[test]

--- a/crates/runner-terminal/src/terminal.rs
+++ b/crates/runner-terminal/src/terminal.rs
@@ -499,6 +499,23 @@ impl TerminalSession {
         }
     }
 
+    pub fn input_reset_guard(&self) -> u64 {
+        self.input_tracker.lock().unwrap().reset_guard()
+    }
+
+    pub fn reset_input_state(&self, guard: u64) {
+        let observation = self
+            .input_tracker
+            .lock()
+            .unwrap()
+            .reset_if_unchanged(guard, Instant::now());
+        if let Some(observation) = observation {
+            self.core
+                .sessions
+                .report_input_state(&self.session_id, observation);
+        }
+    }
+
     pub fn resize(&self, cols: u16, rows: u16) {
         let cols = cols.max(2);
         let rows = rows.max(2);

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -140,7 +140,7 @@ write_plist() {
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>CFBundleExecutable</key>
-    <string>runner-app</string>
+    <string>Runner</string>
     <key>CFBundleIconFile</key>
     <string>Runner.icns</string>
     <key>CFBundleIdentifier</key>
@@ -235,7 +235,7 @@ for target_triple in "${TARGET_TRIPLES[@]}"; do
     cargo build --manifest-path "$ROOT_DIR/Cargo.toml" --locked --release --package runner-cli --bins --target "$target_triple"
 done
 
-for binary in runner-app runner-agent-cli runner-mcp; do
+for binary in Runner runner-agent-cli runner-mcp; do
     arm64_path="$ROOT_DIR/target/aarch64-apple-darwin/release/$binary"
     x86_64_path="$ROOT_DIR/target/x86_64-apple-darwin/release/$binary"
     for binary_path in "$arm64_path" "$x86_64_path"; do
@@ -276,8 +276,8 @@ codesign --force "${CODESIGN_OPTIONS[@]}" --preserve-metadata=entitlements --sig
 codesign --force "${CODESIGN_OPTIONS[@]}" --sign "$SIGNING_IDENTITY" "$SPARKLE_ROOT/Autoupdate"
 codesign --force "${CODESIGN_OPTIONS[@]}" --sign "$SIGNING_IDENTITY" "$SPARKLE_ROOT/Updater.app"
 codesign --force "${CODESIGN_OPTIONS[@]}" --sign "$SIGNING_IDENTITY" "$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
-# Sign sidecars first: codesign resolves runner-app to the enclosing bundle, whose lipo-created x86_64 sidecars lack linker ad-hoc signatures.
-for binary in runner-agent-cli runner-mcp runner-app; do
+# Sign sidecars first: codesign resolves Runner to the enclosing bundle, whose lipo-created x86_64 sidecars lack linker ad-hoc signatures.
+for binary in runner-agent-cli runner-mcp Runner; do
     codesign --force "${CODESIGN_OPTIONS[@]}" --sign "$SIGNING_IDENTITY" "$APP_BUNDLE/Contents/MacOS/$binary"
 done
 codesign --force "${CODESIGN_OPTIONS[@]}" --sign "$SIGNING_IDENTITY" "$APP_BUNDLE"


### PR DESCRIPTION
## Summary

- add New chat as the first WORKSPACE action row and align it with the Command-N modal path
- add project-row quick-create actions and trim tab/mission menus while preserving Archive all for multi-pane tabs
- recover phantom terminal drafts through styled-placeholder detection and a guarded Submit / clear escape hatch
- rename the native executable from runner-app to Runner while keeping the package name unchanged
- derive bundle plist version expectations from the live bundle script and assert CFBundleExecutable

## Validation

- make verify: passed end-to-end on the complete A/B/C tree
- cargo test -p runner-terminal: 48 unit passed, 1 ignored; fixture, input replay, and OSC suites passed
- cargo test -p runner-app --test bundle_mac: 3 passed
- nightly bundle plist reports CFBundleExecutable as Runner
- git diff --check: clean
- Jason manually smoke-tested M6.21 behavior, input-state recovery, and the Runner app name
- working-tree review: A, B, and C CLEAN

## Input-state evidence

The detector regressions use hand-built styled terminal byte sequences based on the existing Claude/Codex fixture shapes; no new live recordings were added. Jason’s manual smoke passed. If the pill misfires again, the next step is recording live Claude and Codex input fixtures.