### PR TITLE
fix(ui): confirm dialog sized to its body; crew delete is one confirm

### DIFF
--- a/crates/runner-app/src/surfaces/crews.rs
+++ b/crates/runner-app/src/surfaces/crews.rs
@@ -130,16 +130,9 @@ enum SlotMenuAction {
     Remove(SlotWithRunner),
 }
 
-#[derive(Clone, Copy, Eq, PartialEq)]
-enum CrewDeleteStage {
-    Slots,
-    History,
-}
-
 struct CrewDeleteConfirm {
     id: String,
     name: String,
-    stage: CrewDeleteStage,
 }
 
 struct SlotRemoveConfirm {
@@ -618,11 +611,7 @@ impl NativeRoot {
         match action {
             CrewMenuAction::Open(id) => self.open_crew_editor(id, window, cx),
             CrewMenuAction::Delete { id, name } => {
-                self.crew_surfaces.delete_confirm = Some(CrewDeleteConfirm {
-                    id,
-                    name,
-                    stage: CrewDeleteStage::Slots,
-                });
+                self.crew_surfaces.delete_confirm = Some(CrewDeleteConfirm { id, name });
                 cx.notify();
             }
         }
@@ -1715,22 +1704,10 @@ impl NativeRoot {
         let root = cx.entity();
         let confirm_root = root.clone();
         let cancel_root = root;
-        let (title, body, label) = match confirm.stage {
-            CrewDeleteStage::Slots => (
-                format!("Delete crew \"{}\"?", confirm.name),
-                "This removes all its slots.".to_owned(),
-                "Continue",
-            ),
-            CrewDeleteStage::History => (
-                format!("Delete crew \"{}\" permanently?", confirm.name),
-                "This also deletes archived missions and session history for this crew. Crews with non-archived missions cannot be deleted until those missions are archived.".to_owned(),
-                "Delete crew",
-            ),
-        };
         ConfirmDialog::new(
-            title,
-            body,
-            label,
+            format!("Delete crew \"{}\" permanently?", confirm.name),
+            "This removes all its slots and deletes its archived missions and session history. Crews with non-archived missions cannot be deleted until those missions are archived.",
+            "Delete crew",
             "Deleting…",
             self.crew_surfaces.delete_busy,
             Rc::new(move |_, cx| {
@@ -2966,15 +2943,10 @@ impl NativeRoot {
     }
 
     fn advance_crew_delete(&mut self, cx: &mut Context<Self>) {
-        let Some(confirm) = self.crew_surfaces.delete_confirm.as_mut() else {
+        let Some(confirm) = self.crew_surfaces.delete_confirm.as_ref() else {
             return;
         };
         if self.crew_surfaces.delete_busy {
-            return;
-        }
-        if confirm.stage == CrewDeleteStage::Slots {
-            confirm.stage = CrewDeleteStage::History;
-            cx.notify();
             return;
         }
         self.crew_surfaces.delete_busy = true;

--- a/crates/runner-app/src/ui/overlay.rs
+++ b/crates/runner-app/src/ui/overlay.rs
@@ -473,6 +473,9 @@ impl RenderOnce for ConfirmDialog {
                             )
                             .child(
                                 div()
+                                    .flex_1()
+                                    .min_w_0()
+                                    .whitespace_normal()
                                     .text_size(rems(15. / 16.))
                                     .font_weight(FontWeight::SEMIBOLD)
                                     .text_color(theme::text())
@@ -481,6 +484,9 @@ impl RenderOnce for ConfirmDialog {
                     )
                     .children((!self.body.is_empty()).then(|| {
                         div()
+                            .w_full()
+                            .min_w_0()
+                            .whitespace_normal()
                             .text_size(rems(13. / 16.))
                             .line_height(rems(20. / 16.))
                             .text_color(theme::muted())


### PR DESCRIPTION
Jason, 2026-08-27: deleting a crew did nothing, and the two-step confirm was unwanted.

**Cause.** `ConfirmDialog`'s body text had no definite width, so gpui measured it as one line while painting three; the Cancel / Delete crew row overflowed below the panel. A mouse-down on the button was outside the panel's hitbox and reached the backdrop's `on_mouse_down`, which cancels the dialog — the click closed it instead of deleting. The backend `ops::crew::delete` was verified fine against a copy of the dev DB. Stage 1 (one-line body) never triggered it; stage 2 (three-line body) always did.

**Fix.** Body gets `w_full().min_w_0().whitespace_normal()`, title `flex_1().min_w_0().whitespace_normal()` — the panel now grows with wrapped text. Also fixes the runner-delete dialog, which shares the component. The crew delete collapses to a single confirm naming slots, archived missions, and session history.

`runner-app` tests, clippy `-D warnings`, fmt green; verified in the dev app — one dialog, buttons inside the panel, crew deleted with the toast.