### PR TITLE
fix(ui): keep the Starting pill up until a TUI that took the screen has painted

### DIFF
--- a/crates/runner-app/src/surfaces/chat.rs
+++ b/crates/runner-app/src/surfaces/chat.rs
@@ -207,6 +207,8 @@ impl NativeRoot {
                         .is_some_and(|activity| activity.last_seq > transition.baseline_seq);
                     let first_paint_seen = activity
                         .is_some_and(|activity| activity.first_paint_seq > transition.baseline_seq);
+                    let tui_ready_seen = activity
+                        .is_some_and(|activity| activity.tui_ready_seq > transition.baseline_seq);
                     let output_idle_for = activity
                         .and_then(|activity| activity.last_output_at)
                         .map(|last| now.saturating_duration_since(last));
@@ -214,6 +216,7 @@ impl NativeRoot {
                         transition.kind,
                         now.saturating_duration_since(transition.started_at),
                         first_paint_seen,
+                        tui_ready_seen,
                         output_seen,
                         output_idle_for,
                     );

--- a/crates/runner-app/src/surfaces/chat_lifecycle.rs
+++ b/crates/runner-app/src/surfaces/chat_lifecycle.rs
@@ -92,16 +92,24 @@ pub(crate) fn shell_exited_subtitle(
     format!("{exit} · {shell} · {cwd}")
 }
 
+/// The pill drops on the first painted frame. The output-idle backstop covers
+/// processes that never paint, but not one that has taken the screen
+/// (`tui_ready_seen`) and is still booting behind it: claude-code's fullscreen
+/// renderer enters the alternate screen at process start and paints its first
+/// frame 1–2 s later, and dropping the pill on the silence between shows a
+/// blank pane.
 pub(crate) fn transition_should_settle(
     kind: TransitionKind,
     elapsed: Duration,
     first_paint_seen: bool,
+    tui_ready_seen: bool,
     output_seen: bool,
     output_idle_for: Option<Duration>,
 ) -> bool {
     first_paint_seen
         || elapsed >= TRANSITION_HARD_TIMEOUT
         || (output_seen
+            && !tui_ready_seen
             && elapsed >= TRANSITION_MIN_VISIBLE
             && output_idle_for.is_some_and(|idle| idle >= TRANSITION_IDLE))
         || (kind == TransitionKind::Starting && !output_seen && elapsed >= TRANSITION_MIN_VISIBLE)
@@ -189,11 +197,13 @@ mod tests {
             Duration::from_millis(20),
             true,
             true,
+            true,
             Some(Duration::ZERO),
         ));
         assert!(!transition_should_settle(
             TransitionKind::Resuming,
             Duration::from_secs(1),
+            false,
             false,
             false,
             None,
@@ -203,11 +213,13 @@ mod tests {
             Duration::from_secs(1),
             false,
             false,
+            false,
             None,
         ));
         assert!(transition_should_settle(
             TransitionKind::Resuming,
             Duration::from_secs(1),
+            false,
             false,
             true,
             Some(Duration::from_millis(400)),
@@ -217,7 +229,40 @@ mod tests {
             Duration::from_secs(10),
             false,
             false,
+            false,
             None,
         ));
+    }
+
+    #[test]
+    fn a_tui_that_took_the_screen_but_has_not_painted_keeps_the_pill() {
+        // claude-code fullscreen: `?1049h` at ~250 ms, then silence while it
+        // boots, first frame at 1–2 s. The idle backstop must not fire.
+        for kind in [TransitionKind::Starting, TransitionKind::Resuming] {
+            assert!(!transition_should_settle(
+                kind,
+                Duration::from_millis(1500),
+                false,
+                true,
+                true,
+                Some(Duration::from_millis(1200)),
+            ));
+            assert!(transition_should_settle(
+                kind,
+                Duration::from_millis(1800),
+                true,
+                true,
+                true,
+                Some(Duration::ZERO),
+            ));
+            assert!(transition_should_settle(
+                kind,
+                TRANSITION_HARD_TIMEOUT,
+                false,
+                true,
+                true,
+                Some(Duration::from_secs(9)),
+            ));
+        }
     }
 }

--- a/crates/runner-app/src/surfaces/mission_workspace.rs
+++ b/crates/runner-app/src/surfaces/mission_workspace.rs
@@ -1412,6 +1412,9 @@ impl MissionWorkspace {
                         activity.is_some_and(|activity| {
                             activity.first_paint_seq > transition.baseline_seq
                         }),
+                        activity.is_some_and(|activity| {
+                            activity.tui_ready_seq > transition.baseline_seq
+                        }),
                         activity
                             .is_some_and(|activity| activity.last_seq > transition.baseline_seq),
                         activity


### PR DESCRIPTION
Jason, 2026-08-27: the Starting chat pill disappeared 1–2 s before claude's TUI appeared.

Cause: claude-code fullscreen enters the alt screen (`?1049h`) ~250 ms after spawn, then is silent while it boots; `transition_should_settle`'s output-idle backstop (`TRANSITION_MIN_VISIBLE` 1 s + `TRANSITION_IDLE` 400 ms) fired on that silence at t = 1 s, over a blank alternate screen, with the first frame 0.5–1.5 s away.

Fix: `transition_should_settle` takes `tui_ready_seen` (M6.11's `tui_ready_seq` past the transition baseline). Once an app has taken the screen without painting, the idle backstop is skipped and the pill waits for `first_paint`; the 10 s hard timeout and the Starting/no-output rule are unchanged. Wired in `chat.rs` and `mission_workspace.rs`.

Test: `a_tui_that_took_the_screen_but_has_not_painted_keeps_the_pill`. `runner-app` suite, clippy `-D warnings`, fmt green. Verified in the dev app — TUI is on screen when the pill goes.