### PR TITLE
fix(ui): project actions menu manages, the + button creates

### DIFF
--- a/crates/runner-app/src/surfaces/sidebar.rs
+++ b/crates/runner-app/src/surfaces/sidebar.rs
@@ -3330,17 +3330,7 @@ fn project_menu_entries(
 ) -> Vec<(UiMenuItem, SidebarMenuAction)> {
     vec![
         (
-            UiMenuItem::new("New chat in project").icon("message-square-plus.svg"),
-            SidebarMenuAction::NewChat(Some(project_id.clone())),
-        ),
-        (
-            UiMenuItem::new("New mission in project").icon("flag.svg"),
-            SidebarMenuAction::NewMission(Some(project_id.clone())),
-        ),
-        (
-            UiMenuItem::new("Rename project")
-                .icon("pencil.svg")
-                .separator_before(true),
+            UiMenuItem::new("Rename project").icon("pencil.svg"),
             SidebarMenuAction::Rename(SidebarRenameTarget::Project {
                 project_id: project_id.clone(),
                 original: project_name,
@@ -3944,12 +3934,7 @@ mod tests {
         let project_entries = project_menu_entries("project-1".into(), "Runner".into());
         assert_eq!(
             menu_labels(&project_entries),
-            [
-                "New chat in project",
-                "New mission in project",
-                "Rename project",
-                "Delete project",
-            ]
+            ["Rename project", "Delete project"]
         );
     }
 


### PR DESCRIPTION
## Summary

Closes #438.

The project row's `…` menu repeated the `+` button's **New chat** / **New mission** one row to the left, and those copies pushed rename and delete below a separator. `project_menu_entries` is now **Rename project** / **Delete project** only.

Right-click on the project row reuses the same function, so it loses the create items too — as the issue specifies, `+` is visible on hover right beside the kebab, and "right-click = manage" matches the tab and mission rows. `project_create_menu_entries` (the `+` menu) is unchanged.

## Test plan
- [x] `project_create_menu_uses_short_labels_and_project_targets` updated to the two-item list and passing
- [x] `cargo test -p runner-app` (60 lib + 143 bin + integration), `make clippy`, `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)