### PR TITLE
fix(ui): read Tauri-era split tabs after update; wrap paused-card subtitle

### DIFF
--- a/crates/runner-app/src/main.rs
+++ b/crates/runner-app/src/main.rs
@@ -348,7 +348,7 @@ impl NativeRoot {
         let sessions = app_store.read(cx).sessions.clone();
         let nodes = app_store.read(cx).nodes.clone();
         let store_revisions = app_store.read(cx).revisions;
-        let mut errors: Vec<_> = app_store.read(cx).error.clone().into_iter().collect();
+        let startup_error = app_store.read(cx).error.clone();
 
         let (chat_event_tx, mut chat_event_rx) =
             futures::channel::mpsc::unbounded::<runner_backend::events::AppEvent>();
@@ -425,13 +425,7 @@ impl NativeRoot {
         .detach();
 
         window.set_rem_size(px(16. * settings.app_zoom));
-        let mut tabs = match TabSet::from_rows(&nodes) {
-            Ok(tabs) => tabs,
-            Err(error) => {
-                errors.push(error.to_string());
-                TabSet::default()
-            }
-        };
+        let mut tabs = TabSet::from_rows(&nodes);
         let route_path = initial_route_path
             .as_deref()
             .unwrap_or_default()
@@ -606,7 +600,7 @@ impl NativeRoot {
             split_sizes_dirty: false,
             chat_secondaries: HashMap::new(),
             dismissed_duplicate_chats: HashSet::new(),
-            error: (!errors.is_empty()).then(|| errors.join("\n")),
+            error: startup_error,
             settings_page,
             route: initial_route.clone(),
             settings_return_route: initial_route,
@@ -704,14 +698,14 @@ impl NativeRoot {
     fn reload_tabs(&mut self, cx: &mut Context<Self>) -> Result<()> {
         self.app_store
             .update(cx, |store, store_cx| store.refresh_nodes(store_cx))?;
-        self.apply_tab_rows(cx)
+        self.apply_tab_rows(cx);
+        Ok(())
     }
 
-    fn apply_tab_rows(&mut self, cx: &mut Context<Self>) -> Result<()> {
-        self.tabs.replace_rows(&self.app_store.read(cx).nodes)?;
+    fn apply_tab_rows(&mut self, cx: &mut Context<Self>) {
+        self.tabs.replace_rows(&self.app_store.read(cx).nodes);
         self.sync_active_project_from_active_tab(cx);
         self.prune_sidebar_collapse_state(cx);
-        Ok(())
     }
 
     fn session_entry<'a>(&self, session_id: &str, cx: &'a App) -> Option<&'a DirectSessionEntry> {
@@ -732,9 +726,7 @@ impl NativeRoot {
             self.error = self.app_store.read(cx).error.clone();
         }
         if reactions.reload_tabs {
-            if let Err(error) = self.apply_tab_rows(cx) {
-                self.error = Some(error.to_string());
-            }
+            self.apply_tab_rows(cx);
         }
         if reactions.prune_sidebar {
             self.prune_sidebar_collapse_state(cx);

--- a/crates/runner-app/src/pane_layout.rs
+++ b/crates/runner-app/src/pane_layout.rs
@@ -3,16 +3,23 @@ use std::collections::BTreeMap;
 use anyhow::{bail, Context as _, Result};
 use runner_backend::ops::node::NodeTabUpsertInput;
 use runner_backend::repo::node::{NodeRow, NodeType};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
+// Wire names are the Tauri-era spellings (`cols-2`, not serde's kebab-case
+// `cols2`); the aliases keep rows written by 0.6.0/0.6.1 readable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
 pub enum PresetKind {
+    #[serde(rename = "single")]
     Single,
+    #[serde(rename = "cols-2", alias = "cols2")]
     Cols2,
+    #[serde(rename = "rows-2", alias = "rows2")]
     Rows2,
+    #[serde(rename = "main-2", alias = "main2")]
     Main2,
+    #[serde(rename = "cols-3", alias = "cols3")]
     Cols3,
+    #[serde(rename = "rows-3", alias = "rows3")]
     Rows3,
 }
 
@@ -168,8 +175,29 @@ struct PersistedLayout {
     preset: PresetKind,
     #[serde(default)]
     slots: Vec<Option<String>>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "lenient_sizes")]
     sizes: BTreeMap<String, [f32; 2]>,
+}
+
+// The Tauri-era writer could persist `[null,null]` sizes (NaN from the panel
+// library stringified) and its reader tolerated any malformed size entry;
+// rejecting the whole layout for a cosmetic gutter value strands the tab.
+fn lenient_sizes<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<BTreeMap<String, [f32; 2]>, D::Error> {
+    let raw = serde_json::Value::deserialize(deserializer)?;
+    let Some(entries) = raw.as_object() else {
+        return Ok(BTreeMap::new());
+    };
+    Ok(entries
+        .iter()
+        .filter_map(|(id, value)| {
+            let [a, b] = value.as_array()?.as_slice() else {
+                return None;
+            };
+            Some((id.clone(), [a.as_f64()? as f32, b.as_f64()? as f32]))
+        })
+        .collect())
 }
 
 impl PaneLayout {
@@ -401,17 +429,23 @@ pub struct TabSet {
 }
 
 impl TabSet {
-    pub fn from_rows(rows: &[NodeRow]) -> Result<Self> {
+    pub fn from_rows(rows: &[NodeRow]) -> Self {
         let tabs = rows
             .iter()
             .filter(|row| row.node_type == NodeType::Tab)
-            .map(PaneLayout::from_node_row)
-            .collect::<Result<Vec<_>>>()?;
+            .filter_map(|row| match PaneLayout::from_node_row(row) {
+                Ok(tab) => Some(tab),
+                Err(error) => {
+                    tracing::warn!(tab_id = %row.id, "skipping unreadable tab layout: {error:#}");
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
         let active_tab_id = tabs.first().map(|tab| tab.id.clone());
-        Ok(Self {
+        Self {
             tabs,
             active_tab_id,
-        })
+        }
     }
 
     pub fn tabs(&self) -> &[PaneLayout] {
@@ -468,14 +502,14 @@ impl TabSet {
         Ok(())
     }
 
-    pub fn replace_rows(&mut self, rows: &[NodeRow]) -> Result<()> {
+    pub fn replace_rows(&mut self, rows: &[NodeRow]) {
         let active_id = self.active_tab_id.clone();
         let focused_pane_id = self.active().map(|tab| tab.focused_pane_id.clone());
         let focused_session = self
             .active()
             .and_then(PaneLayout::focused_session_id)
             .map(str::to_owned);
-        let mut next = Self::from_rows(rows)?;
+        let mut next = Self::from_rows(rows);
         if let Some(active_id) = active_id {
             next.activate(&active_id);
         }
@@ -489,7 +523,6 @@ impl TabSet {
             }
         }
         *self = next;
-        Ok(())
     }
 }
 

--- a/crates/runner-app/src/surfaces/sidebar.rs
+++ b/crates/runner-app/src/surfaces/sidebar.rs
@@ -1802,12 +1802,7 @@ impl Sidebar {
                     "sidebar drop committed"
                 );
                 if let Some(shell) = self.shell.upgrade() {
-                    shell.update(cx, |shell, shell_cx| {
-                        if let Err(error) = shell.tabs.replace_rows(&nodes) {
-                            shell.error = Some(error.to_string());
-                            shell_cx.notify();
-                        }
-                    });
+                    shell.update(cx, |shell, _| shell.tabs.replace_rows(&nodes));
                 }
                 self.app_store
                     .update(cx, |store, store_cx| store.replace_nodes(nodes, store_cx));

--- a/crates/runner-app/src/ui/session_overlay.rs
+++ b/crates/runner-app/src/ui/session_overlay.rs
@@ -205,8 +205,9 @@ impl RenderOnce for SessionOverlay {
                             )
                             .child(
                                 div()
-                                    .flex()
+                                    .debug_selector(|| "SESSION_ENDED_SUBTITLE".into())
                                     .w_full()
+                                    .min_w_0()
                                     .whitespace_normal()
                                     .text_size(rems(13. / 16.))
                                     .line_height(rems(18. / 16.))
@@ -278,5 +279,28 @@ mod tests {
             .debug_bounds("SESSION_ENDED_ACTIONS")
             .expect("actions bounds");
         assert_eq!(card.bottom() - actions.bottom(), px(27.));
+    }
+
+    #[test]
+    fn ended_overlay_subtitle_wraps_inside_the_card() {
+        let mut cx = TestAppContext::single();
+        let window = cx.add_window(|window, _| {
+            window.set_rem_size(px(20.8));
+            EndedOverlayTest
+        });
+        cx.run_until_parked();
+        let mut window = VisualTestContext::from_window(window.into(), &cx);
+        let card = window
+            .debug_bounds("SESSION_ENDED_CARD")
+            .expect("card bounds");
+        let subtitle = window
+            .debug_bounds("SESSION_ENDED_SUBTITLE")
+            .expect("subtitle bounds");
+        let line_height = px(20.8 * 18. / 16.);
+        assert!(
+            subtitle.size.height >= line_height * 2.,
+            "subtitle did not wrap: {subtitle:?}"
+        );
+        assert!(subtitle.right() <= card.right(), "{subtitle:?} vs {card:?}");
     }
 }

--- a/crates/runner-app/tests/pane_layout.rs
+++ b/crates/runner-app/tests/pane_layout.rs
@@ -67,7 +67,7 @@ fn pane_assignment_is_move_not_copy_across_tabs() {
         row("01K00000000000000000000000", 0, &tab_a),
         row("01K00000000000000000000001", 1, &tab_b),
     ];
-    let mut tabs = TabSet::from_rows(&rows).unwrap();
+    let mut tabs = TabSet::from_rows(&rows);
     tabs.assign_to_active("p2", "B").unwrap();
 
     assert_eq!(tabs.tabs()[0].session_ids(), ["A", "B"]);
@@ -188,7 +188,7 @@ fn switching_tabs_preserves_each_tabs_sessions_focus_and_geometry() {
         row("01K00000000000000000000000", 0, &tab_a),
         row("01K00000000000000000000001", 1, &tab_b),
     ];
-    let mut tabs = TabSet::from_rows(&rows).unwrap();
+    let mut tabs = TabSet::from_rows(&rows);
     tabs.active_mut().unwrap().focus_session("B");
 
     assert!(tabs.activate("01K00000000000000000000001"));
@@ -212,9 +212,9 @@ fn rehydration_keeps_the_active_tab_by_stable_id() {
         row("01K00000000000000000000001", 1, &b),
         row("01K00000000000000000000002", 2, &c),
     ];
-    let mut tabs = TabSet::from_rows(&rows).unwrap();
+    let mut tabs = TabSet::from_rows(&rows);
     tabs.activate("01K00000000000000000000001");
-    tabs.replace_rows(&rows[1..]).unwrap();
+    tabs.replace_rows(&rows[1..]);
 
     assert_eq!(tabs.active_tab_id(), Some("01K00000000000000000000001"));
 }
@@ -229,7 +229,7 @@ fn structural_writes_preserve_parent_scope() {
     let mut filed_row = row("01K00000000000000000000000", 7, &filed_tab);
     filed_row.parent_id = Some("folder-1".into());
     let loose_row = row("01K00000000000000000000001", 2, &loose_tab);
-    let tabs = TabSet::from_rows(&[filed_row, loose_row]).unwrap();
+    let tabs = TabSet::from_rows(&[filed_row, loose_row]);
 
     let filed = &tabs.tabs()[0];
     assert_eq!(filed.parent_id.as_deref(), Some("folder-1"));
@@ -239,4 +239,80 @@ fn structural_writes_preserve_parent_scope() {
     );
     let loose = &tabs.tabs()[1];
     assert_eq!(loose.position, 2);
+}
+
+fn raw_row(id: &str, layout: &str) -> NodeRow {
+    NodeRow {
+        id: id.to_owned(),
+        parent_id: None,
+        position: 0,
+        node_type: NodeType::Tab,
+        name: None,
+        ref_id: None,
+        layout: Some(layout.to_owned()),
+        pinned_position: None,
+        last_completed_at: None,
+        last_viewed_at: None,
+        created_at: "2026-07-19T00:00:00Z".into(),
+    }
+}
+
+#[test]
+fn tauri_era_null_sizes_fall_back_to_preset_defaults() {
+    let row = raw_row(
+        "01K00000000000000000000000",
+        r#"{"preset":"cols-2","slots":["A","B"],"sizes":{"cols-2:outer":[null,null],"stale":[70,30,0],"other":"x"}}"#,
+    );
+    let restored = PaneLayout::from_node_row(&row).unwrap();
+
+    assert_eq!(restored.preset, PresetKind::Cols2);
+    assert_eq!(restored.session_ids(), ["A", "B"]);
+    let PaneNode::Split(split) = restored.root else {
+        panic!("cols-2 must have an outer split");
+    };
+    assert_eq!(split.sizes, [50., 50.]);
+}
+
+#[test]
+fn unreadable_tab_row_is_skipped_without_dropping_the_set() {
+    let good = PaneLayout::fresh(PresetKind::Single, Some("A"), &["A".into()]);
+    let rows = [
+        raw_row(
+            "01K00000000000000000000000",
+            r#"{"preset":"nope","slots":["B"]}"#,
+        ),
+        row("01K00000000000000000000001", 1, &good),
+        raw_row("01K00000000000000000000002", "not json"),
+    ];
+    let tabs = TabSet::from_rows(&rows);
+
+    assert_eq!(tabs.tabs().len(), 1);
+    assert_eq!(tabs.active_tab_id(), Some("01K00000000000000000000001"));
+    assert_eq!(tabs.tabs()[0].session_ids(), ["A"]);
+}
+
+#[test]
+fn preset_wire_names_match_tauri_and_accept_the_0_6_0_spelling() {
+    let cases = [
+        (PresetKind::Single, "single", "single"),
+        (PresetKind::Cols2, "cols-2", "cols2"),
+        (PresetKind::Rows2, "rows-2", "rows2"),
+        (PresetKind::Main2, "main-2", "main2"),
+        (PresetKind::Cols3, "cols-3", "cols3"),
+        (PresetKind::Rows3, "rows-3", "rows3"),
+    ];
+    for (preset, canonical, legacy_0_6) in cases {
+        let written = PaneLayout::fresh(preset, None, &[]).serialize().unwrap();
+        assert!(
+            written.contains(&format!("\"preset\":\"{canonical}\"")),
+            "{preset:?} wrote {written}"
+        );
+        for spelling in [canonical, legacy_0_6] {
+            let row = raw_row(
+                "01K00000000000000000000000",
+                &format!("{{\"preset\":\"{spelling}\",\"slots\":[],\"sizes\":{{}}}}"),
+            );
+            assert_eq!(PaneLayout::from_node_row(&row).unwrap().preset, preset);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Two user-reported 0.6.x bugs.

**\`parse tab <id> layout\` on first update from 0.5.x**
- \`PresetKind\` used \`serde(rename_all = "kebab-case")\`, which spells \`Cols2\` as \`cols2\`; the Tauri app persisted \`cols-2\`. Every split tab from 0.5.x failed to parse, and one failing row dropped the entire tab set. Single-pane tabs were unaffected, which is why not everyone saw it.
- Wire names are now pinned to the Tauri spellings (\`cols-2\` …) with \`alias\` for the \`cols2\` rows 0.6.0/0.6.1 already wrote — both spellings read, canonical one written.
- Malformed \`sizes\` entries (the old writer could persist \`[null,null]\`) fall back to preset defaults instead of rejecting the layout.
- \`TabSet::from_rows\` skips an unreadable tab with a \`tracing::warn!\` instead of failing the set; it and \`replace_rows\` no longer return \`Result\`.

**Paused-card subtitle overflows the card**
- The subtitle wrapper was \`div().flex().w_full().whitespace_normal()\`; gpui only wraps text under a definite width, and a flex-row child is measured at max-content. Switched to the \`w_full().min_w_0().whitespace_normal()\` block pattern used elsewhere.

## Test plan
- [x] New \`tests/pane_layout.rs\` cases: Tauri null sizes, garbage row skipped, all six presets round-trip via both spellings
- [x] New \`session_overlay\` visual test asserts the subtitle height ≥ 2 lines (fails on the old layout at 820×23.5px, passes after)
- [x] \`cargo test -p runner-app\`, \`make clippy\`, \`cargo fmt --check\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)