### PR TITLE
fix(ui): clicking an open popup's trigger closes it

### DIFF
--- a/crates/runner-app/src/ui/menu.rs
+++ b/crates/runner-app/src/ui/menu.rs
@@ -202,7 +202,13 @@ pub fn popup_layer(
                     div()
                         .w(viewport.width)
                         .h(viewport.height)
-                        .on_mouse_down(MouseButton::Left, move |_, window, cx| {
+                        // A press on the trigger itself is the trigger's to
+                        // handle: dismissing here too would close on mouse-down
+                        // and let the trigger's click reopen on mouse-up.
+                        .on_mouse_down(MouseButton::Left, move |event, window, cx| {
+                            if anchor.contains(&event.position) {
+                                return;
+                            }
                             dismiss(window, cx);
                         })
                         .on_mouse_down(MouseButton::Right, move |_, window, cx| {

--- a/crates/runner-app/src/ui/select.rs
+++ b/crates/runner-app/src/ui/select.rs
@@ -373,6 +373,7 @@ impl Render for StyledSelect {
             .child(
                 div()
                     .id("styled-select-trigger")
+                    .debug_selector(|| "STYLED_SELECT_TRIGGER".into())
                     .track_focus(&self.focus_handle)
                     .w_full()
                     .h(rems(height / 16.))
@@ -633,6 +634,52 @@ pub fn runtime_select_options(catalog: &[RuntimeCatalogEntry]) -> Vec<SelectOpti
 #[cfg(test)]
 mod tests {
     use super::*;
+    use gpui::{Modifiers, TestAppContext, VisualTestContext};
+
+    struct SelectHost {
+        select: Entity<StyledSelect>,
+    }
+
+    impl Render for SelectHost {
+        fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+            div().size_full().p_4().child(self.select.clone())
+        }
+    }
+
+    #[test]
+    fn clicking_the_trigger_of_an_open_select_closes_it() {
+        let mut cx = TestAppContext::single();
+        let window = cx.add_window(|_, cx| {
+            let focus_handle = cx.focus_handle();
+            let select = cx.new(|cx| {
+                StyledSelect::new(
+                    "select",
+                    focus_handle,
+                    "a",
+                    options(),
+                    Rc::new(|_, _, _| {}),
+                    cx,
+                )
+            });
+            SelectHost { select }
+        });
+        cx.run_until_parked();
+        let select = window
+            .read_with(&cx, |host, _| host.select.clone())
+            .unwrap();
+        let mut window = VisualTestContext::from_window(window.into(), &cx);
+        let trigger = window
+            .debug_bounds("STYLED_SELECT_TRIGGER")
+            .expect("trigger bounds");
+
+        window.simulate_click(trigger.center(), Modifiers::default());
+        window.run_until_parked();
+        assert!(select.read_with(&window, |select, _| select.state.is_open()));
+
+        window.simulate_click(trigger.center(), Modifiers::default());
+        window.run_until_parked();
+        assert!(!select.read_with(&window, |select, _| select.state.is_open()));
+    }
 
     fn options() -> Vec<SelectOption> {
         vec![


### PR DESCRIPTION
## Summary

Clicking the trigger of an already-open dropdown (e.g. **Thinking effort**) re-expanded it instead of collapsing it.

`popup_layer` paints a full-viewport backdrop whose `on_mouse_down` dismisses the popup, while triggers toggle on `on_click` — which fires on mouse **up**. So the second press ran: down → backdrop closes, up → trigger toggles back open. Every popup mounted through that layer had this: selects (effort, model, runtime) and the `+` / `…` popover menus.

The backdrop now ignores a left mouse-down that lands inside the popup's own `anchor` bounds — the trigger rect both `StyledSelect` and `PopoverMenu` already capture — leaving that press to the trigger's click, which toggles it shut. Clicking anywhere else dismisses exactly as before; right-click dismissal is untouched.

## Test plan
- [x] New `clicking_the_trigger_of_an_open_select_closes_it` visual test clicks a `StyledSelect` trigger twice and asserts open → closed; verified it fails on the old code and passes with the fix
- [x] `cargo test -p runner-app` (60 lib + 143 bin + integration), `make clippy`, `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)