### PR TITLE
feat(ui): pin the app font to Inter and drop the App font picker (M6.19)

### DIFF
--- a/crates/runner-app/src/app_settings.rs
+++ b/crates/runner-app/src/app_settings.rs
@@ -45,36 +45,23 @@ impl TerminalTheme {
     }
 }
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
-pub enum AppFontFamily {
-    #[default]
-    Inter,
-    Geist,
-    Roboto,
-    #[serde(rename = "System UI")]
-    SystemUi,
-}
-
-impl AppFontFamily {
-    pub fn font(self) -> Font {
-        let (family, named_fallback) = match self {
-            Self::Inter => ("Inter", Some("Inter Variable")),
-            Self::Geist => ("Geist Variable", Some("Geist")),
-            Self::Roboto => ("Roboto Variable", Some("Roboto")),
-            Self::SystemUi => (".SystemUIFont", None),
-        };
-        let mut fallbacks = Vec::with_capacity(6);
-        if let Some(named_fallback) = named_fallback {
-            fallbacks.push(named_fallback.to_owned());
-            fallbacks.push(".SystemUIFont".to_owned());
-        }
-        fallbacks.extend(
-            ["Segoe UI", "PingFang SC", "Microsoft YaHei", "sans-serif"].map(str::to_owned),
-        );
-        let mut font = font(family);
-        font.fallbacks = Some(FontFallbacks::from_fonts(fallbacks));
-        font
-    }
+/// The UI typeface is pinned to the bundled Inter (`assets/fonts/Inter-*.ttf`);
+/// a legacy `appFontFamily` key in `ui-settings.json` is ignored on load.
+pub fn app_font() -> Font {
+    let mut font = font("Inter");
+    font.fallbacks = Some(FontFallbacks::from_fonts(
+        [
+            "Inter Variable",
+            ".SystemUIFont",
+            "Segoe UI",
+            "PingFang SC",
+            "Microsoft YaHei",
+            "sans-serif",
+        ]
+        .map(str::to_owned)
+        .to_vec(),
+    ));
+    font
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -126,7 +113,6 @@ pub struct AppSettings {
     pub app_theme: ThemeIntent,
     pub light_app_theme: LightTheme,
     pub dark_app_theme: DarkTheme,
-    pub app_font_family: AppFontFamily,
     pub app_zoom: f32,
     pub terminal_theme: TerminalTheme,
     pub terminal_font_family: TerminalFontFamily,
@@ -160,7 +146,6 @@ impl Default for AppSettings {
             app_theme: ThemeIntent::Auto,
             light_app_theme: LightTheme::Codex,
             dark_app_theme: DarkTheme::Runner,
-            app_font_family: AppFontFamily::Inter,
             app_zoom: 1.,
             terminal_theme: TerminalTheme::Runner,
             terminal_font_family: TerminalFontFamily::MesloNerdFont,
@@ -430,7 +415,6 @@ mod tests {
         assert_eq!(value["appTheme"], "auto");
         assert_eq!(value["lightAppTheme"], "codex");
         assert_eq!(value["darkAppTheme"], "carbon");
-        assert_eq!(value["appFontFamily"], "Inter");
         assert_eq!(value["terminalTheme"], "runner");
         assert_eq!(value["terminalFontFamily"], "Meslo Nerd Font");
         assert_eq!(value["defaultCrewId"], "");
@@ -566,8 +550,8 @@ mod tests {
     }
 
     #[test]
-    fn app_fonts_preserve_the_react_fallback_chain() {
-        let inter = AppFontFamily::Inter.font();
+    fn app_font_is_inter_with_the_cjk_fallback_chain() {
+        let inter = app_font();
         assert_eq!(inter.family.as_ref(), "Inter");
         assert_eq!(
             inter.fallbacks.unwrap().fallback_list(),
@@ -580,12 +564,16 @@ mod tests {
                 "sans-serif"
             ]
         );
+    }
 
-        let system = AppFontFamily::SystemUi.font();
-        assert_eq!(system.family.as_ref(), ".SystemUIFont");
-        assert_eq!(
-            system.fallbacks.unwrap().fallback_list(),
-            ["Segoe UI", "PingFang SC", "Microsoft YaHei", "sans-serif"]
-        );
+    #[test]
+    fn legacy_app_font_choices_still_load() {
+        for legacy in ["Inter", "Geist", "Roboto", "System UI"] {
+            let json = format!(r#"{{"appFontFamily":"{legacy}","appZoom":1.25}}"#);
+            let settings: AppSettings = serde_json::from_str(&json).unwrap();
+            assert_eq!(settings.app_zoom, 1.25, "{legacy}");
+        }
+        let value = serde_json::to_value(AppSettings::default()).unwrap();
+        assert!(value.get("appFontFamily").is_none());
     }
 }

--- a/crates/runner-app/src/app_store.rs
+++ b/crates/runner-app/src/app_store.rs
@@ -186,7 +186,6 @@ impl From<&AppSettings> for ShellSettingsSnapshot {
         std::mem::discriminant(&settings.app_theme).hash(&mut hasher);
         std::mem::discriminant(&settings.light_app_theme).hash(&mut hasher);
         std::mem::discriminant(&settings.dark_app_theme).hash(&mut hasher);
-        std::mem::discriminant(&settings.app_font_family).hash(&mut hasher);
         settings.app_zoom.to_bits().hash(&mut hasher);
         std::mem::discriminant(&settings.terminal_theme).hash(&mut hasher);
         std::mem::discriminant(&settings.terminal_font_family).hash(&mut hasher);

--- a/crates/runner-app/src/surfaces/app_shell.rs
+++ b/crates/runner-app/src/surfaces/app_shell.rs
@@ -151,7 +151,7 @@ impl NativeRoot {
             .size_full()
             .overflow_hidden()
             .track_focus(&self.root_focus)
-            .font(self.settings(cx).app_font_family.font())
+            .font(crate::app_settings::app_font())
             .bg(theme::bg())
             .text_color(theme::text())
             .child(chrome)

--- a/crates/runner-app/src/surfaces/settings_page.rs
+++ b/crates/runner-app/src/surfaces/settings_page.rs
@@ -14,9 +14,8 @@ use runner_app::ui::{
 
 use super::*;
 use crate::app_settings::{
-    normalize_zoom, nudge_zoom, AppFontFamily, TerminalCursorStyle, TerminalFontFamily,
-    TerminalTheme, TERMINAL_FONT_SIZE_MAX, TERMINAL_FONT_SIZE_MIN, TERMINAL_SCROLLBACK_LINES,
-    ZOOM_STEPS,
+    normalize_zoom, nudge_zoom, TerminalCursorStyle, TerminalFontFamily, TerminalTheme,
+    TERMINAL_FONT_SIZE_MAX, TERMINAL_FONT_SIZE_MIN, TERMINAL_SCROLLBACK_LINES, ZOOM_STEPS,
 };
 use crate::surfaces::app_shell::TITLEBAR_DRAG_HEIGHT;
 use crate::theme::{DarkTheme, LightTheme, ThemeIntent};
@@ -153,7 +152,6 @@ enum SettingsSelection {
     DefaultCrew,
     LightTheme,
     DarkTheme,
-    AppFont,
     TerminalTheme,
     TerminalFont,
     TerminalCursor,
@@ -174,7 +172,6 @@ pub(crate) struct SettingsState {
     working_dir_browse_focus: FocusHandle,
     light_theme: Entity<StyledSelect>,
     dark_theme: Entity<StyledSelect>,
-    app_font: Entity<StyledSelect>,
     terminal_theme: Entity<StyledSelect>,
     terminal_font: Entity<StyledSelect>,
     terminal_cursor: Entity<StyledSelect>,
@@ -246,17 +243,6 @@ impl SettingsState {
                 SelectOption::new("catppuccin-mocha", "Catppuccin Mocha").swatch(0xcba6f7),
             ],
             SettingsSelection::DarkTheme,
-            cx,
-        );
-        let app_font = settings_select(
-            &root,
-            "settings-app-font",
-            app_font_value(settings.app_font_family),
-            ["Inter", "Geist", "Roboto", "System UI"]
-                .into_iter()
-                .map(|value| SelectOption::new(value, value))
-                .collect(),
-            SettingsSelection::AppFont,
             cx,
         );
         let terminal_theme = settings_select(
@@ -345,7 +331,6 @@ impl SettingsState {
             working_dir_browse_focus: cx.focus_handle(),
             light_theme,
             dark_theme,
-            app_font,
             terminal_theme,
             terminal_font,
             terminal_cursor,
@@ -626,8 +611,6 @@ impl NativeRoot {
                 .is_some_and(|value| update_if_changed(&mut settings.light_app_theme, value)),
             SettingsSelection::DarkTheme => parse_dark_theme(value)
                 .is_some_and(|value| update_if_changed(&mut settings.dark_app_theme, value)),
-            SettingsSelection::AppFont => parse_app_font(value)
-                .is_some_and(|value| update_if_changed(&mut settings.app_font_family, value)),
             SettingsSelection::TerminalTheme => parse_terminal_theme(value)
                 .is_some_and(|value| update_if_changed(&mut settings.terminal_theme, value)),
             SettingsSelection::TerminalFont => parse_terminal_font(value)
@@ -1561,11 +1544,6 @@ impl NativeRoot {
                 SettingsRow::new("Dark theme", self.settings_page.dark_theme.clone())
                     .subtitle("Picked when the OS is dark or Theme = Dark.")
                     .into_any_element(),
-                SettingsRow::new("App font", self.settings_page.app_font.clone())
-                    .subtitle(
-                        "UI typeface across the app. Doesn't apply to the embedded terminal — see Terminal pane.",
-                    )
-                    .into_any_element(),
             ]))
             .into_any_element()
     }
@@ -1769,25 +1747,6 @@ fn parse_dark_theme(value: &str) -> Option<DarkTheme> {
     match value {
         "carbon" => Some(DarkTheme::Runner),
         "catppuccin-mocha" => Some(DarkTheme::CatppuccinMocha),
-        _ => None,
-    }
-}
-
-fn app_font_value(value: AppFontFamily) -> &'static str {
-    match value {
-        AppFontFamily::Inter => "Inter",
-        AppFontFamily::Geist => "Geist",
-        AppFontFamily::Roboto => "Roboto",
-        AppFontFamily::SystemUi => "System UI",
-    }
-}
-
-fn parse_app_font(value: &str) -> Option<AppFontFamily> {
-    match value {
-        "Inter" => Some(AppFontFamily::Inter),
-        "Geist" => Some(AppFontFamily::Geist),
-        "Roboto" => Some(AppFontFamily::Roboto),
-        "System UI" => Some(AppFontFamily::SystemUi),
         _ => None,
     }
 }

--- a/docs/arch/arch.md
+++ b/docs/arch/arch.md
@@ -204,7 +204,7 @@ The mission workspace's per-slot terminal switcher predates this hierarchy and i
 
 ### 3.7 Settings surface
 
-Settings is a full-window route rendered in place of the app shell, with its own grouped sidebar and card-grouped panes: Appearance (app font, zoom, theme), Terminal (font, cursor, theme palette), Agents (runtime discovery and overrides, the login-shell probe outcome), MCP, Keyboard shortcuts (a view over the registry in `runner-app/src/keymap.rs`), Updates, Diagnostics (log path, open-log), About, and Archived. Entry points — the sidebar Settings row, the command palette, and `⌘,` — navigate to the route and return to the caller's location.
+Settings is a full-window route rendered in place of the app shell, with its own grouped sidebar and card-grouped panes: Appearance (zoom, theme), Terminal (font, cursor, theme palette), Agents (runtime discovery and overrides, the login-shell probe outcome), MCP, Keyboard shortcuts (a view over the registry in `runner-app/src/keymap.rs`), Updates, Diagnostics (log path, open-log), About, and Archived. Entry points — the sidebar Settings row, the command palette, and `⌘,` — navigate to the route and return to the caller's location.
 
 Preferences persist in `$APPDATA/ui-settings.json`, read by the app at launch. They do **not** migrate from the Tauri app, which kept them in the webview's localStorage; a first native launch starts from defaults (both apps default resume-on-launch off).
 


### PR DESCRIPTION
Part of #445 (M6.19).

Only Inter is bundled (`assets/fonts/Inter-*.ttf`); Geist and Roboto resolved to whatever the machine had and otherwise fell through to the system font, so the picker promised typefaces the app does not ship.

- `AppFontFamily` → `app_font()` returning Inter with the existing CJK fallback chain.
- Settings → Appearance: App font row, `SettingsSelection::AppFont`, and the value/parse helpers removed.
- `app_font_family` dropped from `AppSettings` and the shell settings fingerprint; a legacy `appFontFamily` key in `ui-settings.json` is ignored on load (unit-tested for all four legacy values).
- `docs/arch/arch.md`: Appearance pane no longer lists app font.

Verified: `cargo test -p runner-app`, workspace clippy `-D warnings`, `fmt --check` all green; smoke-tested by Jason — Appearance shows no App font row, app renders in Inter.
