### PR TITLE
build: enable fat LTO and a single codegen unit for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,10 @@ opt-level = 3
 
 [profile.dev.package.taffy]
 opt-level = 3
+
+# Release binaries ship inside a universal DMG, so every byte counts twice.
+# Not stripped: the panic hook logs backtraces, and stripping would turn their
+# frames into bare addresses.
+[profile.release]
+lto = "fat"
+codegen-units = 1


### PR DESCRIPTION
## Summary
- Add `[profile.release]` with `lto = "fat"` and `codegen-units = 1`. Release binaries ship as universal fat Mach-Os inside one DMG, so every byte counts twice.
- Measured on the arm64 slice (2026-08-24): `Runner` 40.1 MB → 30.0 MB with strip, so ~35 MB without; `runner-mcp` 3.9 → 1.9 MB; `runner-agent-cli` 1.2 → 0.7 MB.
- Not stripped on purpose: the panic hook logs backtraces and stripping would reduce them to bare addresses.
- Dev profile, tests, clippy, and CI are unaffected; release link time is ~+90s per arch.

## Test plan
- [x] `cargo build --locked --release -p runner-app --target aarch64-apple-darwin` and `-p runner-cli --bins` link and run with the profile applied
- [ ] Next nightly/release DMG size

🤖 Generated with [Claude Code](https://claude.com/claude-code)