### PR TITLE
fix(ui): leave the mission route when the open mission is archived (M6.22)

### DIFF
--- a/crates/runner-app/src/surfaces/app_shell.rs
+++ b/crates/runner-app/src/surfaces/app_shell.rs
@@ -31,6 +31,18 @@ impl AppRoute {
     }
 }
 
+fn route_after_mission_archived(
+    route: &AppRoute,
+    mission_id: &str,
+    was_archived: Option<bool>,
+    is_archived: bool,
+) -> Option<AppRoute> {
+    (was_archived == Some(false)
+        && is_archived
+        && matches!(route, AppRoute::Mission(active) if active == mission_id))
+    .then_some(AppRoute::Chat)
+}
+
 #[derive(Clone)]
 struct SidebarResizeDrag;
 
@@ -830,6 +842,30 @@ impl NativeRoot {
         }
     }
 
+    pub(crate) fn leave_archived_mission(
+        &mut self,
+        mission_id: &str,
+        was_archived: Option<bool>,
+        is_archived: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(route) =
+            route_after_mission_archived(&self.route, mission_id, was_archived, is_archived)
+        else {
+            return;
+        };
+        self.set_route(route, cx);
+        match self.ensure_active_tab_attached(window, cx) {
+            Ok(()) => {
+                self.mark_active_tab_viewed(window, cx);
+                self.focus_active_terminal(window, cx);
+            }
+            Err(error) => self.chat_error = Some(error.to_string()),
+        }
+        cx.notify();
+    }
+
     fn toggle_sidebar(&mut self, _: &ToggleSidebar, _: &mut Window, cx: &mut Context<Self>) {
         if self.route == AppRoute::Settings {
             return;
@@ -924,6 +960,43 @@ impl NativeRoot {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn archived_mission_only_leaves_its_open_route() {
+        assert_eq!(
+            route_after_mission_archived(
+                &AppRoute::Mission("mission-1".into()),
+                "mission-1",
+                Some(false),
+                true,
+            ),
+            Some(AppRoute::Chat)
+        );
+        for route in [
+            AppRoute::Mission("mission-2".into()),
+            AppRoute::Runners,
+            AppRoute::Settings,
+            AppRoute::Chat,
+        ] {
+            assert_eq!(
+                route_after_mission_archived(&route, "mission-1", Some(false), true),
+                None
+            );
+        }
+        let open_archived = AppRoute::Mission("mission-1".into());
+        assert_eq!(
+            route_after_mission_archived(&open_archived, "mission-1", Some(true), true),
+            None
+        );
+        assert_eq!(
+            route_after_mission_archived(&open_archived, "mission-1", None, true),
+            None
+        );
+        assert_eq!(
+            route_after_mission_archived(&open_archived, "mission-1", Some(false), false),
+            None
+        );
+    }
 
     #[test]
     fn settings_update_hint_tracks_available_state() {

--- a/crates/runner-app/src/surfaces/mission_workspace.rs
+++ b/crates/runner-app/src/surfaces/mission_workspace.rs
@@ -769,9 +769,24 @@ impl MissionWorkspace {
             })
     }
 
-    fn open_runners(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    fn leave_archived_mission(
+        &mut self,
+        mission_id: &str,
+        was_archived: Option<bool>,
+        is_archived: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if let Some(shell) = self.shell.upgrade() {
-            shell.update(cx, |shell, shell_cx| shell.open_runners(window, shell_cx));
+            shell.update(cx, |shell, shell_cx| {
+                shell.leave_archived_mission(
+                    mission_id,
+                    was_archived,
+                    is_archived,
+                    window,
+                    shell_cx,
+                )
+            });
         }
     }
 
@@ -1757,11 +1772,16 @@ impl MissionWorkspace {
             let _ = weak.update_in(cx, |this, window, cx| {
                 if !this.is_current(&mission_id, generation)
                     || this.refresh_generation != refresh_generation
+                    || !this.is_active(cx)
                 {
                     return;
                 }
                 match result {
                     Ok((mission, sessions)) => {
+                        let was_archived = this
+                            .mission
+                            .as_ref()
+                            .map(|mission| mission.archived_at.is_some());
                         let archived = mission.archived_at.is_some();
                         let valid_ids = sessions
                             .iter()
@@ -1785,6 +1805,13 @@ impl MissionWorkspace {
                                     .remove(&removed_mission_id);
                                 true
                             });
+                            this.leave_archived_mission(
+                                &mission_id,
+                                was_archived,
+                                archived,
+                                window,
+                                cx,
+                            );
                         } else if matches!(
                             &this.active_tab,
                             MissionTab::Session(session_id) if !valid_ids.contains(session_id)
@@ -2080,12 +2107,12 @@ impl MissionWorkspace {
                                 .remove(&removed_mission_id);
                             true
                         });
+                        this.leave_archived_mission(&mission_id, Some(false), true, window, cx);
                         this.refresh_store(StoreRefreshKind::All, cx);
                         this.core(cx).events.emit(
                             "mission/changed",
                             &serde_json::json!({ "mission_id": mission_id }),
                         );
-                        this.open_runners(window, cx);
                     }
                     Err(error) => {
                         this.archiving = false;


### PR DESCRIPTION
## Summary

- Archiving the open mission from the feed header jumped to the Runners page; from the sidebar row menu or the MCP `mission_archive` it stayed parked on the archived mission's feed.
- Every path now converges on `NativeRoot::leave_archived_mission`, which returns to the chat surface on the remembered active tab (the `leave_settings` recipe) — never Runners.
- Gated on the archived *transition* (`route_after_mission_archived`), so a deliberately opened archived mission (Settings → Archived) stays put on unrelated `mission/changed` events.
- Refresh completions no-op once the workspace is inactive, so the header path's own `mission/changed` emit cannot reattach hidden terminals after navigating.

Brief: `docs/impls/gpui-rewrite/briefs/m6-22-archive-leaves-mission.md` (§M6.22). Lands before the `v0.6.0` tag, beside M6.21.

## Validation

- `make verify`, `git diff --check` (coder + reviewer, working-tree review CLEAN — crew mission `01M0PTPD5H83FXDB0BCZ0RN4VN`)
- Pure unit test `archived_mission_only_leaves_its_open_route` pins the transition cases
- Dev-app smoke test by Jason: header, sidebar, and MCP archive each land on the active chat tab