### PR TITLE
fix(ui): make sidebar drops reliable

### DIFF
--- a/crates/runner-app/src/surfaces/app_shell.rs
+++ b/crates/runner-app/src/surfaces/app_shell.rs
@@ -172,14 +172,14 @@ impl NativeRoot {
             .on_mouse_up(
                 MouseButton::Left,
                 cx.listener(|this, _, _, cx| {
-                    this.clear_sidebar_drag(cx);
+                    this.clear_sidebar_drag("root-up", cx);
                     this.clear_crew_slot_drag(cx);
                 }),
             )
             .on_mouse_up_out(
                 MouseButton::Left,
                 cx.listener(|this, _, _, cx| {
-                    this.clear_sidebar_drag(cx);
+                    this.clear_sidebar_drag("root-up-out", cx);
                     this.clear_crew_slot_drag(cx);
                 }),
             )

--- a/crates/runner-app/src/surfaces/sidebar.rs
+++ b/crates/runner-app/src/surfaces/sidebar.rs
@@ -4,10 +4,11 @@ use std::path::Path;
 
 use super::*;
 use crate::surfaces::sidebar_logic::{
-    attention_rollups, complete_unpinned_scope_order, container_drop_target, list_drop_target,
-    mission_attention_state, ordered_pinned_node_ids_after_drop,
+    attention_rollups, complete_unpinned_scope_order, container_drop_target, indicator_visible,
+    list_drop_target, mission_attention_state, ordered_pinned_node_ids_after_drop,
     ordered_root_node_ids_after_project_drop, ordered_visible_node_ids_after_drop,
-    rollup_attention_state, tab_attention_state, AttentionState, DropKind, DropTarget,
+    rollup_attention_state, tab_attention_state, take_drag_state, AttentionState, DropKind,
+    DropTarget,
 };
 use crate::*;
 use gpui::{
@@ -206,6 +207,7 @@ pub(crate) struct Sidebar {
     archiving_sessions: HashSet<String>,
     archiving_missions: HashSet<String>,
     active_project_id: Option<String>,
+    window_id: u64,
     dragged_id: Option<String>,
     drop_target: Option<DropTarget>,
     drop_marker: Option<String>,
@@ -258,6 +260,7 @@ impl Sidebar {
             archiving_sessions: HashSet::new(),
             archiving_missions: HashSet::new(),
             active_project_id,
+            window_id: 0,
             dragged_id: None,
             drop_target: None,
             drop_marker: None,
@@ -480,9 +483,9 @@ impl NativeRoot {
         });
     }
 
-    pub(crate) fn clear_sidebar_drag(&mut self, cx: &mut Context<Self>) {
+    pub(crate) fn clear_sidebar_drag(&mut self, path: &'static str, cx: &mut Context<Self>) {
         self.sidebar.update(cx, |sidebar, sidebar_cx| {
-            sidebar.clear_sidebar_drag(sidebar_cx)
+            sidebar.clear_sidebar_drag(path, sidebar_cx)
         });
     }
 
@@ -548,7 +551,7 @@ impl Sidebar {
         let had_context_menu = self.context_menu.take().is_some();
         self.rename = None;
         self._rename_focus_subscription = None;
-        self.clear_sidebar_drag(cx);
+        self.clear_sidebar_drag("dismiss", cx);
         if had_context_menu {
             self.schedule_shell_notify(cx);
         }
@@ -1360,13 +1363,43 @@ impl NativeRoot {
 }
 
 impl Sidebar {
-    pub(crate) fn clear_sidebar_drag(&mut self, cx: &mut Context<Self>) {
-        if self.dragged_id.take().is_some()
-            || self.drop_target.take().is_some()
-            || self.drop_marker.take().is_some()
-        {
+    pub(crate) fn clear_sidebar_drag(&mut self, path: &'static str, cx: &mut Context<Self>) {
+        let dragged_id = self.dragged_id.clone();
+        let drop_marker = self.drop_marker.clone();
+        let changed = take_drag_state(
+            &mut self.dragged_id,
+            &mut self.drop_target,
+            &mut self.drop_marker,
+        );
+        if changed {
+            tracing::debug!(
+                target: "sidebar::drag",
+                path,
+                window_id = self.window_id,
+                dragged_id = ?dragged_id,
+                marker = ?drop_marker,
+                remaining_dragged_id = ?self.dragged_id,
+                remaining_drop_target = ?self.drop_target,
+                remaining_marker = ?self.drop_marker,
+                "clear sidebar drag"
+            );
             cx.notify();
         }
+    }
+
+    fn start_sidebar_drag(&mut self, dragged_id: String, cx: &mut Context<Self>) {
+        self.dragged_id = Some(dragged_id);
+        self.drop_target = None;
+        self.drop_marker = None;
+        tracing::debug!(
+            target: "sidebar::drag",
+            path = "drag-start",
+            window_id = self.window_id,
+            dragged_id = ?self.dragged_id,
+            marker = ?self.drop_marker,
+            "start sidebar drag"
+        );
+        cx.notify();
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1381,8 +1414,7 @@ impl Sidebar {
         marker: String,
         cx: &mut Context<Self>,
     ) {
-        self.dragged_id = Some(dragged_id.to_owned());
-        self.drop_target = list_drop_target(
+        let drop_target = list_drop_target(
             &self.app_store.read(cx).nodes,
             kind,
             parent_id,
@@ -1391,7 +1423,24 @@ impl Sidebar {
             hovered_id,
             after,
         );
-        self.drop_marker = self.drop_target.as_ref().map(|_| marker);
+        let drop_marker = drop_target.as_ref().map(|_| marker);
+        let changed = self.dragged_id.as_deref() != Some(dragged_id)
+            || self.drop_target != drop_target
+            || self.drop_marker != drop_marker;
+        self.dragged_id = Some(dragged_id.to_owned());
+        self.drop_target = drop_target;
+        self.drop_marker = drop_marker;
+        if changed {
+            tracing::debug!(
+                target: "sidebar::drag",
+                path = "row-target",
+                window_id = self.window_id,
+                dragged_id = ?self.dragged_id,
+                marker = ?self.drop_marker,
+                drop_target = ?self.drop_target,
+                "set sidebar drop target"
+            );
+        }
         cx.notify();
     }
 
@@ -1402,29 +1451,73 @@ impl Sidebar {
         visible_ids: &[String],
         cx: &mut Context<Self>,
     ) {
-        self.dragged_id = Some(dragged_id.to_owned());
-        self.drop_target = container_drop_target(
+        let drop_target = container_drop_target(
             &self.app_store.read(cx).nodes,
             visible_ids,
             dragged_id,
             project_node_id,
         );
-        self.drop_marker = self
-            .drop_target
+        let drop_marker = drop_target
             .as_ref()
             .map(|_| format!("container:{project_node_id}"));
+        let changed = self.dragged_id.as_deref() != Some(dragged_id)
+            || self.drop_target != drop_target
+            || self.drop_marker != drop_marker;
+        self.dragged_id = Some(dragged_id.to_owned());
+        self.drop_target = drop_target;
+        self.drop_marker = drop_marker;
+        if changed {
+            tracing::debug!(
+                target: "sidebar::drag",
+                path = "container-target",
+                window_id = self.window_id,
+                dragged_id = ?self.dragged_id,
+                marker = ?self.drop_marker,
+                drop_target = ?self.drop_target,
+                "set sidebar drop target"
+            );
+        }
         cx.notify();
     }
 
     fn commit_sidebar_drop(&mut self, dragged_id: &str, cx: &mut Context<Self>) {
         if self.dragged_id.as_deref() != Some(dragged_id) {
-            self.clear_sidebar_drag(cx);
+            tracing::debug!(
+                target: "sidebar::drag",
+                path = "commit-early-return",
+                reason = "dragged-id-mismatch",
+                window_id = self.window_id,
+                dragged_id = ?self.dragged_id,
+                marker = ?self.drop_marker,
+                event_dragged_id = dragged_id,
+                "skip sidebar drop"
+            );
+            self.clear_sidebar_drag("commit-early-return", cx);
             return;
         }
         let Some(target) = self.drop_target.clone() else {
-            self.clear_sidebar_drag(cx);
+            tracing::debug!(
+                target: "sidebar::drag",
+                path = "commit-early-return",
+                reason = "missing-drop-target",
+                window_id = self.window_id,
+                dragged_id = ?self.dragged_id,
+                marker = ?self.drop_marker,
+                event_dragged_id = dragged_id,
+                "skip sidebar drop"
+            );
+            self.clear_sidebar_drag("commit-early-return", cx);
             return;
         };
+        tracing::debug!(
+            target: "sidebar::drag",
+            path = "drop",
+            window_id = self.window_id,
+            dragged_id = ?self.dragged_id,
+            marker = ?self.drop_marker,
+            drop_target = ?target,
+            "commit sidebar drop"
+        );
         let rows = self.resolved_sidebar_rows(cx);
         let result = match target.kind {
             DropKind::Pinned => {
@@ -1478,6 +1571,16 @@ impl Sidebar {
         };
         match result {
             Ok(nodes) => {
+                tracing::debug!(
+                    target: "sidebar::drag",
+                    path = "drop-result",
+                    outcome = "ok",
+                    window_id = self.window_id,
+                    dragged_id = ?self.dragged_id,
+                    marker = ?self.drop_marker,
+                    node_count = nodes.len(),
+                    "sidebar drop committed"
+                );
                 if let Some(shell) = self.shell.upgrade() {
                     shell.update(cx, |shell, shell_cx| {
                         if let Err(error) = shell.tabs.replace_rows(&nodes) {
@@ -1490,12 +1593,41 @@ impl Sidebar {
                     .update(cx, |store, store_cx| store.replace_nodes(nodes, store_cx));
                 self.refresh_store(StoreRefreshKind::All, cx);
             }
-            Err(error) => self.report_error(error.to_string(), cx),
+            Err(error) => {
+                tracing::debug!(
+                    target: "sidebar::drag",
+                    path = "drop-result",
+                    outcome = "error",
+                    window_id = self.window_id,
+                    dragged_id = ?self.dragged_id,
+                    marker = ?self.drop_marker,
+                    error = %error,
+                    "sidebar drop failed"
+                );
+                self.report_error(error.to_string(), cx);
+            }
         }
-        self.clear_sidebar_drag(cx);
+        self.clear_sidebar_drag("drop", cx);
     }
 
-    pub(crate) fn render_sidebar_contents(&self, cx: &mut Context<Self>) -> AnyElement {
+    pub(crate) fn render_sidebar_contents(&mut self, cx: &mut Context<Self>) -> AnyElement {
+        if self.drop_marker.is_some()
+            && !indicator_visible(self.drop_marker.as_deref(), cx.has_active_drag())
+        {
+            tracing::debug!(
+                target: "sidebar::drag",
+                path = "render-backstop",
+                window_id = self.window_id,
+                dragged_id = ?self.dragged_id,
+                marker = ?self.drop_marker,
+                "clear inactive sidebar drop indicator before render"
+            );
+            take_drag_state(
+                &mut self.dragged_id,
+                &mut self.drop_target,
+                &mut self.drop_marker,
+            );
+        }
         let route = self
             .shell
             .upgrade()
@@ -1535,7 +1667,11 @@ impl Sidebar {
         }));
         let root_attention = rollups.get(&None).copied().unwrap_or_default();
 
-        let mut scroll = sidebar_scroll_container("sidebar-node-scroll", &self.scroll);
+        let mut scroll = sidebar_scroll_container("sidebar-node-scroll", &self.scroll).on_drop(
+            cx.listener(|this, drag: &SidebarNodeDrag, _, cx| {
+                this.commit_sidebar_drop(&drag.node_id, cx);
+            }),
+        );
         if !pinned.is_empty() {
             let visible = pinned
                 .iter()
@@ -2328,8 +2464,7 @@ impl Sidebar {
                     },
                     move |drag: &SidebarNodeDrag, _, _, cx| {
                         drag_root.update(cx, |this, cx| {
-                            this.dragged_id = Some(drag.node_id.clone());
-                            cx.notify();
+                            this.start_sidebar_drag(drag.node_id.clone(), cx);
                         });
                         cx.new(|_| drag.clone())
                     },
@@ -2553,8 +2688,7 @@ impl Sidebar {
             .child(row)
             .on_drag(drag, move |drag: &SidebarNodeDrag, _, _, cx| {
                 drag_root.update(cx, |this, cx| {
-                    this.dragged_id = Some(drag.node_id.clone());
-                    cx.notify();
+                    this.start_sidebar_drag(drag.node_id.clone(), cx);
                 });
                 cx.new(|_| drag.clone())
             })
@@ -2639,7 +2773,8 @@ impl Sidebar {
 }
 
 impl Render for Sidebar {
-    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        self.window_id = window.window_handle().window_id().as_u64();
         self.render_sidebar_contents(cx)
     }
 }

--- a/crates/runner-app/src/surfaces/sidebar_logic.rs
+++ b/crates/runner-app/src/surfaces/sidebar_logic.rs
@@ -82,6 +82,21 @@ pub(crate) struct DropTarget {
     pub index: usize,
 }
 
+pub(crate) fn indicator_visible(drop_marker: Option<&str>, has_active_drag: bool) -> bool {
+    drop_marker.is_some() && has_active_drag
+}
+
+pub(crate) fn take_drag_state(
+    dragged_id: &mut Option<String>,
+    drop_target: &mut Option<DropTarget>,
+    drop_marker: &mut Option<String>,
+) -> bool {
+    let had_id = dragged_id.take().is_some();
+    let had_target = drop_target.take().is_some();
+    let had_marker = drop_marker.take().is_some();
+    had_id || had_target || had_marker
+}
+
 pub(crate) fn can_drop_in_scope(
     nodes: &[NodeRow],
     dragged_id: &str,
@@ -93,13 +108,8 @@ pub(crate) fn can_drop_in_scope(
     if dragged.pinned_position.is_some() || dragged.node_type == NodeType::Project {
         return false;
     }
-    let leaving_project = dragged
-        .parent_id
-        .as_deref()
-        .and_then(|id| node(nodes, id))
-        .is_some_and(|parent| parent.node_type == NodeType::Project);
     let Some(parent_id) = parent_id else {
-        return !leaving_project;
+        return true;
     };
     node(nodes, parent_id).is_some_and(|parent| {
         parent.node_type == NodeType::Project
@@ -371,13 +381,14 @@ mod tests {
     }
 
     #[test]
-    fn drag_targets_respect_project_boundaries_and_compute_reparent_index() {
+    fn drag_targets_cross_project_boundaries_and_compute_reparent_index() {
         let nodes = vec![
             row("project-a", NodeType::Project, None, 0, None),
             row("project-b", NodeType::Project, None, 1, None),
             row("root-tab", NodeType::Tab, None, 2, None),
             row("inside-a", NodeType::Tab, Some("project-a"), 0, None),
             row("inside-b", NodeType::Mission, Some("project-b"), 0, None),
+            row("pinned", NodeType::Tab, None, 3, Some(0)),
         ];
         assert_eq!(
             container_drop_target(&nodes, &["inside-b".into()], "root-tab", "project-b"),
@@ -387,12 +398,39 @@ mod tests {
                 index: 1,
             })
         );
-        assert!(list_drop_target(
+        let root_target = list_drop_target(
             &nodes,
             DropKind::Leaf,
             None,
             &["root-tab".into()],
             "inside-a",
+            "root-tab",
+            false,
+        )
+        .unwrap();
+        assert_eq!(
+            root_target,
+            DropTarget {
+                kind: DropKind::Leaf,
+                parent_id: None,
+                index: 0,
+            }
+        );
+        let visible = ordered_visible_node_ids_after_drop(
+            &["root-tab".into()],
+            "inside-a",
+            root_target.index,
+        );
+        assert_eq!(
+            complete_unpinned_scope_order(&nodes, None, "inside-a", &visible),
+            ["project-a", "project-b", "inside-a", "root-tab"]
+        );
+        assert!(list_drop_target(
+            &nodes,
+            DropKind::Leaf,
+            None,
+            &["root-tab".into()],
+            "pinned",
             "root-tab",
             false,
         )
@@ -411,6 +449,39 @@ mod tests {
             .index,
             0
         );
+    }
+
+    #[test]
+    fn drop_indicator_requires_an_active_drag() {
+        assert!(indicator_visible(Some("leaf:tab:true"), true));
+        assert!(!indicator_visible(Some("leaf:tab:true"), false));
+        assert!(!indicator_visible(None, true));
+        assert!(!indicator_visible(None, false));
+    }
+
+    #[test]
+    fn taking_drag_state_clears_every_field() {
+        let mut dragged_id = Some("tab-a".into());
+        let mut drop_target = Some(DropTarget {
+            kind: DropKind::Leaf,
+            parent_id: None,
+            index: 1,
+        });
+        let mut drop_marker = Some("leaf:tab-b:true".into());
+
+        assert!(take_drag_state(
+            &mut dragged_id,
+            &mut drop_target,
+            &mut drop_marker
+        ));
+        assert_eq!(dragged_id, None);
+        assert_eq!(drop_target, None);
+        assert_eq!(drop_marker, None);
+        assert!(!take_drag_state(
+            &mut dragged_id,
+            &mut drop_target,
+            &mut drop_marker
+        ));
     }
 
     #[test]

--- a/crates/runner-backend/src/repo/node.rs
+++ b/crates/runner-backend/src/repo/node.rs
@@ -349,10 +349,7 @@ pub fn reorder_pinned(conn: &Connection, ordered_ids: &[String]) -> rusqlite::Re
 ///
 /// Nesting is enforced here at the app layer (the schema allows a
 /// general tree): projects live at root only; leaves (`tab`, `mission`)
-/// live at root or under one project. The sidebar additionally refuses
-/// to DRAG a node out of a project scope (leaving a project is an
-/// explicit menu action); that is a UI affordance, not a shape rule,
-/// so it lives in the frontend's `canDropInScope`, not here.
+/// live at root or under one project.
 ///
 /// Crossing a project boundary writes the domain pointer through:
 /// a tab updates its member sessions' `sessions.project_id`, a mission


### PR DESCRIPTION
## Summary
- clear all sidebar drag state reliably and reset stale targets at the start of each drag
- commit drops that land in row gaps, inter-section slivers, or the empty list remainder
- restore project-to-RECENT dragging and retain debug-level path instrumentation
- add the active-drag render backstop and pure regression coverage

## Root cause and evidence
Jason’s log showed `path="drop"` with `outcome="ok"`, followed by non-empty `remaining_drop_target` and `remaining_marker`. The original `clear_sidebar_drag` used short-circuiting `||`, so taking `dragged_id` prevented the other fields from being cleared. A following root-up could short-circuit again on the target and leave the marker painted. The successful drop log also established that the move itself succeeded in the original failing case.

The intermittent move failures showed a valid after-row target followed by `root-up` without a drop. The pointer had landed in uncovered row gaps or list remainder. A scroll-container fallback now commits the already validated visible target; deeper row listeners still win.

Project-to-RECENT was a regression, not a new capability. `docs/impls/archive/gpui-rewrite/briefs/m6-21-sidebar-entry-points.md:13` removed the row-menu action on the explicit condition that dragging to RECENT retained the capability. The backend already supported moving outward; the UI guard blocked it. Drag is currently the sole path out of a project because the command palette does not carry this action.

## Validation
- Jason smoke-tested all reported issues successfully, including project-to-RECENT
- `make verify`
- `cargo test -p runner-app sidebar_logic` — 6 passed
- `cargo test -p runner-backend repo::node` — 21 passed
- `cargo clippy --workspace --all-targets`
- `cargo fmt --all --check`
- `git diff --check`
- clean working-tree review with no remaining findings

## Authorization and known limits
The M6.20 brief originally required stopping at a clean working-tree review with no commit, push, PR, or merge. After the smoke test passed, Jason explicitly authorized opening and merging this PR if review passed.

The render backstop did not fire in the recorded session; it remains a belt-and-braces rule, with its state-clearing half covered by a pure unit test. It intentionally does not notify during render and is repaint-gated, so after a cross-window release the source window may retain its line until that window next repaints.