### PR TITLE
fix(ui): default a runner chat's name to @handle

### DIFF
--- a/crates/runner-app/src/surfaces/start_chat.rs
+++ b/crates/runner-app/src/surfaces/start_chat.rs
@@ -1653,7 +1653,7 @@ fn runtime_display_name(runtimes: &[RuntimeCatalogEntry], name: &str) -> String 
 }
 
 fn default_title_for_runner(handle: &str) -> String {
-    format!("Chat with @{handle}")
+    format!("@{handle}")
 }
 
 fn default_title_for_runtime(label: &str) -> String {
@@ -1784,12 +1784,8 @@ mod tests {
     #[test]
     fn title_auto_derives_until_the_user_edits_it() {
         assert_eq!(
-            auto_title_after_selection(
-                false,
-                "Chat with @coder",
-                default_title_for_runner("reviewer")
-            ),
-            "Chat with @reviewer"
+            auto_title_after_selection(false, "@coder", default_title_for_runner("reviewer")),
+            "@reviewer"
         );
         assert_eq!(
             auto_title_after_selection(true, "my chat", default_title_for_runtime("Codex")),


### PR DESCRIPTION
Start a chat → Runner: the Chat name field prefilled "Chat with @coder"; it now prefills "@coder" (Jason, 2026-08-27). Direct-chat default (runtime label) unchanged; the field still re-derives on runner switch until edited. Test updated; `runner-app` tests, clippy, fmt green; verified in the dev app.